### PR TITLE
Slurp multiple newlines into a single token

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -8,7 +8,7 @@ parameterStmt -> "parameter" IDENTIFIER(name) IDENTIFIER(type) ("=" value )? NL
 
 value -> NUMBER | STRING | "true" | "false"
 
-NL -> "\n" | "\r\n" | "\r"
+NL -> ("\n" | "\r")+
 ```
 
 Ignore everything below

--- a/src/Bicep.Core.Samples/DataSetsTests.cs
+++ b/src/Bicep.Core.Samples/DataSetsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Bicep.Core.Parser;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -10,6 +11,12 @@ namespace Bicep.Core.Samples
     [TestClass]
     public class DataSetsTests
     {
+        private static readonly Regex Pattern_CRLF = new Regex(@"(\r\n)+", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex Pattern_LF = new Regex(@"(\n)+", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex Pattern_CR = new Regex(@"(\r)+", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
         [DataTestMethod]
         [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
         public void DataSetShouldBeValid(DataSet dataSet)
@@ -33,20 +40,25 @@ namespace Bicep.Core.Samples
             var lineEndingTokens = GetLineEndingTokens(dataSet.Bicep);
             lineEndingTokens.Select(token => token.Type).Should().AllBeEquivalentTo(TokenType.NewLine);
 
-            string? expectedLineEnding = null;
+            Regex? expectedPattern = null;
             if (dataSet.Name.EndsWith("_CRLF"))
             {
-                expectedLineEnding = "\r\n";
+                expectedPattern = Pattern_CRLF;
             }
 
             if (dataSet.Name.EndsWith("_LF"))
             {
-                expectedLineEnding = "\n";
+                expectedPattern = Pattern_LF;
             }
 
-            if (expectedLineEnding != null)
+            if (dataSet.Name.EndsWith("_CR"))
             {
-                lineEndingTokens.All(token => string.Equals(token.Text, expectedLineEnding, StringComparison.Ordinal)).Should().BeTrue();
+                expectedPattern = Pattern_CR;
+            }
+
+            if (expectedPattern != null)
+            {
+                lineEndingTokens.All(token => expectedPattern.IsMatch(token.Text)).Should().BeTrue();
             }
         }
 

--- a/src/Bicep.Core.Samples/InvalidParameters_CRLF/Errors.json
+++ b/src/Bicep.Core.Samples/InvalidParameters_CRLF/Errors.json
@@ -1,18 +1,18 @@
 [
   {
     "message": "This declaration type is not recognized. Specify a parameter declaration.",
-    "span": "[143:150]",
-    "spanText": "wrong\r\n"
+    "span": "[143:152]",
+    "spanText": "wrong\r\n\r\n"
   },
   {
     "message": "Expected a parameter identifier at this location.",
-    "span": "[182:186]",
-    "spanText": "\r\n\r\n"
+    "span": "[182:211]",
+    "spanText": "\r\n\r\nparameter myBool bool\r\n\r\n"
   },
   {
     "message": "Expected a parameter type at this location. Please specify one of the following types: array, bool, int, object, string",
-    "span": "[232:236]",
-    "spanText": "\r\n\r\n"
+    "span": "[232:282]",
+    "spanText": "\r\n\r\nparameter myString2 string= 'string value'\r\n\r\n"
   },
   {
     "message": "The parameter expects a default value of type 'string' but provided value is of type 'int'.",
@@ -21,8 +21,8 @@
   },
   {
     "message": "The type of the specified value is incorrect. Specify a string, boolean, or integer literal.",
-    "span": "[385:387]",
-    "spanText": "\r\n"
+    "span": "[385:389]",
+    "spanText": "\r\n\r\n"
   },
   {
     "message": "The parameter expects a default value of type 'bool' but provided value is of type 'string'.",
@@ -36,8 +36,8 @@
   },
   {
     "message": "Expected a new line character at this location.",
-    "span": "[506:517]",
-    "spanText": ": 'hello'\r\n"
+    "span": "[506:519]",
+    "spanText": ": 'hello'\r\n\r\n"
   },
   {
     "message": "The identifier exceeds the limit of 255. Reduce the length of the identifier.",
@@ -46,8 +46,8 @@
   },
   {
     "message": "Expected a new line character at this location.",
-    "span": "[879:891]",
-    "spanText": "s up doc?'\r\n"
+    "span": "[879:893]",
+    "spanText": "s up doc?'\r\n\r\n"
   },
   {
     "message": "Parameter 'wrongType' is declared several times, which is not allowed.",

--- a/src/Bicep.Core.Samples/InvalidParameters_CRLF/Tokens.json
+++ b/src/Bicep.Core.Samples/InvalidParameters_CRLF/Tokens.json
@@ -1,13 +1,8 @@
 [
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[112:114]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[114:116]"
+    "text": "\r\n\r\n",
+    "span": "[112:116]"
   },
   {
     "type": "parameterKeyword",
@@ -36,13 +31,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[148:150]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[150:152]"
+    "text": "\r\n\r\n",
+    "span": "[148:152]"
   },
   {
     "type": "parameterKeyword",
@@ -71,13 +61,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[182:184]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[184:186]"
+    "text": "\r\n\r\n",
+    "span": "[182:186]"
   },
   {
     "type": "parameterKeyword",
@@ -96,13 +81,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[207:209]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[209:211]"
+    "text": "\r\n\r\n",
+    "span": "[207:211]"
   },
   {
     "type": "parameterKeyword",
@@ -116,13 +96,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[232:234]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[234:236]"
+    "text": "\r\n\r\n",
+    "span": "[232:236]"
   },
   {
     "type": "parameterKeyword",
@@ -151,13 +126,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[278:280]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[280:282]"
+    "text": "\r\n\r\n",
+    "span": "[278:282]"
   },
   {
     "type": "parameterKeyword",
@@ -186,13 +156,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[320:322]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[322:324]"
+    "text": "\r\n\r\n",
+    "span": "[320:324]"
   },
   {
     "type": "parameterKeyword",
@@ -246,13 +211,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[385:387]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[387:389]"
+    "text": "\r\n\r\n",
+    "span": "[385:389]"
   },
   {
     "type": "parameterKeyword",
@@ -311,13 +271,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[465:467]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[467:469]"
+    "text": "\r\n\r\n",
+    "span": "[465:469]"
   },
   {
     "type": "parameterKeyword",
@@ -346,13 +301,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[515:517]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[517:519]"
+    "text": "\r\n\r\n",
+    "span": "[515:519]"
   },
   {
     "type": "parameterKeyword",
@@ -381,13 +331,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[810:812]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[812:814]"
+    "text": "\r\n\r\n",
+    "span": "[810:814]"
   },
   {
     "type": "parameterKeyword",
@@ -441,13 +386,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[889:891]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[891:893]"
+    "text": "\r\n\r\n",
+    "span": "[889:893]"
   },
   {
     "type": "parameterKeyword",
@@ -476,13 +416,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[962:964]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[964:966]"
+    "text": "\r\n\r\n",
+    "span": "[962:966]"
   },
   {
     "type": "parameterKeyword",
@@ -511,13 +446,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[1041:1043]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[1043:1045]"
+    "text": "\r\n\r\n",
+    "span": "[1041:1045]"
   },
   {
     "type": "parameterKeyword",
@@ -546,13 +476,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[1096:1098]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[1098:1100]"
+    "text": "\r\n\r\n",
+    "span": "[1096:1100]"
   },
   {
     "type": "endOfFile",

--- a/src/Bicep.Core.Samples/InvalidParameters_LF/Errors.json
+++ b/src/Bicep.Core.Samples/InvalidParameters_LF/Errors.json
@@ -1,18 +1,18 @@
 [
   {
     "message": "This declaration type is not recognized. Specify a parameter declaration.",
-    "span": "[138:144]",
-    "spanText": "wrong\n"
+    "span": "[138:145]",
+    "spanText": "wrong\n\n"
   },
   {
     "message": "Expected a parameter identifier at this location.",
-    "span": "[174:176]",
-    "spanText": "\n\n"
+    "span": "[174:199]",
+    "spanText": "\n\nparameter myBool bool\n\n"
   },
   {
     "message": "Expected a parameter type at this location. Please specify one of the following types: array, bool, int, object, string",
-    "span": "[220:222]",
-    "spanText": "\n\n"
+    "span": "[220:266]",
+    "spanText": "\n\nparameter myString2 string= 'string value'\n\n"
   },
   {
     "message": "The parameter expects a default value of type 'string' but provided value is of type 'int'.",
@@ -21,8 +21,8 @@
   },
   {
     "message": "The type of the specified value is incorrect. Specify a string, boolean, or integer literal.",
-    "span": "[366:367]",
-    "spanText": "\n"
+    "span": "[366:368]",
+    "spanText": "\n\n"
   },
   {
     "message": "The parameter expects a default value of type 'bool' but provided value is of type 'string'.",
@@ -36,8 +36,8 @@
   },
   {
     "message": "Expected a new line character at this location.",
-    "span": "[482:492]",
-    "spanText": ": 'hello'\n"
+    "span": "[482:493]",
+    "spanText": ": 'hello'\n\n"
   },
   {
     "message": "The identifier exceeds the limit of 255. Reduce the length of the identifier.",
@@ -46,8 +46,8 @@
   },
   {
     "message": "Expected a new line character at this location.",
-    "span": "[850:861]",
-    "spanText": "s up doc?'\n"
+    "span": "[850:862]",
+    "spanText": "s up doc?'\n\n"
   },
   {
     "message": "Parameter 'wrongType' is declared several times, which is not allowed.",

--- a/src/Bicep.Core.Samples/InvalidParameters_LF/Tokens.json
+++ b/src/Bicep.Core.Samples/InvalidParameters_LF/Tokens.json
@@ -1,13 +1,8 @@
 [
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[110:111]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[111:112]"
+    "text": "\n\n",
+    "span": "[110:112]"
   },
   {
     "type": "parameterKeyword",
@@ -36,13 +31,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[143:144]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[144:145]"
+    "text": "\n\n",
+    "span": "[143:145]"
   },
   {
     "type": "parameterKeyword",
@@ -71,13 +61,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[174:175]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[175:176]"
+    "text": "\n\n",
+    "span": "[174:176]"
   },
   {
     "type": "parameterKeyword",
@@ -96,13 +81,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[197:198]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[198:199]"
+    "text": "\n\n",
+    "span": "[197:199]"
   },
   {
     "type": "parameterKeyword",
@@ -116,13 +96,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[220:221]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[221:222]"
+    "text": "\n\n",
+    "span": "[220:222]"
   },
   {
     "type": "parameterKeyword",
@@ -151,13 +126,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[264:265]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[265:266]"
+    "text": "\n\n",
+    "span": "[264:266]"
   },
   {
     "type": "parameterKeyword",
@@ -186,13 +156,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[304:305]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[305:306]"
+    "text": "\n\n",
+    "span": "[304:306]"
   },
   {
     "type": "parameterKeyword",
@@ -246,13 +211,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[366:367]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[367:368]"
+    "text": "\n\n",
+    "span": "[366:368]"
   },
   {
     "type": "parameterKeyword",
@@ -311,13 +271,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[443:444]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[444:445]"
+    "text": "\n\n",
+    "span": "[443:445]"
   },
   {
     "type": "parameterKeyword",
@@ -346,13 +301,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[491:492]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[492:493]"
+    "text": "\n\n",
+    "span": "[491:493]"
   },
   {
     "type": "parameterKeyword",
@@ -381,13 +331,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[784:785]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[785:786]"
+    "text": "\n\n",
+    "span": "[784:786]"
   },
   {
     "type": "parameterKeyword",
@@ -441,13 +386,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[860:861]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[861:862]"
+    "text": "\n\n",
+    "span": "[860:862]"
   },
   {
     "type": "parameterKeyword",
@@ -476,13 +416,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[930:931]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[931:932]"
+    "text": "\n\n",
+    "span": "[930:932]"
   },
   {
     "type": "parameterKeyword",
@@ -511,13 +446,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[1006:1007]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[1007:1008]"
+    "text": "\n\n",
+    "span": "[1006:1008]"
   },
   {
     "type": "parameterKeyword",
@@ -546,13 +476,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[1059:1060]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[1060:1061]"
+    "text": "\n\n",
+    "span": "[1059:1061]"
   },
   {
     "type": "endOfFile",

--- a/src/Bicep.Core.Samples/Parameters_CRLF/Tokens.json
+++ b/src/Bicep.Core.Samples/Parameters_CRLF/Tokens.json
@@ -1,13 +1,8 @@
 [
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[35:37]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[37:39]"
+    "text": "\r\n\r\n",
+    "span": "[35:39]"
   },
   {
     "type": "parameterKeyword",
@@ -66,13 +61,8 @@
   },
   {
     "type": "newLine",
-    "text": "\r\n",
-    "span": "[145:147]"
-  },
-  {
-    "type": "newLine",
-    "text": "\r\n",
-    "span": "[147:149]"
+    "text": "\r\n\r\n",
+    "span": "[145:149]"
   },
   {
     "type": "parameterKeyword",

--- a/src/Bicep.Core.Samples/Parameters_LF/Tokens.json
+++ b/src/Bicep.Core.Samples/Parameters_LF/Tokens.json
@@ -1,13 +1,8 @@
 [
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[33:34]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[34:35]"
+    "text": "\n\n",
+    "span": "[33:35]"
   },
   {
     "type": "parameterKeyword",
@@ -66,13 +61,8 @@
   },
   {
     "type": "newLine",
-    "text": "\n",
-    "span": "[138:139]"
-  },
-  {
-    "type": "newLine",
-    "text": "\n",
-    "span": "[139:140]"
+    "text": "\n\n",
+    "span": "[138:140]"
   },
   {
     "type": "parameterKeyword",

--- a/src/Bicep.Core/Parser/Lexer.cs
+++ b/src/Bicep.Core/Parser/Lexer.cs
@@ -276,6 +276,25 @@ namespace Bicep.Core.Parser
             }
         }
 
+        private void ScanNewLine()
+        {
+            while (true)
+            {
+                if (textWindow.IsAtEnd())
+                {
+                    return;
+                }
+
+                var nextChar = textWindow.Peek();
+                if (IsNewLine(nextChar) == false)
+                {
+                    return;
+                }
+
+                textWindow.Advance();
+            }
+        }
+
         private void ScanString()
         {
             while (true)
@@ -494,17 +513,8 @@ namespace Bicep.Core.Parser
                     ScanString();
                     return TokenType.String;
                 case '\n':
-                    return TokenType.NewLine;
                 case '\r':
-                    if (!textWindow.IsAtEnd())
-                    {
-                        switch (textWindow.Peek())
-                        {
-                            case '\n':
-                                textWindow.Advance();
-                                return TokenType.NewLine;
-                        }
-                    }
+                    this.ScanNewLine();
                     return TokenType.NewLine;
                 default:
                     if (IsDigit(nextChar))
@@ -524,16 +534,14 @@ namespace Bicep.Core.Parser
 
         // TODO: Need IsIdStart and IsIdContinue (to disallow starting identifiers with 0-9, for example)
 
-        private static bool IsAlpha(char c)
-            => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+        private static bool IsAlpha(char c) => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
 
-        private static bool IsAlphaNumeric(char c)
-            => IsAlpha(c) || IsDigit(c);
+        private static bool IsAlphaNumeric(char c) => IsAlpha(c) || IsDigit(c);
 
-        private static bool IsDigit(char c)
-            => c >= '0' && c <= '9';
+        private static bool IsDigit(char c) => c >= '0' && c <= '9';
 
-        private static bool IsWhiteSpace(char c)
-            => c == ' ' || c == '\t';
+        private static bool IsWhiteSpace(char c) => c == ' ' || c == '\t';
+
+        private static bool IsNewLine(char c) => c == '\n' || c == '\r';
     }
 }

--- a/src/Bicep.Core/Parser/Parser.cs
+++ b/src/Bicep.Core/Parser/Parser.cs
@@ -50,6 +50,8 @@ namespace Bicep.Core.Parser
                         return this.ParameterStatement();
 
                     case TokenType.NewLine:
+                        // at this point, this only exists at the beginning of the file
+                        // newlines that break up multiple declarations get slurped up by the lexer into a single token
                         return this.NoOpStatement();
                 }
 


### PR DESCRIPTION
- Lexer now slurps multiple newlines into a single token based on feedback from @bterlson. This reduces the number of `NoOpDeclaration` nodes in a file to 1 (there's one at the beginning if there are leading newlines at the beginning of the file)
- Added support for \r by changing the newline pattern to `(\r|\n)+`