### PR TITLE
upload code coverage to codecov.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         run: dotnet build --configuration ${{ matrix.configuration }}
       
       - name: Test
-        run: dotnet test --configuration ${{ matrix.configuration }} --collect:"XPlat Code Coverage"
+        run: dotnet test --configuration ${{ matrix.configuration }} --collect:"XPlat Code Coverage" --settings ./.github/workflows/codecov.runsettings
 
       - name: Publish Language Server
         run: dotnet publish --configuration ${{ matrix.configuration }} ./src/Bicep.LangServer/Bicep.LangServer.csproj
@@ -74,6 +74,11 @@ jobs:
           name: bicep-${{ matrix.configuration }}-${{ matrix.rid }}
           path: ./src/Bicep.Cli/bin/${{ matrix.configuration }}/netcoreapp3.1/${{ matrix.rid }}/publish/*
           if-no-files-found: error
+
+      - name: Upload Code Coverage
+        uses: codecov/codecov-action@v1
+        with:
+          flags: dotnet
 
   build-vsix:
     name: 'Build VSIX'

--- a/.github/workflows/codecov.runsettings
+++ b/.github/workflows/codecov.runsettings
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <!-- Settings are documented at https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings -->
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <!--
+            By default coverlet includes all assemblies that are referenced by test assemblies.
+            In our case, this includes other test assemblies, which makes the coverage results
+            inconsistent. If we want to exclude all test assemblies in the future, we should
+            use the Exclude setting instead.
+           -->
+          <IncludeTestAssembly>true</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build](https://github.com/Azure/bicep/workflows/Build/badge.svg)
+![Build](https://github.com/Azure/bicep/workflows/Build/badge.svg) [![codecov](https://codecov.io/gh/Azure/bicep/branch/master/graph/badge.svg)](https://codecov.io/gh/Azure/bicep)
 
 # Project Bicep - an ARM DSL
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "90...100"
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
Codecov.io is a service that is free for public repos that keeps history of code coverage and provides UI to visualize, PR comment bot, and ability to enforce coverage levels on PRs via GitHub status checks.
- Builds will now upload code coverage results to codecov.io.
- Added a coverage badge to the repo readme.
- Set coverage thresholds (not enforced yet because we don't have history)

This closes #386.