### PR TITLE
Update 02-using-expressions.md

### DIFF
--- a/docs/tutorial/02-using-expressions.md
+++ b/docs/tutorial/02-using-expressions.md
@@ -109,8 +109,8 @@ resource stg 'Microsoft.Storage/storageAccounts@2019-06-01' = {
     }
 }
 
-output storageId string = storage.id // replacement for resourceId(...)
-output primaryEndpoint string = storage.primaryEndpoints.blob // replacement for reference(...).*
+output storageId string = stg.id // replacement for resourceId(...)
+output primaryEndpoint string = stg.primaryEndpoints.blob // replacement for reference(...).*
 ```
 
 ## Next steps


### PR DESCRIPTION
Referencing the symbolic name of a resource example code is broken. 

```
main.bicep(17,27) : Error BCP057: The name 'storage' does not exist in the current context.
main.bicep(18,33) : Error BCP057: The name 'storage' does not exist in the current context.
```

The final two lines need to use 'stg' not 'storage'