### PR TITLE
Added tests to validate underscores in identifiers

### DIFF
--- a/src/Bicep.Core.Samples/Variables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.bicep
@@ -131,3 +131,9 @@ var myVar3 = any(any({
   something: myVar
 }))
 var myVar4 = length(any(concat('s','a')))
+
+// identifiers can have underscores
+var _ = 3
+var __ = 10 * _
+var _0a_1b = true
+var _1_ = _0a_1b || (__ + _ % 2 == 0)

--- a/src/Bicep.Core.Samples/Variables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.diagnostics.bicep
@@ -132,3 +132,8 @@ var myVar3 = any(any({
 }))
 var myVar4 = length(any(concat('s','a')))
 
+// identifiers can have underscores
+var _ = 3
+var __ = 10 * _
+var _0a_1b = true
+var _1_ = _0a_1b || (__ + _ % 2 == 0)

--- a/src/Bicep.Core.Samples/Variables_LF/main.json
+++ b/src/Bicep.Core.Samples/Variables_LF/main.json
@@ -89,7 +89,11 @@
     "myVar3": {
       "something": "[variables('myVar')]"
     },
-    "myVar4": "[length(concat('s', 'a'))]"
+    "myVar4": "[length(concat('s', 'a'))]",
+    "_": 3,
+    "__": "[mul(10, variables('_'))]",
+    "_0a_1b": true,
+    "_1_": "[or(variables('_0a_1b'), equals(add(variables('__'), mod(variables('_'), 2)), 0))]"
   },
   "resources": [],
   "outputs": {}

--- a/src/Bicep.Core.Samples/Variables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.symbols.bicep
@@ -170,5 +170,14 @@ var myVar3 = any(any({
   something: myVar
 }))
 var myVar4 = length(any(concat('s','a')))
-//@[4:10) Variable myVar4. Type: int. Declaration start char: 0, length: 42
+//@[4:10) Variable myVar4. Type: int. Declaration start char: 0, length: 43
 
+// identifiers can have underscores
+var _ = 3
+//@[4:5) Variable _. Type: int. Declaration start char: 0, length: 10
+var __ = 10 * _
+//@[4:6) Variable __. Type: int. Declaration start char: 0, length: 16
+var _0a_1b = true
+//@[4:10) Variable _0a_1b. Type: bool. Declaration start char: 0, length: 18
+var _1_ = _0a_1b || (__ + _ % 2 == 0)
+//@[4:7) Variable _1_. Type: bool. Declaration start char: 0, length: 37

--- a/src/Bicep.Core.Samples/Variables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.syntax.bicep
@@ -1046,7 +1046,7 @@ var myVar3 = any(any({
 //@[2:3)   RightParen |)|
 //@[3:4)  NewLine |\n|
 var myVar4 = length(any(concat('s','a')))
-//@[0:42) VariableDeclarationSyntax
+//@[0:43) VariableDeclarationSyntax
 //@[0:3)  Identifier |var|
 //@[4:10)  IdentifierSyntax
 //@[4:10)   Identifier |myVar4|
@@ -1075,6 +1075,71 @@ var myVar4 = length(any(concat('s','a')))
 //@[38:39)       RightParen |)|
 //@[39:40)     RightParen |)|
 //@[40:41)   RightParen |)|
-//@[41:42)  NewLine |\n|
+//@[41:43)  NewLine |\n\n|
 
-//@[0:0) EndOfFile ||
+// identifiers can have underscores
+//@[35:36) NoOpDeclarationSyntax
+//@[35:36)  NewLine |\n|
+var _ = 3
+//@[0:10) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:5)  IdentifierSyntax
+//@[4:5)   Identifier |_|
+//@[6:7)  Assignment |=|
+//@[8:9)  NumericLiteralSyntax
+//@[8:9)   Number |3|
+//@[9:10)  NewLine |\n|
+var __ = 10 * _
+//@[0:16) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:6)  IdentifierSyntax
+//@[4:6)   Identifier |__|
+//@[7:8)  Assignment |=|
+//@[9:15)  BinaryOperationSyntax
+//@[9:11)   NumericLiteralSyntax
+//@[9:11)    Number |10|
+//@[12:13)   Asterisk |*|
+//@[14:15)   VariableAccessSyntax
+//@[14:15)    IdentifierSyntax
+//@[14:15)     Identifier |_|
+//@[15:16)  NewLine |\n|
+var _0a_1b = true
+//@[0:18) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:10)  IdentifierSyntax
+//@[4:10)   Identifier |_0a_1b|
+//@[11:12)  Assignment |=|
+//@[13:17)  BooleanLiteralSyntax
+//@[13:17)   TrueKeyword |true|
+//@[17:18)  NewLine |\n|
+var _1_ = _0a_1b || (__ + _ % 2 == 0)
+//@[0:37) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:7)  IdentifierSyntax
+//@[4:7)   Identifier |_1_|
+//@[8:9)  Assignment |=|
+//@[10:37)  BinaryOperationSyntax
+//@[10:16)   VariableAccessSyntax
+//@[10:16)    IdentifierSyntax
+//@[10:16)     Identifier |_0a_1b|
+//@[17:19)   LogicalOr ||||
+//@[20:37)   ParenthesizedExpressionSyntax
+//@[20:21)    LeftParen |(|
+//@[21:36)    BinaryOperationSyntax
+//@[21:31)     BinaryOperationSyntax
+//@[21:23)      VariableAccessSyntax
+//@[21:23)       IdentifierSyntax
+//@[21:23)        Identifier |__|
+//@[24:25)      Plus |+|
+//@[26:31)      BinaryOperationSyntax
+//@[26:27)       VariableAccessSyntax
+//@[26:27)        IdentifierSyntax
+//@[26:27)         Identifier |_|
+//@[28:29)       Modulo |%|
+//@[30:31)       NumericLiteralSyntax
+//@[30:31)        Number |2|
+//@[32:34)     Equals |==|
+//@[35:36)     NumericLiteralSyntax
+//@[35:36)      Number |0|
+//@[36:37)    RightParen |)|
+//@[37:37) EndOfFile ||

--- a/src/Bicep.Core.Samples/Variables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.tokens.bicep
@@ -688,6 +688,43 @@ var myVar4 = length(any(concat('s','a')))
 //@[38:39) RightParen |)|
 //@[39:40) RightParen |)|
 //@[40:41) RightParen |)|
-//@[41:42) NewLine |\n|
+//@[41:43) NewLine |\n\n|
 
-//@[0:0) EndOfFile ||
+// identifiers can have underscores
+//@[35:36) NewLine |\n|
+var _ = 3
+//@[0:3) Identifier |var|
+//@[4:5) Identifier |_|
+//@[6:7) Assignment |=|
+//@[8:9) Number |3|
+//@[9:10) NewLine |\n|
+var __ = 10 * _
+//@[0:3) Identifier |var|
+//@[4:6) Identifier |__|
+//@[7:8) Assignment |=|
+//@[9:11) Number |10|
+//@[12:13) Asterisk |*|
+//@[14:15) Identifier |_|
+//@[15:16) NewLine |\n|
+var _0a_1b = true
+//@[0:3) Identifier |var|
+//@[4:10) Identifier |_0a_1b|
+//@[11:12) Assignment |=|
+//@[13:17) TrueKeyword |true|
+//@[17:18) NewLine |\n|
+var _1_ = _0a_1b || (__ + _ % 2 == 0)
+//@[0:3) Identifier |var|
+//@[4:7) Identifier |_1_|
+//@[8:9) Assignment |=|
+//@[10:16) Identifier |_0a_1b|
+//@[17:19) LogicalOr ||||
+//@[20:21) LeftParen |(|
+//@[21:23) Identifier |__|
+//@[24:25) Plus |+|
+//@[26:27) Identifier |_|
+//@[28:29) Modulo |%|
+//@[30:31) Number |2|
+//@[32:34) Equals |==|
+//@[35:36) Number |0|
+//@[36:37) RightParen |)|
+//@[37:37) EndOfFile ||

--- a/src/Bicep.Core/Parser/Lexer.cs
+++ b/src/Bicep.Core/Parser/Lexer.cs
@@ -214,7 +214,7 @@ namespace Bicep.Core.Parser
         private void LexToken()
         {
             textWindow.Reset();
-            ScanLeadingTrivia();
+            
             // important to force enum evaluation here via .ToImmutableArray()!
             var leadingTrivia = ScanLeadingTrivia().ToImmutableArray();
 
@@ -414,7 +414,7 @@ namespace Bicep.Core.Parser
             }
         }
 
-        private TokenType GetIdentifierTokenType(int length)
+        private TokenType GetIdentifierTokenType()
         {
             var identifier = textWindow.GetText();
 
@@ -427,21 +427,19 @@ namespace Bicep.Core.Parser
 
         private TokenType ScanIdentifier()
         {
-            var length = 1;
             while (true)
             {
                 if (textWindow.IsAtEnd())
                 {
-                    return GetIdentifierTokenType(length);
+                    return GetIdentifierTokenType();
                 }
 
-                if (!IsAlphaNumeric(textWindow.Peek()))
+                if (!IsIdentifierContinuation(textWindow.Peek()))
                 {
-                    return GetIdentifierTokenType(length);
+                    return GetIdentifierTokenType();
                 }
 
                 textWindow.Advance();
-                length++;
             }
         }
 
@@ -612,7 +610,7 @@ namespace Bicep.Core.Parser
                         return TokenType.Number;
                     }
 
-                    if (IsAlpha(nextChar))
+                    if (IsIdentifierStart(nextChar))
                     {
                         return this.ScanIdentifier();
                     }
@@ -621,11 +619,9 @@ namespace Bicep.Core.Parser
             }
         }
 
-        // TODO: Need IsIdStart and IsIdContinue (to disallow starting identifiers with 0-9, for example)
+        private static bool IsIdentifierStart(char c) => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
 
-        private static bool IsAlpha(char c) => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
-
-        private static bool IsAlphaNumeric(char c) => IsAlpha(c) || IsDigit(c);
+        private static bool IsIdentifierContinuation(char c) => IsIdentifierStart(c) || IsDigit(c);
 
         private static bool IsDigit(char c) => c >= '0' && c <= '9';
 


### PR DESCRIPTION
We already supported `_` in identifiers, but we were lacking test coverage for that. As part of this, I also cleaned up some code in the lexer. This closes #501.