### PR TITLE
Minor improvement to integration test depth prefix calculation

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParserTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParserTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
 using System.Text;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.Parser;
@@ -108,7 +107,7 @@ namespace Bicep.Core.IntegrationTests
 
             string getLoggingString(SyntaxCollectorVisitor.SyntaxOrToken data)
             {
-                var depthPrefix = string.Concat(Enumerable.Repeat(" ", data.Depth));
+                var depthPrefix = new string(' ', data.Depth);
                 if (data.Syntax != null)
                 {
                     return $"{depthPrefix}{data.Syntax.GetType().Name}";


### PR DESCRIPTION
This a really simple improvement to a calculation to create the depth prefix for logging. I was exploring the codebase, and this stood out to me. I don't think that this will have a significant improvement, but so long as the depth prefix is a single character I think it will add some benefit.

I created some simple `BenchmarkDotNet` tests to show a comparison between the two, and based the depth values on some that were caught while debugging the test.

**Benchmark**
```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Collections.Generic;
using System.Linq;

class Program
{
    static void Main(string[] args)
    {
        BenchmarkRunner.Run<Tests>();
    }
}

[MemoryDiagnoser]
public class Tests
{
    [Params(0, 1, 2, 4, 8)]
    public int Depth { get; set; }

    [Benchmark(Baseline = true)]
    public string StringConcatEnumerableRepeat() =>
        string.Concat(Enumerable.Repeat(" ", Depth));

    [Benchmark]
    public string NewString() =>
        new string(' ', Depth);
}
```

**Results**
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.450 (2004/?/20H1)
Intel Core i5-4258U CPU 2.40GHz (Haswell), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=5.0.100-preview.5.20279.10
  [Host]     : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT


```
|                       Method | Depth |       Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |------ |-----------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| **StringConcatEnumerableRepeat** |     **0** |  **16.710 ns** | **0.0743 ns** | **0.0695 ns** |  **1.00** |      **-** |     **-** |     **-** |         **-** |
|                    NewString |     0 |   2.660 ns | 0.0484 ns | 0.0429 ns |  0.16 |      - |     - |     - |         - |
|                              |       |            |           |           |       |        |       |       |           |
| **StringConcatEnumerableRepeat** |     **1** |  **42.820 ns** | **0.3366 ns** | **0.2984 ns** |  **1.00** | **0.0255** |     **-** |     **-** |      **40 B** |
|                    NewString |     1 |   9.185 ns | 0.0985 ns | 0.0921 ns |  0.21 | 0.0153 |     - |     - |      24 B |
|                              |       |            |           |           |       |        |       |       |           |
| **StringConcatEnumerableRepeat** |     **2** |  **88.547 ns** | **1.7138 ns** | **1.4311 ns** |  **1.00** | **0.0457** |     **-** |     **-** |      **72 B** |
|                    NewString |     2 |   9.807 ns | 0.0920 ns | 0.0816 ns |  0.11 | 0.0204 |     - |     - |      32 B |
|                              |       |            |           |           |       |        |       |       |           |
| **StringConcatEnumerableRepeat** |     **4** | **103.794 ns** | **0.5806 ns** | **0.5431 ns** |  **1.00** | **0.0457** |     **-** |     **-** |      **72 B** |
|                    NewString |     4 |  10.290 ns | 0.1617 ns | 0.1350 ns |  0.10 | 0.0204 |     - |     - |      32 B |
|                              |       |            |           |           |       |        |       |       |           |
| **StringConcatEnumerableRepeat** |     **8** | **145.738 ns** | **0.6164 ns** | **0.5766 ns** |  **1.00** | **0.0508** |     **-** |     **-** |      **80 B** |
|                    NewString |     8 |  12.237 ns | 0.0952 ns | 0.0795 ns |  0.08 | 0.0255 |     - |     - |      40 B |