### PR TITLE
Downgrade vscode engine to 1.14.0

### DIFF
--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -61,9 +61,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.48.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
-            "integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.14.0.tgz",
+            "integrity": "sha512-0PFarl1nOck6V+vTMycb7b3mrc2ybDkkg3bA8u/8DUyY0/KhYUw3qxCQjxT2c66ferlpOeA05ETgddSmup69fA==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -9,7 +9,7 @@
     "icon": "icons/azure-resource-manager.png",
     "preview": true,
     "engines": {
-        "vscode": "^1.48.0"
+        "vscode": "^1.14.0"
     },
     "categories": [
         "Azure",
@@ -74,7 +74,7 @@
     "devDependencies": {
         "@types/mocha": "^8.0.3",
         "@types/node": "^14.6.0",
-        "@types/vscode": "^1.48.0",
+        "@types/vscode": "^1.14.0",
         "@typescript-eslint/eslint-plugin": "^3.9.1",
         "@typescript-eslint/parser": "^3.9.1",
         "eslint": "^7.7.0",


### PR DESCRIPTION
1.14.0 is the lowest version that `@types/vscode` supports. The `vscode` package is deprecated so we probably should not switch back to `1.8.0`.