### PR TITLE
Add Policy with Initiative Definition and Assignment Example

### DIFF
--- a/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.bicep
+++ b/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.bicep
@@ -51,15 +51,16 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-03
         Environment: environmentName
         CostCenter: costCenterName
     }
-    properties: {
+    properties: any({
         retentionInDays: 30
         features: {
             searchVersion: 1
         }
         sku: {
+            
             name: 'PerGB2018'
         }
-    }
+    })
 }
 
 resource logAnalyticsWorkspaceDiagnostics 'Microsoft.OperationalInsights/workspaces/providers/diagnosticSettings@2017-05-01-preview' = {

--- a/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.bicep
+++ b/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.bicep
@@ -90,7 +90,7 @@ resource logAnalyticsWorkspaceDiagnostics 'Microsoft.OperationalInsights/workspa
 }
 
 resource solutionsVMInsights 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
-    name: '${vmInsights.name}'
+    name: vmInsights.name
     location: location
     dependsOn: [
         logAnalyticsWorkspace
@@ -99,7 +99,7 @@ resource solutionsVMInsights 'Microsoft.OperationsManagement/solutions@2015-11-0
         workspaceResourceId: logAnalyticsWorkspace.id 
     }
     plan: {
-        name: '${vmInsights}.Name'
+        name: vmInsights.name
         publisher: 'Microsoft'
         product: 'OMSGallery/${vmInsights.galleryName}'
         promotionCode: ''
@@ -107,7 +107,7 @@ resource solutionsVMInsights 'Microsoft.OperationsManagement/solutions@2015-11-0
 }
 
 resource solutionsContainerInsights 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
-    name: '${containerInsights.name}'
+    name: containerInsights.name
     location: location
     dependsOn: [
         logAnalyticsWorkspace
@@ -116,7 +116,7 @@ resource solutionsContainerInsights 'Microsoft.OperationsManagement/solutions@20
         workspaceResourceId: logAnalyticsWorkspace.id 
     }
     plan: {
-        name: '${containerInsights}.Name'
+        name: containerInsights.name
         publisher: 'Microsoft'
         product: 'OMSGallery/${containerInsights.galleryName}'
         promotionCode: ''

--- a/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.json
+++ b/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.json
@@ -106,13 +106,13 @@
     {
       "type": "Microsoft.OperationsManagement/solutions",
       "apiVersion": "2015-11-01-preview",
-      "name": "[format('{0}', variables('vmInsights').name)]",
+      "name": "[variables('vmInsights').name]",
       "location": "[parameters('location')]",
       "properties": {
         "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
       },
       "plan": {
-        "name": "[format('{0}.Name', variables('vmInsights'))]",
+        "name": "[variables('vmInsights').name]",
         "publisher": "Microsoft",
         "product": "[format('OMSGallery/{0}', variables('vmInsights').galleryName)]",
         "promotionCode": ""
@@ -124,13 +124,13 @@
     {
       "type": "Microsoft.OperationsManagement/solutions",
       "apiVersion": "2015-11-01-preview",
-      "name": "[format('{0}', variables('containerInsights').name)]",
+      "name": "[variables('containerInsights').name]",
       "location": "[parameters('location')]",
       "properties": {
         "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
       },
       "plan": {
-        "name": "[format('{0}.Name', variables('containerInsights'))]",
+        "name": "[variables('containerInsights').name]",
         "publisher": "Microsoft",
         "product": "[format('OMSGallery/{0}', variables('containerInsights').galleryName)]",
         "promotionCode": ""

--- a/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.json
+++ b/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "allowedValues": [
+        "australiacentral",
+        "australiaeast",
+        "australiasoutheast",
+        "brazilsouth",
+        "canadacentral",
+        "centralindia",
+        "centralus",
+        "eastasia",
+        "eastus",
+        "eastus2",
+        "francecentral",
+        "japaneast",
+        "koreacentral",
+        "northcentralus",
+        "northeurope",
+        "southafricanorth",
+        "southcentralus",
+        "southeastasia",
+        "switzerlandnorth",
+        "switzerlandwest",
+        "uksouth",
+        "ukwest",
+        "westcentralus",
+        "westeurope",
+        "westus",
+        "westus2"
+      ]
+    },
+    "logAnalyticsWorkspaceName": {
+      "type": "string",
+      "defaultValue": "[format('la-{0}', uniqueString(resourceGroup().id))]"
+    }
+  },
+  "functions": [],
+  "variables": {
+    "vmInsights": {
+      "name": "[format('VMInsights({0})', parameters('logAnalyticsWorkspaceName'))]",
+      "galleryName": "VMInsights"
+    },
+    "containerInsights": {
+      "name": "[format('ContainerInsights({0})', parameters('logAnalyticsWorkspaceName'))]",
+      "galleryName": "ContainerInsights"
+    },
+    "environmentName": "Production",
+    "costCenterName": "IT"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2020-03-01-preview",
+      "name": "[parameters('logAnalyticsWorkspaceName')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "Environment": "[variables('environmentName')]",
+        "CostCenter": "[variables('costCenterName')]"
+      },
+      "properties": {
+        "retentionInDays": 30,
+        "features": {
+          "searchVersion": 1
+        },
+        "sku": {
+          "name": "PerGB2018"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.OperationalInsights/workspaces/providers/diagnosticSettings",
+      "apiVersion": "2017-05-01-preview",
+      "name": "[format('{0}/Microsoft.Insights/diagnosticSettings', parameters('logAnalyticsWorkspaceName'))]",
+      "properties": {
+        "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]",
+        "logs": [
+          {
+            "category": "Audit",
+            "enabled": true,
+            "retentionPolicy": {
+              "days": 7,
+              "enabled": true
+            }
+          }
+        ],
+        "metrics": [
+          {
+            "category": "AllMetrics",
+            "enabled": true,
+            "retentionPolicy": {
+              "days": 7,
+              "enabled": true
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.OperationsManagement/solutions",
+      "apiVersion": "2015-11-01-preview",
+      "name": "[format('{0}', variables('vmInsights').name)]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
+      },
+      "plan": {
+        "name": "[format('{0}.Name', variables('vmInsights'))]",
+        "publisher": "Microsoft",
+        "product": "[format('OMSGallery/{0}', variables('vmInsights').galleryName)]",
+        "promotionCode": ""
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.OperationsManagement/solutions",
+      "apiVersion": "2015-11-01-preview",
+      "name": "[format('{0}', variables('containerInsights').name)]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
+      },
+      "plan": {
+        "name": "[format('{0}.Name', variables('containerInsights'))]",
+        "publisher": "Microsoft",
+        "product": "[format('OMSGallery/{0}', variables('containerInsights').galleryName)]",
+        "promotionCode": ""
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/docs/examples/201/policy-with-initiative-definition-and-assignment/main.bicep
+++ b/docs/examples/201/policy-with-initiative-definition-and-assignment/main.bicep
@@ -30,20 +30,20 @@ resource initiativeDefinition 'Microsoft.Authorization/policySetDefinitions@2019
         }
         parameters: {
             listOfAllowedLocations: {
-                type: 'array'
-                metadata: {
+                type: 'Array'
+                metadata: ({
                     description: 'The List of Allowed Locations for Resource Groups and Resources.'
                     strongtype: 'location'
                     displayName: 'Allowed Locations'
-                }
+                })
             }
             listOfAllowedSKUs: {
-                type: 'array'
-                metadata: {
+                type: 'Array'
+                metadata: any({
                     description: 'The List of Allowed SKUs for Virtual Machines.'
                     strongtype: 'vmSKUs'
                     displayName: 'Allowed Virtual Machine Size SKUs'
-                }
+                })
             }
         }
         policyDefinitions: [

--- a/docs/examples/201/policy-with-initiative-definition-and-assignment/main.bicep
+++ b/docs/examples/201/policy-with-initiative-definition-and-assignment/main.bicep
@@ -1,0 +1,97 @@
+param listOfAllowedLocations array = [
+    'eastus'
+    'eastus2'
+    'westus'
+    'westus2'
+]
+
+param listOfAllowedSKUs array = [
+    'Standard_B1ls'
+    'Standard_B1ms'
+    'Standard_B1s'
+    'Standard_B2ms'
+    'Standard_B2s'
+    'Standard_B4ms'
+    'Standard_B4s'
+    'Standard_D2s_v3'
+    'Standard_D4s_v3'
+]
+
+var initiativeDefinitionName = 'BICEP Example Initiative'
+
+resource initiativeDefinition 'Microsoft.Authorization/policySetDefinitions@2019-09-01' = {
+    name: initiativeDefinitionName
+    properties: {
+        policyType: 'Custom'
+        displayName: initiativeDefinitionName
+        description: 'Initiative Definition for Resource Locatoin and VM SKUs'
+        metadata: {
+            category: 'BICEP Example Initiative'
+        }
+        parameters: {
+            listOfAllowedLocations: {
+                type: 'array'
+                metadata: {
+                    description: 'The List of Allowed Locations for Resource Groups and Resources.'
+                    strongtype: 'location'
+                    displayName: 'Allowed Locations'
+                }
+            }
+            listOfAllowedSKUs: {
+                type: 'array'
+                metadata: {
+                    description: 'The List of Allowed SKUs for Virtual Machines.'
+                    strongtype: 'vmSKUs'
+                    displayName: 'Allowed Virtual Machine Size SKUs'
+                }
+            }
+        }
+        policyDefinitions: [
+            {
+                policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988'
+                parameters: {
+                    listOfAllowedLocations: {
+                        value: '[parameters(\'listOfAllowedLocations\')]'
+                    }
+                }
+            }
+            {
+                policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c'
+                parameters: {
+                    listOfAllowedLocations: {
+                        value: '[parameters(\'listOfAllowedLocations\')]'
+                    }
+                }
+            }
+            {
+                policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/cccc23c7-8427-4f53-ad12-b6a63eb452b3'
+                parameters: {
+                    listOfAllowedSKUs: {
+                        value: '[parameters(\'listOfAllowedSKUs\')]'
+                    }
+                }
+            }
+            {
+                policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/0015ea4d-51ff-4ce3-8d8c-f3f8f0179a56'
+                parameters: {}
+            }
+        ]
+    }
+}
+
+resource initiativeDefinitionPolicyAssignment 'Microsoft.Authorization/policyAssignments@2019-09-01' = {
+    name: initiativeDefinitionName
+    properties: {
+        scope: subscription().id
+        enforcementMode: 'Default'
+        policyDefinitionId: initiativeDefinition.id
+        parameters: {
+            listOfAllowedLocations: {
+                value: listOfAllowedLocations
+            }
+            listOfAllowedSKUs: {
+                value: listOfAllowedSKUs
+            }
+        }
+    }
+}

--- a/docs/examples/201/policy-with-initiative-definition-and-assignment/main.json
+++ b/docs/examples/201/policy-with-initiative-definition-and-assignment/main.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "listOfAllowedLocations": {
+      "type": "array",
+      "defaultValue": [
+        "eastus",
+        "eastus2",
+        "westus",
+        "westus2"
+      ]
+    },
+    "listOfAllowedSKUs": {
+      "type": "array",
+      "defaultValue": [
+        "Standard_B1ls",
+        "Standard_B1ms",
+        "Standard_B1s",
+        "Standard_B2ms",
+        "Standard_B2s",
+        "Standard_B4ms",
+        "Standard_B4s",
+        "Standard_D2s_v3",
+        "Standard_D4s_v3"
+      ]
+    }
+  },
+  "functions": [],
+  "variables": {
+    "initiativeDefinitionName": "BICEP Example Initiative"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Authorization/policySetDefinitions",
+      "apiVersion": "2019-09-01",
+      "name": "[variables('initiativeDefinitionName')]",
+      "properties": {
+        "policyType": "Custom",
+        "displayName": "[variables('initiativeDefinitionName')]",
+        "description": "Initiative Definition for Resource Locatoin and VM SKUs",
+        "metadata": {
+          "category": "BICEP Example Initiative"
+        },
+        "parameters": {
+          "listOfAllowedLocations": {
+            "type": "array",
+            "metadata": {
+              "description": "The List of Allowed Locations for Resource Groups and Resources.",
+              "strongtype": "location",
+              "displayName": "Allowed Locations"
+            }
+          },
+          "listOfAllowedSKUs": {
+            "type": "array",
+            "metadata": {
+              "description": "The List of Allowed SKUs for Virtual Machines.",
+              "strongtype": "vmSKUs",
+              "displayName": "Allowed Virtual Machine Size SKUs"
+            }
+          }
+        },
+        "policyDefinitions": [
+          {
+            "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988",
+            "parameters": {
+              "listOfAllowedLocations": {
+                "value": "[[parameters('listOfAllowedLocations')]"
+              }
+            }
+          },
+          {
+            "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c",
+            "parameters": {
+              "listOfAllowedLocations": {
+                "value": "[[parameters('listOfAllowedLocations')]"
+              }
+            }
+          },
+          {
+            "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/cccc23c7-8427-4f53-ad12-b6a63eb452b3",
+            "parameters": {
+              "listOfAllowedSKUs": {
+                "value": "[[parameters('listOfAllowedSKUs')]"
+              }
+            }
+          },
+          {
+            "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0015ea4d-51ff-4ce3-8d8c-f3f8f0179a56",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/policyAssignments",
+      "apiVersion": "2019-09-01",
+      "name": "[variables('initiativeDefinitionName')]",
+      "properties": {
+        "scope": "[subscription().id]",
+        "enforcementMode": "Default",
+        "policyDefinitionId": "[resourceId('Microsoft.Authorization/policySetDefinitions', variables('initiativeDefinitionName'))]",
+        "parameters": {
+          "listOfAllowedLocations": {
+            "value": "[parameters('listOfAllowedLocations')]"
+          },
+          "listOfAllowedSKUs": {
+            "value": "[parameters('listOfAllowedSKUs')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Authorization/policySetDefinitions', variables('initiativeDefinitionName'))]"
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/docs/examples/201/policy-with-initiative-definition-and-assignment/main.json
+++ b/docs/examples/201/policy-with-initiative-definition-and-assignment/main.json
@@ -44,15 +44,11 @@
         },
         "parameters": {
           "listOfAllowedLocations": {
-            "type": "array",
-            "metadata": {
-              "description": "The List of Allowed Locations for Resource Groups and Resources.",
-              "strongtype": "location",
-              "displayName": "Allowed Locations"
-            }
+            "type": "Array",
+            "metadata": "[json('{\"description\":\"The List of Allowed Locations for Resource Groups and Resources.\",\"strongtype\":\"location\",\"displayName\":\"Allowed Locations\"}')]"
           },
           "listOfAllowedSKUs": {
-            "type": "array",
+            "type": "Array",
             "metadata": {
               "description": "The List of Allowed SKUs for Virtual Machines.",
               "strongtype": "vmSKUs",

--- a/src/Bicep.Core.Samples/ExamplesTests.cs
+++ b/src/Bicep.Core.Samples/ExamplesTests.cs
@@ -84,6 +84,7 @@ namespace Bicep.Core.Samples
                 "Resource type \"Microsoft.KeyVault/vaults/secrets@2018-02-14\" does not have types available",
                 "Resource type \"microsoft.web/serverFarms@2018-11-01\" does not have types available",
                 "Resource type \"Microsoft.KeyVault/vaults/secrets@2018-02-14\" does not have types available",
+                "Resource type \"Microsoft.OperationalInsights/workspaces/providers/diagnosticSettings@2017-05-01-preview\" does not have types available",
             };
 
             return permittedMissingTypeDiagnostics.Contains(diagnostic.Message);


### PR DESCRIPTION
Created a sample BICEP file that deploys the following:

Custom Initiative Definition with 4 Built-In Policy Definitions
Assigns the Initiative Definition at the Subscription Scope `scope: subscription().id`