### PR TITLE
fixed generation of single integer literals

### DIFF
--- a/src/Bicep.Core.Samples/Variables_LF/Compiled.json
+++ b/src/Bicep.Core.Samples/Variables_LF/Compiled.json
@@ -10,7 +10,7 @@
     "myFalsehood": false,
     "myObj": {
       "a": "a",
-      "b": "[-12]",
+      "b": -12,
       "c": true,
       "d": "[not(json('true'))]",
       "list": [


### PR DESCRIPTION
In template expressions a single integer expression looks like this in JSON: `"[-14]"`. It looks weird and also breaks the ARM template language service which doesn't recognize this particular case. With this change, such numbers will be generated as `-14` in JSON.