### PR TITLE
Removed commas from language spec

### DIFF
--- a/docs/spec/parameters.md
+++ b/docs/spec/parameters.md
@@ -92,8 +92,8 @@ If applicable to the parameter type, multiple modifiers can be combined together
 ```
 parameter storageAccountName string {
   minLength: 3
-  maxLength: 24,
-  defaultValue: concat(uniqueString(resourceGroup().id), 'sa'),
+  maxLength: 24
+  defaultValue: concat(uniqueString(resourceGroup().id), 'sa')
   metadata: {
     description: "Name of the storage account"
   }

--- a/docs/spec/resources.md
+++ b/docs/spec/resources.md
@@ -45,24 +45,24 @@ resource dnsZone 'Microsoft.Network/dnszones@2018-05-01': {
 ### Storage Account
 ```
 resource myStorageAccount `Microsoft.Storage/storageAccounts@2017-10-01`: {
-  name: storageAccountName,
-  location: resourceGroup().location,
+  name: storageAccountName
+  location: resourceGroup().location
   properties: {
-    supportsHttpsTrafficOnly: true,
-    accessTier: 'Hot',
+    supportsHttpsTrafficOnly: true
+    accessTier: 'Hot'
     encryption: {
-      keySource: 'Microsoft.Storage',
+      keySource: 'Microsoft.Storage'
       services: {
         blob: {
           enabled: true
-        },
+        }
         file: {
           enabled: true
         }
       }
     }
-  },
-  kind: StorageV2,
+  }
+  kind: StorageV2
   sku: {
     name: 'Standard_LRS'
   }


### PR DESCRIPTION
Removed commas from language spec examples to match agreed upon syntax and to avoid confusion.