### PR TITLE
Trailing comment no longer invalidates subsequent declaration

### DIFF
--- a/src/Bicep.Core.Samples/InvalidOutputs_CRLF/Tokens.json
+++ b/src/Bicep.Core.Samples/InvalidOutputs_CRLF/Tokens.json
@@ -5,6 +5,11 @@
     "span": "[0:2]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[22:24]"
+  },
+  {
     "type": "identifier",
     "text": "bad",
     "span": "[24:27]"
@@ -15,6 +20,11 @@
     "span": "[27:31]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[44:46]"
+  },
+  {
     "type": "outputKeyword",
     "text": "output",
     "span": "[46:52]"
@@ -23,6 +33,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[53:57]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[72:74]"
   },
   {
     "type": "outputKeyword",
@@ -38,6 +53,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[84:88]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[117:119]"
   },
   {
     "type": "outputKeyword",
@@ -60,6 +80,11 @@
     "span": "[136:140]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[156:158]"
+  },
+  {
     "type": "outputKeyword",
     "text": "output",
     "span": "[158:164]"
@@ -78,6 +103,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[175:179]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[195:197]"
   },
   {
     "type": "outputKeyword",
@@ -103,6 +133,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[216:220]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[249:251]"
   },
   {
     "type": "outputKeyword",
@@ -275,6 +310,11 @@
     "span": "[378:382]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[408:410]"
+  },
+  {
     "type": "outputKeyword",
     "text": "output",
     "span": "[410:416]"
@@ -445,6 +485,11 @@
     "span": "[516:520]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[547:549]"
+  },
+  {
     "type": "outputKeyword",
     "text": "output",
     "span": "[549:555]"
@@ -583,6 +628,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[634:638]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[667:669]"
   },
   {
     "type": "outputKeyword",
@@ -743,6 +793,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[792:796]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[824:826]"
   },
   {
     "type": "outputKeyword",

--- a/src/Bicep.Core.Samples/InvalidParameters_CRLF/Tokens.json
+++ b/src/Bicep.Core.Samples/InvalidParameters_CRLF/Tokens.json
@@ -335,6 +335,11 @@
     "span": "[858:862]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[885:887]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[887:896]"
@@ -390,6 +395,11 @@
     "span": "[943:947]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[964:966]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[966:975]"
@@ -418,6 +428,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1022:1026]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1049:1051]"
   },
   {
     "type": "parameterKeyword",
@@ -478,6 +493,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1168:1172]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1202:1204]"
   },
   {
     "type": "parameterKeyword",
@@ -555,6 +575,11 @@
     "span": "[1266:1270]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1300:1302]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1302:1311]"
@@ -628,6 +653,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1383:1387]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1412:1414]"
   },
   {
     "type": "parameterKeyword",
@@ -723,6 +753,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1492:1496]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1525:1527]"
   },
   {
     "type": "parameterKeyword",
@@ -910,6 +945,11 @@
     "span": "[1692:1696]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1720:1722]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1722:1731]"
@@ -993,6 +1033,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1806:1810]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1844:1846]"
   },
   {
     "type": "endOfFile",

--- a/src/Bicep.Core.Samples/InvalidParameters_LF/Tokens.json
+++ b/src/Bicep.Core.Samples/InvalidParameters_LF/Tokens.json
@@ -335,6 +335,11 @@
     "span": "[832:834]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[857:858]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[858:867]"
@@ -390,6 +395,11 @@
     "span": "[914:916]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[933:934]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[934:943]"
@@ -418,6 +428,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[990:992]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1015:1016]"
   },
   {
     "type": "parameterKeyword",
@@ -478,6 +493,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[1131:1133]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1163:1164]"
   },
   {
     "type": "parameterKeyword",
@@ -555,6 +575,11 @@
     "span": "[1223:1225]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1255:1256]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1256:1265]"
@@ -628,6 +653,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[1334:1336]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1361:1362]"
   },
   {
     "type": "parameterKeyword",
@@ -723,6 +753,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[1436:1438]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1467:1468]"
   },
   {
     "type": "parameterKeyword",
@@ -910,6 +945,11 @@
     "span": "[1622:1624]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1648:1649]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1649:1658]"
@@ -993,6 +1033,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[1729:1731]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1765:1766]"
   },
   {
     "type": "endOfFile",

--- a/src/Bicep.Core.Samples/InvalidResources_CRLF/Tokens.json
+++ b/src/Bicep.Core.Samples/InvalidResources_CRLF/Tokens.json
@@ -5,6 +5,11 @@
     "span": "[0:2]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[22:24]"
+  },
+  {
     "type": "identifier",
     "text": "bad",
     "span": "[24:27]"
@@ -13,6 +18,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[27:31]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[44:46]"
   },
   {
     "type": "resourceKeyword",
@@ -110,6 +120,11 @@
     "span": "[125:129]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[151:153]"
+  },
+  {
     "type": "resourceKeyword",
     "text": "resource",
     "span": "[153:161]"
@@ -150,6 +165,11 @@
     "span": "[176:180]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[208:210]"
+  },
+  {
     "type": "resourceKeyword",
     "text": "resource",
     "span": "[210:218]"
@@ -188,6 +208,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[265:269]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[307:309]"
   },
   {
     "type": "resourceKeyword",
@@ -268,6 +293,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[394:398]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[426:428]"
   },
   {
     "type": "resourceKeyword",
@@ -398,6 +428,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[549:553]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[576:578]"
   },
   {
     "type": "resourceKeyword",

--- a/src/Bicep.Core.Samples/InvalidVariables_LF/Tokens.json
+++ b/src/Bicep.Core.Samples/InvalidVariables_LF/Tokens.json
@@ -5,6 +5,11 @@
     "span": "[0:1]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[23:24]"
+  },
+  {
     "type": "identifier",
     "text": "bad",
     "span": "[24:27]"
@@ -15,6 +20,11 @@
     "span": "[27:29]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[63:64]"
+  },
+  {
     "type": "variableKeyword",
     "text": "variable",
     "span": "[64:72]"
@@ -23,6 +33,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[72:74]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[96:97]"
   },
   {
     "type": "variableKeyword",
@@ -38,6 +53,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[109:111]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[131:132]"
   },
   {
     "type": "variableKeyword",
@@ -58,6 +78,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[146:148]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[166:167]"
   },
   {
     "type": "variableKeyword",
@@ -83,6 +108,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[183:185]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[197:198]"
   },
   {
     "type": "variableKeyword",

--- a/src/Bicep.Core.Samples/Parameters_CRLF/Tokens.json
+++ b/src/Bicep.Core.Samples/Parameters_CRLF/Tokens.json
@@ -5,6 +5,11 @@
     "span": "[35:39]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[74:76]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[76:85]"
@@ -63,6 +68,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[145:149]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[181:183]"
   },
   {
     "type": "parameterKeyword",
@@ -213,6 +223,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[423:427]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[450:452]"
   },
   {
     "type": "parameterKeyword",
@@ -535,6 +550,11 @@
     "span": "[715:719]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[741:743]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[743:752]"
@@ -603,6 +623,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[805:809]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[839:841]"
   },
   {
     "type": "parameterKeyword",
@@ -700,6 +725,11 @@
     "span": "[936:940]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[956:958]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[958:967]"
@@ -753,6 +783,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1004:1008]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1028:1030]"
   },
   {
     "type": "parameterKeyword",
@@ -810,6 +845,11 @@
     "span": "[1078:1082]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1098:1100]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1100:1109]"
@@ -863,6 +903,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1150:1154]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1171:1173]"
   },
   {
     "type": "parameterKeyword",
@@ -950,6 +995,11 @@
     "span": "[1270:1274]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1306:1308]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1308:1317]"
@@ -1023,6 +1073,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1374:1378]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1410:1412]"
   },
   {
     "type": "parameterKeyword",
@@ -1100,6 +1155,11 @@
     "span": "[1475:1479]"
   },
   {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1496:1498]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1498:1507]"
@@ -1163,6 +1223,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1553:1557]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1571:1573]"
   },
   {
     "type": "parameterKeyword",
@@ -1248,6 +1313,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1661:1665]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1689:1691]"
   },
   {
     "type": "parameterKeyword",
@@ -1453,6 +1523,11 @@
     "type": "newLine",
     "text": "\r\n\r\n",
     "span": "[1862:1866]"
+  },
+  {
+    "type": "newLine",
+    "text": "\r\n",
+    "span": "[1891:1893]"
   },
   {
     "type": "parameterKeyword",

--- a/src/Bicep.Core.Samples/Parameters_LF/Tokens.json
+++ b/src/Bicep.Core.Samples/Parameters_LF/Tokens.json
@@ -5,6 +5,11 @@
     "span": "[33:35]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[70:71]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[71:80]"
@@ -63,6 +68,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[138:140]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[172:173]"
   },
   {
     "type": "parameterKeyword",
@@ -213,6 +223,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[407:409]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[432:433]"
   },
   {
     "type": "parameterKeyword",
@@ -535,6 +550,11 @@
     "span": "[675:677]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[699:700]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[700:709]"
@@ -603,6 +623,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[758:760]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[790:791]"
   },
   {
     "type": "parameterKeyword",
@@ -700,6 +725,11 @@
     "span": "[880:882]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[898:899]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[899:908]"
@@ -753,6 +783,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[943:945]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[965:966]"
   },
   {
     "type": "parameterKeyword",
@@ -810,6 +845,11 @@
     "span": "[1012:1014]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1030:1031]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1031:1040]"
@@ -863,6 +903,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[1079:1081]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1098:1099]"
   },
   {
     "type": "parameterKeyword",
@@ -950,6 +995,11 @@
     "span": "[1191:1193]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1225:1226]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1226:1235]"
@@ -1023,6 +1073,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[1289:1291]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1323:1324]"
   },
   {
     "type": "parameterKeyword",
@@ -1100,6 +1155,11 @@
     "span": "[1384:1386]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1403:1404]"
+  },
+  {
     "type": "parameterKeyword",
     "text": "parameter",
     "span": "[1404:1413]"
@@ -1163,6 +1223,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[1456:1458]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1472:1473]"
   },
   {
     "type": "parameterKeyword",
@@ -1248,6 +1313,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[1557:1559]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1583:1584]"
   },
   {
     "type": "parameterKeyword",
@@ -1453,6 +1523,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[1744:1746]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[1771:1772]"
   },
   {
     "type": "parameterKeyword",

--- a/src/Bicep.Core.Samples/Variables_LF/Tokens.json
+++ b/src/Bicep.Core.Samples/Variables_LF/Tokens.json
@@ -5,6 +5,11 @@
     "span": "[0:1]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[19:20]"
+  },
+  {
     "type": "variableKeyword",
     "text": "variable",
     "span": "[20:28]"
@@ -30,6 +35,11 @@
     "span": "[39:41]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[61:62]"
+  },
+  {
     "type": "variableKeyword",
     "text": "variable",
     "span": "[62:70]"
@@ -53,6 +63,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[84:86]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[97:98]"
   },
   {
     "type": "variableKeyword",
@@ -103,6 +118,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[150:152]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[161:162]"
   },
   {
     "type": "variableKeyword",
@@ -350,6 +370,11 @@
     "span": "[300:302]"
   },
   {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[310:311]"
+  },
+  {
     "type": "variableKeyword",
     "text": "variable",
     "span": "[311:319]"
@@ -413,6 +438,11 @@
     "type": "newLine",
     "text": "\n\n",
     "span": "[359:361]"
+  },
+  {
+    "type": "newLine",
+    "text": "\n",
+    "span": "[382:383]"
   },
   {
     "type": "variableKeyword",

--- a/src/Bicep.Core/Parser/Lexer.cs
+++ b/src/Bicep.Core/Parser/Lexer.cs
@@ -250,12 +250,14 @@ namespace Bicep.Core.Parser
             while (!textWindow.IsAtEnd())
             {
                 var nextChar = textWindow.Peek();
-                textWindow.Advance();
 
-                if (nextChar == '\n')
+                // make sure we don't include the newline in the comment trivia
+                if (IsNewLine(nextChar))
                 {
                     return;
                 }
+
+                textWindow.Advance();
             }
         }
 
@@ -324,7 +326,7 @@ namespace Bicep.Core.Parser
 
                 var nextChar = textWindow.Peek();
 
-                if (nextChar == '\n' || nextChar == '\r')
+                if (IsNewLine(nextChar))
                 {
                     // do not consume the new line character
                     this.AddError("The string at this location is not terminated due to an unexpected new line character.");


### PR DESCRIPTION
When scanning single-line comments, the lexer was including the newline in the trailing token trivia. This caused trailing comments to break subsequent declarations. Given that NewLine is a separate token type, the fix was to stop that behavior in the lexer. This fixes #86.