### PR TITLE
Fixed property highlight regex to allow white space before the colon

### DIFF
--- a/src/vscode-bicep/bicep.grammar.json
+++ b/src/vscode-bicep/bicep.grammar.json
@@ -89,7 +89,7 @@
 			}
 		},
 		"properties": {
-			"match": "\\b([a-zA-Z][a-zA-Z0-9]*)\\w*\\b:",
+			"match": "\\b([a-zA-Z][a-zA-Z0-9]*)\\w*\\b\\s*:",
 			"captures": {
 				"1": {
 					"name": "support.type.property-name.bicep"


### PR DESCRIPTION
Updated the property highlight regex to allow white space before the colon. There will likely be similar bugs elsewhere. The real fix will be to switch everything to semantic highlighting (which we are planning to do piece by piece).

This fixes #128. 