### PR TITLE
Prevent namespace assignment to variable

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
@@ -208,13 +208,13 @@ var propertyAccessOnVariable = x.foo
 
 // function used like a variable
 var funcvarvar = concat + base64 || !uniqueString
-//@[17:23) [BCP063 (Error)] The name "concat" is not a parameter or variable. |concat|
-//@[26:32) [BCP063 (Error)] The name "base64" is not a parameter or variable. |base64|
-//@[37:49) [BCP063 (Error)] The name "uniqueString" is not a parameter or variable. |uniqueString|
+//@[17:23) [BCP063 (Error)] The name "concat" is not a parameter, variable, resource or module. |concat|
+//@[26:32) [BCP063 (Error)] The name "base64" is not a parameter, variable, resource or module. |base64|
+//@[37:49) [BCP063 (Error)] The name "uniqueString" is not a parameter, variable, resource or module. |uniqueString|
 param funcvarparam bool = concat
-//@[26:32) [BCP063 (Error)] The name "concat" is not a parameter or variable. |concat|
+//@[26:32) [BCP063 (Error)] The name "concat" is not a parameter, variable, resource or module. |concat|
 output funcvarout array = padLeft
-//@[26:33) [BCP063 (Error)] The name "padLeft" is not a parameter or variable. |padLeft|
+//@[26:33) [BCP063 (Error)] The name "padLeft" is not a parameter, variable, resource or module. |padLeft|
 
 // non-existent function
 var fakeFunc = red() + green() * orange()
@@ -307,11 +307,11 @@ var invalidInstanceFunctionAccess = a.b.c.bar()
 var invalidInstanceFunctionCall = az.az()
 //@[37:39) [BCP086 (Error)] The function "az" does not exist in namespace "az". |az|
 var invalidPropertyAccessOnAzNamespace = az.az
-//@[41:43) [BCP063 (Error)] The name "az" is not a parameter or variable. |az|
+//@[41:43) [BCP063 (Error)] The name "az" is not a parameter, variable, resource or module. |az|
 var invalidPropertyAccessOnSysNamespace = sys.az
-//@[42:45) [BCP063 (Error)] The name "sys" is not a parameter or variable. |sys|
+//@[42:45) [BCP063 (Error)] The name "sys" is not a parameter, variable, resource or module. |sys|
 var invalidOperands = 1 + az
-//@[26:28) [BCP063 (Error)] The name "az" is not a parameter or variable. |az|
+//@[26:28) [BCP063 (Error)] The name "az" is not a parameter, variable, resource or module. |az|
 
 var bannedFunctions = {
   var: variables()

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
@@ -307,11 +307,11 @@ var invalidInstanceFunctionAccess = a.b.c.bar()
 var invalidInstanceFunctionCall = az.az()
 //@[37:39) [BCP086 (Error)] The function "az" does not exist in namespace "az". |az|
 var invalidPropertyAccessOnAzNamespace = az.az
-//@[44:46) [BCP055 (Error)] Cannot access properties of type "namespace". An "object" type is required. |az|
+//@[41:43) [BCP063 (Error)] The name "az" is not a parameter or variable. |az|
 var invalidPropertyAccessOnSysNamespace = sys.az
-//@[46:48) [BCP055 (Error)] Cannot access properties of type "namespace". An "object" type is required. |az|
+//@[42:45) [BCP063 (Error)] The name "sys" is not a parameter or variable. |sys|
 var invalidOperands = 1 + az
-//@[22:28) [BCP045 (Error)] Cannot apply operator "+" to operands of type "int" and "namespace". |1 + az|
+//@[26:28) [BCP063 (Error)] The name "az" is not a parameter or variable. |az|
 
 var bannedFunctions = {
   var: variables()

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
@@ -83,3 +83,6 @@ var rgName = resourceGroup().name
 
 // invalid use of reserved namespace
 var az = 1
+
+// cannot assign a variable to a namespace
+var invalidNamespaceAssignment = az

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -135,3 +135,7 @@ var rgName = resourceGroup().name
 // invalid use of reserved namespace
 var az = 1
 //@[4:6) [BCP084 (Error)] The symbolic name "az" is reserved. Please use a different symbolic name. Reserved namespaces are "az", "sys". |az|
+
+// cannot assign a variable to a namespace
+var invalidNamespaceAssignment = az
+//@[33:35) [BCP063 (Error)] The name "az" is not a parameter or variable. |az|

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -138,4 +138,4 @@ var az = 1
 
 // cannot assign a variable to a namespace
 var invalidNamespaceAssignment = az
-//@[33:35) [BCP063 (Error)] The name "az" is not a parameter or variable. |az|
+//@[33:35) [BCP063 (Error)] The name "az" is not a parameter, variable, resource or module. |az|

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
@@ -110,3 +110,7 @@ var rgName = resourceGroup().name
 // invalid use of reserved namespace
 var az = 1
 //@[4:6) Variable az. Type: int. Declaration start char: 0, length: 10
+
+// cannot assign a variable to a namespace
+var invalidNamespaceAssignment = az
+//@[4:30) Variable invalidNamespaceAssignment. Type: error. Declaration start char: 0, length: 35

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
@@ -487,4 +487,17 @@ var az = 1
 //@[7:8)  Assignment |=|
 //@[9:10)  NumericLiteralSyntax
 //@[9:10)   Number |1|
-//@[10:10) EndOfFile ||
+//@[10:12) NewLine |\n\n|
+
+// cannot assign a variable to a namespace
+//@[42:43) NewLine |\n|
+var invalidNamespaceAssignment = az
+//@[0:35) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:30)  IdentifierSyntax
+//@[4:30)   Identifier |invalidNamespaceAssignment|
+//@[31:32)  Assignment |=|
+//@[33:35)  VariableAccessSyntax
+//@[33:35)   IdentifierSyntax
+//@[33:35)    Identifier |az|
+//@[35:35) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
@@ -323,4 +323,13 @@ var az = 1
 //@[4:6) Identifier |az|
 //@[7:8) Assignment |=|
 //@[9:10) Number |1|
-//@[10:10) EndOfFile ||
+//@[10:12) NewLine |\n\n|
+
+// cannot assign a variable to a namespace
+//@[42:43) NewLine |\n|
+var invalidNamespaceAssignment = az
+//@[0:3) Identifier |var|
+//@[4:30) Identifier |invalidNamespaceAssignment|
+//@[31:32) Assignment |=|
+//@[33:35) Identifier |az|
+//@[35:35) EndOfFile ||

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -349,7 +349,7 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic SymbolicNameIsNotAVariableOrParameter(string name) => new ErrorDiagnostic(
                 TextSpan,
                 "BCP063",
-                $"The name \"{name}\" is not a parameter or variable.");
+                $"The name \"{name}\" is not a parameter, variable, resource or module.");
 
             public ErrorDiagnostic UnexpectedTokensInInterpolation() => new ErrorDiagnostic(
                 TextSpan,

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -694,8 +694,6 @@ namespace Bicep.Core.TypeSystem
         public override void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
             => AssignType(syntax, () => {
 
-                base.VisitInstanceFunctionCallSyntax(syntax);
-
                 var errors = new List<ErrorDiagnostic>();
                 
                 var baseType = typeManager.GetTypeInfo(syntax.BaseExpression);
@@ -766,7 +764,7 @@ namespace Bicep.Core.TypeSystem
                     case VariableSymbol variable:
                         return new DeferredTypeReference(() => VisitDeclaredSymbol(syntax, variable));
                     
-                    case NamespaceSymbol _:
+                    case NamespaceSymbol _ when hierarchy.GetParent(syntax) is InstanceFunctionCallSyntax:
                         return new UnassignableTypeSymbol("namespace", TypeKind.Never);
 
                     case OutputSymbol _:


### PR DESCRIPTION
This PR intents to prevent assigning a namespace to a variable.

For example, it blocks:

var foo = az