### PR TITLE
Stabilize vscode E2E tests

### DIFF
--- a/src/vscode-bicep/src/test/e2e/environment.ts
+++ b/src/vscode-bicep/src/test/e2e/environment.ts
@@ -22,7 +22,7 @@ class VSCodeEnvironment extends NodeEnvironment {
       await bicepExtension.activate();
     }
 
-    await sleep(1000);
+    await sleep(2000);
 
     this.global.vscode = vscode;
   }

--- a/src/vscode-bicep/src/test/e2e/environment.ts
+++ b/src/vscode-bicep/src/test/e2e/environment.ts
@@ -3,6 +3,10 @@
 import NodeEnvironment = require("jest-environment-node");
 import * as vscode from "vscode";
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 class VSCodeEnvironment extends NodeEnvironment {
   async setup(): Promise<void> {
     await super.setup();
@@ -17,6 +21,8 @@ class VSCodeEnvironment extends NodeEnvironment {
     if (!bicepExtension.isActive) {
       await bicepExtension.activate();
     }
+
+    await sleep(1000);
 
     this.global.vscode = vscode;
   }


### PR DESCRIPTION
The E2E tests in the build pipeline fail occasionally. The reason might be that the language server is not be fully ready when the tests start. The PR adds one second of sleep time when launching the e2e tests. Hopefully this can help solve the issue.