### PR TITLE
Moved declared type logic from the type assignment visitor

### DIFF
--- a/src/Bicep.Core/Syntax/ModuleDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ModuleDeclarationSyntax.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parser;
+using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Syntax
 {
@@ -40,5 +42,29 @@ namespace Bicep.Core.Syntax
         public override TextSpan Span => TextSpan.Between(Keyword, Body);
 
         public StringSyntax? TryGetPath() => Path as StringSyntax;
+
+        public TypeSymbol GetDeclaredType(SemanticModel.SemanticModel moduleSemanticModel)
+        {
+            var paramTypeProperties = new List<TypeProperty>();
+            foreach (var param in moduleSemanticModel.Root.ParameterDeclarations)
+            {
+                var typePropertyFlags = TypePropertyFlags.WriteOnly;
+                if (SyntaxHelper.TryGetDefaultValue(param.DeclaringParameter) == null)
+                {
+                    // if there's no default value, it must be specified
+                    typePropertyFlags |= TypePropertyFlags.Required;
+                }
+
+                paramTypeProperties.Add(new TypeProperty(param.Name, param.Type, typePropertyFlags));
+            }
+
+            var outputTypeProperties = new List<TypeProperty>();
+            foreach (var output in moduleSemanticModel.Root.OutputDeclarations)
+            {
+                outputTypeProperties.Add(new TypeProperty(output.Name, output.Type, TypePropertyFlags.ReadOnly));
+            }
+
+            return LanguageConstants.CreateModuleType(paramTypeProperties, outputTypeProperties, "module");
+        }
     }
 }

--- a/src/Bicep.Core/Syntax/ParameterDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ParameterDeclarationSyntax.cs
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System.Linq;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parser;
+using Bicep.Core.SemanticModel;
+using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Syntax
 {
@@ -38,5 +43,49 @@ namespace Bicep.Core.Syntax
         /// Gets the declared type syntax of this parameter declaration. Certain parse errors will cause it to be null.
         /// </summary>
         public TypeSyntax? ParameterType => this.Type as TypeSyntax;
+
+        public TypeSymbol GetDeclaredType()
+        {
+            // assume "any" type when the parameter has parse errors (either missing or was skipped)
+            var declaredType = this.ParameterType == null
+                ? LanguageConstants.Any
+                : LanguageConstants.TryGetDeclarationType(this.ParameterType.TypeName);
+
+            if (declaredType == null)
+            {
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(this.Type).InvalidParameterType());
+            }
+
+            return declaredType;
+        }
+
+        public TypeSymbol GetAssignedType(ITypeManager typeManager)
+        {
+            var assignedType = this.GetDeclaredType();
+
+            var allowedSyntax = SyntaxHelper.TryGetAllowedSyntax(this);
+            if (allowedSyntax != null && !allowedSyntax.Items.Any())
+            {
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(allowedSyntax).AllowedMustContainItems());
+            }
+
+            if (object.ReferenceEquals(assignedType, LanguageConstants.String))
+            {
+                var allowedItemTypes = allowedSyntax?.Items.Select(typeManager.GetTypeInfo);
+
+                if (allowedItemTypes != null && allowedItemTypes.All(itemType => itemType is StringLiteralType))
+                {
+                    assignedType = UnionType.Create(allowedItemTypes);
+                }
+                else
+                {
+                    // In order to support assignment for a generic string to enum-typed properties (which generally is forbidden),
+                    // we need to relax the validation for string parameters without 'allowed' values specified.
+                    assignedType = LanguageConstants.LooseString;
+                }
+            }
+
+            return assignedType;
+        }
     }
 }

--- a/src/Bicep.Core/Syntax/ResourceDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ResourceDeclarationSyntax.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parser;
+using Bicep.Core.Resources;
+using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Syntax
 {
@@ -39,6 +42,32 @@ namespace Bicep.Core.Syntax
 
         public override TextSpan Span => TextSpan.Between(Keyword, Body);
 
-        public StringSyntax? TryGetType() => Type as StringSyntax;
+        public StringSyntax? TypeString => Type as StringSyntax;
+
+        public TypeSymbol GetDeclaredType(IResourceTypeProvider resourceTypeProvider)
+        {
+            var stringSyntax = this.TypeString;
+
+            if (stringSyntax != null && stringSyntax.IsInterpolated())
+            {
+                // TODO: in the future, we can relax this check to allow interpolation with compile-time constants.
+                // right now, codegen will still generate a format string however, which will cause problems for the type.
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(this.Type).ResourceTypeInterpolationUnsupported());
+            }
+
+            var stringContent = stringSyntax?.TryGetLiteralValue();
+            if (stringContent == null)
+            {
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(this.Type).InvalidResourceType());
+            }
+
+            var typeReference = ResourceTypeReference.TryParse(stringContent);
+            if (typeReference == null)
+            {
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(this.Type).InvalidResourceType());
+            }
+
+            return resourceTypeProvider.GetType(typeReference);
+        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -1,0 +1,283 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Bicep.Core.Extensions;
+using Bicep.Core.Parser;
+using Bicep.Core.SemanticModel;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.TypeSystem
+{
+    public class DeclaredTypeManager
+    {
+        // maps syntax nodes to their declared types
+        // processed nodes found not to have a declared type will have a null value
+        private readonly IDictionary<SyntaxBase, DeclaredTypeAssignment?> declaredTypes = new Dictionary<SyntaxBase, DeclaredTypeAssignment?>();
+
+        private readonly SyntaxHierarchy hierarchy;
+        private readonly ITypeManager typeManager;
+        private readonly IResourceTypeProvider resourceTypeProvider;
+        private readonly IReadOnlyDictionary<SyntaxBase, Symbol> bindings;
+
+        public DeclaredTypeManager(SyntaxHierarchy hierarchy, ITypeManager typeManager, IResourceTypeProvider resourceTypeProvider, IReadOnlyDictionary<SyntaxBase,Symbol> bindings)
+        {
+            this.hierarchy = hierarchy;
+            this.typeManager = typeManager;
+            this.resourceTypeProvider = resourceTypeProvider;
+            this.bindings = bindings;
+        }
+
+        public DeclaredTypeAssignment? GetDeclaredTypeAssignment(SyntaxBase syntax)
+        {
+            if (this.declaredTypes.TryGetValue(syntax, out var assignment))
+            {
+                // syntax node has already been processed
+                // return result as-is (even if null)
+                return assignment;
+            }
+
+            // the node has not been processed
+            // figure out the type
+            var newAssignment = GetTypeAssignment(syntax);
+
+            // cache the result
+            this.declaredTypes[syntax] = newAssignment;
+
+            return newAssignment;
+        }
+
+        public TypeSymbol? GetDeclaredType(SyntaxBase syntax) => this.GetDeclaredTypeAssignment(syntax)?.Reference.Type;
+
+        private DeclaredTypeAssignment? GetTypeAssignment(SyntaxBase syntax)
+        {
+            switch (syntax)
+            {
+                case ParameterDeclarationSyntax parameter:
+                    return GetParameterType(parameter);
+
+                case ResourceDeclarationSyntax resource:
+                    return GetResourceType(resource);
+
+                case ModuleDeclarationSyntax module:
+                    return GetModuleType(module);
+
+                case ArraySyntax array:
+                    return GetArrayType(array);
+
+                case ArrayItemSyntax arrayItem:
+                    return GetArrayItemType(arrayItem);
+
+                case ObjectSyntax @object:
+                    return GetObjectType(@object);
+
+                case ObjectPropertySyntax objectProperty:
+                    return GetObjectPropertyType(objectProperty);
+            }
+
+            return null;
+        }
+
+        private DeclaredTypeAssignment GetParameterType(ParameterDeclarationSyntax syntax) => new DeclaredTypeAssignment(syntax.GetDeclaredType());
+
+        private DeclaredTypeAssignment GetResourceType(ResourceDeclarationSyntax syntax) => new DeclaredTypeAssignment(syntax.GetDeclaredType(this.resourceTypeProvider));
+
+        private DeclaredTypeAssignment GetModuleType(ModuleDeclarationSyntax syntax)
+        {
+            if (!(bindings.TryGetValue(syntax, out var symbol) && symbol is ModuleSymbol moduleSymbol))
+            {
+                return new DeclaredTypeAssignment(ErrorType.Empty());
+            }
+
+            if (!moduleSymbol.TryGetSemanticModel(out var moduleSemanticModel, out var failureDiagnostic))
+            {
+                return new DeclaredTypeAssignment(ErrorType.Create(failureDiagnostic));
+            }
+
+            return new DeclaredTypeAssignment(syntax.GetDeclaredType(moduleSemanticModel));
+        }
+
+        private DeclaredTypeAssignment? GetArrayType(ArraySyntax syntax)
+        {
+            var parent = this.hierarchy.GetParent(syntax);
+
+            // we are only handling paths in the AST that are going to produce a declared type
+            // arrays can exist under a variable declaration, but variables don't have declared types,
+            // so we don't need to check that case
+            if (parent is ObjectPropertySyntax)
+            {
+                // this array is a value of the property
+                // the declared type should be the same as the array and we should propagate the flags
+                return GetDeclaredTypeAssignment(parent);
+            }
+
+            return null;
+        }
+
+        private DeclaredTypeAssignment? GetArrayItemType(ArrayItemSyntax syntax)
+        {
+            var parent = this.hierarchy.GetParent(syntax);
+            switch (parent)
+            {
+                case ArraySyntax _:
+                    // array items can only have array parents
+                    // use the declared item type
+                    var parentType = GetDeclaredTypeAssignment(parent)?.Reference.Type;
+                    if (parentType is ArrayType arrayType)
+                    {
+                        return new DeclaredTypeAssignment(arrayType.Item.Type);
+                    }
+
+                    break;
+            }
+
+            return null;
+        }
+
+        private DeclaredTypeAssignment? GetObjectType(ObjectSyntax syntax)
+        {
+            // local function
+            DeclaredTypeAssignment? CreateAssignment(ITypeReference? typeRef, DeclaredTypeFlags flags = DeclaredTypeFlags.None) => typeRef == null
+                ? null
+                : new DeclaredTypeAssignment(typeRef, flags);
+
+            var parent = this.hierarchy.GetParent(syntax);
+            if (parent == null)
+            {
+                return null;
+            }
+
+            var parentTypeAssignment = GetDeclaredTypeAssignment(parent);
+            if (parentTypeAssignment == null)
+            {
+                return null;
+            }
+
+            var parentType = parentTypeAssignment.Reference.Type;
+
+            switch (parent)
+            {
+                case ResourceDeclarationSyntax _ when parentType is ResourceType resourceType:
+                    // the object literal's parent is a resource declaration, which makes this the body of the resource
+                    // the declared type will be the same as the parent
+                    return CreateAssignment(ResolveDiscriminatedObjects(resourceType.Body.Type, syntax));
+
+                case ModuleDeclarationSyntax _ when parentType is ObjectType objectType:
+                    // the object literal's parent is a module declaration, which makes this the body of the module
+                    // the declared type will be the same as the parent
+                    return CreateAssignment(ResolveDiscriminatedObjects(objectType, syntax));
+
+                case ParameterDeclarationSyntax parameterDeclaration when ReferenceEquals(parameterDeclaration.Modifier, syntax):
+                    // the object is a modifier of a parameter type
+                    // the declared type should be the appropriate modifier type
+                    // however we need the parameter's assigned type to determine the modifier type
+                    var parameterAssignedType = parameterDeclaration.GetAssignedType(this.typeManager);
+                    return CreateAssignment(LanguageConstants.CreateParameterModifierType(parentType, parameterAssignedType));
+
+                case ObjectPropertySyntax _:
+                    // the object is the value of a property of another object
+                    // use the declared type of the property and propagate the flags
+                    return CreateAssignment(ResolveDiscriminatedObjects(parentType, syntax), parentTypeAssignment.Flags);
+
+                case ArrayItemSyntax _:
+                    // the object is an item in an array
+                    // use the item's type and propagate flags
+                    return CreateAssignment(ResolveDiscriminatedObjects(parentType, syntax), parentTypeAssignment.Flags);
+            }
+
+            return null;
+        }
+
+        private DeclaredTypeAssignment? GetObjectPropertyType(ObjectPropertySyntax syntax)
+        {
+            // local function
+            DeclaredTypeFlags ConvertFlags(TypePropertyFlags flags) => flags.HasFlag(TypePropertyFlags.Constant) ? DeclaredTypeFlags.Constant : DeclaredTypeFlags.None;
+
+            var propertyName = syntax.TryGetKeyText();
+            var parent = this.hierarchy.GetParent(syntax);
+            if (propertyName == null || parent == null)
+            {
+                // the property name is an interpolated string (expression) OR the parent is missing
+                // cannot establish declared type
+                // TODO: Improve this when we have constant folding
+                return null;
+            }
+
+            var assignment = GetDeclaredTypeAssignment(parent);
+            switch (assignment?.Reference.Type)
+            {
+                case ObjectType objectType:
+                    // lookup declared property
+                    if (objectType.Properties.TryGetValue(propertyName, out var property))
+                    {
+                        return new DeclaredTypeAssignment(property.TypeReference.Type, ConvertFlags(property.Flags));
+                    }
+
+                    // if there are additional properties, try those
+                    if (objectType.AdditionalPropertiesType != null)
+                    {
+                        return new DeclaredTypeAssignment(objectType.AdditionalPropertiesType.Type, ConvertFlags(objectType.AdditionalPropertiesFlags));
+                    }
+
+                    break;
+
+                case DiscriminatedObjectType discriminated:
+                    if (string.Equals(propertyName, discriminated.DiscriminatorProperty.Name, LanguageConstants.IdentifierComparison))
+                    {
+                        // the property is the discriminator property - use its type
+                        return new DeclaredTypeAssignment(discriminated.DiscriminatorProperty.TypeReference.Type);
+                    }
+
+                    break;
+            }
+
+            return null;
+        }
+
+        private TypeSymbol? ResolveDiscriminatedObjects(TypeSymbol type, ObjectSyntax syntax)
+        {
+            if (!(type is DiscriminatedObjectType discriminated))
+            {
+                // not a discriminated object type - return as-is
+                return type;
+            }
+
+            var discriminatorProperties = syntax.Properties
+                .Where(p => string.Equals(p.TryGetKeyText(), discriminated.DiscriminatorKey, LanguageConstants.IdentifierComparison))
+                .ToList();
+
+            if (discriminatorProperties.Count != 1)
+            {
+                // the object has duplicate properties with name matching the discriminator key
+                // don't select any of the union members
+                return type;
+            }
+
+            // calling the type check here would prevent the declared type from being assigned to the property
+            // because we haven't yet assigned the declared type to the object
+            // for the purposes of resolving the discriminated object, we just need to check if it's a literal string
+            // which doesn't require the full type check, so we're fine
+            var discriminatorProperty = discriminatorProperties.Single();
+            if (!(discriminatorProperty.Value is StringSyntax stringSyntax))
+            {
+                // the discriminator property value is not a string
+                return type;
+            }
+
+            var discriminatorValue = stringSyntax.TryGetLiteralValue();
+            if (discriminatorValue == null)
+            {
+                // the string value was interpolated
+                return type;
+            }
+
+            // discriminator values are stored in the dictionary as bicep literal string text
+            // we must escape the literal value to successfully retrieve a match
+            var matchingObjectType = discriminated.UnionMembersByKey.TryGetValue(StringUtils.EscapeBicepString(discriminatorValue));
+
+            // return the match if we have it
+            return matchingObjectType?.Type;
+        }
+    }
+}

--- a/src/Bicep.Core/TypeSystem/ErrorType.cs
+++ b/src/Bicep.Core/TypeSystem/ErrorType.cs
@@ -24,6 +24,9 @@ namespace Bicep.Core.TypeSystem
         public static ErrorType Create(IEnumerable<ErrorDiagnostic> errors)
             => new ErrorType(errors.ToImmutableArray());
 
+        public static ErrorType Empty()
+            => new ErrorType(ImmutableArray<ErrorDiagnostic>.Empty);
+
         public override IEnumerable<ErrorDiagnostic> GetDiagnostics() => this.errors;
 
         public override TypeSymbolValidationFlags ValidationFlags => TypeSymbolValidationFlags.PreventAssignment;

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -7,9 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
-using Bicep.Core.Navigation;
 using Bicep.Core.Parser;
-using Bicep.Core.Resources;
 using Bicep.Core.SemanticModel;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
@@ -42,7 +40,6 @@ namespace Bicep.Core.TypeSystem
         private readonly IReadOnlyDictionary<SyntaxBase, Symbol> bindings;
         private readonly IReadOnlyDictionary<DeclaredSymbol, ImmutableArray<DeclaredSymbol>> cyclesBySymbol;
         private readonly IDictionary<SyntaxBase, TypeAssignment> assignedTypes;
-        private readonly IDictionary<SyntaxBase, DeclaredTypeAssignment> declaredTypes;
         private readonly SyntaxHierarchy hierarchy;
 
         public TypeAssignmentVisitor(
@@ -60,7 +57,6 @@ namespace Bicep.Core.TypeSystem
             this.bindings = bindings;
             this.cyclesBySymbol = cyclesBySymbol;
             this.assignedTypes = new Dictionary<SyntaxBase, TypeAssignment>();
-            this.declaredTypes = new Dictionary<SyntaxBase, DeclaredTypeAssignment>();
             this.hierarchy = hierarchy;
         }
 
@@ -76,23 +72,8 @@ namespace Bicep.Core.TypeSystem
             return typeAssignment;
         }
 
-        public DeclaredTypeAssignment? GetDeclaredTypeAssignment(SyntaxBase syntax)
-        {
-            // causes stack overflow Visit(syntax);
-
-            if (declaredTypes.TryGetValue(syntax, out var typeAssignment))
-            {
-                return typeAssignment;
-            }
-
-            return null;
-        }
-
         public TypeSymbol GetTypeInfo(SyntaxBase syntax)
             => GetTypeAssignment(syntax).Reference.Type;
-
-        public TypeSymbol? GetDeclaredType(SyntaxBase syntax)
-            => GetDeclaredTypeAssignment(syntax)?.Reference.Type;
 
         public IEnumerable<Diagnostic> GetAllDiagnostics()
             => assignedTypes.Values.SelectMany(x => x.Diagnostics);
@@ -112,22 +93,6 @@ namespace Bicep.Core.TypeSystem
             }
 
             assignedTypes[syntax] = assignFunc();
-        }
-
-        private void AssignDeclaredType(SyntaxBase syntax, ITypeReference? typeReference)
-        {
-            if (typeReference != null)
-            {
-                AssignDeclaredType(syntax, new DeclaredTypeAssignment(typeReference));
-            }
-        }
-
-        private void AssignDeclaredType(SyntaxBase syntax, DeclaredTypeAssignment? assignment)
-        {
-            if (assignment != null)
-            {
-                this.declaredTypes[syntax] = assignment;
-            }
         }
 
         private void AssignType(SyntaxBase syntax, Func<ITypeReference> assignFunc)
@@ -169,33 +134,13 @@ namespace Bicep.Core.TypeSystem
         }
 
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
-            => AssignTypeWithDiagnostics(syntax, diagnostics => {
-                var stringSyntax = syntax.TryGetType();
-
-                if (stringSyntax != null && stringSyntax.IsInterpolated())
+            => AssignTypeWithDiagnostics(syntax, diagnostics =>
+            {
+                var declaredType = syntax.GetDeclaredType(resourceTypeProvider);
+                if (declaredType is ErrorType)
                 {
-                    // TODO: in the future, we can relax this check to allow interpolation with compile-time constants.
-                    // right now, codegen will still generate a format string however, which will cause problems for the type.
-                    return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).ResourceTypeInterpolationUnsupported());
+                    return declaredType;
                 }
-
-                var stringContent = stringSyntax?.TryGetLiteralValue();
-                if (stringContent == null)
-                {
-                    return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).InvalidResourceType());
-                }
-
-                // TODO: This needs proper namespace, type, and version resolution logic in the future
-                var typeReference = ResourceTypeReference.TryParse(stringContent);
-                if (typeReference == null)
-                {
-                    return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).InvalidResourceType());
-                }
-
-                var declaredType = resourceTypeProvider.GetType(typeReference);
-                
-                // just established the declared type - assign it!
-                AssignDeclaredType(syntax, declaredType);
 
                 if (declaredType is ResourceType resourceType && !resourceTypeProvider.HasType(resourceType.TypeReference))
                 {
@@ -205,36 +150,12 @@ namespace Bicep.Core.TypeSystem
                 return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, syntax.Body, declaredType, diagnostics);
             });
 
-        private static TypeSymbol GetDeclaredModuleType(SemanticModel.SemanticModel moduleSemanticModel, string typeName)
-        {
-            var paramTypeProperties = new List<TypeProperty>();
-            foreach (var param in moduleSemanticModel.Root.ParameterDeclarations)
-            {
-                var typePropertyFlags = TypePropertyFlags.WriteOnly;
-                if (SyntaxHelper.TryGetDefaultValue(param.DeclaringParameter) == null)
-                {
-                    // if there's no default value, it must be specified
-                    typePropertyFlags |= TypePropertyFlags.Required;
-                }
-
-                paramTypeProperties.Add(new TypeProperty(param.Name, param.Type, typePropertyFlags));
-            }
-
-            var outputTypeProperties = new List<TypeProperty>();
-            foreach (var output in moduleSemanticModel.Root.OutputDeclarations)
-            {
-                outputTypeProperties.Add(new TypeProperty(output.Name, output.Type, TypePropertyFlags.ReadOnly));
-            }
-
-            return LanguageConstants.CreateModuleType(paramTypeProperties, outputTypeProperties, typeName);
-        }
-
         public override void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax)
             => AssignTypeWithDiagnostics(syntax, diagnostics => {
                 if (!(bindings.TryGetValue(syntax, out var symbol) && symbol is ModuleSymbol moduleSymbol))
                 {
                     // TODO: Ideally we'd still be able to return a type here, but we'd need access to the compilation to get it.
-                    return ErrorType.Create(Enumerable.Empty<ErrorDiagnostic>());
+                    return ErrorType.Empty();
                 }
 
                 if (!moduleSymbol.TryGetSemanticModel(out var moduleSemanticModel, out var failureDiagnostic))
@@ -242,16 +163,13 @@ namespace Bicep.Core.TypeSystem
                     return ErrorType.Create(failureDiagnostic);
                 }
 
+                var declaredType = syntax.GetDeclaredType(moduleSemanticModel);
+
                 if (moduleSemanticModel.HasErrors())
                 {
                     diagnostics.Add(DiagnosticBuilder.ForPosition(syntax.Path).ReferencedModuleHasErrors());
                 }
-
-                var declaredType = GetDeclaredModuleType(moduleSemanticModel, "module");
                 
-                // just established the declared type - assign it!
-                AssignDeclaredType(syntax, declaredType);
-
                 return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, syntax.Body, declaredType, diagnostics);
             });
 
@@ -259,20 +177,13 @@ namespace Bicep.Core.TypeSystem
             => AssignTypeWithDiagnostics(syntax, diagnostics => {
                 diagnostics.AddRange(this.ValidateIdentifierAccess(syntax));
 
-                // assume "any" type when the parameter has parse errors (either missing or was skipped)
-                var declaredType = syntax.ParameterType == null
-                    ? LanguageConstants.Any
-                    : LanguageConstants.TryGetDeclarationType(syntax.ParameterType.TypeName);
-
-                if (declaredType == null)
+                var declaredType = syntax.GetDeclaredType();
+                if (declaredType is ErrorType)
                 {
-                    return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).InvalidParameterType());
+                    return declaredType;
                 }
 
-                // just established the declared type
-                AssignDeclaredType(syntax, declaredType);
-
-                var assignedType = GetParameterAssignedType(syntax, declaredType);
+                var assignedType = syntax.GetAssignedType(this.typeManager);
 
                 switch (syntax.Modifier)
                 {
@@ -368,16 +279,15 @@ namespace Bicep.Core.TypeSystem
             => AssignType(syntax, () => LanguageConstants.Null);
 
         public override void VisitSkippedTriviaSyntax(SkippedTriviaSyntax syntax)
-            => AssignType(syntax, () => {
+            => AssignType(syntax, () => 
+            {
                 // error should have already been raised by the ParseDiagnosticsVisitor - no need to add another
                 return ErrorType.Create(Enumerable.Empty<ErrorDiagnostic>());
             });
 
         public override void VisitObjectSyntax(ObjectSyntax syntax)
-            => AssignType(syntax, () => {
-                // assigning declared type depends on parent and nothing in the object itself
-                // so do it immediately
-                AssignDeclaredType(syntax, GetDeclaredTypeAssignmentInternal(syntax));
+            => AssignType(syntax, () => 
+            {
                 var errors = new List<ErrorDiagnostic>();
 
                 var propertyTypes = new List<TypeSymbol>();
@@ -411,8 +321,6 @@ namespace Bicep.Core.TypeSystem
         public override void VisitObjectPropertySyntax(ObjectPropertySyntax syntax)
             => AssignType(syntax, () =>
             {
-                 AssignDeclaredType(syntax, GetDeclaredTypeAssignmentInternal(syntax));
-
                 var errors = new List<ErrorDiagnostic>();
                 var types = new List<TypeSymbol>();
 
@@ -436,11 +344,7 @@ namespace Bicep.Core.TypeSystem
             });
 
         public override void VisitArrayItemSyntax(ArrayItemSyntax syntax)
-            => AssignType(syntax, () =>
-            {
-                AssignDeclaredType(syntax, GetDeclaredTypeInternal(syntax));
-                return typeManager.GetTypeInfo(syntax.Value);
-            });
+            => AssignType(syntax, () => typeManager.GetTypeInfo(syntax.Value));
 
         public override void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax)
             => AssignType(syntax, () => typeManager.GetTypeInfo(syntax.Expression));
@@ -451,8 +355,6 @@ namespace Bicep.Core.TypeSystem
         public override void VisitArraySyntax(ArraySyntax syntax)
             => AssignType(syntax, () =>
             {
-                AssignDeclaredType(syntax, GetDeclaredTypeAssignmentInternal(syntax));
-                
                 var errors = new List<ErrorDiagnostic>();
 
                 var itemTypes = new List<TypeSymbol>(syntax.Children.Length);
@@ -1046,217 +948,6 @@ namespace Bicep.Core.TypeSystem
                     return accumulated;
                 },
                 accumulated => accumulated);
-        }
-
-        private TypeSymbol GetParameterAssignedType(ParameterDeclarationSyntax syntax, TypeSymbol declaredType)
-        {
-            var assignedType = declaredType;
-
-            var allowedSyntax = SyntaxHelper.TryGetAllowedSyntax(syntax);
-            if (allowedSyntax != null && !allowedSyntax.Items.Any())
-            {
-                return ErrorType.Create(DiagnosticBuilder.ForPosition(allowedSyntax).AllowedMustContainItems());
-            }
-
-            if (object.ReferenceEquals(assignedType, LanguageConstants.String))
-            {
-                var allowedItemTypes = allowedSyntax?.Items.Select(typeManager.GetTypeInfo);
-
-                if (allowedItemTypes != null && allowedItemTypes.All(itemType => itemType is StringLiteralType))
-                {
-                    assignedType = UnionType.Create(allowedItemTypes);
-                }
-                else
-                {
-                    // In order to support assignment for a generic string to enum-typed properties (which generally is forbidden),
-                    // we need to relax the validation for string parameters without 'allowed' values specified.
-                    assignedType = LanguageConstants.LooseString;
-                }
-            }
-
-            return assignedType;
-        }
-
-        private DeclaredTypeAssignment? GetDeclaredTypeAssignmentInternal(ArraySyntax syntax)
-        {
-            var parent = this.hierarchy.GetParent(syntax);
-
-            // we are only handling paths in the AST that are going to produce a declared type
-            // arrays can exist under a variable declaration, but variables don't have declared types,
-            // so we don't need to check that case
-            if (parent is ObjectPropertySyntax)
-            {
-                // this array is a value of the property
-                // the declared type should be the same as the array and we should propagate the flags
-                return GetDeclaredTypeAssignment(parent);
-            }
-
-            return null;
-        }
-
-        private TypeSymbol? GetDeclaredTypeInternal(ArrayItemSyntax syntax)
-        {
-            var parent = this.hierarchy.GetParent(syntax);
-            switch (parent)
-            {
-                case ArraySyntax _:
-                    // array items can only have array parents
-                    // use the declared item type
-                    var parentType = GetDeclaredTypeAssignment(parent)?.Reference.Type;
-                    if (parentType is ArrayType arrayType)
-                    {
-                        return arrayType.Item.Type;
-                    }
-
-                    break;
-            }
-
-            return null;
-        }
-
-        private DeclaredTypeAssignment? GetDeclaredTypeAssignmentInternal(ObjectSyntax syntax)
-        {
-            // local function
-            DeclaredTypeAssignment? CreateAssignment(ITypeReference? typeRef, DeclaredTypeFlags flags = DeclaredTypeFlags.None) => typeRef == null
-                ? null
-                : new DeclaredTypeAssignment(typeRef, flags);
-
-            var parent = this.hierarchy.GetParent(syntax);
-            if (parent == null)
-            {
-                return null;
-            }
-
-            var parentTypeAssignment = GetDeclaredTypeAssignment(parent);
-            if (parentTypeAssignment == null)
-            {
-                return null;
-            }
-
-            var parentType = parentTypeAssignment.Reference.Type;
-
-            switch (parent)
-            {
-                case ResourceDeclarationSyntax _ when parentType is ResourceType resourceType:
-                    // the object literal's parent is a resource declaration, which makes this the body of the resource
-                    // the declared type will be the same as the parent
-                    return CreateAssignment(ResolveDiscriminatedObjects(resourceType.Body.Type, syntax));
-
-                case ModuleDeclarationSyntax _ when parentType is ObjectType objectType:
-                    // the object literal's parent is a module declaration, which makes this the body of the module
-                    // the declared type will be the same as the parent
-                    return CreateAssignment(ResolveDiscriminatedObjects(objectType, syntax));
-
-                case ParameterDeclarationSyntax parameterDeclaration when ReferenceEquals(parameterDeclaration.Modifier, syntax):
-                    // the object is a modifier of a parameter type
-                    // the declared type should be the appropriate modifier type
-                    // however we need the parameter's assigned type to determine the modifier type
-                    var parameterAssignedType = GetParameterAssignedType(parameterDeclaration, parentType.Type.Type);
-                    return CreateAssignment(LanguageConstants.CreateParameterModifierType(parentType, parameterAssignedType));
-
-                case ObjectPropertySyntax _:
-                    // the object is the value of a property of another object
-                    // use the declared type of the property and propagate the flags
-                    return CreateAssignment(ResolveDiscriminatedObjects(parentType, syntax), parentTypeAssignment.Flags);
-
-                case ArrayItemSyntax _:
-                    // the object is an item in an array
-                    // use the item's type and propagate flags
-                    return CreateAssignment(ResolveDiscriminatedObjects(parentType, syntax), parentTypeAssignment.Flags);
-            }
-
-            return null;
-        }
-
-        private DeclaredTypeAssignment? GetDeclaredTypeAssignmentInternal(ObjectPropertySyntax syntax)
-        {
-            // local function
-            DeclaredTypeFlags ConvertFlags(TypePropertyFlags flags) => flags.HasFlag(TypePropertyFlags.Constant) ? DeclaredTypeFlags.Constant : DeclaredTypeFlags.None;
-
-            var propertyName = syntax.TryGetKeyText();
-            var parent = this.hierarchy.GetParent(syntax);
-            if (propertyName == null || parent == null)
-            {
-                // the property name is an interpolated string (expression) OR the parent is missing
-                // cannot establish declared type
-                // TODO: Improve this when we have constant folding
-                return null;
-            }
-
-            var assignment = GetDeclaredTypeAssignment(parent);
-            switch (assignment?.Reference.Type)
-            {
-                case ObjectType objectType:
-                    // lookup declared property
-                    if (objectType.Properties.TryGetValue(propertyName, out var property))
-                    {
-                        return new DeclaredTypeAssignment(property.TypeReference.Type, ConvertFlags(property.Flags));
-                    }
-
-                    // if there are additional properties, try those
-                    if (objectType.AdditionalPropertiesType != null)
-                    {
-                        return new DeclaredTypeAssignment(objectType.AdditionalPropertiesType.Type, ConvertFlags(objectType.AdditionalPropertiesFlags));
-                    }
-
-                    break;
-
-                case DiscriminatedObjectType discriminated:
-                    if (string.Equals(propertyName, discriminated.DiscriminatorProperty.Name, LanguageConstants.IdentifierComparison))
-                    {
-                        // the property is the discriminator property - use its type
-                        return new DeclaredTypeAssignment(discriminated.DiscriminatorProperty.TypeReference.Type);
-                    }
-
-                    break;
-            }
-
-            return null;
-        }
-
-        private TypeSymbol? ResolveDiscriminatedObjects(TypeSymbol type, ObjectSyntax syntax)
-        {
-            if (!(type is DiscriminatedObjectType discriminated))
-            {
-                // not a discriminated object type - return as-is
-                return type;
-            }
-
-            var discriminatorProperties = syntax.Properties
-                .Where(p => string.Equals(p.TryGetKeyText(), discriminated.DiscriminatorKey, LanguageConstants.IdentifierComparison))
-                .ToList();
-
-            if (discriminatorProperties.Count != 1)
-            {
-                // the object has duplicate properties with name matching the discriminator key
-                // don't select any of the union members
-                return type;
-            }
-
-            // calling the type check here would prevent the declared type from being assigned to the property
-            // because we haven't yet assigned the declared type to the object
-            // for the purposes of resolving the discriminated object, we just need to check if it's a literal string
-            // which doesn't require the full type check, so we're fine
-            var discriminatorProperty = discriminatorProperties.Single();
-            if (!(discriminatorProperty.Value is StringSyntax stringSyntax))
-            {
-                // the discriminator property value is not a string
-                return type;
-            }
-
-            var discriminatorValue = stringSyntax.TryGetLiteralValue();
-            if (discriminatorValue == null)
-            {
-                // the string value was interpolated
-                return type;
-            }
-
-            // discriminator values are stored in the dictionary as bicep literal string text
-            // we must escape the literal value to successfully retrieve a match
-            var matchingObjectType = discriminated.UnionMembersByKey.TryGetValue(StringUtils.EscapeBicepString(discriminatorValue));
-
-            // return the match if we have it
-            return matchingObjectType?.Type;
         }
     }
 }

--- a/src/Bicep.Core/TypeSystem/TypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/TypeManager.cs
@@ -12,6 +12,7 @@ namespace Bicep.Core.TypeSystem
     {
         // stores results of type checks
         private readonly TypeAssignmentVisitor typeAssignmentVisitor;
+        private readonly DeclaredTypeManager declaredTypeManager;
 
         public TypeManager(IResourceTypeProvider resourceTypeProvider, IReadOnlyDictionary<SyntaxBase, Symbol> bindings, IReadOnlyDictionary<DeclaredSymbol, ImmutableArray<DeclaredSymbol>> cyclesBySymbol, SyntaxHierarchy hierarchy)
         {
@@ -21,6 +22,8 @@ namespace Bicep.Core.TypeSystem
             // so we can't make an immutable copy here
             // (using the IReadOnlyDictionary to prevent accidental mutation)
             this.typeAssignmentVisitor = new TypeAssignmentVisitor(resourceTypeProvider, this, bindings, cyclesBySymbol, hierarchy);
+
+            this.declaredTypeManager = new DeclaredTypeManager(hierarchy, this, resourceTypeProvider, bindings);
         }
 
         public IResourceTypeProvider ResourceTypeProvider { get; }
@@ -29,10 +32,10 @@ namespace Bicep.Core.TypeSystem
             => typeAssignmentVisitor.GetTypeInfo(syntax);
 
         public TypeSymbol? GetDeclaredType(SyntaxBase syntax)
-            => typeAssignmentVisitor.GetDeclaredType(syntax);
+            => declaredTypeManager.GetDeclaredType(syntax);
 
         public DeclaredTypeAssignment? GetDeclaredTypeAssignment(SyntaxBase syntax)
-            => typeAssignmentVisitor.GetDeclaredTypeAssignment(syntax);
+            => declaredTypeManager.GetDeclaredTypeAssignment(syntax);
 
         public IEnumerable<Diagnostic> GetAllDiagnostics()
             => typeAssignmentVisitor.GetAllDiagnostics();


### PR DESCRIPTION
To support dot property and array access completions I need to make changes to how the declared types are flowing. This is easier to do if the declared type logic is separate from the type assignment visitor, so here we are 🙂.

As part of this refactor, the logic to determine the declared type for modules, resources and parameters was moved into places that can be invoked from the type assignment visitor and the new declared type manager.