### PR TITLE
Detect usage of expressions that cannot be compiled into valid IL

### DIFF
--- a/src/Bicep.Core.Samples/InvalidExpressions_LF/main.bicep
+++ b/src/Bicep.Core.Samples/InvalidExpressions_LF/main.bicep
@@ -138,3 +138,39 @@ var test2 = lsitKeys('abcd', '2020-01-01')
 
 // just 'list' 
 var test3 = list('abcd', '2020-01-01')
+
+// cannot compile an expression like this
+var emitLimit = [
+  concat('s')
+  '${4}'
+  {
+    a: {
+      b: base64('s')
+      c: concat([
+        12 + 3
+      ], [
+        !true
+        'hello'
+      ])
+      d: resourceGroup().location
+      e: concat([
+        true
+      ])
+      f: concat([
+        's' == 12
+      ])
+    }
+  }
+]
+
+// cannot compile an expression like this
+var emitLimit2 = {
+  a: {
+    b: {
+      a: resourceGroup().location
+    } == 2
+    c: concat([
+
+    ], true)
+  }
+}

--- a/src/Bicep.Core.Samples/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/InvalidExpressions_LF/main.diagnostics.bicep
@@ -160,6 +160,7 @@ var nestedTernary = (null ? 1 : 2) ? (true ? 'a': 'b') : (false ? 'd' : 15)
 // bad array access
 var errorInsideArrayAccess = [
   !null
+//@[2:7) Error The expression is inside an object or array literal that is itself part of another expression. This is not currently supported. |!null|
 //@[2:7) Error Cannot apply operator '!' to operand of type 'null'. |!null|
 ][!0]
 //@[2:4) Error Cannot apply operator '!' to operand of type 'int'. |!0|
@@ -234,3 +235,44 @@ var test2 = lsitKeys('abcd', '2020-01-01')
 // just 'list' 
 var test3 = list('abcd', '2020-01-01')
 //@[12:16) Error The name 'list' does not exist in the current context. |list|
+
+// cannot compile an expression like this
+var emitLimit = [
+  concat('s')
+  '${4}'
+  {
+    a: {
+      b: base64('s')
+      c: concat([
+        12 + 3
+//@[8:14) Error The expression is inside an object or array literal that is itself part of another expression. This is not currently supported. |12 + 3|
+      ], [
+        !true
+//@[8:13) Error The expression is inside an object or array literal that is itself part of another expression. This is not currently supported. |!true|
+        'hello'
+      ])
+      d: resourceGroup().location
+      e: concat([
+        true
+      ])
+      f: concat([
+        's' == 12
+//@[8:17) Error The expression is inside an object or array literal that is itself part of another expression. This is not currently supported. |'s' == 12|
+      ])
+    }
+  }
+]
+
+// cannot compile an expression like this
+var emitLimit2 = {
+  a: {
+    b: {
+      a: resourceGroup().location
+//@[9:33) Error The expression is inside an object or array literal that is itself part of another expression. This is not currently supported. |resourceGroup().location|
+    } == 2
+    c: concat([
+//@[7:31) Error Cannot resolve function concat(array, bool). |concat([\r\n\r\n    ], true)|
+
+    ], true)
+  }
+}

--- a/src/Bicep.Core.Samples/InvalidExpressions_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/InvalidExpressions_LF/main.symbols.bicep
@@ -191,4 +191,42 @@ var test2 = lsitKeys('abcd', '2020-01-01')
 
 // just 'list' 
 var test3 = list('abcd', '2020-01-01')
-//@[4:9) Variable test3. Declaration start char: 0, length: 38
+//@[4:9) Variable test3. Declaration start char: 0, length: 42
+
+// cannot compile an expression like this
+var emitLimit = [
+//@[4:13) Variable emitLimit. Declaration start char: 0, length: 313
+  concat('s')
+  '${4}'
+  {
+    a: {
+      b: base64('s')
+      c: concat([
+        12 + 3
+      ], [
+        !true
+        'hello'
+      ])
+      d: resourceGroup().location
+      e: concat([
+        true
+      ])
+      f: concat([
+        's' == 12
+      ])
+    }
+  }
+]
+
+// cannot compile an expression like this
+var emitLimit2 = {
+//@[4:14) Variable emitLimit2. Declaration start char: 0, length: 124
+  a: {
+    b: {
+      a: resourceGroup().location
+    } == 2
+    c: concat([
+
+    ], true)
+  }
+}

--- a/src/Bicep.Core.Samples/InvalidExpressions_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/InvalidExpressions_LF/main.tokens.bicep
@@ -820,4 +820,169 @@ var test3 = list('abcd', '2020-01-01')
 //@[23:24) Comma |,|
 //@[25:37) StringComplete |'2020-01-01'|
 //@[37:38) RightParen |)|
-//@[38:38) EndOfFile ||
+//@[38:42) NewLine |\r\n\r\n|
+
+// cannot compile an expression like this
+//@[41:43) NewLine |\r\n|
+var emitLimit = [
+//@[0:3) Identifier |var|
+//@[4:13) Identifier |emitLimit|
+//@[14:15) Assignment |=|
+//@[16:17) LeftSquare |[|
+//@[17:19) NewLine |\r\n|
+  concat('s')
+//@[2:8) Identifier |concat|
+//@[8:9) LeftParen |(|
+//@[9:12) StringComplete |'s'|
+//@[12:13) RightParen |)|
+//@[13:15) NewLine |\r\n|
+  '${4}'
+//@[2:5) StringLeftPiece |'${|
+//@[5:6) Number |4|
+//@[6:8) StringRightPiece |}'|
+//@[8:10) NewLine |\r\n|
+  {
+//@[2:3) LeftBrace |{|
+//@[3:5) NewLine |\r\n|
+    a: {
+//@[4:5) Identifier |a|
+//@[5:6) Colon |:|
+//@[7:8) LeftBrace |{|
+//@[8:10) NewLine |\r\n|
+      b: base64('s')
+//@[6:7) Identifier |b|
+//@[7:8) Colon |:|
+//@[9:15) Identifier |base64|
+//@[15:16) LeftParen |(|
+//@[16:19) StringComplete |'s'|
+//@[19:20) RightParen |)|
+//@[20:22) NewLine |\r\n|
+      c: concat([
+//@[6:7) Identifier |c|
+//@[7:8) Colon |:|
+//@[9:15) Identifier |concat|
+//@[15:16) LeftParen |(|
+//@[16:17) LeftSquare |[|
+//@[17:19) NewLine |\r\n|
+        12 + 3
+//@[8:10) Number |12|
+//@[11:12) Plus |+|
+//@[13:14) Number |3|
+//@[14:16) NewLine |\r\n|
+      ], [
+//@[6:7) RightSquare |]|
+//@[7:8) Comma |,|
+//@[9:10) LeftSquare |[|
+//@[10:12) NewLine |\r\n|
+        !true
+//@[8:9) Exclamation |!|
+//@[9:13) TrueKeyword |true|
+//@[13:15) NewLine |\r\n|
+        'hello'
+//@[8:15) StringComplete |'hello'|
+//@[15:17) NewLine |\r\n|
+      ])
+//@[6:7) RightSquare |]|
+//@[7:8) RightParen |)|
+//@[8:10) NewLine |\r\n|
+      d: resourceGroup().location
+//@[6:7) Identifier |d|
+//@[7:8) Colon |:|
+//@[9:22) Identifier |resourceGroup|
+//@[22:23) LeftParen |(|
+//@[23:24) RightParen |)|
+//@[24:25) Dot |.|
+//@[25:33) Identifier |location|
+//@[33:35) NewLine |\r\n|
+      e: concat([
+//@[6:7) Identifier |e|
+//@[7:8) Colon |:|
+//@[9:15) Identifier |concat|
+//@[15:16) LeftParen |(|
+//@[16:17) LeftSquare |[|
+//@[17:19) NewLine |\r\n|
+        true
+//@[8:12) TrueKeyword |true|
+//@[12:14) NewLine |\r\n|
+      ])
+//@[6:7) RightSquare |]|
+//@[7:8) RightParen |)|
+//@[8:10) NewLine |\r\n|
+      f: concat([
+//@[6:7) Identifier |f|
+//@[7:8) Colon |:|
+//@[9:15) Identifier |concat|
+//@[15:16) LeftParen |(|
+//@[16:17) LeftSquare |[|
+//@[17:19) NewLine |\r\n|
+        's' == 12
+//@[8:11) StringComplete |'s'|
+//@[12:14) Equals |==|
+//@[15:17) Number |12|
+//@[17:19) NewLine |\r\n|
+      ])
+//@[6:7) RightSquare |]|
+//@[7:8) RightParen |)|
+//@[8:10) NewLine |\r\n|
+    }
+//@[4:5) RightBrace |}|
+//@[5:7) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+]
+//@[0:1) RightSquare |]|
+//@[1:5) NewLine |\r\n\r\n|
+
+// cannot compile an expression like this
+//@[41:43) NewLine |\r\n|
+var emitLimit2 = {
+//@[0:3) Identifier |var|
+//@[4:14) Identifier |emitLimit2|
+//@[15:16) Assignment |=|
+//@[17:18) LeftBrace |{|
+//@[18:20) NewLine |\r\n|
+  a: {
+//@[2:3) Identifier |a|
+//@[3:4) Colon |:|
+//@[5:6) LeftBrace |{|
+//@[6:8) NewLine |\r\n|
+    b: {
+//@[4:5) Identifier |b|
+//@[5:6) Colon |:|
+//@[7:8) LeftBrace |{|
+//@[8:10) NewLine |\r\n|
+      a: resourceGroup().location
+//@[6:7) Identifier |a|
+//@[7:8) Colon |:|
+//@[9:22) Identifier |resourceGroup|
+//@[22:23) LeftParen |(|
+//@[23:24) RightParen |)|
+//@[24:25) Dot |.|
+//@[25:33) Identifier |location|
+//@[33:35) NewLine |\r\n|
+    } == 2
+//@[4:5) RightBrace |}|
+//@[6:8) Equals |==|
+//@[9:10) Number |2|
+//@[10:12) NewLine |\r\n|
+    c: concat([
+//@[4:5) Identifier |c|
+//@[5:6) Colon |:|
+//@[7:13) Identifier |concat|
+//@[13:14) LeftParen |(|
+//@[14:15) LeftSquare |[|
+//@[15:19) NewLine |\r\n\r\n|
+
+    ], true)
+//@[4:5) RightSquare |]|
+//@[5:6) Comma |,|
+//@[7:11) TrueKeyword |true|
+//@[11:12) RightParen |)|
+//@[12:14) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:1) EndOfFile ||

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -331,6 +331,11 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP068",
                 "Expected a resource type string. Specify a valid resource type of format '<provider>/<types>@<apiVersion>'.");
+
+            public ErrorDiagnostic EmitLimitationDetected() => new ErrorDiagnostic(
+                TextSpan,
+                "BCP069",
+                "The expression is inside an object or array literal that is itself part of another expression. This is not currently supported.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/EmitLimitationVisitor.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationVisitor.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Emit
+{
+    /// <summary>
+    /// Visitor responsible for detecting issue caused by IL limitations
+    /// </summary>
+    public class EmitLimitationVisitor : SyntaxVisitor
+    {
+        private readonly IList<Diagnostic> diagnostics;
+
+        private readonly Stack<VisitorState> stack = new Stack<VisitorState>();
+
+        public EmitLimitationVisitor(IList<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        protected override void VisitInternal(SyntaxBase node)
+        {
+            var kind = (node as IExpressionSyntax)?.ExpressionKind ?? ExpressionKind.None;
+            var newState = GetNewState(kind);
+
+            if (newState == VisitorState.SecondOperatorChainInsideComplexLiteralInsideFirstOperatorChain)
+            {
+                this.diagnostics.Add(DiagnosticBuilder.ForPosition(node.Span).EmitLimitationDetected());
+                
+                // we won't suddenly regain the ability to compile the expression by visiting children,
+                // so let's not continue deeper into the tree
+                return;
+            }
+
+            this.stack.Push(newState);
+
+            base.VisitInternal(node);
+
+            this.stack.Pop();
+        }
+
+        private VisitorState GetNewState(ExpressionKind kind)
+        {
+            var current = this.stack.Count <= 0 ? VisitorState.None : this.stack.Peek();
+
+            switch (current)
+            {
+                case VisitorState.None:
+                    switch (kind)
+                    {
+                        case ExpressionKind.None:
+                        case ExpressionKind.SimpleLiteral:
+                        case ExpressionKind.ComplexLiteral:
+                            // simple literals are not interesting for this
+                            // outer complex literals are also fine
+                            return VisitorState.None;
+
+                        case ExpressionKind.Operator:
+                            return VisitorState.FirstOperatorChain;
+                    }
+
+                    break;
+
+                case VisitorState.FirstOperatorChain:
+                    switch (kind)
+                    {
+                        case ExpressionKind.None:
+                        case ExpressionKind.Operator:
+                        case ExpressionKind.SimpleLiteral:
+                            // operator doesn't change the state since we're already in the operator chain
+                            // simple literal also doesn't change anything
+                            return VisitorState.FirstOperatorChain;
+
+                        case ExpressionKind.ComplexLiteral:
+                            // update state
+                            return VisitorState.ComplexLiteralInsideFirstOperatorChain;
+                    }
+
+                    break;
+
+                case VisitorState.ComplexLiteralInsideFirstOperatorChain:
+                    switch (kind)
+                    {
+                        case ExpressionKind.None:
+                        case ExpressionKind.ComplexLiteral:
+                        case ExpressionKind.SimpleLiteral:
+                            // literals don't change the state
+                            return VisitorState.ComplexLiteralInsideFirstOperatorChain;
+
+                        case ExpressionKind.Operator:
+                            // update state
+                            return VisitorState.SecondOperatorChainInsideComplexLiteralInsideFirstOperatorChain;
+                    }
+
+                    break;
+
+                case VisitorState.SecondOperatorChainInsideComplexLiteralInsideFirstOperatorChain:
+                    // once we enter this state, we cannot leave it
+                    return VisitorState.SecondOperatorChainInsideComplexLiteralInsideFirstOperatorChain;
+            }
+
+            throw new NotImplementedException($"Unexpected current state '{current}' and/or expression kind '{kind}'.");
+        }
+
+        private enum VisitorState
+        {
+            /// <summary>
+            /// Initial state
+            /// </summary>
+            None,
+
+            /// <summary>
+            /// The first operator chain has begun.
+            /// </summary>
+            FirstOperatorChain,
+
+            /// <summary>
+            /// A complex literal (array or object) was detected inside the first operator chain.
+            /// </summary>
+            ComplexLiteralInsideFirstOperatorChain,
+
+            /// <summary>
+            /// A second operator chain was detected inside a literal that is also inside the first operator chain.
+            /// </summary>
+            SecondOperatorChainInsideComplexLiteralInsideFirstOperatorChain
+        }
+    }
+}

--- a/src/Bicep.Core/Syntax/ArrayAccessSyntax.cs
+++ b/src/Bicep.Core/Syntax/ArrayAccessSyntax.cs
@@ -26,5 +26,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitArrayAccessSyntax(this);
 
         public override TextSpan Span => TextSpan.Between(BaseExpression, CloseSquare);
+        
+        public ExpressionKind ExpressionKind => ExpressionKind.Operator;
     }
 }

--- a/src/Bicep.Core/Syntax/ArrayItemSyntax.cs
+++ b/src/Bicep.Core/Syntax/ArrayItemSyntax.cs
@@ -5,7 +5,7 @@ using Bicep.Core.Parser;
 
 namespace Bicep.Core.Syntax
 {
-    public class ArrayItemSyntax : SyntaxBase, IExpressionSyntax, ILiteralSyntax
+    public class ArrayItemSyntax : SyntaxBase, IExpressionSyntax
     {
         public ArrayItemSyntax(SyntaxBase value, IEnumerable<Token> newLines)
         {
@@ -22,5 +22,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitArrayItemSyntax(this);
 
         public override TextSpan Span => TextSpan.Between(this.Value, this.NewLines.Last());
+        
+        public ExpressionKind ExpressionKind => ExpressionKind.SimpleLiteral;
     }
 }

--- a/src/Bicep.Core/Syntax/ArraySyntax.cs
+++ b/src/Bicep.Core/Syntax/ArraySyntax.cs
@@ -4,7 +4,7 @@ using Bicep.Core.Parser;
 
 namespace Bicep.Core.Syntax
 {
-    public class ArraySyntax : SyntaxBase, IExpressionSyntax, ILiteralSyntax
+    public class ArraySyntax : SyntaxBase, IExpressionSyntax
     {
         public ArraySyntax(Token openBracket, IEnumerable<Token> newLines, IEnumerable<SyntaxBase> children, Token closeBracket)
         {
@@ -34,5 +34,7 @@ namespace Bicep.Core.Syntax
         public override TextSpan Span => TextSpan.Between(this.OpenBracket, this.CloseBracket);
 
         public IEnumerable<ArrayItemSyntax> Items => this.Children.OfType<ArrayItemSyntax>();
+        
+        public ExpressionKind ExpressionKind => ExpressionKind.ComplexLiteral;
     }
 }

--- a/src/Bicep.Core/Syntax/BinaryOperationSyntax.cs
+++ b/src/Bicep.Core/Syntax/BinaryOperationSyntax.cs
@@ -28,5 +28,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitBinaryOperationSyntax(this);
 
         public override TextSpan Span => TextSpan.Between(this.LeftExpression, this.RightExpression);
+        
+        public ExpressionKind ExpressionKind => ExpressionKind.Operator;
     }
 }

--- a/src/Bicep.Core/Syntax/BooleanLiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/BooleanLiteralSyntax.cs
@@ -2,7 +2,7 @@ using Bicep.Core.Parser;
 
 namespace Bicep.Core.Syntax
 {
-    public class BooleanLiteralSyntax : SyntaxBase, IExpressionSyntax, ILiteralSyntax
+    public class BooleanLiteralSyntax : SyntaxBase, IExpressionSyntax
     {
         public BooleanLiteralSyntax(Token literal, bool value)
         {
@@ -19,5 +19,7 @@ namespace Bicep.Core.Syntax
 
         public override TextSpan Span
             => TextSpan.Between(Literal, Literal);
+
+        public ExpressionKind ExpressionKind => ExpressionKind.SimpleLiteral;
     }
 }

--- a/src/Bicep.Core/Syntax/ExpressionKind.cs
+++ b/src/Bicep.Core/Syntax/ExpressionKind.cs
@@ -1,0 +1,28 @@
+﻿namespace Bicep.Core.Syntax
+{
+    /// <summary>
+    /// Represents a non-recursive kind of expression syntax node.
+    /// </summary>
+    public enum ExpressionKind
+    {
+        /// <summary>
+        /// Not an expression node.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Represents a simple literal like null, boolean, number, or an uninterpolated string.
+        /// </summary>
+        SimpleLiteral,
+
+        /// <summary>
+        /// Represents a complex literal like an object or array. Operators may appear in child nodes of complex literals.
+        /// </summary>
+        ComplexLiteral,
+
+        /// <summary>
+        /// Represents an operator.
+        /// </summary>
+        Operator
+    }
+}

--- a/src/Bicep.Core/Syntax/FunctionArgumentSyntax.cs
+++ b/src/Bicep.Core/Syntax/FunctionArgumentSyntax.cs
@@ -22,5 +22,7 @@ namespace Bicep.Core.Syntax
         public override TextSpan Span => this.Comma == null 
             ? this.Expression.Span
             : TextSpan.Between(this.Expression, this.Comma);
+
+        public ExpressionKind ExpressionKind => ExpressionKind.SimpleLiteral;
     }
 }

--- a/src/Bicep.Core/Syntax/FunctionCallSyntax.cs
+++ b/src/Bicep.Core/Syntax/FunctionCallSyntax.cs
@@ -29,5 +29,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitFunctionCallSyntax(this);
 
         public override TextSpan Span => TextSpan.Between(Name, CloseParen);
+
+        public ExpressionKind ExpressionKind => ExpressionKind.Operator;
     }
 }

--- a/src/Bicep.Core/Syntax/IExpressionSyntax.cs
+++ b/src/Bicep.Core/Syntax/IExpressionSyntax.cs
@@ -5,5 +5,9 @@
     /// </summary>
     public interface IExpressionSyntax
     {
+        /// <summary>
+        /// Gets the type of the expression node.
+        /// </summary>
+        ExpressionKind ExpressionKind { get; }
     }
 }

--- a/src/Bicep.Core/Syntax/ILiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/ILiteralSyntax.cs
@@ -1,9 +1,0 @@
-﻿namespace Bicep.Core.Syntax
-{
-    /// <summary>
-    /// Indicates that the syntax node is allowed in literal expressions. Does not guarantee that that the subtree represents a literal expression.
-    /// </summary>
-    public interface ILiteralSyntax
-    {
-    }
-}

--- a/src/Bicep.Core/Syntax/NullLiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/NullLiteralSyntax.cs
@@ -2,7 +2,7 @@ using Bicep.Core.Parser;
 
 namespace Bicep.Core.Syntax
 {
-    public class NullLiteralSyntax : SyntaxBase, IExpressionSyntax, ILiteralSyntax
+    public class NullLiteralSyntax : SyntaxBase, IExpressionSyntax
     {
         public NullLiteralSyntax(Token nullKeyword)
         {
@@ -16,5 +16,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitNullLiteralSyntax(this);
 
         public override TextSpan Span => this.NullKeyword.Span;
+        
+        public ExpressionKind ExpressionKind => ExpressionKind.SimpleLiteral;
     }
 }

--- a/src/Bicep.Core/Syntax/NumericLiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/NumericLiteralSyntax.cs
@@ -2,7 +2,7 @@ using Bicep.Core.Parser;
 
 namespace Bicep.Core.Syntax
 {
-    public class NumericLiteralSyntax : SyntaxBase, IExpressionSyntax, ILiteralSyntax
+    public class NumericLiteralSyntax : SyntaxBase, IExpressionSyntax
     {
         public NumericLiteralSyntax(Token literal, int value)
         {
@@ -19,5 +19,7 @@ namespace Bicep.Core.Syntax
 
         public override TextSpan Span
             => TextSpan.Between(Literal, Literal);
+
+        public ExpressionKind ExpressionKind => ExpressionKind.SimpleLiteral;
     }
 }

--- a/src/Bicep.Core/Syntax/ObjectPropertySyntax.cs
+++ b/src/Bicep.Core/Syntax/ObjectPropertySyntax.cs
@@ -6,7 +6,7 @@ using Bicep.Core.Parser;
 
 namespace Bicep.Core.Syntax
 {
-    public class ObjectPropertySyntax : SyntaxBase, IExpressionSyntax, ILiteralSyntax
+    public class ObjectPropertySyntax : SyntaxBase, IExpressionSyntax
     {
         public ObjectPropertySyntax(SyntaxBase key, Token colon, SyntaxBase value, IEnumerable<Token> newLines)
         {
@@ -39,5 +39,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitObjectPropertySyntax(this);
 
         public override TextSpan Span => TextSpan.Between(this.Key, this.NewLines.Last());
+
+        public ExpressionKind ExpressionKind => ExpressionKind.SimpleLiteral;
     }
 }

--- a/src/Bicep.Core/Syntax/ObjectSyntax.cs
+++ b/src/Bicep.Core/Syntax/ObjectSyntax.cs
@@ -4,7 +4,7 @@ using Bicep.Core.Parser;
 
 namespace Bicep.Core.Syntax
 {
-    public class ObjectSyntax : SyntaxBase, IExpressionSyntax, ILiteralSyntax
+    public class ObjectSyntax : SyntaxBase, IExpressionSyntax
     {
         public ObjectSyntax(Token openBrace, IEnumerable<Token> newLines, IEnumerable<SyntaxBase> children, Token closeBrace)
         {
@@ -39,5 +39,7 @@ namespace Bicep.Core.Syntax
         /// Gets the object properties. May return duplicate properties.
         /// </summary>
         public IEnumerable<ObjectPropertySyntax> Properties => this.Children.OfType<ObjectPropertySyntax>();
+
+        public ExpressionKind ExpressionKind => ExpressionKind.ComplexLiteral;
     }
 }

--- a/src/Bicep.Core/Syntax/ParenthesizedExpressionSyntax.cs
+++ b/src/Bicep.Core/Syntax/ParenthesizedExpressionSyntax.cs
@@ -24,5 +24,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitParenthesizedExpressionSyntax(this);
 
         public override TextSpan Span => TextSpan.Between(this.OpenParen, this.CloseParen);
+
+        public ExpressionKind ExpressionKind => ExpressionKind.Operator;
     }
 }

--- a/src/Bicep.Core/Syntax/PropertyAccessSyntax.cs
+++ b/src/Bicep.Core/Syntax/PropertyAccessSyntax.cs
@@ -22,5 +22,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitPropertyAccessSyntax(this);
 
         public override TextSpan Span => TextSpan.Between(BaseExpression, PropertyName);
+
+        public ExpressionKind ExpressionKind => ExpressionKind.Operator;
     }
 }

--- a/src/Bicep.Core/Syntax/StringSyntax.cs
+++ b/src/Bicep.Core/Syntax/StringSyntax.cs
@@ -5,7 +5,7 @@ using Bicep.Core.Parser;
 
 namespace Bicep.Core.Syntax
 {
-    public class StringSyntax : SyntaxBase, IExpressionSyntax, ILiteralSyntax
+    public class StringSyntax : SyntaxBase, IExpressionSyntax
     {
         public StringSyntax(IEnumerable<Token> stringTokens, IEnumerable<SyntaxBase> expressions, IEnumerable<string> segmentValues)
         {
@@ -25,5 +25,7 @@ namespace Bicep.Core.Syntax
 
         public override TextSpan Span
             => TextSpan.Between(StringTokens.First(), StringTokens.Last());
+
+        public ExpressionKind ExpressionKind => this.IsInterpolated() ? ExpressionKind.Operator : ExpressionKind.SimpleLiteral;
     }
 }

--- a/src/Bicep.Core/Syntax/SyntaxExtensions.cs
+++ b/src/Bicep.Core/Syntax/SyntaxExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Emit;
 using Bicep.Core.Parser;
 
 namespace Bicep.Core.Syntax
@@ -10,9 +11,13 @@ namespace Bicep.Core.Syntax
         public static IList<Diagnostic> GetParseDiagnostics(this SyntaxBase syntax)
         {
             var diagnostics = new List<Diagnostic>();
-            var visitor = new ParseDiagnosticsVisitor(diagnostics);
-            visitor.Visit(syntax);
+            var parseErrorVisitor = new ParseDiagnosticsVisitor(diagnostics);
+            parseErrorVisitor.Visit(syntax);
 
+            // TODO: Remove this when we fix IL limitations
+            var emitLimitationVisitor = new EmitLimitationVisitor(diagnostics);
+            emitLimitationVisitor.Visit(syntax);
+            
             return diagnostics;
         }
 

--- a/src/Bicep.Core/Syntax/TernaryOperationSyntax.cs
+++ b/src/Bicep.Core/Syntax/TernaryOperationSyntax.cs
@@ -29,5 +29,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitTernaryOperationSyntax(this);
 
         public override TextSpan Span => TextSpan.Between(this.ConditionExpression, this.FalseExpression);
+
+        public ExpressionKind ExpressionKind => ExpressionKind.Operator;
     }
 }

--- a/src/Bicep.Core/Syntax/UnaryOperationSyntax.cs
+++ b/src/Bicep.Core/Syntax/UnaryOperationSyntax.cs
@@ -25,5 +25,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitUnaryOperationSyntax(this);
 
         public override TextSpan Span => TextSpan.Between(OperatorToken, Expression);
+        
+        public ExpressionKind ExpressionKind => ExpressionKind.Operator;
     }
 }

--- a/src/Bicep.Core/Syntax/VariableAccessSyntax.cs
+++ b/src/Bicep.Core/Syntax/VariableAccessSyntax.cs
@@ -16,5 +16,7 @@ namespace Bicep.Core.Syntax
         public override void Accept(SyntaxVisitor visitor) => visitor.VisitVariableAccessSyntax(this);
 
         public override TextSpan Span => this.Name.Span;
+
+        public ExpressionKind ExpressionKind => ExpressionKind.Operator;
     }
 }


### PR DESCRIPTION
In cases of expressions inside object or array literals that are themselves part of another expression, we can generate the IL but it will not be evaluated correctly by the runtime. (See #121) Until the runtime limitation is fixed, we will detect this condition and block it with an error. This fixes #197.