### PR TITLE
added completion test "framework" and a few basic tests

### DIFF
--- a/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
+++ b/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
@@ -27,6 +27,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Completions\declarations.json" />
+    <None Remove="Variables_LF\completions.declarations.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Completions\declarations.json" />
+    <EmbeddedResource Include="Variables_LF\Completions\symbolsPlusTypes.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/src/Bicep.Core.Samples/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Completions/declarations.json
@@ -1,0 +1,237 @@
+[
+  {
+    "label": "output",
+    "kind": "keyword",
+    "detail": "Output keyword",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "output",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "output",
+    "kind": "snippet",
+    "detail": "Output declaration",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\noutput Identifier Type = \n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "output ${1:Identifier} ${2:Type} = $0",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "param",
+    "kind": "keyword",
+    "detail": "Parameter keyword",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "param",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "param",
+    "kind": "snippet",
+    "detail": "Parameter declaration",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nparam Identifier Type\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "param ${1:Identifier} ${2:Type}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "param",
+    "kind": "snippet",
+    "detail": "Parameter declaration with default value",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nparam Identifier Type = DefaultValue\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "param ${1:Identifier} ${2:Type} = ${3:DefaultValue}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "param",
+    "kind": "snippet",
+    "detail": "Parameter declaration with default and allowed values",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nparam Identifier Type {\r\n  default: \r\n  allowed: [\r\n    \r\n  ]\r\n}\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "param ${1:Identifier} ${2:Type} {\r\n  default: $3\r\n  allowed: [\r\n    $4\r\n  ]\r\n}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "param",
+    "kind": "snippet",
+    "detail": "Parameter declaration with options",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nparam Identifier Type {\r\n  \r\n}\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "param ${1:Identifier} ${2:Type} {\r\n  $0\r\n}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "param",
+    "kind": "snippet",
+    "detail": "Secure string parameter",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nparam Identifier string {\r\n  secure: true\r\n}\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "param ${1:Identifier} string {\r\n  secure: true\r\n}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "resource",
+    "kind": "keyword",
+    "detail": "Resource keyword",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "resource",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Resource with defaults",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\r\n  name: \r\n  location: \r\n  properties: {\r\n    \r\n  }\r\n}\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {\r\n  name: $5\r\n  location: $6\r\n  properties: {\r\n    $0\r\n  }\r\n}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Child Resource with defaults",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\r\n  name: \r\n  properties: {\r\n    \r\n  }\r\n}\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {\r\n  name: $6\r\n  properties: {\r\n    $0\r\n  }\r\n}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Resource without defaults",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\r\n  name: \r\n  \r\n}\r\n\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {\r\n  name: $5\r\n  $0\r\n}\r\n",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Child Resource without defaults",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\r\n  name: \r\n  \r\n}\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {\r\n  name: $6\r\n  $0\r\n}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "var",
+    "kind": "keyword",
+    "detail": "Variable keyword",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "var",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "var",
+    "kind": "snippet",
+    "detail": "Variable declaration",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nvar Identifier = \n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "var ${1:Identifier} = $0",
+    "insertTextFormat": "snippet"
+  }
+]

--- a/src/Bicep.Core.Samples/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Completions/declarations.json
@@ -82,13 +82,13 @@
       "hasString": false,
       "markupContent": {
         "kind": "markdown",
-        "value": "```bicep\nparam Identifier Type {\r\n  default: \r\n  allowed: [\r\n    \r\n  ]\r\n}\n```"
+        "value": "```bicep\nparam Identifier Type {\n  default: \n  allowed: [\n    \n  ]\n}\n```"
       },
       "hasMarkupContent": true
     },
     "deprecated": false,
     "preselect": false,
-    "insertText": "param ${1:Identifier} ${2:Type} {\r\n  default: $3\r\n  allowed: [\r\n    $4\r\n  ]\r\n}",
+    "insertText": "param ${1:Identifier} ${2:Type} {\n  default: $3\n  allowed: [\n    $4\n  ]\n}",
     "insertTextFormat": "snippet"
   },
   {
@@ -99,13 +99,13 @@
       "hasString": false,
       "markupContent": {
         "kind": "markdown",
-        "value": "```bicep\nparam Identifier Type {\r\n  \r\n}\n```"
+        "value": "```bicep\nparam Identifier Type {\n  \n}\n```"
       },
       "hasMarkupContent": true
     },
     "deprecated": false,
     "preselect": false,
-    "insertText": "param ${1:Identifier} ${2:Type} {\r\n  $0\r\n}",
+    "insertText": "param ${1:Identifier} ${2:Type} {\n  $0\n}",
     "insertTextFormat": "snippet"
   },
   {
@@ -116,13 +116,13 @@
       "hasString": false,
       "markupContent": {
         "kind": "markdown",
-        "value": "```bicep\nparam Identifier string {\r\n  secure: true\r\n}\n```"
+        "value": "```bicep\nparam Identifier string {\n  secure: true\n}\n```"
       },
       "hasMarkupContent": true
     },
     "deprecated": false,
     "preselect": false,
-    "insertText": "param ${1:Identifier} string {\r\n  secure: true\r\n}",
+    "insertText": "param ${1:Identifier} string {\n  secure: true\n}",
     "insertTextFormat": "snippet"
   },
   {
@@ -145,13 +145,13 @@
       "hasString": false,
       "markupContent": {
         "kind": "markdown",
-        "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\r\n  name: \r\n  location: \r\n  properties: {\r\n    \r\n  }\r\n}\n```"
+        "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\n  name: \n  location: \n  properties: {\n    \n  }\n}\n```"
       },
       "hasMarkupContent": true
     },
     "deprecated": false,
     "preselect": false,
-    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {\r\n  name: $5\r\n  location: $6\r\n  properties: {\r\n    $0\r\n  }\r\n}",
+    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {\n  name: $5\n  location: $6\n  properties: {\n    $0\n  }\n}",
     "insertTextFormat": "snippet"
   },
   {
@@ -162,13 +162,13 @@
       "hasString": false,
       "markupContent": {
         "kind": "markdown",
-        "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\r\n  name: \r\n  properties: {\r\n    \r\n  }\r\n}\n```"
+        "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
       },
       "hasMarkupContent": true
     },
     "deprecated": false,
     "preselect": false,
-    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {\r\n  name: $6\r\n  properties: {\r\n    $0\r\n  }\r\n}",
+    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {\n  name: $6\n  properties: {\n    $0\n  }\n}",
     "insertTextFormat": "snippet"
   },
   {
@@ -179,13 +179,13 @@
       "hasString": false,
       "markupContent": {
         "kind": "markdown",
-        "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\r\n  name: \r\n  \r\n}\r\n\n```"
+        "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\n  name: \n  \n}\n\n```"
       },
       "hasMarkupContent": true
     },
     "deprecated": false,
     "preselect": false,
-    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {\r\n  name: $5\r\n  $0\r\n}\r\n",
+    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {\n  name: $5\n  $0\n}\n",
     "insertTextFormat": "snippet"
   },
   {
@@ -196,13 +196,13 @@
       "hasString": false,
       "markupContent": {
         "kind": "markdown",
-        "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\r\n  name: \r\n  \r\n}\n```"
+        "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\n  name: \n  \n}\n```"
       },
       "hasMarkupContent": true
     },
     "deprecated": false,
     "preselect": false,
-    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {\r\n  name: $6\r\n  $0\r\n}",
+    "insertText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {\n  name: $6\n  $0\n}",
     "insertTextFormat": "snippet"
   },
   {

--- a/src/Bicep.Core.Samples/DataSets.cs
+++ b/src/Bicep.Core.Samples/DataSets.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -45,6 +46,7 @@ namespace Bicep.Core.Samples
                 .Select(property => property.GetValue(null))
                 .Cast<DataSet>();
 
+        public static ImmutableDictionary<string, string> Completions => DataSet.ReadDataSetDictionary($"{DataSet.Prefix}{DataSet.TestCompletionsPrefix}");
 
         private static DataSet CreateDataSet([CallerMemberName] string? dataSetName = null) => new DataSet(dataSetName!);
     }

--- a/src/Bicep.Core.Samples/InvalidVariables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/InvalidVariables_LF/main.bicep
@@ -2,7 +2,7 @@
 // unknown declaration
 bad
 
-// incomplete variable declaration
+// incomplete variable declaration #completionTest(0,1,2) -> declarations
 var
 
 // unassigned variable

--- a/src/Bicep.Core.Samples/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/InvalidVariables_LF/main.diagnostics.bicep
@@ -3,7 +3,7 @@
 bad
 //@[0:3) [BCP007 (Error)] This declaration type is not recognized. Specify a parameter, variable, resource, or output declaration. |bad|
 
-// incomplete variable declaration
+// incomplete variable declaration #completionTest(0,1,2) -> declarations
 var
 //@[3:3) [BCP015 (Error)] Expected a variable identifier at this location. ||
 

--- a/src/Bicep.Core.Samples/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/InvalidVariables_LF/main.symbols.bicep
@@ -2,7 +2,7 @@
 // unknown declaration
 bad
 
-// incomplete variable declaration
+// incomplete variable declaration #completionTest(0,1,2) -> declarations
 var
 
 // unassigned variable

--- a/src/Bicep.Core.Samples/InvalidVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/InvalidVariables_LF/main.syntax.bicep
@@ -7,8 +7,8 @@ bad
 //@[0:3)  Identifier |bad|
 //@[3:5) NewLine |\n\n|
 
-// incomplete variable declaration
-//@[34:35) NewLine |\n|
+// incomplete variable declaration #completionTest(0,1,2) -> declarations
+//@[73:74) NewLine |\n|
 var
 //@[0:3) SkippedTriviaSyntax
 //@[0:3)  Identifier |var|

--- a/src/Bicep.Core.Samples/InvalidVariables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/InvalidVariables_LF/main.tokens.bicep
@@ -6,8 +6,8 @@ bad
 //@[0:3) Identifier |bad|
 //@[3:5) NewLine |\n\n|
 
-// incomplete variable declaration
-//@[34:35) NewLine |\n|
+// incomplete variable declaration #completionTest(0,1,2) -> declarations
+//@[73:74) NewLine |\n|
 var
 //@[0:3) Identifier |var|
 //@[3:5) NewLine |\n\n|

--- a/src/Bicep.Core.Samples/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Variables_LF/Completions/symbolsPlusTypes.json
@@ -1,0 +1,1106 @@
+[
+  {
+    "label": "_",
+    "kind": "variable",
+    "detail": "_",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "_",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "__",
+    "kind": "variable",
+    "detail": "__",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "__",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "_0a_1b",
+    "kind": "variable",
+    "detail": "_0a_1b",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "_0a_1b",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "_1_",
+    "kind": "variable",
+    "detail": "_1_",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "_1_",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "add",
+    "kind": "function",
+    "detail": "add",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "add",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "and",
+    "kind": "function",
+    "detail": "and",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "and",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "any",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "anyIndexOnAny",
+    "kind": "variable",
+    "detail": "anyIndexOnAny",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "anyIndexOnAny",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "array",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "array",
+    "kind": "class",
+    "detail": "array",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "array",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "base64",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "base64ToJson",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "base64ToString",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "bool",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "bool",
+    "kind": "class",
+    "detail": "bool",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "bool",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "bracketAtBeginning",
+    "kind": "variable",
+    "detail": "bracketAtBeginning",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "bracketAtBeginning",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "bracketInTheMiddle",
+    "kind": "variable",
+    "detail": "bracketInTheMiddle",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "bracketInTheMiddle",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "bracketStringInExpression",
+    "kind": "variable",
+    "detail": "bracketStringInExpression",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "bracketStringInExpression",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "coalesce",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "concat",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "contains",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "createArray",
+    "kind": "function",
+    "detail": "createArray",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "createArray",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "curliesInInterp",
+    "kind": "variable",
+    "detail": "curliesInInterp",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "curliesInInterp",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "curliesWithNoInterp",
+    "kind": "variable",
+    "detail": "curliesWithNoInterp",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "curliesWithNoInterp",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "dataUri",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "dataUriToString",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "dateTimeAdd",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "deployment",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "div",
+    "kind": "function",
+    "detail": "div",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "div",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "doubleInterp",
+    "kind": "variable",
+    "detail": "doubleInterp",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "doubleInterp",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "empty",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "emptyJsonArray",
+    "kind": "variable",
+    "detail": "emptyJsonArray",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "emptyJsonArray",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "enclosingBrackets",
+    "kind": "variable",
+    "detail": "enclosingBrackets",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "enclosingBrackets",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "endsWith",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "environment",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "equals",
+    "kind": "function",
+    "detail": "equals",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "equals",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "expressionIndexOnAny",
+    "kind": "variable",
+    "detail": "expressionIndexOnAny",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "expressionIndexOnAny",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "extensionResourceId",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "first",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "format",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "functionOnIndexer1",
+    "kind": "variable",
+    "detail": "functionOnIndexer1",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "functionOnIndexer1",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "functionOnIndexer2",
+    "kind": "variable",
+    "detail": "functionOnIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "functionOnIndexer2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "functionOnIndexer3",
+    "kind": "variable",
+    "detail": "functionOnIndexer3",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "functionOnIndexer3",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "greater",
+    "kind": "function",
+    "detail": "greater",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "greater",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "greaterOrEquals",
+    "kind": "function",
+    "detail": "greaterOrEquals",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "greaterOrEquals",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "guid",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "if",
+    "kind": "function",
+    "detail": "if",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "if",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "indexOf",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "int",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "int",
+    "kind": "class",
+    "detail": "int",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "int",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "interp1",
+    "kind": "variable",
+    "detail": "interp1",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "interp1",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "interp2",
+    "kind": "variable",
+    "detail": "interp2",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "interp2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "interp3",
+    "kind": "variable",
+    "detail": "interp3",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "interp3",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "interp4",
+    "kind": "variable",
+    "detail": "interp4",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "interp4",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "interpolatedBrackets",
+    "kind": "variable",
+    "detail": "interpolatedBrackets",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "interpolatedBrackets",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "intersection",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "intIndexer",
+    "kind": "variable",
+    "detail": "intIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "intIndexer",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "json",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "last",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "lastIndexOf",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "length",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "less",
+    "kind": "function",
+    "detail": "less",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "less",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "lessOrEquals",
+    "kind": "function",
+    "detail": "lessOrEquals",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "lessOrEquals",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "listKeys",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "max",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "min",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "mod",
+    "kind": "function",
+    "detail": "mod",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "mod",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "mul",
+    "kind": "function",
+    "detail": "mul",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "mul",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myArr",
+    "kind": "variable",
+    "detail": "myArr",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myArr",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myArrWithObjects",
+    "kind": "variable",
+    "detail": "myArrWithObjects",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myArrWithObjects",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myEmptyArray",
+    "kind": "variable",
+    "detail": "myEmptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myEmptyArray",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myEmptyObj",
+    "kind": "variable",
+    "detail": "myEmptyObj",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myEmptyObj",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myFalsehood",
+    "kind": "variable",
+    "detail": "myFalsehood",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myFalsehood",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myInt",
+    "kind": "variable",
+    "detail": "myInt",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myInt",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myObj",
+    "kind": "variable",
+    "detail": "myObj",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myObj",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myPropertyName",
+    "kind": "variable",
+    "detail": "myPropertyName",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myPropertyName",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myStr",
+    "kind": "variable",
+    "detail": "myStr",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myStr",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myTruth",
+    "kind": "variable",
+    "detail": "myTruth",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myTruth",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myVar",
+    "kind": "variable",
+    "detail": "myVar",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myVar",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myVar2",
+    "kind": "variable",
+    "detail": "myVar2",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myVar2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myVar3",
+    "kind": "variable",
+    "detail": "myVar3",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myVar3",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myVar4",
+    "kind": "variable",
+    "detail": "myVar4",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "myVar4",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "namedPropertyIndexer",
+    "kind": "variable",
+    "detail": "namedPropertyIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "namedPropertyIndexer",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "nestedBrackets",
+    "kind": "variable",
+    "detail": "nestedBrackets",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "nestedBrackets",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "nestedInterpolatedBrackets",
+    "kind": "variable",
+    "detail": "nestedInterpolatedBrackets",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "nestedInterpolatedBrackets",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "newGuid",
+    "kind": "function",
+    "detail": "newGuid",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "newGuid",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "not",
+    "kind": "function",
+    "detail": "not",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "not",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "object",
+    "kind": "class",
+    "detail": "object",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "object",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "or",
+    "kind": "function",
+    "detail": "or",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "or",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "padLeft",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "pickZones",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "previousEmitLimit",
+    "kind": "variable",
+    "detail": "previousEmitLimit",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "previousEmitLimit",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "providers",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "range",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "reference",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "replace",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "resourceGroup",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "resourceId",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "singleQuote",
+    "kind": "variable",
+    "detail": "singleQuote",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "singleQuote",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "skip",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "split",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "startsWith",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "string",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "string",
+    "kind": "class",
+    "detail": "string",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "string",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "sub",
+    "kind": "function",
+    "detail": "sub",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "sub",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "subscription",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "subscriptionResourceId",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "substring",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "take",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "tenantResourceId",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "toLower",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "toUpper",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "trim",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "union",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "uniqueString",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "unusedIntermediate",
+    "kind": "variable",
+    "detail": "unusedIntermediate",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "unusedIntermediate",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "unusedIntermediateRef",
+    "kind": "variable",
+    "detail": "unusedIntermediateRef",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "unusedIntermediateRef",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "uri",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "uriComponent",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "uriComponentToString",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "utcNow",
+    "kind": "function",
+    "detail": "utcNow",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "utcNow",
+    "insertTextFormat": "plainText"
+  }
+]

--- a/src/Bicep.Core.Samples/Variables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.bicep
@@ -12,8 +12,11 @@ var interp4 = 'abc${123}${456}jk$l${789}p$'
 var doubleInterp = 'abc${'def${123}'}_${'${456}${789}'}'
 var curliesInInterp = '{${123}{0}${true}}'
 
+// #completionTest(0) -> declarations
+
 // verify correct bracket escaping
 var bracketInTheMiddle = 'a[b]'
+// #completionTest(25) -> symbolsPlusTypes
 var bracketAtBeginning = '[test'
 var enclosingBrackets = '[test]'
 var emptyJsonArray = '[]'
@@ -122,6 +125,8 @@ var previousEmitLimit = [
     }
   }
 ]
+
+// #completionTest(0) -> declarations
 
 var myVar = 'hello'
 var myVar2 = any({

--- a/src/Bicep.Core.Samples/Variables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.diagnostics.bicep
@@ -12,8 +12,11 @@ var interp4 = 'abc${123}${456}jk$l${789}p$'
 var doubleInterp = 'abc${'def${123}'}_${'${456}${789}'}'
 var curliesInInterp = '{${123}{0}${true}}'
 
+// #completionTest(0) -> declarations
+
 // verify correct bracket escaping
 var bracketInTheMiddle = 'a[b]'
+// #completionTest(25) -> symbolsPlusTypes
 var bracketAtBeginning = '[test'
 var enclosingBrackets = '[test]'
 var emptyJsonArray = '[]'
@@ -122,6 +125,8 @@ var previousEmitLimit = [
     }
   }
 ]
+
+// #completionTest(0) -> declarations
 
 var myVar = 'hello'
 var myVar2 = any({

--- a/src/Bicep.Core.Samples/Variables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.symbols.bicep
@@ -21,9 +21,12 @@ var doubleInterp = 'abc${'def${123}'}_${'${456}${789}'}'
 var curliesInInterp = '{${123}{0}${true}}'
 //@[4:19) Variable curliesInInterp. Type: string. Declaration start char: 0, length: 42
 
+// #completionTest(0) -> declarations
+
 // verify correct bracket escaping
 var bracketInTheMiddle = 'a[b]'
 //@[4:22) Variable bracketInTheMiddle. Type: 'a[b]'. Declaration start char: 0, length: 31
+// #completionTest(25) -> symbolsPlusTypes
 var bracketAtBeginning = '[test'
 //@[4:22) Variable bracketAtBeginning. Type: '[test'. Declaration start char: 0, length: 32
 var enclosingBrackets = '[test]'
@@ -158,6 +161,8 @@ var previousEmitLimit = [
     }
   }
 ]
+
+// #completionTest(0) -> declarations
 
 var myVar = 'hello'
 //@[4:9) Variable myVar. Type: 'hello'. Declaration start char: 0, length: 19

--- a/src/Bicep.Core.Samples/Variables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.syntax.bicep
@@ -126,6 +126,9 @@ var curliesInInterp = '{${123}{0}${true}}'
 //@[39:42)   StringRightPiece |}}'|
 //@[42:44) NewLine |\n\n|
 
+// #completionTest(0) -> declarations
+//@[37:39) NewLine |\n\n|
+
 // verify correct bracket escaping
 //@[34:35) NewLine |\n|
 var bracketInTheMiddle = 'a[b]'
@@ -137,6 +140,8 @@ var bracketInTheMiddle = 'a[b]'
 //@[25:31)  StringSyntax
 //@[25:31)   StringComplete |'a[b]'|
 //@[31:32) NewLine |\n|
+// #completionTest(25) -> symbolsPlusTypes
+//@[42:43) NewLine |\n|
 var bracketAtBeginning = '[test'
 //@[0:32) VariableDeclarationSyntax
 //@[0:3)  Identifier |var|
@@ -966,6 +971,9 @@ var previousEmitLimit = [
 ]
 //@[0:1)   RightSquare |]|
 //@[1:3) NewLine |\n\n|
+
+// #completionTest(0) -> declarations
+//@[37:39) NewLine |\n\n|
 
 var myVar = 'hello'
 //@[0:19) VariableDeclarationSyntax

--- a/src/Bicep.Core.Samples/Variables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Variables_LF/main.tokens.bicep
@@ -86,6 +86,9 @@ var curliesInInterp = '{${123}{0}${true}}'
 //@[39:42) StringRightPiece |}}'|
 //@[42:44) NewLine |\n\n|
 
+// #completionTest(0) -> declarations
+//@[37:39) NewLine |\n\n|
+
 // verify correct bracket escaping
 //@[34:35) NewLine |\n|
 var bracketInTheMiddle = 'a[b]'
@@ -94,6 +97,8 @@ var bracketInTheMiddle = 'a[b]'
 //@[23:24) Assignment |=|
 //@[25:31) StringComplete |'a[b]'|
 //@[31:32) NewLine |\n|
+// #completionTest(25) -> symbolsPlusTypes
+//@[42:43) NewLine |\n|
 var bracketAtBeginning = '[test'
 //@[0:3) Identifier |var|
 //@[4:22) Identifier |bracketAtBeginning|
@@ -628,6 +633,9 @@ var previousEmitLimit = [
 ]
 //@[0:1) RightSquare |]|
 //@[1:3) NewLine |\n\n|
+
+// #completionTest(0) -> declarations
+//@[37:39) NewLine |\n\n|
 
 var myVar = 'hello'
 //@[0:3) Identifier |var|

--- a/src/Bicep.Core.UnitTests/Utils/DataSetContractResolver.cs
+++ b/src/Bicep.Core.UnitTests/Utils/DataSetContractResolver.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+
+namespace Bicep.Core.UnitTests.Utils
+{
+    public class DataSetContractResolver : CamelCasePropertyNamesContractResolver
+    {
+        protected override JsonContract CreateContract(Type objectType)
+        {
+            var contract = base.CreateContract(objectType);
+
+            // the omnisharp library specifies the NumberEnumConverter on some of the enum types
+            // which supercedes our serialization settings
+            if (objectType.IsEnum && !(contract.Converter is StringEnumConverter))
+            {
+                // force our converter on enum types
+                contract.Converter = DataSetSerialization.CreateEnumConverter();
+            }
+
+            return contract;
+        }
+    }
+}

--- a/src/Bicep.Core.UnitTests/Utils/DataSetSerialization.cs
+++ b/src/Bicep.Core.UnitTests/Utils/DataSetSerialization.cs
@@ -16,15 +16,17 @@ namespace Bicep.Core.UnitTests.Utils
             {
                 DateParseHandling = DateParseHandling.None,
                 Formatting = Formatting.Indented,
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                ContractResolver = new DataSetContractResolver(),
                 NullValueHandling = NullValueHandling.Ignore,
                 TypeNameHandling = TypeNameHandling.None
             };
 
-            settings.Converters.Add(new StringEnumConverter {NamingStrategy = new CamelCaseNamingStrategy()});
+            settings.Converters.Add(CreateEnumConverter());
 
             return settings;
         }
+
+        public static StringEnumConverter CreateEnumConverter() => new StringEnumConverter {NamingStrategy = new CamelCaseNamingStrategy(), AllowIntegerValues = false};
 
         public static JsonSerializer CreateSerializer() => JsonSerializer.Create(CreateSerializerSettings());
 

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -1,0 +1,176 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Bicep.Core.Extensions;
+using Bicep.Core.Samples;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.LangServer.IntegrationTests.Completions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Bicep.LangServer.IntegrationTests
+{
+    [TestClass]
+    public class CompletionTests
+    {
+        public TestContext? TestContext { get; set; }
+
+        [TestMethod]
+        public async Task EmptyFileShouldProduceDeclarationCompletions()
+        {
+            const string expectedSetName = "declarations";
+            var uri = DocumentUri.From($"/{this.TestContext!.TestName}");
+
+            using var client = await IntegrationTestHelper.StartServerWithText(string.Empty, uri);
+
+            var actual = await GetActualCompletions(client, uri, new Position(0, 0));
+            var actualLocation = FileHelper.SaveResultFile(this.TestContext!, $"{this.TestContext.TestName}_{expectedSetName}", actual.ToString(Formatting.Indented));
+            
+            var expectedStr = DataSets.Completions.TryGetValue(GetFullSetName(expectedSetName));
+            if (expectedStr == null)
+            {
+                throw new AssertFailedException($"The completion set '{expectedSetName}' does not exist.");
+            }
+            
+            var expected = JToken.Parse(expectedStr);
+
+            actual.Should().EqualWithJsonDiffOutput(expected, GetGlobalCompletionSetPath(expectedSetName), actualLocation);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetDisplayName))]
+        public async Task CompletionRequestShouldProduceExpectedCompletions(DataSet dataSet, string setName, IList<Position> positions)
+        {
+            var uri = DocumentUri.From($"/{dataSet.Name}");
+
+            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+
+            var intermediate = new List<(Position position, JToken actual)>();
+
+            foreach (var position in positions)
+            {
+                var actual = await GetActualCompletions(client, uri, position);
+
+                intermediate.Add((position, actual));
+            }
+
+            ValidateCompletions(dataSet, setName, intermediate);
+        }
+
+        private void ValidateCompletions(DataSet dataSet, string setName, List<(Position position, JToken actual)> intermediate)
+        {
+            // if the test author asserts on the wrong completion set in their tests
+            // it will not be possible to update the expected completions in a way that makes the test pass
+            // to save investigation time, we will produce an error message when this condition is detected
+            var groupsByActual = intermediate.GroupBy(g => g.actual.ToString(Formatting.None)).ToList();
+
+            if (groupsByActual.Count != 1)
+            {
+                var buffer = new StringBuilder();
+                buffer.AppendLine($"The following groups completion trigger positions asserted the same expected completion set '{setName}' but produced different actual completions:");
+
+                foreach (var group in groupsByActual)
+                {
+                    buffer.Append("- ");
+                    buffer.Append(group.Select(tuple => FormatPosition(tuple.position)).ConcatString(", "));
+                    buffer.AppendLine();
+                }
+
+                // we encountered multiple different completions sets
+                throw new AssertFailedException(buffer.ToString());
+            }
+
+            var single = groupsByActual.Single();
+
+            var expectedInfo = ResolveExpectedCompletions(dataSet, setName);
+            if (expectedInfo.HasValue == false)
+            {
+                throw new AssertFailedException($"The completion set with the name '{setName}' does not exist. The following completion trigger positions assert this set: {single.Select(item => FormatPosition(item.position)).ConcatString(", ")}");
+            }
+
+            var actual = JToken.Parse(single.Key);
+            var actualLocation = FileHelper.SaveResultFile(this.TestContext!, $"{dataSet.Name}_{setName}_Actual.json", actual.ToString(Formatting.Indented));
+
+            var expected = expectedInfo.Value.content;
+            var expectedLocation = expectedInfo.Value.scope switch
+            {
+                ExpectedCompletionsScope.DataSet => Path.Combine("src", "Bicep.Core.Samples", dataSet.Name, DataSet.TestCompletionsDirectory, GetFullSetName(setName)),
+                _ => GetGlobalCompletionSetPath(setName)
+            };
+
+            actual.Should().EqualWithJsonDiffOutput(expected, expectedLocation, actualLocation, "because ");
+        }
+
+        private static string GetGlobalCompletionSetPath(string setName) => Path.Combine("src", "Bicep.Core.Samples", DataSet.TestCompletionsDirectory, GetFullSetName(setName));
+
+        public static string GetDisplayName(MethodInfo info, object[] row)
+        {
+            row.Should().HaveCount(3);
+            row[0].Should().BeOfType<DataSet>();
+            row[1].Should().BeOfType<string>();
+            row[2].Should().BeAssignableTo<IList<Position>>();
+
+            return $"{info.Name}_{((DataSet) row[0]).Name}_{row[1]}";
+        }
+
+        private static string FormatPosition(Position position) => $"({position.Line}, {position.Character})";
+
+        private static async Task<JToken> GetActualCompletions(ILanguageClient client, DocumentUri uri, Position position)
+        {
+            var completions = await client.RequestCompletion(new CompletionParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = position
+            });
+
+            return JToken.FromObject(completions.OrderBy(c => c.Label), DataSetSerialization.CreateSerializer());
+        }
+
+        private static (JToken content, ExpectedCompletionsScope scope)? ResolveExpectedCompletions(DataSet dataSet, string setName)
+        {
+            var fullSetName = GetFullSetName(setName);
+            var str = dataSet.Completions.TryGetValue(fullSetName);
+            if (str != null)
+            {
+                return (JToken.Parse(str), ExpectedCompletionsScope.DataSet);
+            }
+
+            str = DataSets.Completions.TryGetValue(fullSetName);
+            if (str != null)
+            {
+                return (JToken.Parse(str), ExpectedCompletionsScope.Global);
+            }
+
+            return null;
+        }
+
+        private static string GetFullSetName(string setName) => setName + ".json";
+
+        private static IEnumerable<object[]> GetData() =>
+            DataSets.AllDataSets
+                .Select(ds => (dataset: ds, triggers: CompletionTestDirectiveParser.GetTriggers(ds.Bicep)))
+                .Where(tuple => tuple.triggers.Any())
+                .SelectMany(tuple => tuple.triggers.Select(trigger => (tuple.dataset, trigger.Position, trigger.SetName)))
+                .GroupBy(tuple => (tuple.dataset, tuple.SetName), tuple => tuple.Position)
+                .Select(group => new object[] {group.Key.dataset, group.Key.SetName, group.ToList()});
+
+        private enum ExpectedCompletionsScope
+        {
+            Global,
+            DataSet
+        }
+    }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTestDirectiveParser.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTestDirectiveParser.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+using Bicep.Core.Syntax;
+using Bicep.Core.Text;
+using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Bicep.LangServer.IntegrationTests.Completions
+{
+    public static class CompletionTestDirectiveParser
+    {
+        public static IList<CompletionTrigger> GetTriggers(string text)
+        {
+            var program = SyntaxFactory.CreateFromText(text);
+            var lineStarts = TextCoordinateConverter.GetLineStarts(text);
+            var triggers = new List<CompletionTrigger>();
+            
+            var visitor = new CompletionTriggerCollector(triggers, lineStarts);
+            visitor.Visit(program);
+
+            return triggers;
+        }
+
+        private sealed class CompletionTriggerCollector : SyntaxVisitor
+        {
+            private static readonly Regex TriggerPattern = new Regex(@"#\s*completionTest\s*\(\s*(?<char>\d+)\s*(,\s*(?<char>\d+)\s*)*\)\s*->\s*(?<set>\w+)", RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+            private readonly IList<CompletionTrigger> triggers;
+            private readonly ImmutableArray<int> lineStarts;
+
+            public CompletionTriggerCollector(IList<CompletionTrigger> triggers, ImmutableArray<int> lineStarts)
+            {
+                this.triggers = triggers;
+                this.lineStarts = lineStarts;
+            }
+
+            public override void VisitSyntaxTrivia(SyntaxTrivia syntaxTrivia)
+            {
+                if (syntaxTrivia.Type == SyntaxTriviaType.SingleLineComment || syntaxTrivia.Type == SyntaxTriviaType.MultiLineComment)
+                {
+                    var matches = TriggerPattern.Matches(syntaxTrivia.Text);
+                    foreach (Match? match in matches)
+                    {
+                        this.ProcessMatch(syntaxTrivia, match!);
+                    }
+                }
+
+                base.VisitSyntaxTrivia(syntaxTrivia);
+            }
+
+            private void ProcessMatch(SyntaxTrivia syntaxTrivia, Match match)
+            {
+                var setName = match.Groups["set"].Value;
+
+                foreach (Capture? capture in match.Groups["char"].Captures)
+                {
+                    ProcessIndexCapture(syntaxTrivia, capture!, setName);
+                }
+            }
+
+            private void ProcessIndexCapture(SyntaxTrivia syntaxTrivia, Capture capture, string setName)
+            {
+                var charStr = capture.Value;
+                if (int.TryParse(charStr, out int charIndex) == false)
+                {
+                    throw new FormatException($"Comment '{syntaxTrivia.Text}' contains a completion test directive with an invalid character index '{charStr}'. Please specify a valid 32-bit integer.");
+                }
+
+                // this is the position of the end of the comment
+                var commentEndPosition = PositionHelper.GetPosition(this.lineStarts, syntaxTrivia.Span.Position + syntaxTrivia.Span.Length);
+
+                // the trigger should apply to the char index at the next line
+                var triggerPosition = new Position(commentEndPosition.Line + 1, charIndex);
+
+                this.triggers.Add(new CompletionTrigger(triggerPosition, setName));
+            }
+        }
+    }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTestDirectiveParserTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTestDirectiveParserTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Bicep.LangServer.IntegrationTests.Completions
+{
+    [TestClass]
+    public class CompletionTestDirectiveParserTests
+    {
+        [TestMethod]
+        public void ParserShouldFindExpectedDirectives()
+        {
+            const string text = @"// an int variable
+var myInt = 42
+
+// a string variable #completionTest(0) -> example
+var myStr = 'str'
+var curliesWithNoInterp = '}{1}{'
+var interp1 = 'abc${123}def'
+var interp2 = '${123}def'
+var interp3 = 'abc${123}'
+// #completionTest(3) -> foo
+var interp4 = 'abc${123}${456}jk$l${789}p$'
+var doubleInterp = 'abc${'def${123}'}_${'${456}${789}'}'
+var curliesInInterp = '{${123}{0}${true}}'
+
+// verify correct bracket escaping
+var bracketInTheMiddle = 'a[b]'
+var bracketAtBeginning = '[test'
+var enclosingBrackets = '[test]'
+var emptyJsonArray = '[]'
+/*
+  #completionTest(3,4,5) -> test
+  #completionTest(41) -> other
+*/
+var interpolatedBrackets = '[${myInt}]'
+var nestedBrackets = '[test[]test2]'
+var nestedInterpolatedBrackets = '[${emptyJsonArray}]'
+var bracketStringInExpression = concat('[', '\'test\'',']')
+";
+
+            var triggers = CompletionTestDirectiveParser.GetTriggers(text);
+            triggers.Should().SatisfyRespectively(
+                t =>
+                {
+                    t.Position.Should().Be(new Position(4, 0));
+                    t.SetName.Should().Be("example");
+                },
+                t =>
+                {
+                    t.Position.Should().Be(new Position(10, 3));
+                    t.SetName.Should().Be("foo");
+                },
+                t =>
+                {
+                    t.Position.Should().Be(new Position(23, 3));
+                    t.SetName.Should().Be("test");
+                },
+                t =>
+                {
+                    t.Position.Should().Be(new Position(23, 4));
+                    t.SetName.Should().Be("test");
+                },
+                t =>
+                {
+                    t.Position.Should().Be(new Position(23, 5));
+                    t.SetName.Should().Be("test");
+                },
+                t =>
+                {
+                    t.Position.Should().Be(new Position(23, 41));
+                    t.SetName.Should().Be("other");
+                });
+        }
+
+        [TestMethod]
+        public void ParserShouldThrowOnInvalidCharIndex()
+        {
+            const string text = @"// an int variable
+var myInt = 42
+
+// a string variable #completionTest(0) -> example
+var myStr = 'str'
+var curliesWithNoInterp = '}{1}{'
+var interp1 = 'abc${123}def'
+var interp2 = '${123}def'
+var interp3 = 'abc${123}'
+// #completionTest(3) -> foo
+var interp4 = 'abc${123}${456}jk$l${789}p$'
+var doubleInterp = 'abc${'def${123}'}_${'${456}${789}'}'
+var curliesInInterp = '{${123}{0}${true}}'
+
+// verify correct bracket escaping
+var bracketInTheMiddle = 'a[b]'
+var bracketAtBeginning = '[test'
+var enclosingBrackets = '[test]'
+var emptyJsonArray = '[]'
+/*
+  #completionTest(3,4,53333333333333333333333333333333333333333333333333333333333) -> test
+  #completionTest(41) -> other
+*/
+var interpolatedBrackets = '[${myInt}]'
+var nestedBrackets = '[test[]test2]'
+var nestedInterpolatedBrackets = '[${emptyJsonArray}]'
+var bracketStringInExpression = concat('[', '\'test\'',']')
+";
+            Action badIndex = () => CompletionTestDirectiveParser.GetTriggers(text);
+            badIndex.Should().Throw<FormatException>().WithMessage(@"Comment '/*
+  #completionTest(3,4,53333333333333333333333333333333333333333333333333333333333) -> test
+  #completionTest(41) -> other
+*/' contains a completion test directive with an invalid character index '53333333333333333333333333333333333333333333333333333333333'. Please specify a valid 32-bit integer.");
+        }
+    }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTrigger.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTrigger.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Bicep.LangServer.IntegrationTests.Completions
+{
+    [DebuggerDisplay("Position = {Position}, SetName = {SetName}")]
+    public sealed class CompletionTrigger
+    {
+        public CompletionTrigger(Position position, string setName)
+        {
+            this.Position = position;
+            this.SetName = setName;
+        }
+
+        public Position Position { get; }
+
+        public string SetName { get; }
+    }
+}


### PR DESCRIPTION
Added a capability to the language server integration tests to assert on completions returned by the language server for a specific location in a specific file. The assert declares the position where completions will be requested and the expected set of expected completions that it will be compared against. If a mismatch is detected, the test will fail.

The following directive will request completions at the beginning of the line following the comment and will compare the results against the `declarations` set of expected completions.
```bicep
// #completionTest(0) -> declarations
```

The following directive will request completions at characters 1 and 2 (0-based) in the line following the comment and compare against the `declarations` set. Additionally, completions will also be requested at character 33 (0-based) in the line following the comment and compared against the `otherThings` set of expected completions.
```bicep
// #completionTest(1, 2) -> declarations #completionTest(33) -> otherThings
```

The sets of expected completions can be shared globally and associated with a specific sample (like `Variables_LF` or `InvalidParameters_CRLF`). When authoring new tests, the the best option is to simply create a new JSON file with the set and set it to `[]`. When the test fails, the test failure message will contain a set of copy commands for Unix and Windows that will allow you to easily fix it.