### PR TITLE
ResourceType inherits from TypeSymbol instead of NamedObjectType

### DIFF
--- a/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
@@ -832,7 +832,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
         {
             var typeReference = ResourceTypeReference.Parse("Mock.Rp/mockType@2020-01-01");
 
-            return new ResourceType(typeReference, LanguageConstants.CreateResourceProperties(typeReference));
+            return new ResourceType(typeReference, new NamedObjectType(typeReference.FormatName(), LanguageConstants.CreateResourceProperties(typeReference), null));
         }
 
         private TypeManager CreateTypeManager() => new TypeManager(TestResourceTypeProvider.CreateRegistrar(), new Dictionary<SyntaxBase, Symbol>(), new Dictionary<SyntaxBase, ImmutableArray<DeclaredSymbol>>());

--- a/src/Bicep.Core.UnitTests/Utils/TestResourceTypeProvider.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestResourceTypeProvider.cs
@@ -8,7 +8,7 @@ namespace Bicep.Core.UnitTests.Utils
     public class TestResourceTypeProvider : IResourceTypeProvider
     {
         public ResourceType GetType(ResourceTypeReference reference)
-            => new ResourceType(reference, LanguageConstants.CreateResourceProperties(reference));
+            => new ResourceType(reference, new NamedObjectType(reference.FormatName(), LanguageConstants.CreateResourceProperties(reference), null));
 
         public bool HasType(ResourceTypeReference typeReference)
             => true;

--- a/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
@@ -122,14 +122,9 @@ namespace Bicep.Core.Emit
             switch (model.GetSymbolInfo(variableAccessSyntax))
             {
                 case ResourceSymbol resourceSymbol:
-                    if (!(resourceSymbol.Type is ResourceType resourceType))
+                    if (!(resourceSymbol.Type is ResourceType resourceType && resourceType.Body is ObjectType bodyObjectType))
                     {
-                        // Type could be an ErrorType here
-                        return;
-                    }
-
-                    if (!(resourceType.Body is ObjectType bodyObjectType))
-                    {
+                        // Resource or body could be an ErrorType here. We only want to attempt property access on an object body.
                         return;
                     }
 

--- a/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
@@ -128,8 +128,13 @@ namespace Bicep.Core.Emit
                         return;
                     }
 
+                    if (!(resourceType.Body is ObjectType bodyObjectType))
+                    {
+                        return;
+                    }
+
                     var property = syntax.PropertyName.IdentifierName;
-                    if (!resourceType.Properties.TryGetValue(property, out var propertyType))
+                    if (!bodyObjectType.Properties.TryGetValue(property, out var propertyType))
                     {
                         // unknown property
                         return;

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
@@ -26,10 +26,13 @@ namespace Bicep.Core.TypeSystem.Az
 
             return (reference, () => new ResourceType(
                 reference,
-                GetCommonResourceProperties(reference).Concat(
-                    new TypeProperty("location", LanguageConstants.String, TypePropertyFlags.Required),
-                    new TypeProperty("tags", LanguageConstants.Tags, TypePropertyFlags.None)
-                )));
+                new NamedObjectType(
+                    reference.FormatName(),
+                        GetCommonResourceProperties(reference).Concat(
+                        new TypeProperty("location", LanguageConstants.String, TypePropertyFlags.Required),
+                        new TypeProperty("tags", LanguageConstants.Tags, TypePropertyFlags.None)
+                    ),
+                    null)));
         }
 
         public ResourceType GetType(ResourceTypeReference typeReference)
@@ -42,7 +45,7 @@ namespace Bicep.Core.TypeSystem.Az
             }
 
             // TODO move default definition into types assembly
-            return new ResourceType(typeReference, LanguageConstants.CreateResourceProperties(typeReference));
+            return new ResourceType(typeReference, new NamedObjectType(typeReference.FormatName(), LanguageConstants.CreateResourceProperties(typeReference), null));
         }
 
         public bool HasType(ResourceTypeReference typeReference)

--- a/src/Bicep.Core/TypeSystem/ResourceType.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceType.cs
@@ -1,20 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Collections.Generic;
 using Bicep.Core.Resources;
 
 namespace Bicep.Core.TypeSystem
 {
-    public class ResourceType : NamedObjectType
+    public class ResourceType : TypeSymbol
     {
-        public ResourceType(ResourceTypeReference typeReference, IEnumerable<TypeProperty> properties, ITypeReference? additionalPropertiesType = null)
-            : base(typeReference.FormatName(), properties, additionalPropertiesType)
+        public ResourceType(ResourceTypeReference typeReference, ITypeReference body)
+            : base(typeReference.FormatName())
         {
             TypeReference = typeReference;
+            Body = body;
         }
 
         public override TypeKind TypeKind => TypeKind.Resource;
 
         public ResourceTypeReference TypeReference { get; }
+
+        public ITypeReference Body { get; }
     }
 }

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -21,7 +21,7 @@ namespace Bicep.Core.TypeSystem
 
         private readonly IReadOnlyDictionary<SyntaxBase, ImmutableArray<DeclaredSymbol>> cyclesBySyntax;
 
-        private readonly IDictionary<SyntaxBase, TypeSymbol> assignedTypes;
+        private readonly IDictionary<SyntaxBase, ITypeReference> assignedTypes;
 
         public TypeAssignmentVisitor(ResourceTypeRegistrar resourceTypeRegistrar, IReadOnlyDictionary<SyntaxBase, Symbol> bindings, IReadOnlyDictionary<SyntaxBase, ImmutableArray<DeclaredSymbol>> cyclesBySyntax)
         {
@@ -31,7 +31,7 @@ namespace Bicep.Core.TypeSystem
             // (using the IReadOnlyDictionary to prevent accidental mutation)
             this.bindings = bindings; 
             this.cyclesBySyntax = cyclesBySyntax;
-            this.assignedTypes = new Dictionary<SyntaxBase, TypeSymbol>();
+            this.assignedTypes = new Dictionary<SyntaxBase, ITypeReference>();
         }
 
         public TypeSymbol GetTypeSymbol(SyntaxBase syntax) => VisitAndReturnType(syntax);
@@ -59,7 +59,7 @@ namespace Bicep.Core.TypeSystem
             return null;
         }
 
-        private void AssignTypeWithCaching(SyntaxBase syntax, Func<TypeSymbol> assignFunc)
+        private void AssignTypeWithCaching(SyntaxBase syntax, Func<ITypeReference> assignFunc)
         {
             if (assignedTypes.ContainsKey(syntax))
             {
@@ -85,7 +85,7 @@ namespace Bicep.Core.TypeSystem
                 return new ErrorTypeSymbol(DiagnosticBuilder.ForPosition(syntax).InvalidExpression());
             }
 
-            return typeSymbol;
+            return typeSymbol.Type;
         }
 
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
@@ -454,6 +454,12 @@ namespace Bicep.Core.TypeSystem
                     return new ErrorTypeSymbol(errors);
                 }
 
+                if (baseType is ResourceType resourceType)
+                {
+                    // use the resource body for property access
+                    baseType = resourceType.Body.Type;
+                }
+
                 if (TypeValidator.AreTypesAssignable(baseType, LanguageConstants.Object) != true)
                 {
                     // can only access properties of objects
@@ -520,13 +526,13 @@ namespace Bicep.Core.TypeSystem
                     case ResourceSymbol resource:
                         // resource bodies can participate in cycles
                         // need to explicitly force a type check on the body
-                        return VisitDeclaredSymbol(syntax, resource);
+                        return new DeferredTypeReference(() => VisitDeclaredSymbol(syntax, resource));
 
                     case ParameterSymbol parameter:
-                        return VisitDeclaredSymbol(syntax, parameter);
+                        return new DeferredTypeReference(() => VisitDeclaredSymbol(syntax, parameter));
 
                     case VariableSymbol variable:
-                        return VisitDeclaredSymbol(syntax, variable);
+                        return new DeferredTypeReference(() => VisitDeclaredSymbol(syntax, variable));
 
                     case OutputSymbol _:
                         return new ErrorTypeSymbol(DiagnosticBuilder.ForPosition(syntax.Name.Span).OutputReferenceNotSupported(syntax.Name.IdentifierName));

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -456,7 +456,7 @@ namespace Bicep.Core.TypeSystem
 
                 if (baseType is ResourceType resourceType)
                 {
-                    // use the resource body for property access
+                    // We're accessing a property on the resource body.
                     baseType = resourceType.Body.Type;
                 }
 

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -56,6 +56,9 @@ namespace Bicep.Core.TypeSystem
                 case ResourceRefType _:
                     return sourceType.TypeKind == TypeKind.Resource;
 
+                case TypeSymbol _ when sourceType is ResourceType sourceResourceType:
+                    return AreTypesAssignable(sourceResourceType.Body.Type, targetType);
+
                 case StringLiteralType _ when sourceType is StringLiteralType:
                     // The name *is* the escaped string value, so we must have an exact match.
                     return targetType.Name == sourceType.Name;
@@ -126,6 +129,12 @@ namespace Bicep.Core.TypeSystem
             bool skipConstantCheck,
             bool skipTypeErrors)
         {
+            if (targetType is ResourceType targetResourceType)
+            {
+                GetExpressionAssignmentDiagnosticsInternal(typeManager, expression, targetResourceType.Body.Type, diagnostics, typeMismatchErrorFactory, skipConstantCheck, skipTypeErrors);
+                return;
+            }
+
             // TODO: The type of this expression and all subexpressions should be cached
             TypeSymbol? expressionType = typeManager.GetTypeInfo(expression);
 

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -57,6 +57,7 @@ namespace Bicep.Core.TypeSystem
                     return sourceType.TypeKind == TypeKind.Resource;
 
                 case TypeSymbol _ when sourceType is ResourceType sourceResourceType:
+                    // When assigning a resource, we're really assigning the value of the resource body.
                     return AreTypesAssignable(sourceResourceType.Body.Type, targetType);
 
                 case StringLiteralType _ when sourceType is StringLiteralType:
@@ -131,6 +132,7 @@ namespace Bicep.Core.TypeSystem
         {
             if (targetType is ResourceType targetResourceType)
             {
+                // When assigning a resource, we're really assigning the value of the resource body.
                 GetExpressionAssignmentDiagnosticsInternal(typeManager, expression, targetResourceType.Body.Type, diagnostics, typeMismatchErrorFactory, skipConstantCheck, skipTypeErrors);
                 return;
             }


### PR DESCRIPTION
This is required to support polymorphic resource types. Working towards #562 