### PR TITLE
added declaration type completions

### DIFF
--- a/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
+++ b/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
@@ -28,11 +28,15 @@
 
   <ItemGroup>
     <None Remove="Completions\declarations.json" />
+    <None Remove="Completions\outputTypes.json" />
+    <None Remove="Completions\paramTypes.json" />
     <None Remove="Variables_LF\completions.declarations.json" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Completions\declarations.json" />
+    <EmbeddedResource Include="Completions\outputTypes.json" />
+    <EmbeddedResource Include="Completions\paramTypes.json" />
     <EmbeddedResource Include="Variables_LF\Completions\symbolsPlusTypes.json" />
   </ItemGroup>
 

--- a/src/Bicep.Core.Samples/Completions/outputTypes.json
+++ b/src/Bicep.Core.Samples/Completions/outputTypes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "label": "array",
+    "kind": "class",
+    "detail": "array",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "array",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "bool",
+    "kind": "class",
+    "detail": "bool",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "bool",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "int",
+    "kind": "class",
+    "detail": "int",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "int",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "object",
+    "kind": "class",
+    "detail": "object",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "object",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "string",
+    "kind": "class",
+    "detail": "string",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "string",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/Completions/paramTypes.json
+++ b/src/Bicep.Core.Samples/Completions/paramTypes.json
@@ -1,0 +1,96 @@
+[
+  {
+    "label": "array",
+    "kind": "class",
+    "detail": "array",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "array",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "bool",
+    "kind": "class",
+    "detail": "bool",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "bool",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "int",
+    "kind": "class",
+    "detail": "int",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "int",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "object",
+    "kind": "class",
+    "detail": "object",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "object",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  },
+  {
+    "label": "secureObject",
+    "kind": "snippet",
+    "detail": "Secure object",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nobject {\n  secure: true\n}\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "object {\n  secure: true\n}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "secureString",
+    "kind": "snippet",
+    "detail": "Secure string",
+    "documentation": {
+      "hasString": false,
+      "markupContent": {
+        "kind": "markdown",
+        "value": "```bicep\nstring {\n  secure: true\n}\n```"
+      },
+      "hasMarkupContent": true
+    },
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "string {\n  secure: true\n}",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "string",
+    "kind": "class",
+    "detail": "string",
+    "deprecated": false,
+    "preselect": false,
+    "insertText": "string",
+    "insertTextFormat": "plainText",
+    "commitCharacters": [
+      " "
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.bicep
@@ -5,8 +5,13 @@ bad
 // incomplete
 output 
 
-// missing type
 output foo
+
+// space after identifier #completionTest(20) -> outputTypes
+output spaceAfterId 
+
+// partial type #completionTest(19, 20, 21, 22) -> outputTypes
+output partialType obj
 
 // malformed identifier
 output 2

--- a/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.diagnostics.bicep
@@ -7,10 +7,18 @@ bad
 output 
 //@[7:7) [BCP016 (Error)] Expected an output identifier at this location. ||
 
-// missing type
 output foo
 //@[7:10) [BCP028 (Error)] Identifier 'foo' is declared multiple times. Remove or rename the duplicates. |foo|
 //@[10:10) [BCP014 (Error)] Expected a parameter type at this location. Please specify one of the following types: array, bool, int, object, string. ||
+
+// space after identifier #completionTest(20) -> outputTypes
+output spaceAfterId 
+//@[20:20) [BCP014 (Error)] Expected a parameter type at this location. Please specify one of the following types: array, bool, int, object, string. ||
+
+// partial type #completionTest(19, 20, 21, 22) -> outputTypes
+output partialType obj
+//@[19:22) [BCP030 (Error)] The output type is not valid. Please specify one of the following types: array, bool, int, object, string. |obj|
+//@[22:22) [BCP018 (Error)] Expected the '=' character at this location. ||
 
 // malformed identifier
 output 2

--- a/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.symbols.bicep
@@ -6,9 +6,16 @@ bad
 output 
 //@[7:7) Output <missing>. Type: any. Declaration start char: 0, length: 7
 
-// missing type
 output foo
 //@[7:10) Output foo. Type: any. Declaration start char: 0, length: 10
+
+// space after identifier #completionTest(20) -> outputTypes
+output spaceAfterId 
+//@[7:19) Output spaceAfterId. Type: any. Declaration start char: 0, length: 20
+
+// partial type #completionTest(19, 20, 21, 22) -> outputTypes
+output partialType obj
+//@[7:18) Output partialType. Type: error. Declaration start char: 0, length: 22
 
 // malformed identifier
 output 2

--- a/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.syntax.bicep
@@ -19,8 +19,6 @@ output
 //@[7:7)  SkippedTriviaSyntax
 //@[7:11) NewLine |\r\n\r\n|
 
-// missing type
-//@[15:17) NewLine |\r\n|
 output foo
 //@[0:10) OutputDeclarationSyntax
 //@[0:6)  Identifier |output|
@@ -30,6 +28,31 @@ output foo
 //@[10:10)  SkippedTriviaSyntax
 //@[10:10)  SkippedTriviaSyntax
 //@[10:14) NewLine |\r\n\r\n|
+
+// space after identifier #completionTest(20) -> outputTypes
+//@[60:62) NewLine |\r\n|
+output spaceAfterId 
+//@[0:20) OutputDeclarationSyntax
+//@[0:6)  Identifier |output|
+//@[7:19)  IdentifierSyntax
+//@[7:19)   Identifier |spaceAfterId|
+//@[20:20)  SkippedTriviaSyntax
+//@[20:20)  SkippedTriviaSyntax
+//@[20:20)  SkippedTriviaSyntax
+//@[20:24) NewLine |\r\n\r\n|
+
+// partial type #completionTest(19, 20, 21, 22) -> outputTypes
+//@[62:64) NewLine |\r\n|
+output partialType obj
+//@[0:22) OutputDeclarationSyntax
+//@[0:6)  Identifier |output|
+//@[7:18)  IdentifierSyntax
+//@[7:18)   Identifier |partialType|
+//@[19:22)  TypeSyntax
+//@[19:22)   Identifier |obj|
+//@[22:22)  SkippedTriviaSyntax
+//@[22:22)  SkippedTriviaSyntax
+//@[22:26) NewLine |\r\n\r\n|
 
 // malformed identifier
 //@[23:25) NewLine |\r\n|

--- a/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/InvalidOutputs_CRLF/main.tokens.bicep
@@ -12,12 +12,25 @@ output
 //@[0:6) Identifier |output|
 //@[7:11) NewLine |\r\n\r\n|
 
-// missing type
-//@[15:17) NewLine |\r\n|
 output foo
 //@[0:6) Identifier |output|
 //@[7:10) Identifier |foo|
 //@[10:14) NewLine |\r\n\r\n|
+
+// space after identifier #completionTest(20) -> outputTypes
+//@[60:62) NewLine |\r\n|
+output spaceAfterId 
+//@[0:6) Identifier |output|
+//@[7:19) Identifier |spaceAfterId|
+//@[20:24) NewLine |\r\n\r\n|
+
+// partial type #completionTest(19, 20, 21, 22) -> outputTypes
+//@[62:64) NewLine |\r\n|
+output partialType obj
+//@[0:6) Identifier |output|
+//@[7:18) Identifier |partialType|
+//@[19:22) Identifier |obj|
+//@[22:26) NewLine |\r\n\r\n|
 
 // malformed identifier
 //@[23:25) NewLine |\r\n|

--- a/src/Bicep.Core.Samples/InvalidParameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/InvalidParameters_LF/main.bicep
@@ -16,6 +16,15 @@ param myBool bool
 
 param missingType
 
+// space after identifier #completionTest(32) -> paramTypes
+param missingTypeWithSpaceAfter 
+
+// tab after identifier #completionTest(30) -> paramTypes
+param missingTypeWithTabAfter	
+
+// partial type #completionTest(18, 19, 20, 21) -> paramTypes
+param partialType str
+
 param malformedType 44
 
 // malformed type but type check should still happen

--- a/src/Bicep.Core.Samples/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/InvalidParameters_LF/main.diagnostics.bicep
@@ -24,6 +24,18 @@ param myBool bool
 param missingType
 //@[17:17) [BCP014 (Error)] Expected a parameter type at this location. Please specify one of the following types: array, bool, int, object, string. ||
 
+// space after identifier #completionTest(32) -> paramTypes
+param missingTypeWithSpaceAfter 
+//@[32:32) [BCP014 (Error)] Expected a parameter type at this location. Please specify one of the following types: array, bool, int, object, string. ||
+
+// tab after identifier #completionTest(30) -> paramTypes
+param missingTypeWithTabAfter	
+//@[30:30) [BCP014 (Error)] Expected a parameter type at this location. Please specify one of the following types: array, bool, int, object, string. ||
+
+// partial type #completionTest(18, 19, 20, 21) -> paramTypes
+param partialType str
+//@[18:21) [BCP031 (Error)] The parameter type is not valid. Please specify one of the following types: array, bool, int, object, string. |str|
+
 param malformedType 44
 //@[20:22) [BCP014 (Error)] Expected a parameter type at this location. Please specify one of the following types: array, bool, int, object, string. |44|
 

--- a/src/Bicep.Core.Samples/InvalidParameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/InvalidParameters_LF/main.symbols.bicep
@@ -24,6 +24,18 @@ param myBool bool
 param missingType
 //@[6:17) Parameter missingType. Type: any. Declaration start char: 0, length: 17
 
+// space after identifier #completionTest(32) -> paramTypes
+param missingTypeWithSpaceAfter 
+//@[6:31) Parameter missingTypeWithSpaceAfter. Type: any. Declaration start char: 0, length: 32
+
+// tab after identifier #completionTest(30) -> paramTypes
+param missingTypeWithTabAfter	
+//@[6:29) Parameter missingTypeWithTabAfter. Type: any. Declaration start char: 0, length: 30
+
+// partial type #completionTest(18, 19, 20, 21) -> paramTypes
+param partialType str
+//@[6:17) Parameter partialType. Type: error. Declaration start char: 0, length: 21
+
 param malformedType 44
 //@[6:19) Parameter malformedType. Type: any. Declaration start char: 0, length: 22
 

--- a/src/Bicep.Core.Samples/InvalidParameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/InvalidParameters_LF/main.syntax.bicep
@@ -80,6 +80,37 @@ param missingType
 //@[17:17)  SkippedTriviaSyntax
 //@[17:19) NewLine |\n\n|
 
+// space after identifier #completionTest(32) -> paramTypes
+//@[59:60) NewLine |\n|
+param missingTypeWithSpaceAfter 
+//@[0:32) ParameterDeclarationSyntax
+//@[0:5)  Identifier |param|
+//@[6:31)  IdentifierSyntax
+//@[6:31)   Identifier |missingTypeWithSpaceAfter|
+//@[32:32)  SkippedTriviaSyntax
+//@[32:34) NewLine |\n\n|
+
+// tab after identifier #completionTest(30) -> paramTypes
+//@[57:58) NewLine |\n|
+param missingTypeWithTabAfter	
+//@[0:30) ParameterDeclarationSyntax
+//@[0:5)  Identifier |param|
+//@[6:29)  IdentifierSyntax
+//@[6:29)   Identifier |missingTypeWithTabAfter|
+//@[30:30)  SkippedTriviaSyntax
+//@[30:32) NewLine |\n\n|
+
+// partial type #completionTest(18, 19, 20, 21) -> paramTypes
+//@[61:62) NewLine |\n|
+param partialType str
+//@[0:21) ParameterDeclarationSyntax
+//@[0:5)  Identifier |param|
+//@[6:17)  IdentifierSyntax
+//@[6:17)   Identifier |partialType|
+//@[18:21)  TypeSyntax
+//@[18:21)   Identifier |str|
+//@[21:23) NewLine |\n\n|
+
 param malformedType 44
 //@[0:22) ParameterDeclarationSyntax
 //@[0:5)  Identifier |param|

--- a/src/Bicep.Core.Samples/InvalidParameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/InvalidParameters_LF/main.tokens.bicep
@@ -50,6 +50,28 @@ param missingType
 //@[6:17) Identifier |missingType|
 //@[17:19) NewLine |\n\n|
 
+// space after identifier #completionTest(32) -> paramTypes
+//@[59:60) NewLine |\n|
+param missingTypeWithSpaceAfter 
+//@[0:5) Identifier |param|
+//@[6:31) Identifier |missingTypeWithSpaceAfter|
+//@[32:34) NewLine |\n\n|
+
+// tab after identifier #completionTest(30) -> paramTypes
+//@[57:58) NewLine |\n|
+param missingTypeWithTabAfter	
+//@[0:5) Identifier |param|
+//@[6:29) Identifier |missingTypeWithTabAfter|
+//@[30:32) NewLine |\n\n|
+
+// partial type #completionTest(18, 19, 20, 21) -> paramTypes
+//@[61:62) NewLine |\n|
+param partialType str
+//@[0:5) Identifier |param|
+//@[6:17) Identifier |partialType|
+//@[18:21) Identifier |str|
+//@[21:23) NewLine |\n\n|
+
 param malformedType 44
 //@[0:5) Identifier |param|
 //@[6:19) Identifier |malformedType|

--- a/src/Bicep.Core.Samples/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Variables_LF/Completions/symbolsPlusTypes.json
@@ -81,18 +81,6 @@
     "insertTextFormat": "plainText"
   },
   {
-    "label": "array",
-    "kind": "class",
-    "detail": "array",
-    "deprecated": false,
-    "preselect": false,
-    "insertText": "array",
-    "insertTextFormat": "plainText",
-    "commitCharacters": [
-      " "
-    ]
-  },
-  {
     "label": "base64",
     "kind": "function",
     "detail": "base64",
@@ -127,18 +115,6 @@
     "preselect": false,
     "insertText": "bool",
     "insertTextFormat": "plainText"
-  },
-  {
-    "label": "bool",
-    "kind": "class",
-    "detail": "bool",
-    "deprecated": false,
-    "preselect": false,
-    "insertText": "bool",
-    "insertTextFormat": "plainText",
-    "commitCharacters": [
-      " "
-    ]
   },
   {
     "label": "bracketAtBeginning",
@@ -445,18 +421,6 @@
     "preselect": false,
     "insertText": "int",
     "insertTextFormat": "plainText"
-  },
-  {
-    "label": "int",
-    "kind": "class",
-    "detail": "int",
-    "deprecated": false,
-    "preselect": false,
-    "insertText": "int",
-    "insertTextFormat": "plainText",
-    "commitCharacters": [
-      " "
-    ]
   },
   {
     "label": "interp1",
@@ -792,18 +756,6 @@
     "insertTextFormat": "plainText"
   },
   {
-    "label": "object",
-    "kind": "class",
-    "detail": "object",
-    "deprecated": false,
-    "preselect": false,
-    "insertText": "object",
-    "insertTextFormat": "plainText",
-    "commitCharacters": [
-      " "
-    ]
-  },
-  {
     "label": "objWithInterp",
     "kind": "variable",
     "detail": "objWithInterp",
@@ -946,18 +898,6 @@
     "preselect": false,
     "insertText": "string",
     "insertTextFormat": "plainText"
-  },
-  {
-    "label": "string",
-    "kind": "class",
-    "detail": "string",
-    "deprecated": false,
-    "preselect": false,
-    "insertText": "string",
-    "insertTextFormat": "plainText",
-    "commitCharacters": [
-      " "
-    ]
   },
   {
     "label": "sub",

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -13,8 +13,18 @@ namespace Bicep.LanguageServer.Completions
         None = 0,
 
         /// <summary>
-        /// The current location represents 
+        /// The current location represents the beginning of a declaration.
         /// </summary>
-        Declaration = 1
+        DeclarationStart = 1 << 0,
+
+        /// <summary>
+        /// The current location needs a parameter type.
+        /// </summary>
+        ParameterType = 1 << 1,
+
+        /// <summary>
+        /// The current location needs an output type.
+        /// </summary>
+        OutputType = 1 << 2
     }
 }


### PR DESCRIPTION
Completion for `string`, `int`, `bool`, `array` and `object` types now appear only when editing a parameter or output type. In the parameter case, I also added contextual snippets for secure strings and secure objects. Fixes #463.

## All parameter completions
![image](https://user-images.githubusercontent.com/22460039/94984352-f47df880-04ff-11eb-84ed-09f83cff12bd.png)

## All Output completions
![image](https://user-images.githubusercontent.com/22460039/94984359-06f83200-0500-11eb-8ae7-270c0d551b03.png)

## Completions while typing a partial type
![image](https://user-images.githubusercontent.com/22460039/94984365-1a0b0200-0500-11eb-9568-6e2736c79b0a.png)
