### PR TITLE
Revert "Bump vscode-languageclient in /src/vscode-bicep (#716)"

### DIFF
--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -9702,25 +9702,25 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "6.0.0-next.7",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.7.tgz",
-            "integrity": "sha512-1nG+6cuTtpzmXe7yYfO9GCkYlyV6Ai+jDnwidHiT2T7zhc+bJM+VTtc0T/CdTlDyTNTqIcCj0V1nD4TcVjJ7Ug=="
+            "version": "6.0.0-next.6",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.6.tgz",
+            "integrity": "sha512-w3w1T9tGsInSbGyv2kpi4o6ciMIyfVkM+kAvkxEv4zIv3fs69q3Qyt7ZMLiXnaRFXecIOY2ALDKwIMi0n2IwHQ=="
         },
         "vscode-languageclient": {
-            "version": "7.0.0-next.12",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.12.tgz",
-            "integrity": "sha512-OrzvOvhS5o26C0KctTJC7hkwh3avCwkVhllzy42AqwpIUZ3p2aVqkSG2uVxaeodq8ThBb3TLgtg50vxyWs6FEg==",
+            "version": "7.0.0-next.10",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.10.tgz",
+            "integrity": "sha512-J9Hp64j1aaQfXlhMPGI1XAcdsIcSNPAL6022JElzgxsfAydmQfZeKCCNdyybjhmZ+xrep2yoVRAeD5TZFP7y6g==",
             "requires": {
                 "semver": "^6.3.0",
-                "vscode-languageserver-protocol": "3.16.0-next.10"
+                "vscode-languageserver-protocol": "3.16.0-next.8"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.16.0-next.10",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.10.tgz",
-            "integrity": "sha512-YRTctHUZvts0Z1xXKNYU0ha0o+Tlgtwr+6O8OmDquM086N8exiSKBMwMC+Ra1QtIE+1mfW43Wxsme2FnMkAS9A==",
+            "version": "3.16.0-next.8",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.8.tgz",
+            "integrity": "sha512-AWMc7vVN7xuTpQf6A7yvaYjxyKEeMBQWJpkcRgT3EFAYU8PXJK2NCL0wPrgHH2soF/bErxJwajA1vNtCqrsRsg==",
             "requires": {
-                "vscode-jsonrpc": "6.0.0-next.7",
+                "vscode-jsonrpc": "6.0.0-next.6",
                 "vscode-languageserver-types": "3.16.0-next.4"
             }
         },

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -107,7 +107,7 @@
     "dependencies": {
         "triple-beam": "^1.3.0",
         "vscode-azureextensionui": "^0.36.1",
-        "vscode-languageclient": "^7.0.0-next.12",
+        "vscode-languageclient": "^7.0.0-next.10",
         "winston": "^3.3.3",
         "winston-transport": "^4.4.0"
     },


### PR DESCRIPTION
This reverts commit f845af62ab7d2f5ef5041ecc645e1aa52436610d. The LSP spec was updated (I believe to clarify that the capability should be named `textDocument/semanticTokens`); the VSCode language client library has picked this up, but will need a corresponding change to the Omnisharp library.

Fixes #728 

I've looked into adding tests to make sure this doesn't get broken again, but as per https://github.com/microsoft/vscode/issues/580, it seems like it's by design that token highlighting info is not made available via the editor API.