### PR TITLE
Fixed position helper bug

### DIFF
--- a/Bicep.LangServer.UnitTests/Utils/PositionHelperTests.cs
+++ b/Bicep.LangServer.UnitTests/Utils/PositionHelperTests.cs
@@ -46,6 +46,7 @@ namespace Bicep.LangServer.UnitTests.Utils
             yield return new object[] { new List<int> { 0, 12, 45 }.AsReadOnly(), 44, new Position(1, 32) };
             yield return new object[] { new List<int> { 0, 12, 45 }.AsReadOnly(), 45, new Position(2, 0) };
             yield return new object[] { new List<int> { 0, 12, 45 }.AsReadOnly(), 99, new Position(2, 54) };
+            yield return new object[] {new List<int> {0, 7, 9}.AsReadOnly(), 0, new Position(0, 0)};
         }
     }
 }

--- a/src/Bicep.LangServer/BicepTextDocumentSyncHandler.cs
+++ b/src/Bicep.LangServer/BicepTextDocumentSyncHandler.cs
@@ -95,6 +95,7 @@ namespace Bicep.LanguageServer
         private List<Diagnostic> GetDiagnostics(string contents)
         {
             var newLinePositions = new List<int>();
+            newLinePositions.Add(0);
             for (var i = 0; i < contents.Length; i++)
             {
                 if (contents[i] == '\n')


### PR DESCRIPTION
The new binary search coordinate converter algorithm requires first line start to be 0.