### PR TITLE
Add configuration to enable language server tracing

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -42,8 +42,20 @@
     "contributes": {
         "configuration": {
             "type": "object",
-            "title": "Bicep Configuration",
-            "properties": {}
+            "title": "Bicep",
+            "properties": {
+                "bicep.trace.server": {
+                    "type": "string",
+                    "enum": [
+                        "Off",
+                        "Messages",
+                        "Verbose"
+                    ],
+                    "default": "Off",
+                    "description": "Configure tracing of messages sent to the Bicep language server.",
+                    "scope": "window"
+                }
+            }
         },
         "languages": [
             {

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 
 import { createLogger } from "./utils/logger";
-import { launchLanugageServiceWithProgressReport } from "./language/client";
+import { launchLanguageServiceWithProgressReport } from "./language/client";
 import { activateWithTelemetryAndErrorHandling } from "./utils/telemetry";
 import { createAzExtOutputChannel } from "vscode-azureextensionui";
 
@@ -18,7 +18,7 @@ export async function activate(
     async () => {
       createLogger(context, outputChannel);
 
-      await launchLanugageServiceWithProgressReport(context, outputChannel);
+      await launchLanguageServiceWithProgressReport(context, outputChannel);
     }
   );
 }

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -10,7 +10,7 @@ import { createAzExtOutputChannel } from "vscode-azureextensionui";
 export async function activate(
   context: vscode.ExtensionContext
 ): Promise<void> {
-  const outputChannel = createAzExtOutputChannel('Bicep', 'bicep');
+  const outputChannel = createAzExtOutputChannel("Bicep", "bicep");
 
   await activateWithTelemetryAndErrorHandling(
     context,

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -5,11 +5,12 @@ import * as vscode from "vscode";
 import { createLogger } from "./utils/logger";
 import { launchLanugageServiceWithProgressReport } from "./language/client";
 import { activateWithTelemetryAndErrorHandling } from "./utils/telemetry";
+import { createAzExtOutputChannel } from "vscode-azureextensionui";
 
 export async function activate(
   context: vscode.ExtensionContext
 ): Promise<void> {
-  const outputChannel = vscode.window.createOutputChannel("Bicep");
+  const outputChannel = createAzExtOutputChannel('Bicep', 'bicep');
 
   await activateWithTelemetryAndErrorHandling(
     context,
@@ -17,7 +18,7 @@ export async function activate(
     async () => {
       createLogger(context, outputChannel);
 
-      await launchLanugageServiceWithProgressReport(context);
+      await launchLanugageServiceWithProgressReport(context, outputChannel);
     }
   );
 }

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -70,7 +70,7 @@ async function launchLanguageService(
 
   configureTelemetry(client);
 
-  // To enable language server tracing, you MUST have a package setting named 'bicep.trace.server'; I was unable to find a way to enable it through code. 
+  // To enable language server tracing, you MUST have a package setting named 'bicep.trace.server'; I was unable to find a way to enable it through code.
   // See https://github.com/microsoft/vscode-languageserver-node/blob/77c3a10a051ac619e4e3ef62a3865717702b64a3/client/src/common/client.ts#L3268
 
   context.subscriptions.push(client.start());

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -15,19 +15,21 @@ const dotnetRuntimeVersion = "3.1";
 const packagedServerPath = "bicepLanguageServer/Bicep.LangServer.dll";
 
 export async function launchLanugageServiceWithProgressReport(
-  context: vscode.ExtensionContext
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel
 ): Promise<void> {
   await vscode.window.withProgress(
     {
       title: "Launching Bicep language service...",
       location: vscode.ProgressLocation.Notification,
     },
-    async () => await launchLanguageService(context)
+    async () => await launchLanguageService(context, outputChannel)
   );
 }
 
 async function launchLanguageService(
-  context: vscode.ExtensionContext
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel
 ): Promise<void> {
   getLogger().info("Launching Bicep language service...");
 
@@ -45,11 +47,13 @@ async function launchLanguageService(
   const serverOptions: lsp.ServerOptions = {
     run: serverExecutable,
     debug: serverExecutable,
+    options: { shell: false },
   };
 
   const clientOptions: lsp.LanguageClientOptions = {
     documentSelector: [{ language: "bicep" }],
     progressOnInitialization: true,
+    outputChannel,
     synchronize: {
       fileEvents: vscode.workspace.createFileSystemWatcher("**/*.bicep"),
     },
@@ -62,11 +66,12 @@ async function launchLanguageService(
     clientOptions
   );
 
-  // TODO: expose Trace as a configuration item.
-  client.trace = lsp.Trace.Off;
   client.registerProposedFeatures();
 
   configureTelemetry(client);
+
+  // To enable language server tracing, you MUST have a package setting named 'bicep.trace.server'; I was unable to find a way to enable it through code. 
+  // See https://github.com/microsoft/vscode-languageserver-node/blob/77c3a10a051ac619e4e3ef62a3865717702b64a3/client/src/common/client.ts#L3268
 
   context.subscriptions.push(client.start());
 

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -14,7 +14,7 @@ import { ErrorAction, Message, CloseAction } from "vscode-languageclient/node";
 const dotnetRuntimeVersion = "3.1";
 const packagedServerPath = "bicepLanguageServer/Bicep.LangServer.dll";
 
-export async function launchLanugageServiceWithProgressReport(
+export async function launchLanguageServiceWithProgressReport(
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel
 ): Promise<void> {
@@ -47,7 +47,6 @@ async function launchLanguageService(
   const serverOptions: lsp.ServerOptions = {
     run: serverExecutable,
     debug: serverExecutable,
-    options: { shell: false },
   };
 
   const clientOptions: lsp.LanguageClientOptions = {

--- a/src/vscode-bicep/src/utils/telemetry.ts
+++ b/src/vscode-bicep/src/utils/telemetry.ts
@@ -4,20 +4,20 @@ import * as vscode from "vscode";
 import {
   registerUIExtensionVariables,
   AzureUserInput,
-  createAzExtOutputChannel,
   callWithTelemetryAndErrorHandling,
   IActionContext,
+  IAzExtOutputChannel,
 } from "vscode-azureextensionui";
 
 export async function activateWithTelemetryAndErrorHandling(
   context: vscode.ExtensionContext,
-  outputChannel: vscode.OutputChannel,
+  outputChannel: IAzExtOutputChannel,
   activateCallback: () => Promise<void>
 ): Promise<void> {
   const startTime = Date.now();
   registerUIExtensionVariables({
     context,
-    outputChannel: createAzExtOutputChannel(outputChannel.name, "bicep"),
+    outputChannel,
     ui: new AzureUserInput(context.globalState),
   });
 


### PR DESCRIPTION
This also fixes the fact that we're opening multiple logging output channels when the extension loads.