### PR TITLE
Exclude utcNow() and newGuid() functions from completions outside parameter context

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/symbolsPlusParamDefaultFunctions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/symbolsPlusParamDefaultFunctions.json
@@ -1,22 +1,12 @@
 [
   {
-    "label": "'AzureCLI'",
-    "kind": "enumMember",
-    "detail": "'AzureCLI'",
+    "label": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
+    "kind": "field",
+    "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzureCLI'",
-    "insertText": "'AzureCLI'",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "'AzurePowerShell'",
-    "kind": "enumMember",
-    "detail": "'AzurePowerShell'",
-    "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzurePowerShell'",
-    "insertText": "'AzurePowerShell'",
+    "preselect": false,
+    "sortText": "2_WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
+    "insertText": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "insertTextFormat": "plainText"
   },
   {
@@ -50,73 +40,23 @@
     "insertTextFormat": "plainText"
   },
   {
-    "label": "badDepends",
-    "kind": "interface",
-    "detail": "badDepends",
+    "label": "badInterpolatedString",
+    "kind": "field",
+    "detail": "badInterpolatedString",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_badDepends",
-    "insertText": "badDepends",
+    "sortText": "2_badInterpolatedString",
+    "insertText": "badInterpolatedString",
     "insertTextFormat": "plainText"
   },
   {
-    "label": "badDepends2",
-    "kind": "interface",
-    "detail": "badDepends2",
+    "label": "badInterpolatedString2",
+    "kind": "field",
+    "detail": "badInterpolatedString2",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_badDepends2",
-    "insertText": "badDepends2",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "badDepends3",
-    "kind": "interface",
-    "detail": "badDepends3",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badDepends3",
-    "insertText": "badDepends3",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "badDepends4",
-    "kind": "interface",
-    "detail": "badDepends4",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badDepends4",
-    "insertText": "badDepends4",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "badDepends5",
-    "kind": "interface",
-    "detail": "badDepends5",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badDepends5",
-    "insertText": "badDepends5",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "badInterp",
-    "kind": "interface",
-    "detail": "badInterp",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badInterp",
-    "insertText": "badInterp",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "bar",
-    "kind": "interface",
-    "detail": "bar",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_bar",
-    "insertText": "bar",
+    "sortText": "2_badInterpolatedString2",
+    "insertText": "badInterpolatedString2",
     "insertTextFormat": "plainText"
   },
   {
@@ -148,16 +88,6 @@
     "sortText": "3_base64ToString",
     "insertText": "base64ToString($0)",
     "insertTextFormat": "snippet"
-  },
-  {
-    "label": "baz",
-    "kind": "interface",
-    "detail": "baz",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_baz",
-    "insertText": "baz",
-    "insertTextFormat": "plainText"
   },
   {
     "label": "bool",
@@ -230,6 +160,16 @@
     "insertTextFormat": "snippet"
   },
   {
+    "label": "defaultValueCompletions",
+    "kind": "field",
+    "detail": "defaultValueCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_defaultValueCompletions",
+    "insertText": "defaultValueCompletions",
+    "insertTextFormat": "plainText"
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "detail": "deployment()",
@@ -240,33 +180,13 @@
     "insertTextFormat": "snippet"
   },
   {
-    "label": "discriminatorKeyMissing",
-    "kind": "interface",
-    "detail": "discriminatorKeyMissing",
+    "label": "duplicatedModifierProperty",
+    "kind": "field",
+    "detail": "duplicatedModifierProperty",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_discriminatorKeyMissing",
-    "insertText": "discriminatorKeyMissing",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "discriminatorKeySetOne",
-    "kind": "interface",
-    "detail": "discriminatorKeySetOne",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetOne",
-    "insertText": "discriminatorKeySetOne",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "discriminatorKeySetTwo",
-    "kind": "interface",
-    "detail": "discriminatorKeySetTwo",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwo",
-    "insertText": "discriminatorKeySetTwo",
+    "sortText": "2_duplicatedModifierProperty",
+    "insertText": "duplicatedModifierProperty",
     "insertTextFormat": "plainText"
   },
   {
@@ -278,6 +198,26 @@
     "sortText": "3_empty",
     "insertText": "empty($0)",
     "insertTextFormat": "snippet"
+  },
+  {
+    "label": "emptyAllowedInt",
+    "kind": "field",
+    "detail": "emptyAllowedInt",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyAllowedInt",
+    "insertText": "emptyAllowedInt",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "emptyAllowedString",
+    "kind": "field",
+    "detail": "emptyAllowedString",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyAllowedString",
+    "insertText": "emptyAllowedString",
+    "insertTextFormat": "plainText"
   },
   {
     "label": "endsWith",
@@ -320,26 +260,6 @@
     "insertTextFormat": "snippet"
   },
   {
-    "label": "fo",
-    "kind": "interface",
-    "detail": "fo",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_fo",
-    "insertText": "fo",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "foo",
-    "kind": "interface",
-    "detail": "foo",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_foo",
-    "insertText": "foo",
-    "insertTextFormat": "plainText"
-  },
-  {
     "label": "format",
     "kind": "function",
     "detail": "format()",
@@ -358,26 +278,6 @@
     "sortText": "3_guid",
     "insertText": "guid($0)",
     "insertTextFormat": "snippet"
-  },
-  {
-    "label": "incorrectPropertiesKey",
-    "kind": "interface",
-    "detail": "incorrectPropertiesKey",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_incorrectPropertiesKey",
-    "insertText": "incorrectPropertiesKey",
-    "insertTextFormat": "plainText"
-  },
-  {
-    "label": "incorrectPropertiesKey2",
-    "kind": "interface",
-    "detail": "incorrectPropertiesKey2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_incorrectPropertiesKey2",
-    "insertText": "incorrectPropertiesKey2",
-    "insertTextFormat": "plainText"
   },
   {
     "label": "indexOf",
@@ -400,13 +300,13 @@
     "insertTextFormat": "snippet"
   },
   {
-    "label": "interpVal",
-    "kind": "variable",
-    "detail": "interpVal",
+    "label": "intModifierCompletions",
+    "kind": "field",
+    "detail": "intModifierCompletions",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_interpVal",
-    "insertText": "interpVal",
+    "sortText": "2_intModifierCompletions",
+    "insertText": "intModifierCompletions",
     "insertTextFormat": "plainText"
   },
   {
@@ -460,6 +360,36 @@
     "insertTextFormat": "snippet"
   },
   {
+    "label": "malformedModifier",
+    "kind": "field",
+    "detail": "malformedModifier",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_malformedModifier",
+    "insertText": "malformedModifier",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "malformedType",
+    "kind": "field",
+    "detail": "malformedType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_malformedType",
+    "insertText": "malformedType",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "malformedType2",
+    "kind": "field",
+    "detail": "malformedType2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_malformedType2",
+    "insertText": "malformedType2",
+    "insertTextFormat": "plainText"
+  },
+  {
     "label": "max",
     "kind": "function",
     "detail": "max()",
@@ -480,23 +410,123 @@
     "insertTextFormat": "snippet"
   },
   {
-    "label": "missingTopLevelProperties",
-    "kind": "interface",
-    "detail": "missingTopLevelProperties",
+    "label": "missingType",
+    "kind": "field",
+    "detail": "missingType",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_missingTopLevelProperties",
-    "insertText": "missingTopLevelProperties",
+    "sortText": "2_missingType",
+    "insertText": "missingType",
     "insertTextFormat": "plainText"
   },
   {
-    "label": "missingTopLevelPropertiesExceptName",
-    "kind": "interface",
-    "detail": "missingTopLevelPropertiesExceptName",
+    "label": "missingTypeWithSpaceAfter",
+    "kind": "field",
+    "detail": "missingTypeWithSpaceAfter",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_missingTopLevelPropertiesExceptName",
-    "insertText": "missingTopLevelPropertiesExceptName",
+    "sortText": "2_missingTypeWithSpaceAfter",
+    "insertText": "missingTypeWithSpaceAfter",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "missingTypeWithTabAfter",
+    "kind": "field",
+    "detail": "missingTypeWithTabAfter",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTypeWithTabAfter",
+    "insertText": "missingTypeWithTabAfter",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myBool",
+    "kind": "field",
+    "detail": "myBool",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_myBool",
+    "insertText": "myBool",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myFalsehood",
+    "kind": "field",
+    "detail": "myFalsehood",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_myFalsehood",
+    "insertText": "myFalsehood",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myInt",
+    "kind": "field",
+    "detail": "myInt",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_myInt",
+    "insertText": "myInt",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myInt2",
+    "kind": "field",
+    "detail": "myInt2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_myInt2",
+    "insertText": "myInt2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myString",
+    "kind": "field",
+    "detail": "myString",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_myString",
+    "insertText": "myString",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myString2",
+    "kind": "field",
+    "detail": "myString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_myString2",
+    "insertText": "myString2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "myTruth",
+    "kind": "field",
+    "detail": "myTruth",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_myTruth",
+    "insertText": "myTruth",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "newGuid",
+    "kind": "function",
+    "detail": "newGuid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_newGuid",
+    "insertText": "newGuid()$0",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "noValueAfterColon",
+    "kind": "field",
+    "detail": "noValueAfterColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_noValueAfterColon",
+    "insertText": "noValueAfterColon",
     "insertTextFormat": "plainText"
   },
   {
@@ -508,6 +538,166 @@
     "sortText": "3_padLeft",
     "insertText": "padLeft($0)",
     "insertTextFormat": "snippet"
+  },
+  {
+    "label": "paramAccessingOutput",
+    "kind": "field",
+    "detail": "paramAccessingOutput",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramAccessingOutput",
+    "insertText": "paramAccessingOutput",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramAccessingOutput2",
+    "kind": "field",
+    "detail": "paramAccessingOutput2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramAccessingOutput2",
+    "insertText": "paramAccessingOutput2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramAccessingResource",
+    "kind": "field",
+    "detail": "paramAccessingResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramAccessingResource",
+    "insertText": "paramAccessingResource",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramAccessingResource2",
+    "kind": "field",
+    "detail": "paramAccessingResource2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramAccessingResource2",
+    "insertText": "paramAccessingResource2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramAccessingVar",
+    "kind": "field",
+    "detail": "paramAccessingVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramAccessingVar",
+    "insertText": "paramAccessingVar",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramAccessingVar2",
+    "kind": "field",
+    "detail": "paramAccessingVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramAccessingVar2",
+    "insertText": "paramAccessingVar2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramDefaultOneCycle",
+    "kind": "field",
+    "detail": "paramDefaultOneCycle",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramDefaultOneCycle",
+    "insertText": "paramDefaultOneCycle",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramDefaultTwoCycle1",
+    "kind": "field",
+    "detail": "paramDefaultTwoCycle1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramDefaultTwoCycle1",
+    "insertText": "paramDefaultTwoCycle1",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramDefaultTwoCycle2",
+    "kind": "field",
+    "detail": "paramDefaultTwoCycle2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramDefaultTwoCycle2",
+    "insertText": "paramDefaultTwoCycle2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramMixedTwoCycle1",
+    "kind": "field",
+    "detail": "paramMixedTwoCycle1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramMixedTwoCycle1",
+    "insertText": "paramMixedTwoCycle1",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramMixedTwoCycle2",
+    "kind": "field",
+    "detail": "paramMixedTwoCycle2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramMixedTwoCycle2",
+    "insertText": "paramMixedTwoCycle2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramModifierOneCycle",
+    "kind": "field",
+    "detail": "paramModifierOneCycle",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramModifierOneCycle",
+    "insertText": "paramModifierOneCycle",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramModifierSelfCycle",
+    "kind": "field",
+    "detail": "paramModifierSelfCycle",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramModifierSelfCycle",
+    "insertText": "paramModifierSelfCycle",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramModifierTwoCycle1",
+    "kind": "field",
+    "detail": "paramModifierTwoCycle1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramModifierTwoCycle1",
+    "insertText": "paramModifierTwoCycle1",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "paramModifierTwoCycle2",
+    "kind": "field",
+    "detail": "paramModifierTwoCycle2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_paramModifierTwoCycle2",
+    "insertText": "paramModifierTwoCycle2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "partialType",
+    "kind": "field",
+    "detail": "partialType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_partialType",
+    "insertText": "partialType",
+    "insertTextFormat": "plainText"
   },
   {
     "label": "pickZones",
@@ -580,23 +770,33 @@
     "insertTextFormat": "snippet"
   },
   {
-    "label": "resrefpar",
-    "kind": "field",
-    "detail": "resrefpar",
+    "label": "sampleResource",
+    "kind": "interface",
+    "detail": "sampleResource",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_resrefpar",
-    "insertText": "resrefpar",
+    "sortText": "2_sampleResource",
+    "insertText": "sampleResource",
     "insertTextFormat": "plainText"
   },
   {
-    "label": "resrefvar",
+    "label": "sampleVar",
     "kind": "variable",
-    "detail": "resrefvar",
+    "detail": "sampleVar",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_resrefvar",
-    "insertText": "resrefvar",
+    "sortText": "2_sampleVar",
+    "insertText": "sampleVar",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "secureInt",
+    "kind": "field",
+    "detail": "secureInt",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_secureInt",
+    "insertText": "secureInt",
     "insertTextFormat": "plainText"
   },
   {
@@ -608,6 +808,16 @@
     "sortText": "3_skip",
     "insertText": "skip($0)",
     "insertTextFormat": "snippet"
+  },
+  {
+    "label": "someArray",
+    "kind": "field",
+    "detail": "someArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someArray",
+    "insertText": "someArray",
+    "insertTextFormat": "plainText"
   },
   {
     "label": "split",
@@ -638,6 +848,46 @@
     "sortText": "3_string",
     "insertText": "string($0)",
     "insertTextFormat": "snippet"
+  },
+  {
+    "label": "stringLiteral",
+    "kind": "field",
+    "detail": "stringLiteral",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_stringLiteral",
+    "insertText": "stringLiteral",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "stringLiteral2",
+    "kind": "field",
+    "detail": "stringLiteral2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_stringLiteral2",
+    "insertText": "stringLiteral2",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "stringLiteral3",
+    "kind": "field",
+    "detail": "stringLiteral3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_stringLiteral3",
+    "insertText": "stringLiteral3",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "stringModifierCompletions",
+    "kind": "field",
+    "detail": "stringModifierCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_stringModifierCompletions",
+    "insertText": "stringModifierCompletions",
+    "insertTextFormat": "plainText"
   },
   {
     "label": "subscription",
@@ -730,16 +980,6 @@
     "insertTextFormat": "snippet"
   },
   {
-    "label": "unfinishedVnet",
-    "kind": "interface",
-    "detail": "unfinishedVnet",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_unfinishedVnet",
-    "insertText": "unfinishedVnet",
-    "insertTextFormat": "plainText"
-  },
-  {
     "label": "union",
     "kind": "function",
     "detail": "union()",
@@ -788,5 +1028,65 @@
     "sortText": "3_uriComponentToString",
     "insertText": "uriComponentToString($0)",
     "insertTextFormat": "snippet"
+  },
+  {
+    "label": "utcNow",
+    "kind": "function",
+    "detail": "utcNow()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_utcNow",
+    "insertText": "utcNow($0)",
+    "insertTextFormat": "snippet"
+  },
+  {
+    "label": "wrongAssignmentToken",
+    "kind": "field",
+    "detail": "wrongAssignmentToken",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongAssignmentToken",
+    "insertText": "wrongAssignmentToken",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "wrongDefaultValue",
+    "kind": "field",
+    "detail": "wrongDefaultValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongDefaultValue",
+    "insertText": "wrongDefaultValue",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "wrongIntModifier",
+    "kind": "field",
+    "detail": "wrongIntModifier",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongIntModifier",
+    "insertText": "wrongIntModifier",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "wrongMetadataSchema",
+    "kind": "field",
+    "detail": "wrongMetadataSchema",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongMetadataSchema",
+    "insertText": "wrongMetadataSchema",
+    "insertTextFormat": "plainText"
+  },
+  {
+    "label": "wrongType",
+    "kind": "field",
+    "detail": "wrongType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongType",
+    "insertText": "wrongType",
+    "insertTextFormat": "plainText"
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
@@ -123,6 +123,7 @@ param wrongMetadataSchema string {
 
 // expression in modifier
 param expressionInModifier string {
+  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
   minLength: foo()

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
@@ -212,6 +212,7 @@ param wrongMetadataSchema string {
 
 // expression in modifier
 param expressionInModifier string {
+  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
 //@[11:16) [BCP036 (Error)] The property "default" expected a value of type "string" but the provided value is of type "int". |2 + 3|
   maxLength: a + 2

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
@@ -167,7 +167,8 @@ param wrongMetadataSchema string {
 
 // expression in modifier
 param expressionInModifier string {
-//@[6:26) Parameter expressionInModifier. Type: string. Declaration start char: 0, length: 115
+//@[6:26) Parameter expressionInModifier. Type: string. Declaration start char: 0, length: 179
+  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
   minLength: foo()

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
@@ -777,15 +777,17 @@ param wrongMetadataSchema string {
 // expression in modifier
 //@[25:26) NewLine |\n|
 param expressionInModifier string {
-//@[0:115) ParameterDeclarationSyntax
+//@[0:179) ParameterDeclarationSyntax
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |expressionInModifier|
 //@[27:33)  TypeSyntax
 //@[27:33)   Identifier |string|
-//@[34:115)  ObjectSyntax
+//@[34:179)  ObjectSyntax
 //@[34:35)   LeftBrace |{|
 //@[35:36)   NewLine |\n|
+  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+//@[63:64)   NewLine |\n|
   default: 2 + 3
 //@[2:16)   ObjectPropertySyntax
 //@[2:9)    IdentifierSyntax

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
@@ -509,6 +509,8 @@ param expressionInModifier string {
 //@[27:33) Identifier |string|
 //@[34:35) LeftBrace |{|
 //@[35:36) NewLine |\n|
+  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+//@[63:64) NewLine |\n|
   default: 2 + 3
 //@[2:9) Identifier |default|
 //@[9:10) Colon |:|

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -490,16 +490,6 @@
     "insertTextFormat": "plainText"
   },
   {
-    "label": "newGuid",
-    "kind": "function",
-    "detail": "newGuid()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_newGuid",
-    "insertText": "newGuid()$0",
-    "insertTextFormat": "snippet"
-  },
-  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",
@@ -787,16 +777,6 @@
     "preselect": false,
     "sortText": "3_uriComponentToString",
     "insertText": "uriComponentToString($0)",
-    "insertTextFormat": "snippet"
-  },
-  {
-    "label": "utcNow",
-    "kind": "function",
-    "detail": "utcNow()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_utcNow",
-    "insertText": "utcNow($0)",
     "insertTextFormat": "snippet"
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -510,16 +510,6 @@
     "insertTextFormat": "plainText"
   },
   {
-    "label": "newGuid",
-    "kind": "function",
-    "detail": "newGuid()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_newGuid",
-    "insertText": "newGuid()$0",
-    "insertTextFormat": "snippet"
-  },
-  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",
@@ -807,16 +797,6 @@
     "preselect": false,
     "sortText": "3_uriComponentToString",
     "insertText": "uriComponentToString($0)",
-    "insertTextFormat": "snippet"
-  },
-  {
-    "label": "utcNow",
-    "kind": "function",
-    "detail": "utcNow()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_utcNow",
-    "insertText": "utcNow($0)",
     "insertTextFormat": "snippet"
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -480,16 +480,6 @@
     "insertTextFormat": "plainText"
   },
   {
-    "label": "newGuid",
-    "kind": "function",
-    "detail": "newGuid()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_newGuid",
-    "insertText": "newGuid()$0",
-    "insertTextFormat": "snippet"
-  },
-  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",
@@ -777,16 +767,6 @@
     "preselect": false,
     "sortText": "3_uriComponentToString",
     "insertText": "uriComponentToString($0)",
-    "insertTextFormat": "snippet"
-  },
-  {
-    "label": "utcNow",
-    "kind": "function",
-    "detail": "utcNow()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_utcNow",
-    "insertText": "utcNow($0)",
     "insertTextFormat": "snippet"
   },
   {

--- a/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
@@ -870,16 +870,6 @@
     "insertTextFormat": "plainText"
   },
   {
-    "label": "newGuid",
-    "kind": "function",
-    "detail": "newGuid()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_newGuid",
-    "insertText": "newGuid()$0",
-    "insertTextFormat": "snippet"
-  },
-  {
     "label": "not",
     "kind": "variable",
     "detail": "not",
@@ -1287,16 +1277,6 @@
     "preselect": false,
     "sortText": "3_uriComponentToString",
     "insertText": "uriComponentToString($0)",
-    "insertTextFormat": "snippet"
-  },
-  {
-    "label": "utcNow",
-    "kind": "function",
-    "detail": "utcNow()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_utcNow",
-    "insertText": "utcNow($0)",
     "insertTextFormat": "snippet"
   },
   {

--- a/src/Bicep.LangServer.UnitTests/Completions/SymbolKindTestExtensions.cs
+++ b/src/Bicep.LangServer.UnitTests/Completions/SymbolKindTestExtensions.cs
@@ -18,6 +18,7 @@ namespace Bicep.LangServer.UnitTests.Completions
                 SymbolKind.Output => CompletionItemKind.Value,
                 SymbolKind.Namespace => CompletionItemKind.Reference,
                 SymbolKind.Function => CompletionItemKind.Function,
+                SymbolKind.Module => CompletionItemKind.Module,
                 _ => throw new AssertFailedException($"Unexpected symbol kind '{symbolKind}'.")
             };
     }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -167,6 +167,13 @@ namespace Bicep.LanguageServer.Completions
             {
                 foreach (var function in @namespace.Descendants.OfType<FunctionSymbol>())
                 {
+                    if (function.FunctionFlags.HasFlag(FunctionFlags.ParamDefaultsOnly) && !(enclosingDeclarationSymbol is ParameterSymbol))
+                    {
+                        // this function is only allowed in param defaults but the enclosing declaration is not bound to a parameter symbol
+                        // therefore we should not suggesting this function as a viable completion
+                        continue;
+                    }
+
                     if (completions.ContainsKey(function.Name) || alwaysFullyQualifiedNames.Contains(function.Name))
                     {
                         // either there is a declaration with the same name as the function or the function is ambiguous between the imported namespaces
@@ -182,9 +189,6 @@ namespace Bicep.LanguageServer.Completions
                 }
             }
 
-            AddSymbolCompletions(completions, model.Root.ImportedNamespaces
-                .SelectMany(kvp => kvp.Value.Descendants.OfType<FunctionSymbol>()));
-            
             return completions.Values;
         }
 


### PR DESCRIPTION
The functions `utcNow()` and `newGuid()` are only allowed inside parameter default values and are not allowed anywhere else. We already had validation to produce diagnostics in this case, but these functions were still incorrectly suggested by IntelliSense. This fixes #669. 