### PR TITLE
Create TypeValidationVisitor in preparation for resource type narrowing

### DIFF
--- a/src/Bicep.Core/Emit/EmitLimitationVisitor.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationVisitor.cs
@@ -13,12 +13,12 @@ namespace Bicep.Core.Emit
     /// </summary>
     public class EmitLimitationVisitor : SyntaxVisitor
     {
-        private readonly IList<ErrorDiagnostic> diagnostics;
+        private readonly IList<Diagnostic> diagnostics;
         private readonly SemanticModel.SemanticModel model;
 
         private readonly Stack<VisitorState> stack = new Stack<VisitorState>();
 
-        public EmitLimitationVisitor(IList<ErrorDiagnostic> diagnostics, SemanticModel.SemanticModel model)
+        public EmitLimitationVisitor(IList<Diagnostic> diagnostics, SemanticModel.SemanticModel model)
         {
             this.diagnostics = diagnostics;
             this.model = model;

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -85,9 +85,8 @@ namespace Bicep.Core.Emit
         {
             // local function
             bool IsSecure(SyntaxBase? value) => value is BooleanLiteralSyntax boolLiteral && boolLiteral.Value;
-            var primitiveType = parameterSymbol.TryGetPrimitiveType();
 
-            if (primitiveType == null)
+            if (!(SyntaxHelper.TryGetPrimitiveType(parameterSymbol.DeclaringParameter) is TypeSymbol primitiveType))
             {
                 // this should have been caught by the type checker long ago
                 throw new ArgumentException($"Unable to find primitive type for parameter {parameterSymbol.Name}");

--- a/src/Bicep.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Bicep.Core/Extensions/EnumerableExtensions.cs
@@ -15,6 +15,14 @@ namespace Bicep.Core.Extensions
         {
             yield return single;
         }
+
+        public static void AddRange<T>(this IList<T> list, IEnumerable<T> range)
+        {
+            foreach (var element in range)
+            {
+                list.Add(element);
+            }
+        }
     }
 }
 

--- a/src/Bicep.Core/SemanticModel/OutputSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/OutputSymbol.cs
@@ -35,24 +35,6 @@ namespace Bicep.Core.SemanticModel
                 yield return this.Type;
             }
         }
-
-        public override IEnumerable<ErrorDiagnostic> GetDiagnostics()
-        {
-            TypeSymbol valueType = this.Context.TypeManager.GetTypeInfo(this.Value);
-
-            // this type is not a property in a symbol so the semantic error visitor won't collect the errors automatically
-            if (valueType is ErrorTypeSymbol)
-            {
-                return valueType.GetDiagnostics();
-            }
-
-            if (TypeValidator.AreTypesAssignable(valueType, this.Type) == false)
-            {
-                return this.CreateError(this.Value, b => b.OutputTypeMismatch(this.Type.Name, valueType.Name)).AsEnumerable();
-            }
-
-            return Enumerable.Empty<ErrorDiagnostic>();
-        }
     }
 }
 

--- a/src/Bicep.Core/SemanticModel/ParameterSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/ParameterSymbol.cs
@@ -20,9 +20,6 @@ namespace Bicep.Core.SemanticModel
 
         public ParameterDeclarationSyntax DeclaringParameter => (ParameterDeclarationSyntax) this.DeclaringSyntax;
 
-        public TypeSymbol? TryGetPrimitiveType()
-            => LanguageConstants.TryGetDeclarationType(this.DeclaringParameter.Type.TypeName);
-
         public SyntaxBase? Modifier { get; }
 
         public override SymbolKind Kind => SymbolKind.Parameter;
@@ -38,71 +35,6 @@ namespace Bicep.Core.SemanticModel
             {
                 yield return this.Type;
             }
-        }
-
-        public override IEnumerable<ErrorDiagnostic> GetDiagnostics()
-        {
-            var diagnostics = this.ValidateIdentifierAccess();
-
-            switch (this.Modifier)
-            {
-                case ParameterDefaultValueSyntax defaultValueSyntax:
-                    diagnostics = diagnostics.Concat(ValidateDefaultValue(defaultValueSyntax));
-                    break;
-
-                case ObjectSyntax modifierSyntax:
-                    if (this.Type.TypeKind != TypeKind.Error && this.TryGetPrimitiveType() is TypeSymbol primitiveType)
-                    {
-                        var modifierType = LanguageConstants.CreateParameterModifierType(primitiveType, this.Type);
-                        diagnostics = diagnostics.Concat(TypeValidator.GetExpressionAssignmentDiagnostics(this.Context.TypeManager, modifierSyntax, modifierType));
-                    }
-                    break;
-            }
-
-            return diagnostics;
-        }
-
-        private IEnumerable<ErrorDiagnostic> ValidateDefaultValue(ParameterDefaultValueSyntax defaultValueSyntax)
-        {
-            // figure out type of the default value
-            TypeSymbol? defaultValueType = this.Context.TypeManager.GetTypeInfo(defaultValueSyntax.DefaultValue);
-
-            // this type is not a property in a symbol so the semantic error visitor won't collect the errors automatically
-            if (defaultValueType is ErrorTypeSymbol)
-            {
-                return defaultValueType.GetDiagnostics();
-            }
-
-            if (TypeValidator.AreTypesAssignable(defaultValueType, this.Type) == false)
-            {
-                return this.CreateError(defaultValueSyntax.DefaultValue, b => b.ParameterTypeMismatch(this.Type.Name, defaultValueType.Name)).AsEnumerable();
-            }
-
-            return Enumerable.Empty<ErrorDiagnostic>();
-        }
-
-        private IEnumerable<ErrorDiagnostic> ValidateIdentifierAccess()
-        {
-            return SyntaxAggregator.Aggregate(this.DeclaringParameter, new List<ErrorDiagnostic>(), (accumulated, current) =>
-                {
-                    if (current is VariableAccessSyntax)
-                    {
-                        Symbol? symbol = this.Context.Bindings.TryGetValue(current);
-                        
-                        // excluded symbol kinds already generate errors - no need to duplicate
-                        if (symbol != null &&
-                            symbol.Kind != SymbolKind.Error &&
-                            symbol.Kind != SymbolKind.Parameter &&
-                            symbol.Kind != SymbolKind.Function &&
-                            symbol.Kind != SymbolKind.Output)
-                        {
-                            accumulated.Add(DiagnosticBuilder.ForPosition(current).CannotReferenceSymbolInParamDefaultValue());
-                        }
-                    }
-
-                    return accumulated;
-                },
-                accumulated => accumulated);
         }
     }
 }

--- a/src/Bicep.Core/SemanticModel/ResourceSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/ResourceSymbol.cs
@@ -30,11 +30,5 @@ namespace Bicep.Core.SemanticModel
                 yield return this.Type;
             }
         }
-
-        public override IEnumerable<ErrorDiagnostic> GetDiagnostics()
-        {
-            return TypeValidator.GetExpressionAssignmentDiagnostics(this.Context.TypeManager, this.Body, this.Type);
-        }
     }
 }
-

--- a/src/Bicep.Core/SemanticModel/SemanticDiagnosticVisitor.cs
+++ b/src/Bicep.Core/SemanticModel/SemanticDiagnosticVisitor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
 using Bicep.Core.Diagnostics;
@@ -6,11 +6,11 @@ using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.SemanticModel
 {
-    public class SemanticErrorVisitor : SymbolVisitor
+    public class SemanticDiagnosticVisitor : SymbolVisitor
     {
         private readonly IList<Diagnostic> diagnostics;
 
-        public SemanticErrorVisitor(IList<Diagnostic> diagnostics)
+        public SemanticDiagnosticVisitor(IList<Diagnostic> diagnostics)
         {
             this.diagnostics = diagnostics;
         }
@@ -71,7 +71,7 @@ namespace Bicep.Core.SemanticModel
 
         protected void CollectDiagnostics(Symbol symbol)
         {
-            foreach (ErrorDiagnostic diagnostic in symbol.GetDiagnostics())
+            foreach (var diagnostic in symbol.GetDiagnostics())
             {
                 this.diagnostics.Add(diagnostic);
             }

--- a/src/Bicep.Core/SemanticModel/SemanticErrorVisitor.cs
+++ b/src/Bicep.Core/SemanticModel/SemanticErrorVisitor.cs
@@ -8,9 +8,9 @@ namespace Bicep.Core.SemanticModel
 {
     public class SemanticErrorVisitor : SymbolVisitor
     {
-        private readonly IList<ErrorDiagnostic> diagnostics;
+        private readonly IList<Diagnostic> diagnostics;
 
-        public SemanticErrorVisitor(IList<ErrorDiagnostic> diagnostics)
+        public SemanticErrorVisitor(IList<Diagnostic> diagnostics)
         {
             this.diagnostics = diagnostics;
         }

--- a/src/Bicep.Core/SemanticModel/SemanticModel.cs
+++ b/src/Bicep.Core/SemanticModel/SemanticModel.cs
@@ -40,8 +40,8 @@ namespace Bicep.Core.SemanticModel
             var visitor = new SemanticDiagnosticVisitor(diagnostics);
             visitor.Visit(this.Root);
 
-            var typeDiagnosticsVisitor = new TypeValidationVisitor(bindings, typeManager, diagnostics);
-            typeDiagnosticsVisitor.Visit(this.Root.Syntax);
+            var typeValidationDiagnostics = TypeValidationVisitor.GetTypeValidationDiagnostics(bindings, typeManager, this.Root.Syntax);
+            diagnostics.AddRange(typeValidationDiagnostics);
 
             // TODO: Remove this when we fix IL limitations
             var emitLimitationVisitor = new EmitLimitationVisitor(diagnostics, this);

--- a/src/Bicep.Core/SemanticModel/SemanticModel.cs
+++ b/src/Bicep.Core/SemanticModel/SemanticModel.cs
@@ -37,7 +37,7 @@ namespace Bicep.Core.SemanticModel
         {
             var diagnostics = new List<Diagnostic>();
             
-            var visitor = new SemanticErrorVisitor(diagnostics);
+            var visitor = new SemanticDiagnosticVisitor(diagnostics);
             visitor.Visit(this.Root);
 
             var typeDiagnosticsVisitor = new TypeValidationVisitor(bindings, typeManager, diagnostics);

--- a/src/Bicep.Core/SemanticModel/SemanticModel.cs
+++ b/src/Bicep.Core/SemanticModel/SemanticModel.cs
@@ -33,12 +33,15 @@ namespace Bicep.Core.SemanticModel
         /// Gets all the semantic diagnostics unsorted. Does not include parser and lexer diagnostics.
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<ErrorDiagnostic> GetSemanticDiagnostics()
+        public IEnumerable<Diagnostic> GetSemanticDiagnostics()
         {
-            var diagnostics = new List<ErrorDiagnostic>();
+            var diagnostics = new List<Diagnostic>();
             
             var visitor = new SemanticErrorVisitor(diagnostics);
             visitor.Visit(this.Root);
+
+            var typeDiagnosticsVisitor = new TypeValidationVisitor(bindings, typeManager, diagnostics);
+            typeDiagnosticsVisitor.Visit(this.Root.Syntax);
 
             // TODO: Remove this when we fix IL limitations
             var emitLimitationVisitor = new EmitLimitationVisitor(diagnostics, this);

--- a/src/Bicep.Core/Syntax/SyntaxHelper.cs
+++ b/src/Bicep.Core/Syntax/SyntaxHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System.Collections.Generic;
 using System.Linq;
+using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Syntax
 {
@@ -27,5 +28,8 @@ namespace Bicep.Core.Syntax
 
             return allowedArraySyntax.Items.Select(i => i.Value);
         }
+
+        public static TypeSymbol? TryGetPrimitiveType(ParameterDeclarationSyntax parameterDeclarationSyntax)
+            => LanguageConstants.TryGetDeclarationType(parameterDeclarationSyntax.Type.TypeName);
     }
 }

--- a/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
@@ -12,11 +12,11 @@ namespace Bicep.Core.TypeSystem
     /// </summary>
     public sealed class CompileTimeConstantVisitor : SyntaxVisitor
     {
-        private readonly IList<ErrorDiagnostic> errors;
+        private readonly IList<Diagnostic> diagnostics;
 
-        public CompileTimeConstantVisitor(IList<ErrorDiagnostic> errors)
+        public CompileTimeConstantVisitor(IList<Diagnostic> diagnostics)
         {
-            this.errors = errors;
+            this.diagnostics = diagnostics;
         }
 
         /*
@@ -68,7 +68,7 @@ namespace Bicep.Core.TypeSystem
 
         private void AppendError(SyntaxBase syntax)
         {
-            this.errors.Add(DiagnosticBuilder.ForPosition(syntax).CompileTimeConstantRequired());
+            this.diagnostics.Add(DiagnosticBuilder.ForPosition(syntax).CompileTimeConstantRequired());
         }
     }
 }

--- a/src/Bicep.Core/TypeSystem/TypeValidationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidationVisitor.cs
@@ -16,14 +16,14 @@ namespace Bicep.Core.TypeSystem
         private readonly IReadOnlyDictionary<SyntaxBase, Symbol> bindings;
         private readonly ITypeManager typeManager;
         private readonly IList<Diagnostic> diagnostics;
-        private readonly IDictionary<SyntaxBase, ImmutableArray<ErrorDiagnostic>> syntaxDiagnostics;
+        private readonly IDictionary<SyntaxBase, ImmutableArray<Diagnostic>> syntaxDiagnostics;
 
         public TypeValidationVisitor(IReadOnlyDictionary<SyntaxBase, Symbol> bindings, ITypeManager typeManager, IList<Diagnostic> diagnostics)
         {
             this.bindings = bindings;
             this.typeManager = typeManager;
             this.diagnostics = diagnostics;
-            this.syntaxDiagnostics = new Dictionary<SyntaxBase, ImmutableArray<ErrorDiagnostic>>();
+            this.syntaxDiagnostics = new Dictionary<SyntaxBase, ImmutableArray<Diagnostic>>();
         }
 
         public override void VisitProgramSyntax(ProgramSyntax syntax)
@@ -77,7 +77,7 @@ namespace Bicep.Core.TypeSystem
             syntaxDiagnostics[syntax] = diagnostics.ToImmutableArray();
         }
 
-        private IEnumerable<ErrorDiagnostic> GetOutputDeclarationDiagnostics(OutputDeclarationSyntax syntax)
+        private IEnumerable<Diagnostic> GetOutputDeclarationDiagnostics(OutputDeclarationSyntax syntax)
         {
             var assignedType = typeManager.GetTypeInfo(syntax);
             var valueType = typeManager.GetTypeInfo(syntax.Value);
@@ -93,10 +93,10 @@ namespace Bicep.Core.TypeSystem
                 return DiagnosticBuilder.ForPosition(syntax.Value).OutputTypeMismatch(assignedType.Name, valueType.Name).AsEnumerable();
             }
 
-            return Enumerable.Empty<ErrorDiagnostic>();
+            return Enumerable.Empty<Diagnostic>();
         }
 
-        private IEnumerable<ErrorDiagnostic> ValidateDefaultValue(ParameterDefaultValueSyntax defaultValueSyntax, TypeSymbol assignedType)
+        private IEnumerable<Diagnostic> ValidateDefaultValue(ParameterDefaultValueSyntax defaultValueSyntax, TypeSymbol assignedType)
         {
             // figure out type of the default value
             var defaultValueType = typeManager.GetTypeInfo(defaultValueSyntax.DefaultValue);
@@ -112,12 +112,12 @@ namespace Bicep.Core.TypeSystem
                 return DiagnosticBuilder.ForPosition(defaultValueSyntax.DefaultValue).ParameterTypeMismatch(assignedType.Name, defaultValueType.Name).AsEnumerable();
             }
 
-            return Enumerable.Empty<ErrorDiagnostic>();
+            return Enumerable.Empty<Diagnostic>();
         }
 
-        private IEnumerable<ErrorDiagnostic> ValidateIdentifierAccess(ParameterDeclarationSyntax syntax)
+        private IEnumerable<Diagnostic> ValidateIdentifierAccess(ParameterDeclarationSyntax syntax)
         {
-            return SyntaxAggregator.Aggregate(syntax, new List<ErrorDiagnostic>(), (accumulated, current) =>
+            return SyntaxAggregator.Aggregate(syntax, new List<Diagnostic>(), (accumulated, current) =>
                 {
                     if (current is VariableAccessSyntax)
                     {

--- a/src/Bicep.Core/TypeSystem/TypeValidationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidationVisitor.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Extensions;
+using Bicep.Core.SemanticModel;
+using Bicep.Core.Syntax;
+using Bicep.Core.Syntax.Visitors;
+
+namespace Bicep.Core.TypeSystem
+{
+    public sealed class TypeValidationVisitor : SyntaxVisitor
+    {
+        private readonly IReadOnlyDictionary<SyntaxBase, Symbol> bindings;
+        private readonly ITypeManager typeManager;
+        private readonly IList<Diagnostic> diagnostics;
+        private readonly IDictionary<SyntaxBase, ImmutableArray<ErrorDiagnostic>> syntaxDiagnostics;
+
+        public TypeValidationVisitor(IReadOnlyDictionary<SyntaxBase, Symbol> bindings, ITypeManager typeManager, IList<Diagnostic> diagnostics)
+        {
+            this.bindings = bindings;
+            this.typeManager = typeManager;
+            this.diagnostics = diagnostics;
+            this.syntaxDiagnostics = new Dictionary<SyntaxBase, ImmutableArray<ErrorDiagnostic>>();
+        }
+
+        public override void VisitProgramSyntax(ProgramSyntax syntax)
+        {
+            base.VisitProgramSyntax(syntax);
+            diagnostics.AddRange(syntaxDiagnostics.Values.SelectMany(x => x));
+        }
+
+        public override void VisitParameterDeclarationSyntax(ParameterDeclarationSyntax syntax)
+        {
+            var diagnostics = this.ValidateIdentifierAccess(syntax);
+
+            var assignedType = typeManager.GetTypeInfo(syntax);
+
+            switch (syntax.Modifier)
+            {
+                case ParameterDefaultValueSyntax defaultValueSyntax:
+                    diagnostics = diagnostics.Concat(ValidateDefaultValue(defaultValueSyntax, assignedType));
+                    break;
+
+                case ObjectSyntax modifierSyntax:
+                    if (assignedType.TypeKind != TypeKind.Error && SyntaxHelper.TryGetPrimitiveType(syntax) is PrimitiveType primitiveType)
+                    {
+                        var modifierType = LanguageConstants.CreateParameterModifierType(primitiveType, assignedType);
+                        diagnostics = diagnostics.Concat(TypeValidator.GetExpressionAssignmentDiagnostics(typeManager, modifierSyntax, modifierType));
+                    }
+                    break;
+            }
+
+            syntaxDiagnostics[syntax] = diagnostics.ToImmutableArray();
+        }
+
+        public override void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax)
+        {
+
+        }
+
+        public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
+        {
+            var assignedType = typeManager.GetTypeInfo(syntax);
+            
+            var diagnostics = TypeValidator.GetExpressionAssignmentDiagnostics(typeManager, syntax.Body, assignedType);
+
+            syntaxDiagnostics[syntax] = diagnostics.ToImmutableArray();
+        }
+
+        public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
+        {
+            var diagnostics = GetOutputDeclarationDiagnostics(syntax);
+
+            syntaxDiagnostics[syntax] = diagnostics.ToImmutableArray();
+        }
+
+        private IEnumerable<ErrorDiagnostic> GetOutputDeclarationDiagnostics(OutputDeclarationSyntax syntax)
+        {
+            var assignedType = typeManager.GetTypeInfo(syntax);
+            var valueType = typeManager.GetTypeInfo(syntax.Value);
+
+            // this type is not a property in a symbol so the semantic error visitor won't collect the errors automatically
+            if (valueType is ErrorTypeSymbol)
+            {
+                return valueType.GetDiagnostics();
+            }
+
+            if (TypeValidator.AreTypesAssignable(valueType, assignedType) == false)
+            {
+                return DiagnosticBuilder.ForPosition(syntax.Value).OutputTypeMismatch(assignedType.Name, valueType.Name).AsEnumerable();
+            }
+
+            return Enumerable.Empty<ErrorDiagnostic>();
+        }
+
+        private IEnumerable<ErrorDiagnostic> ValidateDefaultValue(ParameterDefaultValueSyntax defaultValueSyntax, TypeSymbol assignedType)
+        {
+            // figure out type of the default value
+            var defaultValueType = typeManager.GetTypeInfo(defaultValueSyntax.DefaultValue);
+
+            // this type is not a property in a symbol so the semantic error visitor won't collect the errors automatically
+            if (defaultValueType is ErrorTypeSymbol)
+            {
+                return defaultValueType.GetDiagnostics();
+            }
+
+            if (TypeValidator.AreTypesAssignable(defaultValueType, assignedType) == false)
+            {
+                return DiagnosticBuilder.ForPosition(defaultValueSyntax.DefaultValue).ParameterTypeMismatch(assignedType.Name, defaultValueType.Name).AsEnumerable();
+            }
+
+            return Enumerable.Empty<ErrorDiagnostic>();
+        }
+
+        private IEnumerable<ErrorDiagnostic> ValidateIdentifierAccess(ParameterDeclarationSyntax syntax)
+        {
+            return SyntaxAggregator.Aggregate(syntax, new List<ErrorDiagnostic>(), (accumulated, current) =>
+                {
+                    if (current is VariableAccessSyntax)
+                    {
+                        var symbol = bindings[current];
+                        
+                        // excluded symbol kinds already generate errors - no need to duplicate
+                        if (symbol.Kind != SymbolKind.Error &&
+                            symbol.Kind != SymbolKind.Parameter &&
+                            symbol.Kind != SymbolKind.Function &&
+                            symbol.Kind != SymbolKind.Output)
+                        {
+                            accumulated.Add(DiagnosticBuilder.ForPosition(current).CannotReferenceSymbolInParamDefaultValue());
+                        }
+                    }
+
+                    return accumulated;
+                },
+                accumulated => accumulated);
+        }
+    }
+}


### PR DESCRIPTION
1. Combine type validation into a new visitor class
2. Modified TypeValidator functions to update a list rather than returning enumerables (prep for supporting a narrowed type return value)
3. Updated a few places to use `Diagnostic` rather than `ErrorDiagnostic` (prep for returning non-error diagnostics)