### PR TITLE
Fixed duplicate identifier error spans

### DIFF
--- a/src/Bicep.Core.Samples/InvalidParameters_CRLF/Errors.json
+++ b/src/Bicep.Core.Samples/InvalidParameters_CRLF/Errors.json
@@ -55,9 +55,9 @@
     "spanText": "'"
   },
   {
-    "message": "Parameter 'wrongType' is declared multiple times. Remove or rename the duplicate parameters.",
-    "span": "[912:962]",
-    "spanText": "parameter wrongType fluffyBunny = 'what\\s up doc?'"
+    "message": "Identifier 'wrongType' is declared multiple times. Remove or rename the duplicates.",
+    "span": "[922:931]",
+    "spanText": "wrongType"
   },
   {
     "message": "The parameter type is not valid. Please specify one of the following types: array, bool, int, object, string",
@@ -70,9 +70,9 @@
     "spanText": "\\s"
   },
   {
-    "message": "Parameter 'wrongType' is declared multiple times. Remove or rename the duplicate parameters.",
-    "span": "[991:1041]",
-    "spanText": "parameter wrongType fluffyBunny = 'what\\'s up doc?"
+    "message": "Identifier 'wrongType' is declared multiple times. Remove or rename the duplicates.",
+    "span": "[1001:1010]",
+    "spanText": "wrongType"
   },
   {
     "message": "The parameter type is not valid. Please specify one of the following types: array, bool, int, object, string",
@@ -85,9 +85,9 @@
     "spanText": "'what\\'s up doc?"
   },
   {
-    "message": "Parameter 'wrongType' is declared multiple times. Remove or rename the duplicate parameters.",
-    "span": "[1045:1096]",
-    "spanText": "parameter wrongType fluffyBunny = 'what\\'s up doc?'"
+    "message": "Identifier 'wrongType' is declared multiple times. Remove or rename the duplicates.",
+    "span": "[1055:1064]",
+    "spanText": "wrongType"
   },
   {
     "message": "The parameter type is not valid. Please specify one of the following types: array, bool, int, object, string",

--- a/src/Bicep.Core.Samples/InvalidParameters_LF/Errors.json
+++ b/src/Bicep.Core.Samples/InvalidParameters_LF/Errors.json
@@ -55,9 +55,9 @@
     "spanText": "'"
   },
   {
-    "message": "Parameter 'wrongType' is declared multiple times. Remove or rename the duplicate parameters.",
-    "span": "[880:930]",
-    "spanText": "parameter wrongType fluffyBunny = 'what\\s up doc?'"
+    "message": "Identifier 'wrongType' is declared multiple times. Remove or rename the duplicates.",
+    "span": "[890:899]",
+    "spanText": "wrongType"
   },
   {
     "message": "The parameter type is not valid. Please specify one of the following types: array, bool, int, object, string",
@@ -70,9 +70,9 @@
     "spanText": "\\s"
   },
   {
-    "message": "Parameter 'wrongType' is declared multiple times. Remove or rename the duplicate parameters.",
-    "span": "[956:1006]",
-    "spanText": "parameter wrongType fluffyBunny = 'what\\'s up doc?"
+    "message": "Identifier 'wrongType' is declared multiple times. Remove or rename the duplicates.",
+    "span": "[966:975]",
+    "spanText": "wrongType"
   },
   {
     "message": "The parameter type is not valid. Please specify one of the following types: array, bool, int, object, string",
@@ -85,9 +85,9 @@
     "spanText": "'what\\'s up doc?"
   },
   {
-    "message": "Parameter 'wrongType' is declared multiple times. Remove or rename the duplicate parameters.",
-    "span": "[1008:1059]",
-    "spanText": "parameter wrongType fluffyBunny = 'what\\'s up doc?'"
+    "message": "Identifier 'wrongType' is declared multiple times. Remove or rename the duplicates.",
+    "span": "[1018:1027]",
+    "spanText": "wrongType"
   },
   {
     "message": "The parameter type is not valid. Please specify one of the following types: array, bool, int, object, string",

--- a/src/Bicep.Core/SemanticModel/DeclaredSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/DeclaredSymbol.cs
@@ -17,5 +17,10 @@ namespace Bicep.Core.SemanticModel
         /// Gets the syntax node that declared this symbol.
         /// </summary>
         public SyntaxBase DeclaringSyntax { get; }
+
+        /// <summary>
+        /// Gets the syntax node of the identifier. May be null if the symbol is in an invalid state.
+        /// </summary>
+        public abstract SyntaxBase? NameSyntax { get; }
     }
 }

--- a/src/Bicep.Core/SemanticModel/FileSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/FileSymbol.cs
@@ -56,9 +56,14 @@ namespace Bicep.Core.SemanticModel
             {
                 foreach (DeclaredSymbol duplicatedSymbol in group)
                 {
-                    yield return this.CreateError($"Parameter '{duplicatedSymbol.Name}' is declared multiple times. Remove or rename the duplicate parameters.", duplicatedSymbol.DeclaringSyntax);
+                    // use the identifier node as the error location with fallback to full declaration span
+                    SyntaxBase identifierNode = duplicatedSymbol.NameSyntax ?? duplicatedSymbol.DeclaringSyntax;
+
+                    yield return this.CreateError($"Identifier '{duplicatedSymbol.Name}' is declared multiple times. Remove or rename the duplicates.", identifierNode);
                 }
             }
         }
+
+        public override SyntaxBase? NameSyntax => null;
     }
 }

--- a/src/Bicep.Core/SemanticModel/OutputSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/OutputSymbol.cs
@@ -42,5 +42,7 @@ namespace Bicep.Core.SemanticModel
                 yield return this.CreateError($"The output expects a value of type '{this.Type.Name} but the provided value is of type '{valueType?.Name}'.", this.Value);
             }
         }
+
+        public override SyntaxBase? NameSyntax => (this.DeclaringSyntax as OutputDeclarationSyntax)?.Name;
     }
 }

--- a/src/Bicep.Core/SemanticModel/ParameterSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/ParameterSymbol.cs
@@ -46,5 +46,7 @@ namespace Bicep.Core.SemanticModel
                 }
             }
         }
+
+        public override SyntaxBase? NameSyntax => (this.DeclaringSyntax as ParameterDeclarationSyntax)?.Name;
     }
 }

--- a/src/Bicep.Core/SemanticModel/ResourceSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/ResourceSymbol.cs
@@ -34,5 +34,7 @@ namespace Bicep.Core.SemanticModel
         {
             return TypeValidator.GetExpressionAssignmentDiagnostics(this.Context, this.Body, this.Type);
         }
+
+        public override SyntaxBase? NameSyntax => (this.DeclaringSyntax as ResourceDeclarationSyntax)?.Name;
     }
 }

--- a/src/Bicep.Core/SemanticModel/VariableSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/VariableSymbol.cs
@@ -29,5 +29,7 @@ namespace Bicep.Core.SemanticModel
                 yield return this.Type;
             }
         }
+
+        public override SyntaxBase? NameSyntax => (this.DeclaringSyntax as VariableDeclarationSyntax)?.Name;
     }
 }

--- a/src/Bicep.LangServer/BicepDocumentSymbolHandler.cs
+++ b/src/Bicep.LangServer/BicepDocumentSymbolHandler.cs
@@ -62,8 +62,8 @@ namespace Bicep.LanguageServer
                 Kind = SelectSymbolKind(symbol),
                 Detail = FormatDetail(symbol),
                 Range = symbol.DeclaringSyntax.ToRange(lineStarts),
-                // TODO: Use name syntax node here
-                SelectionRange = symbol.DeclaringSyntax.ToRange(lineStarts)
+                // use the name node span with fallback to entire declaration span
+                SelectionRange = (symbol.NameSyntax ?? symbol.DeclaringSyntax).ToRange(lineStarts)
             };
 
         private SymbolKind SelectSymbolKind(DeclaredSymbol symbol)


### PR DESCRIPTION
- Duplicate identifier error spans are no longer on entire declarations. The error spans now point to the identifier node in the syntax tree.
- Also fixed misleading error message on the duplicate identifier error.