### PR TITLE
upgraded to omnisharp server and client 18

### DIFF
--- a/src/Bicep.Core.Samples/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Completions/declarations.json
@@ -16,12 +16,8 @@
     "kind": "snippet",
     "detail": "Output declaration",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\noutput Identifier Type = \n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\noutput Identifier Type = \n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -45,12 +41,8 @@
     "kind": "snippet",
     "detail": "Parameter declaration",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nparam Identifier Type\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nparam Identifier Type\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -62,12 +54,8 @@
     "kind": "snippet",
     "detail": "Parameter declaration with default value",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nparam Identifier Type = DefaultValue\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nparam Identifier Type = DefaultValue\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -79,12 +67,8 @@
     "kind": "snippet",
     "detail": "Parameter declaration with default and allowed values",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nparam Identifier Type {\n  default: \n  allowed: [\n    \n  ]\n}\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nparam Identifier Type {\n  default: \n  allowed: [\n    \n  ]\n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -96,12 +80,8 @@
     "kind": "snippet",
     "detail": "Parameter declaration with options",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nparam Identifier Type {\n  \n}\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nparam Identifier Type {\n  \n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -113,12 +93,8 @@
     "kind": "snippet",
     "detail": "Secure string parameter",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nparam Identifier string {\n  secure: true\n}\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nparam Identifier string {\n  secure: true\n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -142,12 +118,8 @@
     "kind": "snippet",
     "detail": "Resource with defaults",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\n  name: \n  location: \n  properties: {\n    \n  }\n}\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\n  name: \n  location: \n  properties: {\n    \n  }\n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -159,12 +131,8 @@
     "kind": "snippet",
     "detail": "Child Resource with defaults",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -176,12 +144,8 @@
     "kind": "snippet",
     "detail": "Resource without defaults",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\n  name: \n  \n}\n\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\n  name: \n  \n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -193,12 +157,8 @@
     "kind": "snippet",
     "detail": "Child Resource without defaults",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\n  name: \n  \n}\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\n  name: \n  \n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -222,12 +182,8 @@
     "kind": "snippet",
     "detail": "Variable declaration",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nvar Identifier = \n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nvar Identifier = \n```"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Completions/paramTypes.json
+++ b/src/Bicep.Core.Samples/Completions/paramTypes.json
@@ -52,12 +52,8 @@
     "kind": "snippet",
     "detail": "Secure object",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nobject {\n  secure: true\n}\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nobject {\n  secure: true\n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -69,12 +65,8 @@
     "kind": "snippet",
     "detail": "Secure string",
     "documentation": {
-      "hasString": false,
-      "markupContent": {
-        "kind": "markdown",
-        "value": "```bicep\nstring {\n  secure: true\n}\n```"
-      },
-      "hasMarkupContent": true
+      "kind": "markdown",
+      "value": "```bicep\nstring {\n  secure: true\n}\n```"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
+++ b/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" Version="4.14.6" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.17.4" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.18.0" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -24,6 +25,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 namespace Bicep.LangServer.IntegrationTests
 {
     [TestClass]
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class CompletionTests
     {
         public TestContext? TestContext { get; set; }
@@ -34,7 +36,7 @@ namespace Bicep.LangServer.IntegrationTests
             const string expectedSetName = "declarations";
             var uri = DocumentUri.From($"/{this.TestContext!.TestName}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(string.Empty, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(string.Empty, uri);
 
             var actual = await GetActualCompletions(client, uri, new Position(0, 0));
             var actualLocation = FileHelper.SaveResultFile(this.TestContext!, $"{this.TestContext.TestName}_{expectedSetName}", actual.ToString(Formatting.Indented));
@@ -56,7 +58,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
 
             var intermediate = new List<(Position position, JToken actual)>();
 

--- a/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Bicep.Core.Parser;
@@ -23,6 +24,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 namespace Bicep.LangServer.IntegrationTests
 {
     [TestClass]
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class DefinitionTests
     {
         [DataTestMethod]
@@ -31,7 +33,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);
@@ -71,7 +73,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);
@@ -101,7 +103,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);

--- a/src/Bicep.LangServer.IntegrationTests/DocumentSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DocumentSymbolTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,6 +14,7 @@ using Bicep.LangServer.IntegrationTests.Helpers;
 namespace Bicep.LangServer.IntegrationTests
 {
     [TestClass]
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class DocumentSymbolTests
     {
         [TestMethod]
@@ -20,7 +23,7 @@ namespace Bicep.LangServer.IntegrationTests
             var documentUri = DocumentUri.From("/template.bicep");
             var diagsReceived = new TaskCompletionSource<PublishDiagnosticsParams>();
 
-            var client = await IntegrationTestHelper.StartServerWithClientConnection(options => 
+            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(options => 
             {
                 options.OnPublishDiagnostics(diags => {
                     diagsReceived.SetResult(diags);

--- a/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Bicep.Core.Navigation;
@@ -24,6 +25,7 @@ using SymbolKind = Bicep.Core.SemanticModel.SymbolKind;
 namespace Bicep.LangServer.IntegrationTests
 {
     [TestClass]
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class HighlightTests
     {
         [DataTestMethod]
@@ -32,7 +34,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);
@@ -66,7 +68,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);
 

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parser;
@@ -24,6 +25,7 @@ using SymbolKind = Bicep.Core.SemanticModel.SymbolKind;
 namespace Bicep.LangServer.IntegrationTests
 {
     [TestClass]
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class HoverTests
     {
         [DataTestMethod]
@@ -31,7 +33,7 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task HoveringOverSymbolReferencesAndDeclarationsShouldProduceHovers(DataSet dataSet)
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
-            var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
 
             // construct a parallel compilation
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
@@ -94,7 +96,7 @@ namespace Bicep.LangServer.IntegrationTests
             bool IsNonHoverable(SyntaxBase node) => !(node is ISymbolReference) && !(node is IDeclarationSyntax) && !(node is Token);
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
-            var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
 
             // construct a parallel compilation
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));

--- a/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Bicep.Core.Navigation;
@@ -23,6 +24,7 @@ using SymbolKind = Bicep.Core.SemanticModel.SymbolKind;
 namespace Bicep.LangServer.IntegrationTests
 {
     [TestClass]
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class ReferencesTests
     {
         [DataTestMethod]
@@ -31,7 +33,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);
@@ -70,7 +72,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);
@@ -113,7 +115,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);
 

--- a/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Bicep.Core.Navigation;
@@ -25,6 +26,7 @@ using SymbolKind = Bicep.Core.SemanticModel.SymbolKind;
 namespace Bicep.LangServer.IntegrationTests
 {
     [TestClass]
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class RenameSymbolTests
     {
         [DataTestMethod]
@@ -33,7 +35,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);
@@ -79,7 +81,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);
@@ -111,7 +113,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithText(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxFactory.CreateFromText(dataSet.Bicep));
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = TextCoordinateConverter.GetLineStarts(dataSet.Bicep);

--- a/src/Bicep.LangServer.IntegrationTests/TextDocumentSyncTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TextDocumentSyncTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,12 +17,13 @@ namespace Bicep.LangServer.IntegrationTests
     public class TextDocumentSyncTests
     {
         [TestMethod]
+        [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
         public async Task DidOpenTextDocument_should_trigger_PublishDiagnostics()
         {
             var documentUri = DocumentUri.From("/template.bicep");
             var diagsReceived = new TaskCompletionSource<PublishDiagnosticsParams>();
 
-            var client = await IntegrationTestHelper.StartServerWithClientConnection(options => 
+            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(options => 
             {
                 options.OnPublishDiagnostics(diags => {
                     diagsReceived.SetResult(diags);
@@ -36,7 +39,7 @@ resource myRes 'invalidFormat' = {
 randomToken
 ", 1));
 
-            var response = await IntegrationTestHelper.WithTimeout(diagsReceived.Task);
+            var response = await IntegrationTestHelper.WithTimeoutAsync(diagsReceived.Task);
             response.Diagnostics.Should().SatisfyRespectively(
                 d => {
                     d.Range.Should().HaveRange((1, 23), (1, 24));
@@ -62,7 +65,7 @@ resource myRes 'invalidFormat' = {
 randomToken
 ", 2));
 
-            response = await IntegrationTestHelper.WithTimeout(diagsReceived.Task);
+            response = await IntegrationTestHelper.WithTimeoutAsync(diagsReceived.Task);
             response.Diagnostics.Should().SatisfyRespectively(
                 d => {
                     d.Range.Should().HaveRange((2, 15), (2, 30));
@@ -78,7 +81,7 @@ randomToken
             diagsReceived = new TaskCompletionSource<PublishDiagnosticsParams>();
             client.TextDocument.DidCloseTextDocument(TextDocumentParamHelper.CreateDidCloseTextDocumentParams(documentUri, 3));
 
-            response = await IntegrationTestHelper.WithTimeout(diagsReceived.Task);
+            response = await IntegrationTestHelper.WithTimeoutAsync(diagsReceived.Task);
             response.Diagnostics.Should().BeEmpty();
         }
     }

--- a/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
+++ b/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Moq" Version="4.14.6" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.17.4" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.18.0" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -33,7 +33,7 @@ namespace Bicep.LangServer.UnitTests
 
             var manager = new BicepCompilationManager(server.Object, new BicepCompilationProvider(TestResourceTypeProvider.Create()));
 
-            const long version = 42;
+            const int version = 42;
             var uri = DocumentUri.File(this.TestContext!.TestName);
 
             // first get should not return anything
@@ -76,7 +76,7 @@ namespace Bicep.LangServer.UnitTests
 
             var manager = new BicepCompilationManager(server.Object, new BicepCompilationProvider(TestResourceTypeProvider.Create()));
 
-            const long version = 42;
+            const int version = 42;
             var uri = DocumentUri.File(this.TestContext!.TestName);
 
             // first get should not return anything
@@ -143,7 +143,7 @@ namespace Bicep.LangServer.UnitTests
 
             var manager = new BicepCompilationManager(server.Object, new BicepCompilationProvider(TestResourceTypeProvider.Create()));
 
-            const long version = 42;
+            const int version = 42;
             var uri = DocumentUri.File(this.TestContext!.TestName);
 
             // first get should not return anything
@@ -173,7 +173,7 @@ namespace Bicep.LangServer.UnitTests
             firstActual.Should().BeSameAs(firstUpserted);
 
             // upsert second one
-            const long newVersion = version + 1;
+            const int newVersion = version + 1;
             var secondUpserted = manager.UpsertCompilation(uri, newVersion, "hello\r\nthere\r\n");
 
             secondUpserted.Should().NotBeNull();
@@ -200,7 +200,7 @@ namespace Bicep.LangServer.UnitTests
         [TestMethod]
         public void GetNonExistentCompilation_ShouldNotThrow()
         {
-            var server = Repository.Create<ILanguageServer>();
+            var server = Repository.Create<ILanguageServerFacade>();
 
             var manager = new BicepCompilationManager(server.Object, new BicepCompilationProvider(TestResourceTypeProvider.Create()));
 
@@ -252,7 +252,7 @@ namespace Bicep.LangServer.UnitTests
 
             var manager = new BicepCompilationManager(server.Object, provider.Object);
 
-            const long version = 74;
+            const int version = 74;
             var uri = DocumentUri.File(this.TestContext!.TestName);
 
             // upsert should fail because of the mock fatal exception
@@ -307,7 +307,7 @@ namespace Bicep.LangServer.UnitTests
 
             var manager = new BicepCompilationManager(server.Object, provider.Object);
 
-            const long version = 74;
+            const int version = 74;
             var uri = DocumentUri.File(this.TestContext!.TestName);
 
             // upsert should fail because of the mock fatal exception
@@ -362,9 +362,9 @@ namespace Bicep.LangServer.UnitTests
             return document;
         }
 
-        private static Mock<ILanguageServer> CreateMockServer(Mock<ITextDocumentLanguageServer> document)
+        private static Mock<ILanguageServerFacade> CreateMockServer(Mock<ITextDocumentLanguageServer> document)
         {
-            var server = Repository.Create<ILanguageServer>();
+            var server = Repository.Create<ILanguageServerFacade>();
             server
                 .Setup(m => m.TextDocument)
                 .Returns(document.Object);

--- a/src/Bicep.LangServer/Bicep.LangServer.csproj
+++ b/src/Bicep.LangServer/Bicep.LangServer.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.4" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.18.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -17,19 +17,19 @@ namespace Bicep.LanguageServer
 {
     public class BicepCompilationManager : ICompilationManager
     {
-        private readonly ILanguageServer server;
+        private readonly ILanguageServerFacade server;
         private readonly ICompilationProvider provider;
 
         // represents compilations of open bicep files
         private readonly ConcurrentDictionary<DocumentUri, CompilationContext> activeContexts = new ConcurrentDictionary<DocumentUri, CompilationContext>();
 
-        public BicepCompilationManager(ILanguageServer server, ICompilationProvider provider)
+        public BicepCompilationManager(ILanguageServerFacade server, ICompilationProvider provider)
         {
             this.server = server;
             this.provider = provider;
         }
 
-        public CompilationContext? UpsertCompilation(DocumentUri uri, long version, string text)
+        public CompilationContext? UpsertCompilation(DocumentUri uri, int? version, string text)
         {
             try
             {
@@ -94,7 +94,7 @@ namespace Bicep.LanguageServer
         // TODO: Remove the lexer part when we stop it from emitting errors
         private IEnumerable<Core.Diagnostics.Diagnostic> GetDiagnosticsFromContext(CompilationContext context) => context.Compilation.GetSemanticModel().GetAllDiagnostics();
 
-        private void PublishDocumentDiagnostics(DocumentUri uri, long version, IEnumerable<OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic> diagnostics)
+        private void PublishDocumentDiagnostics(DocumentUri uri, int? version, IEnumerable<OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic> diagnostics)
         {
             server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
             {

--- a/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
+++ b/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
@@ -6,7 +6,7 @@ namespace Bicep.LanguageServer.CompilationManager
 {
     public interface ICompilationManager
     {
-        CompilationContext? UpsertCompilation(DocumentUri uri, long version, string text);
+        CompilationContext? UpsertCompilation(DocumentUri uri, int? version, string text);
 
         void CloseCompilation(DocumentUri uri);
 

--- a/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
@@ -43,11 +43,6 @@ namespace Bicep.LanguageServer.Handlers
             return Task.FromResult(request);
         }
 
-        public override bool CanResolve(CompletionItem value)
-        {
-            return false;
-        }
-
         private static CompletionRegistrationOptions CreateRegistrationOptions() => new CompletionRegistrationOptions
         {
             DocumentSelector = DocumentSelectorFactory.Create(),

--- a/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
@@ -13,7 +13,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    class BicepTextDocumentSyncHandler : TextDocumentSyncHandler
+    public class BicepTextDocumentSyncHandler : TextDocumentSyncHandler
     {
         private readonly ICompilationManager compilationManager;
 

--- a/src/Bicep.LangServer/Program.cs
+++ b/src/Bicep.LangServer/Program.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 
 namespace Bicep.LanguageServer
@@ -11,16 +10,16 @@ namespace Bicep.LanguageServer
     public class Program
     {
         public static async Task Main(string[] args)
-            => await RunWithCancellation(async cancellationToken =>
+            => await RunWithCancellationAsync(async cancellationToken =>
             {
                 // the server uses JSON-RPC over stdin & stdout to communicate,
                 // so be careful not to use console for logging!
                 var server = new Server(Console.OpenStandardInput(), Console.OpenStandardOutput(), () => new AzResourceTypeProvider());
 
-                await server.Run(cancellationToken);
+                await server.RunAsync(cancellationToken);
             });
 
-        private static async Task RunWithCancellation(Func<CancellationToken, Task> runFunc)
+        private static async Task RunWithCancellationAsync(Func<CancellationToken, Task> runFunc)
         {
             var cancellationTokenSource = new CancellationTokenSource();
 

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -53,7 +53,7 @@ namespace Bicep.LanguageServer
             });
         }
 
-        public async Task Run(CancellationToken cancellationToken)
+        public async Task RunAsync(CancellationToken cancellationToken)
         {
             await server.Initialize(cancellationToken);
 


### PR DESCRIPTION
Upgraded to omnisharp server and client 18. (Dependabot couldn't do it automatically due to breaking changes.) Theoretically this fixes the PrepareRename handler, so we can leverage it and make it easier to run the language server as-is in the playground.