### PR TITLE
Fix build job dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,7 @@ jobs:
     name: 'Create Release'
     runs-on: 'ubuntu-latest'
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    needs: [build-bicep, build-vsix, build-playground]
+    needs: [build-bicep, build-vsix, build-playground, build-windows-setup]
 
     steps:
       - name: Download Build Artifacts


### PR DESCRIPTION
Release build was unable to download the windows installer due to a missing build job dependency (artifact didn't exist). This is now fixed.