### PR TITLE
Initial and *extremely* basic completions

### DIFF
--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -93,7 +93,7 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic ExpectedParameterType() => new ErrorDiagnostic(
                 TextSpan,
                 "BCP014",
-                $"Expected a parameter type at this location. Please specify one of the following types: {LanguageConstants.PrimitiveTypesString}.");
+                $"Expected a parameter type at this location. Please specify one of the following types: {LanguageConstants.DeclarationTypesString}.");
 
             public ErrorDiagnostic ExpectedVariableIdentifier() => new ErrorDiagnostic(
                 TextSpan,
@@ -173,12 +173,12 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic InvalidOutputType() => new ErrorDiagnostic(
                 TextSpan,
                 "BCP030",
-                $"The output type is not valid. Please specify one of the following types: {LanguageConstants.PrimitiveTypesString}.");
+                $"The output type is not valid. Please specify one of the following types: {LanguageConstants.DeclarationTypesString}.");
 
             public ErrorDiagnostic InvalidParameterType() => new ErrorDiagnostic(
                 TextSpan,
                 "BCP031",
-                $"The parameter type is not valid. Please specify one of the following types: {LanguageConstants.PrimitiveTypesString}.");
+                $"The parameter type is not valid. Please specify one of the following types: {LanguageConstants.DeclarationTypesString}.");
 
             public ErrorDiagnostic CompileTimeConstantRequired() => new ErrorDiagnostic(
                 TextSpan,

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System;
+
 using System.Collections.Immutable;
 using System.Linq;
-using Arm.Expression.Expressions;
 using Bicep.Core.Extensions;
-using Bicep.Core.Resources;
 using Bicep.Core.SemanticModel;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -20,7 +20,7 @@ namespace Bicep.Core
         public const string OutputKeyword = "output";
         public const string VariableKeyword = "var";
         public const string ResourceKeyword = "resource";
-		
+
         public static readonly StringComparer IdentifierComparer = StringComparer.Ordinal;
         public static readonly StringComparison IdentifierComparison = StringComparison.Ordinal;
 
@@ -47,7 +47,7 @@ namespace Bicep.Core
         // types allowed to use in output and parameter declarations
         public static readonly ImmutableSortedDictionary<string, TypeSymbol> DeclarationTypes = new[] {String, Object, Int, Bool, Array}.ToImmutableSortedDictionary(type => type.Name, type => type, StringComparer.Ordinal);
 
-        public static readonly string PrimitiveTypesString = LanguageConstants.DeclarationTypes.Keys.ConcatString(ListSeparator);
+        public static readonly string DeclarationTypesString = LanguageConstants.DeclarationTypes.Keys.ConcatString(ListSeparator);
 
         public static TypeSymbol CreateParameterModifierType(TypeSymbol parameterType)
         {

--- a/src/Bicep.LangServer/Completions/SymbolExtensions.cs
+++ b/src/Bicep.LangServer/Completions/SymbolExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.SemanticModel;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SymbolKind = Bicep.Core.SemanticModel.SymbolKind;
+
+namespace Bicep.LanguageServer.Completions
+{
+    public static class SymbolExtensions
+    {
+        public static CompletionItem ToCompletionItem(this Symbol symbol)
+        {
+            return new CompletionItem
+            {
+                Label = symbol.Name,
+                Kind = GetKind(symbol),
+                Detail = symbol.Name,
+                InsertText = symbol.Name,
+                InsertTextFormat = InsertTextFormat.PlainText
+            };
+        }
+
+        private static CompletionItemKind GetKind(this Symbol symbol)
+        {
+            return symbol.Kind switch
+            {
+                SymbolKind.Function => CompletionItemKind.Function,
+                SymbolKind.File => CompletionItemKind.File,
+                SymbolKind.Variable => CompletionItemKind.Variable,
+                SymbolKind.Namespace => CompletionItemKind.Reference,
+                SymbolKind.Output => CompletionItemKind.Value,
+                SymbolKind.Parameter => CompletionItemKind.Field,
+                SymbolKind.Resource => CompletionItemKind.Interface,
+                _ => CompletionItemKind.Text
+            };
+        }
+    }
+}

--- a/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bicep.Core;
+using Bicep.Core.SemanticModel;
+using Bicep.Core.TypeSystem;
+using Bicep.LanguageServer.CompilationManager;
+using Bicep.LanguageServer.Completions;
+using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Bicep.LanguageServer.Handlers
+{
+    public class BicepCompletionHandler : CompletionHandler
+    {
+        private readonly ICompilationManager compilationManager;
+
+        public BicepCompletionHandler(ICompilationManager compilationManager)
+            : base(CreateRegistrationOptions())
+        {
+            this.compilationManager = compilationManager;
+        }
+
+        public override Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
+        {
+            var completions = GetKeywordCompletions()
+                .Concat(GetSymbolCompletions(request))
+                .Concat(GetPrimitiveTypeCompletions());
+            return Task.FromResult(new CompletionList(completions, isIncomplete: false));
+        }
+
+        public override Task<CompletionItem> Handle(CompletionItem request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(request);
+        }
+
+        public override bool CanResolve(CompletionItem value)
+        {
+            return false;
+        }
+
+        private static CompletionRegistrationOptions CreateRegistrationOptions() => new CompletionRegistrationOptions
+        {
+            DocumentSelector = DocumentSelectorFactory.Create(),
+            AllCommitCharacters = new Container<string>(),
+            ResolveProvider = false,
+            TriggerCharacters = new Container<string>()
+        };
+
+        private IEnumerable<CompletionItem> GetKeywordCompletions()
+        {
+            yield return CreateKeywordCompletion(LanguageConstants.ParameterKeyword);
+            yield return CreateKeywordCompletion(LanguageConstants.VariableKeyword);
+            yield return CreateKeywordCompletion(LanguageConstants.ResourceKeyword);
+            yield return CreateKeywordCompletion(LanguageConstants.OutputKeyword);
+        }
+
+        private IEnumerable<CompletionItem> GetSymbolCompletions(CompletionParams request)
+        {
+            var context = this.compilationManager.GetCompilation(request.TextDocument.Uri);
+            if (context == null)
+            {
+                return Enumerable.Empty<CompletionItem>();
+            }
+
+            var model = context.Compilation.GetSemanticModel();
+
+            return GetAccessibleSymbols(model)
+                .Select(sym => sym.ToCompletionItem());
+        }
+
+        private IEnumerable<CompletionItem> GetPrimitiveTypeCompletions() => LanguageConstants.DeclarationTypes.Values.Select(CreateTypeCompletion);
+
+        private IEnumerable<Symbol> GetAccessibleSymbols(SemanticModel model)
+        {
+            var accessibleSymbols = new Dictionary<string, Symbol>();
+
+            // local function
+            void AddAccessibleSymbols(IDictionary<string, Symbol> result, IEnumerable<Symbol> symbols)
+            {
+                foreach (var declaration in symbols)
+                {
+                    if (result.ContainsKey(declaration.Name) == false)
+                    {
+                        result.Add(declaration.Name, declaration);
+                    }
+                }
+            }
+
+            AddAccessibleSymbols(accessibleSymbols, model.Root.AllDeclarations
+                .Where(decl => !(decl is OutputSymbol)));
+
+            AddAccessibleSymbols(accessibleSymbols, model.Root.ImportedNamespaces
+                .SelectMany(ns => ns.Descendants.OfType<FunctionSymbol>()));
+
+            return accessibleSymbols.Values;
+        }
+
+        private static CompletionItem CreateKeywordCompletion(string keyword) =>
+            new CompletionItem
+            {
+                Kind = CompletionItemKind.Keyword,
+                Label = keyword,
+                InsertTextFormat = InsertTextFormat.PlainText,
+                InsertText = keyword,
+                CommitCharacters = new Container<string>(" "),
+                Detail = keyword
+            };
+
+        private static CompletionItem CreateTypeCompletion(TypeSymbol type) =>
+            new CompletionItem
+            {
+                Kind = CompletionItemKind.Class,
+                Label = type.Name,
+                InsertTextFormat = InsertTextFormat.PlainText,
+                InsertText = type.Name,
+                CommitCharacters = new Container<string>(" "),
+                Detail = type.Name
+            };
+    }
+}

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -40,6 +40,7 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepDocumentHighlightHandler>()
                     .WithHandler<BicepRenameHandler>()
                     .WithHandler<BicepHoverHandler>()
+                    .WithHandler<BicepCompletionHandler>()
 #pragma warning disable 0612 // disable 'obsolete' warning for proposed LSP feature
                     .WithHandler<BicepSemanticTokensHandler>()
 #pragma warning restore 0612


### PR DESCRIPTION
Added (as the title says) extremely basic completions support. The suggested completions currently include keywords, existing keyword snippets, primitive types and names of accessible symbols (vars, params, resources, and functions). 

Limitations:
- The completions are not at all context aware. In other words, it will list the same completions everywhere regardless if they are valid in that place or not. 
- No completions are offered for properties of objects anywhere.

We have to start here because implementing a completion handler in the language server completely removes the built-in completions which provide some help right now.

Next steps:
- Incrementally build up context awareness to reduce the set of completions being returned.
- Add object property completions.
- Make snippets more contextual
- More snippets in specific contexts (for example, we could have snippets that are offered only for parameter types and nowhere else).
- Implementing dynamic snippets. For example, we could auto generate a minimum resource snippet for resources with accurate `required` metadata in swaggers.
- Tests!