### PR TITLE
Escape sequence highlighting now matches the lexer

### DIFF
--- a/src/vscode-bicep/bicep.grammar.json
+++ b/src/vscode-bicep/bicep.grammar.json
@@ -42,7 +42,7 @@
 			"patterns": [
 				{
 					"name": "constant.character.escape.bicep",
-					"match": "(?x)\\\\(?:[\"\\\\/bfnrt$]|[0-9a-fA-F]{4})"
+					"match": "(?x)\\\\(?:[\\\\nrt'$]|[0-9a-fA-F]{4})"
 				},
 				{
 					"include": "#stringinterp"


### PR DESCRIPTION
The currently supported escape sequences in the lexer are `\\`, `\r`, `\n`, `\t`, `\$` and `\'`. Updating the TextMate grammar string escape highlighting regex to match. (I kept the Unicode escape part of the regex because we will add Unicode support in the future.)