### PR TITLE
Fixed dotnet sdk rollforward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,12 +1,10 @@
 {
-  // Defines version of MSBuild project SDKs to use
-  // https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk?view=vs-2019#how-project-sdks-are-resolved
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "2.0.1"
   },
   "sdk": {
-    "comment": "Need to use a particular version to ensure consistency across machines no matter what SDK versions they have installed.",
+    "allowPrerelease": false,
     "version": "3.1.301",
-    "RollForward": "latestFeature"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
There was a typo in the `rollForward` property that prevented our build from picking up higher versions installed on developer machines. (Tested on WSL.) Also disabled pre-release SDKs. 