### PR TITLE
Stabilize vscode e2e tests second trail

### DIFF
--- a/src/vscode-bicep/src/test/e2e/completion.test.ts
+++ b/src/vscode-bicep/src/test/e2e/completion.test.ts
@@ -7,6 +7,7 @@ import { Position } from "vscode";
 import { readExampleFile } from "./examples";
 import { executeCompletionItemProviderCommand } from "./commands";
 import { expectDefined } from "../utils/assert";
+import { sleep } from "../utils/time";
 
 describe("completion", (): void => {
   let document: vscode.TextDocument;
@@ -20,6 +21,10 @@ describe("completion", (): void => {
     });
 
     editor = await vscode.window.showTextDocument(document);
+
+    // Give the language server sometime to finish compilation. If this is the first test
+    // to run it may take long for the compilation to complete because JIT is not "warmed up".
+    await sleep(2000);
   });
 
   afterAll(async () => {

--- a/src/vscode-bicep/src/test/e2e/environment.ts
+++ b/src/vscode-bicep/src/test/e2e/environment.ts
@@ -22,6 +22,7 @@ class VSCodeEnvironment extends NodeEnvironment {
       await bicepExtension.activate();
     }
 
+    await vscode.workspace.openTextDocument({ language: "bicep" });
     await sleep(2000);
 
     this.global.vscode = vscode;

--- a/src/vscode-bicep/src/test/e2e/environment.ts
+++ b/src/vscode-bicep/src/test/e2e/environment.ts
@@ -3,10 +3,6 @@
 import NodeEnvironment = require("jest-environment-node");
 import * as vscode from "vscode";
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 class VSCodeEnvironment extends NodeEnvironment {
   async setup(): Promise<void> {
     await super.setup();
@@ -21,9 +17,6 @@ class VSCodeEnvironment extends NodeEnvironment {
     if (!bicepExtension.isActive) {
       await bicepExtension.activate();
     }
-
-    await vscode.workspace.openTextDocument({ language: "bicep" });
-    await sleep(2000);
 
     this.global.vscode = vscode;
   }

--- a/src/vscode-bicep/src/test/e2e/hover.test.ts
+++ b/src/vscode-bicep/src/test/e2e/hover.test.ts
@@ -3,6 +3,7 @@
 import * as vscode from "vscode";
 
 import { expectDefined, expectRange } from "../utils/assert";
+import { sleep } from "../utils/time";
 import { executeHoverProviderCommand } from "./commands";
 import { readExampleFile } from "./examples";
 
@@ -17,6 +18,10 @@ describe("hover", (): void => {
     });
 
     await vscode.window.showTextDocument(document);
+
+    // Give the language server sometime to finish compilation. If this is the first test
+    // to run it may take long for the compilation to complete because JIT is not "warmed up".
+    await sleep(2000);
   });
 
   afterAll(async () => {

--- a/src/vscode-bicep/src/test/utils/time.ts
+++ b/src/vscode-bicep/src/test/utils/time.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Ironically the first PR didn't help...

One observation is that it is always the first test suite that fails, which only take a few ms to run ,and the second test suite always passes. This makes me think the first `openTextDocument` is the key. So I'm trying to add another step to open a empty bicep file to warm up language server.