### PR TITLE
Updated slash on prepublish script

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -59,7 +59,7 @@
         ]
     },
     "scripts": {
-        "vscode:prepublish": "dotnet build ..\\Bicep.LangServer --configuration Release --output bicepLanguageServer && tsc -p ./",
+        "vscode:prepublish": "dotnet build ../Bicep.LangServer --configuration Release --output bicepLanguageServer && tsc -p ./",
         "compile": "tsc -p ./",
         "update-vscode": "node ./node_modules/vscode/bin/install",
         "postinstall": "node ./node_modules/vscode/bin/install",


### PR DESCRIPTION
This small PR updates the prepublish command from backslash to forward slash.

Tested on Mac OS 10.15.4 and Windows 10 and worked