### PR TITLE
Trigger LanguageServer recompilation on module changes

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/ProgramTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/ProgramTests.cs
@@ -15,6 +15,7 @@ using Bicep.Core.Text;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Json;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -386,7 +387,7 @@ namespace Bicep.Cli.IntegrationTests
 
         private IEnumerable<string> GetAllDiagnostics(string bicepFilePath)
         {
-            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), bicepFilePath);
+            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), new Workspace(), bicepFilePath);
             var compilation = new Compilation(TestResourceTypeProvider.Create(), syntaxTreeGrouping);
 
             var output = new List<string>();

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -16,6 +16,7 @@ using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Workspaces;
 
 namespace Bicep.Cli
 {
@@ -129,7 +130,7 @@ namespace Bicep.Cli
 
         private void BuildSingleFile(IDiagnosticLogger logger, string bicepPath, string outputPath)
         {
-            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), bicepPath);
+            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), new Workspace(), bicepPath);
             var compilation = new Compilation(resourceTypeProvider, syntaxTreeGrouping);
 
             var success = LogDiagnosticsAndCheckSuccess(logger, compilation);
@@ -154,7 +155,7 @@ namespace Bicep.Cli
             }
             foreach(var bicepPath in bicepPaths)
             {
-                var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), bicepPath);
+                var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), new Workspace(), bicepPath);
                 var compilation = new Compilation(resourceTypeProvider, syntaxTreeGrouping);
 
                 var success = LogDiagnosticsAndCheckSuccess(logger, compilation);

--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -11,6 +11,7 @@ using Bicep.Core.SemanticModel;
 using Bicep.Core.Syntax;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -33,7 +34,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             var compiledFilePath = FileHelper.GetResultFilePath(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainCompiled));
 
             // emitting the template should be successful
-            var result = this.EmitTemplate(SyntaxTreeGroupingBuilder.Build(new FileResolver(), bicepFilePath), compiledFilePath);
+            var result = this.EmitTemplate(SyntaxTreeGroupingBuilder.Build(new FileResolver(), new Workspace(), bicepFilePath), compiledFilePath);
             result.Status.Should().Be(EmitStatus.Succeeded);
             result.Diagnostics.Should().BeEmpty();
 
@@ -72,7 +73,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             MemoryStream memoryStream = new MemoryStream();
 
             // emitting the template should be successful
-            var result = this.EmitTemplate(SyntaxTreeGroupingBuilder.Build(new FileResolver(), bicepFilePath), memoryStream);
+            var result = this.EmitTemplate(SyntaxTreeGroupingBuilder.Build(new FileResolver(), new Workspace(), bicepFilePath), memoryStream);
             result.Diagnostics.Should().BeEmpty();
             result.Status.Should().Be(EmitStatus.Succeeded);
 
@@ -96,7 +97,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             string filePath = FileHelper.GetResultFilePath(this.TestContext, $"{dataSet.Name}_Compiled_Original.json");
 
             // emitting the template should fail
-            var result = this.EmitTemplate(SyntaxTreeGroupingBuilder.Build(new FileResolver(), bicepFilePath), filePath);
+            var result = this.EmitTemplate(SyntaxTreeGroupingBuilder.Build(new FileResolver(), new Workspace(), bicepFilePath), filePath);
             result.Status.Should().Be(EmitStatus.Failed);
             result.Diagnostics.Should().NotBeEmpty();
         }

--- a/src/Bicep.Core.IntegrationTests/ModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleTests.cs
@@ -15,6 +15,7 @@ using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -172,7 +173,7 @@ module main 'main.bicep' = {
             string? tryReadOutput;
             mockFileResolver.Setup(x => x.TryRead("/path/to/main.bicep", out tryReadOutput)).Returns(new TryReadDelegate((string fileName, out string? failureMessage) => { failureMessage = "Mock read failure!"; return null; }));
 
-            Action buildAction = () => SyntaxTreeGroupingBuilder.Build(mockFileResolver.Object, "main.bicep");
+            Action buildAction = () => SyntaxTreeGroupingBuilder.Build(mockFileResolver.Object, new Workspace(), "main.bicep");
             buildAction.Should().Throw<ErrorDiagnosticException>()
                 .And.Diagnostic.Should().HaveCodeAndSeverity("BCP091", DiagnosticLevel.Error).And.HaveMessage("An error occurred loading the module. Mock read failure!");
         }
@@ -201,7 +202,7 @@ module modulea 'modulea.bicep' = {
             mockFileResolver.Setup(x => x.TryRead("/path/to/main.bicep", out tryReadOutput)).Returns(new TryReadDelegate((string fileName, out string? failureMessage) => { failureMessage = null; return mainFileContents; }));
             mockFileResolver.Setup(x => x.TryResolveModulePath("/path/to/main.bicep", "modulea.bicep")).Returns((string?)null);
 
-            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingBuilder.Build(mockFileResolver.Object, "main.bicep"));
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingBuilder.Build(mockFileResolver.Object, new Workspace(), "main.bicep"));
 
             var (success, diagnosticsByFile) = GetSuccessAndDiagnosticsByFile(compilation);
             diagnosticsByFile["/path/to/main.bicep"].Should().HaveDiagnostics(new[] {
@@ -235,7 +236,7 @@ module modulea 'modulea.bicep' = {
             mockFileResolver.Setup(x => x.TryRead("/path/to/modulea.bicep", out tryReadOutput)).Returns(new TryReadDelegate((string fileName, out string? failureMessage) => { failureMessage = "Mock read failure!"; return null; }));
             mockFileResolver.Setup(x => x.TryResolveModulePath("/path/to/main.bicep", "modulea.bicep")).Returns("/path/to/modulea.bicep");
 
-            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingBuilder.Build(mockFileResolver.Object, "main.bicep"));
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingBuilder.Build(mockFileResolver.Object, new Workspace(), "main.bicep"));
 
             var (success, diagnosticsByFile) = GetSuccessAndDiagnosticsByFile(compilation);
             diagnosticsByFile["/path/to/main.bicep"].Should().HaveDiagnostics(new[] {

--- a/src/Bicep.Core.Samples/DataSetsExtensions.cs
+++ b/src/Bicep.Core.Samples/DataSetsExtensions.cs
@@ -7,6 +7,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.SemanticModel;
 using Bicep.Core.Syntax;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bicep.Core.Samples
@@ -26,7 +27,7 @@ namespace Bicep.Core.Samples
         public static Compilation CopyFilesAndCreateCompilation(this DataSet dataSet, TestContext testContext, out string outputDirectory)
         {
             outputDirectory = dataSet.SaveFilesToTestDirectory(testContext, dataSet.Name);
-            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), Path.Combine(outputDirectory, DataSet.TestFileMain));
+            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), new Workspace(), Path.Combine(outputDirectory, DataSet.TestFileMain));
 
             return new Compilation(TestResourceTypeProvider.Create(), syntaxTreeGrouping);
         }

--- a/src/Bicep.Core.Samples/ExamplesTests.cs
+++ b/src/Bicep.Core.Samples/ExamplesTests.cs
@@ -14,6 +14,7 @@ using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -96,7 +97,7 @@ namespace Bicep.Core.Samples
             var bicepFileName = Path.Combine(outputDirectory, Path.GetFileName(example.BicepStreamName));
             var jsonFileName = Path.Combine(outputDirectory, Path.GetFileName(example.JsonStreamName));
             
-            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), bicepFileName);
+            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), new Workspace(), bicepFileName);
             var compilation = new Compilation(new AzResourceTypeProvider(), syntaxTreeGrouping);
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel());
 

--- a/src/Bicep.Core.UnitTests/Utils/SyntaxFactory.cs
+++ b/src/Bicep.Core.UnitTests/Utils/SyntaxFactory.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Syntax;
+using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.UnitTests.Utils
 {
@@ -19,7 +20,7 @@ namespace Bicep.Core.UnitTests.Utils
         {
             var fileResolver = new InMemoryFileResolver(files);
 
-            return SyntaxTreeGroupingBuilder.Build(fileResolver, entryFileName);
+            return SyntaxTreeGroupingBuilder.Build(fileResolver, new Workspace(), entryFileName);
         }
     }
 }

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -574,6 +574,11 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP103",
                 $"The following token is not recognized: \"{token}\". Strings are defined using single quotes in bicep.");
+
+            public ErrorDiagnostic ReferencedModuleHasErrors() => new ErrorDiagnostic(
+                TextSpan,
+                "BCP104",
+                $"The referenced module has errors.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/FileSystem/InMemoryFileResolver.cs
+++ b/src/Bicep.Core/FileSystem/InMemoryFileResolver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Bicep.Core.FileSystem
 {
@@ -13,12 +12,17 @@ namespace Bicep.Core.FileSystem
 
         public InMemoryFileResolver(IReadOnlyDictionary<string, string> fileLookup, Func<string, string>? missingFileFailureBuilder = null)
         {
+            foreach (var (filePath, fileContents) in fileLookup)
+            {
+                AssertPathFullyQualified(filePath);
+            }
+
             this.fileLookup = fileLookup;
             this.missingFileFailureBuilder = missingFileFailureBuilder ?? (filePath => $"Could not find file {filePath}");
         }
 
         public string GetNormalizedFileName(string filePath)
-            => filePath;
+            => new Uri($"file://{filePath}").AbsolutePath;
 
         public string? TryRead(string filePath, out string? failureMessage)
         {
@@ -32,9 +36,24 @@ namespace Bicep.Core.FileSystem
             return fileContents;
         }
 
-        public string? TryResolveModulePath(string parentFileName, string childFileName)
-            => Path.Combine(Path.GetDirectoryName(parentFileName), childFileName).Replace(Path.DirectorySeparatorChar, '/');
+        public string? TryResolveModulePath(string parentFilePath, string childFilePath)
+        {
+            AssertPathFullyQualified(parentFilePath);
+
+            var parentDirUri = new Uri(new Uri($"file://{parentFilePath}"), ".");
+            var moduleUri = new Uri(parentDirUri, childFilePath);
+
+            return moduleUri.AbsolutePath;
+        }
 
         public StringComparer PathComparer => StringComparer.Ordinal;
+
+        private static void AssertPathFullyQualified(string filePath)
+        {
+            if (!filePath.StartsWith("/"))
+            {
+                throw new InvalidOperationException($"Expected a fully qualified path, but got \"{filePath}\"");
+            }
+        }
     }
 }

--- a/src/Bicep.Core/SemanticModel/SemanticModel.cs
+++ b/src/Bicep.Core/SemanticModel/SemanticModel.cs
@@ -52,6 +52,9 @@ namespace Bicep.Core.SemanticModel
             .Concat(GetSemanticDiagnostics())
             .OrderBy(diag => diag.Span.Position);
 
+        public bool HasDiagnosticErrors()
+            => GetAllDiagnostics().Any(x => x.Level == DiagnosticLevel.Error);
+
         public TypeSymbol GetTypeInfo(SyntaxBase syntax) => this.typeManager.GetTypeInfo(syntax);
 
         public TypeSymbol? GetDeclaredType(SyntaxBase syntax) => this.typeManager.GetDeclaredType(syntax);

--- a/src/Bicep.Core/SemanticModel/SemanticModel.cs
+++ b/src/Bicep.Core/SemanticModel/SemanticModel.cs
@@ -52,7 +52,7 @@ namespace Bicep.Core.SemanticModel
             .Concat(GetSemanticDiagnostics())
             .OrderBy(diag => diag.Span.Position);
 
-        public bool HasDiagnosticErrors()
+        public bool HasErrors()
             => GetAllDiagnostics().Any(x => x.Level == DiagnosticLevel.Error);
 
         public TypeSymbol GetTypeInfo(SyntaxBase syntax) => this.typeManager.GetTypeInfo(syntax);

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -241,6 +241,11 @@ namespace Bicep.Core.TypeSystem
                     return UnassignableTypeSymbol.CreateErrors(failureDiagnostic);
                 }
 
+                if (moduleSemanticModel.HasDiagnosticErrors())
+                {
+                    diagnostics.Add(DiagnosticBuilder.ForPosition(syntax.Path).ReferencedModuleHasErrors());
+                }
+
                 var declaredType = GetDeclaredModuleType(moduleSemanticModel, "module");
                 
                 // just established the declared type - assign it!

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -241,7 +241,7 @@ namespace Bicep.Core.TypeSystem
                     return UnassignableTypeSymbol.CreateErrors(failureDiagnostic);
                 }
 
-                if (moduleSemanticModel.HasDiagnosticErrors())
+                if (moduleSemanticModel.HasErrors())
                 {
                     diagnostics.Add(DiagnosticBuilder.ForPosition(syntax.Path).ReferencedModuleHasErrors());
                 }

--- a/src/Bicep.Core/Workspaces/IReadOnlyWorkspace.cs
+++ b/src/Bicep.Core/Workspaces/IReadOnlyWorkspace.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Workspaces
+{
+    public interface IReadOnlyWorkspace
+    {
+        // TODO use file URI internally instead of string
+        bool TryGetSyntaxTree(string normalizedFileName, [NotNullWhen(true)] out SyntaxTree? syntaxTree);
+
+        IEnumerable<SyntaxTree> GetSyntaxTreesForDirectory(string normalizedFilePath);
+    }
+}

--- a/src/Bicep.Core/Workspaces/IWorkspace.cs
+++ b/src/Bicep.Core/Workspaces/IWorkspace.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Workspaces
+{
+    public interface IWorkspace : IReadOnlyWorkspace
+    {
+        (ImmutableArray<SyntaxTree> added, ImmutableArray<SyntaxTree> removed) UpsertSyntaxTrees(IEnumerable<SyntaxTree> syntaxTrees);
+
+        void RemoveSyntaxTrees(IEnumerable<SyntaxTree> syntaxTrees);
+    }
+}

--- a/src/Bicep.Core/Workspaces/Workspace.cs
+++ b/src/Bicep.Core/Workspaces/Workspace.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Workspaces
+{
+    public class Workspace : IWorkspace
+    {
+        private readonly IDictionary<string, SyntaxTree> activeSyntaxTrees = new Dictionary<string, SyntaxTree>();
+
+        public bool TryGetSyntaxTree(string normalizedFileName, [NotNullWhen(true)] out SyntaxTree? syntaxTree)
+            => activeSyntaxTrees.TryGetValue(normalizedFileName, out syntaxTree);
+
+        public IEnumerable<SyntaxTree> GetSyntaxTreesForDirectory(string normalizedFilePath)
+            => activeSyntaxTrees
+                .Where(kvp => kvp.Key.Length > normalizedFilePath.Length && kvp.Key.StartsWith(normalizedFilePath))
+                .Select(kvp => kvp.Value);
+
+        public (ImmutableArray<SyntaxTree> added, ImmutableArray<SyntaxTree> removed) UpsertSyntaxTrees(IEnumerable<SyntaxTree> syntaxTrees)
+        {
+            var addedTrees = new List<SyntaxTree>();
+            var removedTrees = new List<SyntaxTree>();
+
+            foreach (var newSyntaxTree in syntaxTrees)
+            {
+                if (activeSyntaxTrees.TryGetValue(newSyntaxTree.FilePath, out var oldSyntaxTree))
+                {
+                    if (oldSyntaxTree == newSyntaxTree)
+                    {
+                        continue;
+                    }
+
+                    removedTrees.Add(oldSyntaxTree);
+                }
+
+                addedTrees.Add(newSyntaxTree);
+
+                activeSyntaxTrees[newSyntaxTree.FilePath] = newSyntaxTree;
+            }
+
+            return (addedTrees.ToImmutableArray(), removedTrees.ToImmutableArray());
+        }
+
+        public void RemoveSyntaxTrees(IEnumerable<SyntaxTree> syntaxTrees)
+        {
+            foreach (var syntaxTree in syntaxTrees)
+            {
+                if (activeSyntaxTrees.TryGetValue(syntaxTree.FilePath, out var treeToRemove) && treeToRemove == syntaxTree)
+                {
+                    activeSyntaxTrees.Remove(syntaxTree.FilePath);
+                }
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/Workspaces/Workspace.cs
+++ b/src/Bicep.Core/Workspaces/Workspace.cs
@@ -8,6 +8,9 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Workspaces
 {
+    /// <summary>
+    /// Represents the active set of files and shared data that can be utilized to compile one or more bicep files.
+    /// </summary>
     public class Workspace : IWorkspace
     {
         private readonly IDictionary<string, SyntaxTree> activeSyntaxTrees = new Dictionary<string, SyntaxTree>();

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -62,7 +62,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri, typeProviderBuilder: () => TypeProvider);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri, resourceTypeProvider: TypeProvider);
 
             var intermediate = new List<(Position position, JToken actual)>();
 

--- a/src/Bicep.LangServer.IntegrationTests/FileWatcherTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/FileWatcherTests.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Bicep.Core.FileSystem;
+using Bicep.LangServer.IntegrationTests.Helpers;
+using Bicep.Core.UnitTests.Assertions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+using System.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
+
+namespace Bicep.LangServer.IntegrationTests
+{
+    [TestClass]
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
+    public class FileWatcherTests
+    {
+        private static void SendDidChangeWatchedFiles(ILanguageClient client, params (DocumentUri documentUri, FileChangeType changeType)[] changes)
+        {
+            var fileChanges = new Container<FileEvent>(changes.Select(x => new FileEvent
+            {
+                Type = x.changeType,
+                Uri = x.documentUri,
+            }));
+
+            client.Workspace.DidChangeWatchedFiles(new DidChangeWatchedFilesParams
+            {
+                Changes = fileChanges,
+            });
+        }
+
+        [TestMethod]
+        public async Task Module_file_change_should_trigger_a_recompilation()
+        {
+            var fileSystemDict = new Dictionary<string, string>();
+            var diagsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
+            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(
+                options => 
+                {
+                    options.OnPublishDiagnostics(diags => diagsListener.AddMessage(diags));
+                },
+                fileResolver: new InMemoryFileResolver(fileSystemDict));
+
+            var mainFile = "/path/to/main.bicep";
+            var mainUri = DocumentUri.FromFileSystemPath(mainFile);
+            fileSystemDict[mainFile] = @"
+module myMod '../toOther/module.bicep' = {
+  name: 'myMod'
+  params: {
+    requiredInput: 'hello!'
+  }
+}
+";
+
+            var moduleFile = "/path/toOther/module.bicep";
+            var moduleUri = DocumentUri.FromFileSystemPath(moduleFile);
+            fileSystemDict[moduleFile] = @"
+// mis-spelling!
+param requiredIpnut string
+";
+
+            // open the main document
+            {
+                client.TextDocument.DidOpenTextDocument(TextDocumentParamHelper.CreateDidOpenDocumentParams(mainUri, fileSystemDict[mainFile], 1));
+
+                var diagsParams = await diagsListener.WaitNext();
+                diagsParams.Uri.Should().Be(mainUri);
+                diagsParams.Diagnostics.Should().Contain(x => x.Message.Contains("The specified object is missing the following required properties: \"requiredIpnut\"."));
+            }
+
+            // open the module document. this should trigger diagnostics for both the module and the main doc which references it.
+            {
+                client.TextDocument.DidOpenTextDocument(TextDocumentParamHelper.CreateDidOpenDocumentParams(moduleUri, fileSystemDict[moduleFile], 1));
+
+                var diagsParams = await diagsListener.WaitNext();
+                diagsParams.Uri.Should().Be(moduleUri);
+                diagsParams.Diagnostics.Should().BeEmpty();
+
+                diagsParams = await diagsListener.WaitNext();
+                diagsParams.Uri.Should().Be(mainUri);
+                diagsParams.Diagnostics.Should().Contain(x => x.Message.Contains("The specified object is missing the following required properties: \"requiredIpnut\"."));
+            }
+
+            // fix the mis-spelling in the module! We should again get two sets of diagnostics, but with no errors
+            {
+                var updatedModuleContents = @"
+// mis-spelling fixed!
+param requiredInput string
+";
+                client.TextDocument.DidChangeTextDocument(TextDocumentParamHelper.CreateDidChangeTextDocumentParams(moduleUri, updatedModuleContents, 2));
+
+                var diagsParams = await diagsListener.WaitNext();
+                diagsParams.Uri.Should().Be(moduleUri);
+                diagsParams.Diagnostics.Should().BeEmpty();
+
+                diagsParams = await diagsListener.WaitNext();
+                diagsParams.Uri.Should().Be(mainUri);
+                diagsParams.Diagnostics.Should().BeEmpty();
+            }
+
+            // close the module file. the language server should send empty diagnostics to clear the IDE state.
+            {
+                client.TextDocument.DidCloseTextDocument(TextDocumentParamHelper.CreateDidCloseTextDocumentParams(moduleUri, 2));
+
+                var diagsParams = await diagsListener.WaitNext();
+                diagsParams.Uri.Should().Be(moduleUri);
+                diagsParams.Diagnostics.Should().BeEmpty();
+            }
+        }
+
+        [TestMethod]
+        public async Task Background_file_deletion_should_trigger_a_recompilation()
+        {
+            var fileSystemDict = new Dictionary<string, string>();
+            var diagsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
+            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(
+                options => 
+                {
+                    options.OnPublishDiagnostics(diags => diagsListener.AddMessage(diags));
+                },
+                fileResolver: new InMemoryFileResolver(fileSystemDict));
+
+            var mainFile = "/path/to/main.bicep";
+            var mainUri = DocumentUri.FromFileSystemPath(mainFile);
+            fileSystemDict[mainFile] = @"
+module myMod '../toOther/module.bicep' = {
+  name: 'myMod'
+  params: {
+    requiredInput: 'hello!'
+  }
+}
+";
+
+            var moduleFile = "/path/toOther/module.bicep";
+            var moduleUri = DocumentUri.FromFileSystemPath(moduleFile);
+            fileSystemDict[moduleFile] = @"
+// mis-spelling!
+param requiredIpnut string
+";
+
+            // open the main document
+            {
+                client.TextDocument.DidOpenTextDocument(TextDocumentParamHelper.CreateDidOpenDocumentParams(mainUri, fileSystemDict[mainFile], 1));
+
+                var diagsParams = await diagsListener.WaitNext();
+                diagsParams.Uri.Should().Be(mainUri);
+                diagsParams.Diagnostics.Should().Contain(x => x.Message.Contains("The specified object is missing the following required properties: \"requiredIpnut\"."));
+            }
+
+            // delete the module file with a background process
+            {
+                fileSystemDict.Remove(moduleFile);
+                SendDidChangeWatchedFiles(client, (moduleUri, FileChangeType.Deleted));
+
+                var nextDiags = await diagsListener.WaitNext();
+                nextDiags.Uri.Should().Be(mainUri);
+                nextDiags.Diagnostics.Should().Contain(x => x.Message.Contains("An error occurred loading the module. Could not find file /path/toOther/module.bicep"));
+            }
+
+            // delete the main file with a background process. this should be ignored, as the close document event should clean it up
+            {
+                fileSystemDict.Remove(mainFile);
+                SendDidChangeWatchedFiles(client, (mainUri, FileChangeType.Deleted));
+
+                await diagsListener.EnsureNoMessageSent();
+            }
+
+            // close the main file. the language server should send empty diagnostics to clear the IDE state.
+            {
+                client.TextDocument.DidCloseTextDocument(TextDocumentParamHelper.CreateDidCloseTextDocumentParams(mainUri, 1));
+
+                var diagsParams = await diagsListener.WaitNext();
+                diagsParams.Uri.Should().Be(mainUri);
+                diagsParams.Diagnostics.Should().BeEmpty();
+            }
+        }
+
+
+        [TestMethod]
+        public async Task Background_folder_deletion_should_trigger_a_recompilation()
+        {
+            var fileSystemDict = new Dictionary<string, string>();
+            var diagsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
+            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(
+                options => 
+                {
+                    options.OnPublishDiagnostics(diags => diagsListener.AddMessage(diags));
+                },
+                fileResolver: new InMemoryFileResolver(fileSystemDict));
+
+            var mainFile = "/path/to/main.bicep";
+            var mainUri = DocumentUri.FromFileSystemPath(mainFile);
+            fileSystemDict[mainFile] = @"
+module myMod '../toOther/module.bicep' = {
+  name: 'myMod'
+  params: {
+    requiredInput: 'hello!'
+  }
+}
+";
+
+            var moduleFile = "/path/toOther/module.bicep";
+            var moduleUri = DocumentUri.FromFileSystemPath(moduleFile);
+            fileSystemDict[moduleFile] = @"
+// mis-spelling!
+param requiredIpnut string
+";
+
+            // open the main document
+            {
+                client.TextDocument.DidOpenTextDocument(TextDocumentParamHelper.CreateDidOpenDocumentParams(mainUri, fileSystemDict[mainFile], 1));
+
+                var diagsParams = await diagsListener.WaitNext();
+                diagsParams.Uri.Should().Be(mainUri);
+                diagsParams.Diagnostics.Should().Contain(x => x.Message.Contains("The specified object is missing the following required properties: \"requiredIpnut\"."));
+            }
+
+            // delete the module folder with a background process
+            {
+                fileSystemDict.Remove(moduleFile);
+                SendDidChangeWatchedFiles(client, (DocumentUri.FromFileSystemPath("/path/toOther"), FileChangeType.Deleted));
+
+                var nextDiags = await diagsListener.WaitNext();
+                nextDiags.Uri.Should().Be(mainUri);
+                nextDiags.Diagnostics.Should().Contain(x => x.Message.Contains("An error occurred loading the module. Could not find file /path/toOther/module.bicep"));
+            }
+        }
+    }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/MultipleMessageListener.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/MultipleMessageListener.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace Bicep.LangServer.IntegrationTests
+{
+    // helper class to read messages in order and assert things about them
+    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test code does not need to follow this convention.")]
+    public class MultipleMessageListener<T>
+    {
+        private object lockObj = new object();
+        private int listenPosition = 0;
+        private int writePosition = 0;
+        private List<TaskCompletionSource<T>> completionSources = new List<TaskCompletionSource<T>>();
+
+        public async Task<T> WaitNext(int timeout = 10000)
+        {
+            Task<T> onMessageTask;
+            lock (lockObj)
+            {
+                while (listenPosition >= completionSources.Count)
+                {
+                    completionSources.Add(new TaskCompletionSource<T>());
+                }
+
+                onMessageTask = completionSources[listenPosition].Task;
+                listenPosition++;
+            }
+
+            return await IntegrationTestHelper.WithTimeoutAsync(onMessageTask, timeout);
+        }
+
+        public async Task EnsureNoMessageSent(int timeout = 10000)
+        {
+            Task<T> onMessageTask;
+            lock (lockObj)
+            {
+                while (listenPosition >= completionSources.Count)
+                {
+                    completionSources.Add(new TaskCompletionSource<T>());
+                }
+
+                onMessageTask = completionSources[listenPosition].Task;
+            }
+
+            await IntegrationTestHelper.EnsureTaskDoesntCompleteAsync(onMessageTask, timeout);
+        }
+
+        public void AddMessage(T message)
+        {
+            lock (lockObj)
+            {
+                while (writePosition >= completionSources.Count)
+                {
+                    completionSources.Add(new TaskCompletionSource<T>());
+                }
+                
+                completionSources[writePosition].SetResult(message);
+                writePosition++;
+            }
+        }
+    }
+}

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
+using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Samples;
+using Bicep.Core.Syntax;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.Providers;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,7 +26,10 @@ namespace Bicep.LangServer.UnitTests
             var provider = new BicepCompilationProvider(TestResourceTypeProvider.Create(), CreateEmptyFileResolver());
 
             var fileUri = DocumentUri.Parse($"/{DataSets.Parameters_LF.Name}.bicep");
-            var context = provider.Create(fileUri, DataSets.Parameters_LF.Bicep);
+            var syntaxTree = SyntaxTree.Create(fileUri.GetFileSystemPath(), DataSets.Parameters_LF.Bicep);
+            var workspace = new Workspace();
+            workspace.UpsertSyntaxTrees(syntaxTree.AsEnumerable());
+            var context = provider.Create(workspace, fileUri);
 
             context.Compilation.Should().NotBeNull();
             context.Compilation.GetEntrypointSemanticModel().GetAllDiagnostics().Should().BeEmpty();

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -3,7 +3,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using Bicep.Core.Extensions;
+using Bicep.Core.Syntax;
+using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Extensions;
 using Bicep.LanguageServer.Providers;
@@ -17,72 +21,146 @@ namespace Bicep.LanguageServer
 {
     public class BicepCompilationManager : ICompilationManager
     {
+        private readonly IWorkspace workspace;
         private readonly ILanguageServerFacade server;
         private readonly ICompilationProvider provider;
 
         // represents compilations of open bicep files
         private readonly ConcurrentDictionary<DocumentUri, CompilationContext> activeContexts = new ConcurrentDictionary<DocumentUri, CompilationContext>();
 
-        public BicepCompilationManager(ILanguageServerFacade server, ICompilationProvider provider)
+        public BicepCompilationManager(ILanguageServerFacade server, ICompilationProvider provider, IWorkspace workspace)
         {
             this.server = server;
             this.provider = provider;
+            this.workspace = workspace;
         }
 
-        public CompilationContext? UpsertCompilation(DocumentUri uri, int? version, string text)
+        private ImmutableArray<SyntaxTree> CloseCompilationInternal(DocumentUri documentUri, int? version, IEnumerable<Diagnostic> closingDiagnostics)
+        {
+            this.activeContexts.TryRemove(documentUri, out var removedContext);
+
+            this.PublishDocumentDiagnostics(documentUri, version, closingDiagnostics);
+
+            if (removedContext == null)
+            {
+                return ImmutableArray<SyntaxTree>.Empty;
+            }
+
+            var closedSyntaxTrees = removedContext.Compilation.SyntaxTreeGrouping.SyntaxTrees.ToHashSet();
+            foreach (var (entrypointUri, context) in activeContexts)
+            {
+                closedSyntaxTrees.ExceptWith(context.Compilation.SyntaxTreeGrouping.SyntaxTrees);
+            }
+
+            workspace.RemoveSyntaxTrees(closedSyntaxTrees);
+
+            return closedSyntaxTrees.ToImmutableArray();
+        }
+
+        private (ImmutableArray<SyntaxTree> added, ImmutableArray<SyntaxTree> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version)
         {
             try
             {
-                var context = this.provider.Create(uri, text);
+                var context = this.provider.Create(workspace, documentUri);
+
+                var output = workspace.UpsertSyntaxTrees(context.Compilation.SyntaxTreeGrouping.SyntaxTrees);
 
                 // there shouldn't be concurrent upsert requests (famous last words...), so a simple overwrite should be sufficient
-                this.activeContexts[uri] = context;
+                this.activeContexts[documentUri] = context;
 
                 // convert all the diagnostics to LSP diagnostics
                 var diagnostics = GetDiagnosticsFromContext(context).ToDiagnostics(context.LineStarts);
 
                 // publish all the diagnostics
-                this.PublishDocumentDiagnostics(uri, version, diagnostics);
+                this.PublishDocumentDiagnostics(documentUri, version, diagnostics);
 
-                return context;
+                return output;
             }
             catch (Exception exception)
             {
                 // this is a fatal error likely due to a code defect
-                
-                // the file is no longer in a state that can be parsed
-                // clear all info to prevent cascading failures elsewhere
-                this.activeContexts.TryRemove(uri, out _);
 
                 // publish a single fatal error diagnostic to tell the user something horrible has occurred
                 // TODO: Tell user how to create an issue on GitHub.
-                this.PublishDocumentDiagnostics(uri, version, new[]
+                var fatalError = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic
                 {
-                    new OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic
+                    Range = new Range
                     {
-                        Range = new Range
-                        {
-                            Start = new Position(0, 0),
-                            End = new Position(1, 0),
-                        },
-                        Severity = DiagnosticSeverity.Error,
-                        Message = exception.Message,
-                        Code = new DiagnosticCode("Fatal")
-                    }
-                });
+                        Start = new Position(0, 0),
+                        End = new Position(1, 0),
+                    },
+                    Severity = DiagnosticSeverity.Error,
+                    Message = exception.Message,
+                    Code = new DiagnosticCode("Fatal")
+                };
+                
+                // the file is no longer in a state that can be parsed
+                // clear all info to prevent cascading failures elsewhere
+                var closedTrees = CloseCompilationInternal(documentUri, version, fatalError.AsEnumerable());
 
-                return null;
+                return (ImmutableArray<SyntaxTree>.Empty, closedTrees);
             }
         }
 
-        public void CloseCompilation(DocumentUri uri)
+        public void UpsertCompilation(DocumentUri uri, int? version, string fileContents)
         {
-            // remove the active compilation
-            this.activeContexts.TryRemove(uri, out _);
+            var newSyntaxTree = this.provider.BuildSyntaxTree(uri, fileContents);
+            var firstChanges = workspace.UpsertSyntaxTrees(newSyntaxTree.AsEnumerable());
+            var secondChanges = UpdateCompilationInternal(uri, version);
+            
+            var addedTrees = firstChanges.added.Concat(secondChanges.added);
+            var removedTrees = firstChanges.removed.Concat(secondChanges.removed);
 
-            // clear diagnostics for the file
+            foreach (var (entrypointUri, context) in activeContexts)
+            {
+                if (removedTrees.Any(x => context.Compilation.SyntaxTreeGrouping.SyntaxTrees.Contains(x)))
+                {
+                    UpdateCompilationInternal(entrypointUri, null);
+                }
+            }
+        }
+
+        public void CloseCompilation(DocumentUri documentUri)
+        {
+            // close and clear diagnostics for the file
             // if upsert failed to create a compilation due to a fatal error, we still need to clean up the diagnostics
-            PublishDocumentDiagnostics(uri, 0, Enumerable.Empty<OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic>());
+            CloseCompilationInternal(documentUri, 0, Enumerable.Empty<OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic>());
+        }
+
+        public void HandleFileChanges(IEnumerable<FileEvent> fileEvents)
+        {
+            var removedTrees = new HashSet<SyntaxTree>();
+            foreach (var change in fileEvents.Where(x => x.Type == FileChangeType.Changed || x.Type == FileChangeType.Deleted))
+            {
+                if (activeContexts.ContainsKey(change.Uri))
+                {
+                    // We should expect an explicit request to update this file if it's open. Otherwise we may
+                    // overwrite the 'dirty' copy of the file with a clean one.
+                    continue;
+                }
+
+                // We treat both updates and deletes as 'removes' to force the new SyntaxTree to be reloaded from disk
+                if (workspace.TryGetSyntaxTree(change.Uri.GetFileSystemPath(), out var removedTree))
+                {
+                    removedTrees.Add(removedTree);
+                }
+                else if (change.Type == FileChangeType.Deleted)
+                {
+                    // If we don't know definitively that we're deleting a file, we have to assume it's a directory; the file system watcher does not give us any information to differentiate reliably.
+                    // We could possibly assume that if the path ends in '.bicep', we've got a file, but this would discount directories ending in '.bicep', however unlikely.
+                    var subdirRemovedTrees = workspace.GetSyntaxTreesForDirectory(change.Uri.GetFileSystemPath());
+                    removedTrees.UnionWith(subdirRemovedTrees);
+                }
+            }
+
+            workspace.RemoveSyntaxTrees(removedTrees);
+            foreach (var (entrypointUri, context) in activeContexts)
+            {
+                if (removedTrees.Any(x => context.Compilation.SyntaxTreeGrouping.SyntaxTrees.Contains(x)))
+                {
+                    UpdateCompilationInternal(entrypointUri, null);
+                }
+            }
         }
 
         public CompilationContext? GetCompilation(DocumentUri uri)

--- a/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
+++ b/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
@@ -1,12 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Collections;
+using System.Collections.Generic;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.CompilationManager
 {
     public interface ICompilationManager
     {
-        CompilationContext? UpsertCompilation(DocumentUri uri, int? version, string text);
+        void HandleFileChanges(IEnumerable<FileEvent> fileEvents);
+
+        void UpsertCompilation(DocumentUri uri, int? version, string text);
 
         void CloseCompilation(DocumentUri uri);
 

--- a/src/Bicep.LangServer/Handlers/BicepDidChangeWatchedFilesHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDidChangeWatchedFilesHandler.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Bicep.Core.Extensions;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Parser;
+using Bicep.Core.Syntax;
+using Bicep.LanguageServer.CompilationManager;
+using MediatR;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+
+namespace Bicep.LanguageServer.Handlers
+{
+    public sealed class BicepDidChangeWatchedFilesHandler : DidChangeWatchedFilesHandler
+    {
+        private readonly ICompilationManager compilationManager;
+        private readonly IFileResolver fileResolver;
+
+        public BicepDidChangeWatchedFilesHandler(ICompilationManager compilationManager, IFileResolver fileResolver)
+            : base(GetDidChangeWatchedFilesRegistrationOptions())
+        {
+            this.compilationManager = compilationManager;
+            this.fileResolver = fileResolver;
+        }
+
+        private static DidChangeWatchedFilesRegistrationOptions GetDidChangeWatchedFilesRegistrationOptions()
+            => new DidChangeWatchedFilesRegistrationOptions()
+            {
+                Watchers = new Container<FileSystemWatcher>(
+                    new FileSystemWatcher()
+                    {
+                        Kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete,
+                        GlobPattern = "**/*.*"
+                    }
+                )
+            };
+
+        public override Task<Unit> Handle(DidChangeWatchedFilesParams request, CancellationToken cancellationToken)
+        {
+            compilationManager.HandleFileChanges(request.Changes);
+
+            return Unit.Task;
+        }
+    }
+}

--- a/src/Bicep.LangServer/Handlers/BicepDidChangeWatchedFilesHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDidChangeWatchedFilesHandler.cs
@@ -33,11 +33,17 @@ namespace Bicep.LanguageServer.Handlers
         private static DidChangeWatchedFilesRegistrationOptions GetDidChangeWatchedFilesRegistrationOptions()
             => new DidChangeWatchedFilesRegistrationOptions()
             {
+                // These file watcher globs should be kept in-sync with those defined in client.ts
                 Watchers = new Container<FileSystemWatcher>(
                     new FileSystemWatcher()
                     {
                         Kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete,
-                        GlobPattern = "**/*.*"
+                        GlobPattern = "**/"
+                    },
+                    new FileSystemWatcher()
+                    {
+                        Kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete,
+                        GlobPattern = "**/*.bicep"
                     }
                 )
             };

--- a/src/Bicep.LangServer/Program.cs
+++ b/src/Bicep.LangServer/Program.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Bicep.Core.FileSystem;
 using Bicep.Core.TypeSystem.Az;
 
 namespace Bicep.LanguageServer
@@ -14,7 +15,14 @@ namespace Bicep.LanguageServer
             {
                 // the server uses JSON-RPC over stdin & stdout to communicate,
                 // so be careful not to use console for logging!
-                var server = new Server(Console.OpenStandardInput(), Console.OpenStandardOutput(), () => new AzResourceTypeProvider());
+                var server = new Server(
+                    Console.OpenStandardInput(),
+                    Console.OpenStandardOutput(),
+                    new Server.CreationOptions
+                    {
+                        ResourceTypeProvider = new AzResourceTypeProvider(),
+                        FileResolver = new FileResolver(),
+                    });
 
                 await server.RunAsync(cancellationToken);
             });

--- a/src/Bicep.LangServer/Providers/BicepCompilationProvider.cs
+++ b/src/Bicep.LangServer/Providers/BicepCompilationProvider.cs
@@ -4,6 +4,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.SemanticModel;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
+using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 
@@ -24,10 +25,17 @@ namespace Bicep.LanguageServer.Providers
             this.fileResolver = fileResolver;
         }
 
-        public CompilationContext Create(DocumentUri documentUri, string text)
+        public SyntaxTree BuildSyntaxTree(DocumentUri documentUri, string fileContents)
+        {
+            var filePath = fileResolver.GetNormalizedFileName(documentUri.GetFileSystemPath());
+
+            return SyntaxTree.Create(filePath, fileContents);
+        }
+
+        public CompilationContext Create(IReadOnlyWorkspace workspace, DocumentUri documentUri)
         {
             var mainFileName = documentUri.GetFileSystemPath();
-            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.BuildWithPreloadedFile(fileResolver, mainFileName, text);
+            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(fileResolver, workspace, mainFileName);
             var compilation = new Compilation(resourceTypeProvider, syntaxTreeGrouping);
 
             return new CompilationContext(compilation);

--- a/src/Bicep.LangServer/Providers/ICompilationProvider.cs
+++ b/src/Bicep.LangServer/Providers/ICompilationProvider.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using Bicep.Core.Syntax;
+using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 
@@ -7,6 +9,8 @@ namespace Bicep.LanguageServer.Providers
 {
     public interface ICompilationProvider
     {
-        CompilationContext Create(DocumentUri documentUri, string text);
+        SyntaxTree BuildSyntaxTree(DocumentUri documentUri, string fileContents);
+
+        CompilationContext Create(IReadOnlyWorkspace workspace, DocumentUri documentUri);
     }
 }

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Bicep.Core.FileSystem;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Completions;
 using Bicep.LanguageServer.Handlers;
@@ -20,19 +21,26 @@ namespace Bicep.LanguageServer
 {
     public class Server
     {
+        public class CreationOptions
+        {
+            public IResourceTypeProvider? ResourceTypeProvider { get; set; }
+
+            public IFileResolver? FileResolver { get; set; }
+        }
+
         private readonly OmnisharpLanguageServer server;
 
-        public Server(PipeReader input, PipeWriter output, Func<IResourceTypeProvider> resourceTypeProviderBuilder)
-            : this(resourceTypeProviderBuilder, options => options.WithInput(input).WithOutput(output))
+        public Server(PipeReader input, PipeWriter output, CreationOptions creationOptions)
+            : this(creationOptions, options => options.WithInput(input).WithOutput(output))
         {
         }
 
-        public Server(Stream input, Stream output, Func<IResourceTypeProvider> resourceTypeProviderBuilder)
-            : this(resourceTypeProviderBuilder, options => options.WithInput(input).WithOutput(output))
+        public Server(Stream input, Stream output, CreationOptions creationOptions)
+            : this(creationOptions, options => options.WithInput(input).WithOutput(output))
         {
         }
         
-        private Server(Func<IResourceTypeProvider> resourceTypeProviderBuilder, Action<LanguageServerOptions> onOptionsFunc)
+        private Server(CreationOptions creationOptions, Action<LanguageServerOptions> onOptionsFunc)
         {
             server = OmniSharp.Extensions.LanguageServer.Server.LanguageServer.PreInit(options =>
             {
@@ -46,10 +54,11 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepHoverHandler>()
                     .WithHandler<BicepCompletionHandler>()
                     .WithHandler<BicepCodeActionHandler>()
+                    .WithHandler<BicepDidChangeWatchedFilesHandler>()
 #pragma warning disable 0612 // disable 'obsolete' warning for proposed LSP feature
                     .WithHandler<BicepSemanticTokensHandler>()
 #pragma warning restore 0612
-                    .WithServices(services => RegisterServices(resourceTypeProviderBuilder, services));
+                    .WithServices(services => RegisterServices(creationOptions, services));
 
                 onOptionsFunc(options);
             });
@@ -62,12 +71,13 @@ namespace Bicep.LanguageServer
             await server.WaitForExit;
         }
 
-        private static void RegisterServices(Func<IResourceTypeProvider> resourceTypeProviderBuilder, IServiceCollection services)
+        private static void RegisterServices(CreationOptions creationOptions, IServiceCollection services)
         {
             // using type based registration so dependencies can be injected automatically
             // without manually constructing up the graph
-            services.AddSingleton<IResourceTypeProvider>(services => resourceTypeProviderBuilder());
-            services.AddSingleton<IFileResolver, FileResolver>();
+            services.AddSingleton<IResourceTypeProvider>(services => creationOptions.ResourceTypeProvider ?? new AzResourceTypeProvider());
+            services.AddSingleton<IFileResolver>(services => creationOptions.FileResolver ?? new FileResolver());
+            services.AddSingleton<IWorkspace, Workspace>();
             services.AddSingleton<ICompilationManager, BicepCompilationManager>();
             services.AddSingleton<ICompilationProvider, BicepCompilationProvider>();
             services.AddSingleton<ISymbolResolver, BicepSymbolResolver>();

--- a/src/Bicep.Wasm/Interop.cs
+++ b/src/Bicep.Wasm/Interop.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Workspaces;
 
 namespace Bicep.Wasm
 {
@@ -118,7 +119,7 @@ namespace Bicep.Wasm
         {
             var fileName = "/main.bicep";
             var fileResolver = new InMemoryFileResolver(new Dictionary<string, string> { [fileName] = text }, filePath => "Modules are not supported in the Bicep Playground");
-            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(fileResolver, fileName);
+            var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(fileResolver, new Workspace(), fileName);
 
             return new Compilation(resourceTypeProvider, syntaxTreeGrouping);
         }

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -58,7 +58,10 @@ async function launchLanguageService(
     progressOnInitialization: true,
     outputChannel,
     synchronize: {
-      fileEvents: vscode.workspace.createFileSystemWatcher("**/*.bicep"),
+      fileEvents: [
+        vscode.workspace.createFileSystemWatcher("**/"), // folder changes
+        vscode.workspace.createFileSystemWatcher("**/*.bicep"), // .bicep file changes
+      ],
     },
   };
 

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -58,6 +58,7 @@ async function launchLanguageService(
     progressOnInitialization: true,
     outputChannel,
     synchronize: {
+      // These file watcher globs should be kept in-sync with those defined in BicepDidChangeWatchedFilesHander.cs
       fileEvents: [
         vscode.workspace.createFileSystemWatcher("**/"), // folder changes
         vscode.workspace.createFileSystemWatcher("**/*.bicep"), // .bicep file changes


### PR DESCRIPTION
Closes #678 
1. Subscribe to didChangeWatchedFiles notifications and trigger recompilation of any dependent files if necessary.
1. Trigger recompilation on documentSync notifications for dependent files where necessary.
1. Introduce a `Workspace` class to share SyntaxTree instances where possible in the Language Server.