### PR TITLE
Dot property access completions now work with non top-level discriminators

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -741,6 +741,84 @@
     }
   },
   {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -767,6 +767,84 @@
     }
   },
   {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createMode.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createMode.json
@@ -1,0 +1,22 @@
+[
+  {
+    "label": "createMode",
+    "kind": "property",
+    "detail": "createMode (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Default' | 'Restore'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_createMode",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "createMode"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeProperties.json
@@ -1,0 +1,562 @@
+[
+  {
+    "label": "apiProperties",
+    "kind": "property",
+    "detail": "apiProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ApiProperties`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_apiProperties",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "apiProperties"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "backupPolicy",
+    "kind": "property",
+    "detail": "backupPolicy",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `BackupPolicy`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_backupPolicy",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "backupPolicy"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "capabilities",
+    "kind": "property",
+    "detail": "capabilities",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Capability[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_capabilities",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "capabilities"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "connectorOffer",
+    "kind": "property",
+    "detail": "connectorOffer",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Small'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_connectorOffer",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "connectorOffer"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "consistencyPolicy",
+    "kind": "property",
+    "detail": "consistencyPolicy",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ConsistencyPolicy`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_consistencyPolicy",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "consistencyPolicy"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "cors",
+    "kind": "property",
+    "detail": "cors",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `CorsPolicy[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cors",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "cors"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "createMode",
+    "kind": "property",
+    "detail": "createMode (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Default'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_createMode",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "createMode"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "databaseAccountOfferType",
+    "kind": "property",
+    "detail": "databaseAccountOfferType (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_databaseAccountOfferType",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "databaseAccountOfferType"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "disableKeyBasedMetadataWriteAccess",
+    "kind": "property",
+    "detail": "disableKeyBasedMetadataWriteAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_disableKeyBasedMetadataWriteAccess",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "disableKeyBasedMetadataWriteAccess"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "documentEndpoint",
+    "kind": "property",
+    "detail": "documentEndpoint",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_documentEndpoint",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "documentEndpoint"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "enableAnalyticalStorage",
+    "kind": "property",
+    "detail": "enableAnalyticalStorage",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_enableAnalyticalStorage",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "enableAnalyticalStorage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "enableAutomaticFailover",
+    "kind": "property",
+    "detail": "enableAutomaticFailover",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_enableAutomaticFailover",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "enableAutomaticFailover"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "enableCassandraConnector",
+    "kind": "property",
+    "detail": "enableCassandraConnector",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_enableCassandraConnector",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "enableCassandraConnector"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "enableFreeTier",
+    "kind": "property",
+    "detail": "enableFreeTier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_enableFreeTier",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "enableFreeTier"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "enableMultipleWriteLocations",
+    "kind": "property",
+    "detail": "enableMultipleWriteLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_enableMultipleWriteLocations",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "enableMultipleWriteLocations"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "failoverPolicies",
+    "kind": "property",
+    "detail": "failoverPolicies",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `FailoverPolicy[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_failoverPolicies",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "failoverPolicies"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "instanceId",
+    "kind": "property",
+    "detail": "instanceId",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_instanceId",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "instanceId"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "ipRules",
+    "kind": "property",
+    "detail": "ipRules",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `IpAddressOrRange[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_ipRules",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "ipRules"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "isVirtualNetworkFilterEnabled",
+    "kind": "property",
+    "detail": "isVirtualNetworkFilterEnabled",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_isVirtualNetworkFilterEnabled",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "isVirtualNetworkFilterEnabled"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "keyVaultKeyUri",
+    "kind": "property",
+    "detail": "keyVaultKeyUri",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_keyVaultKeyUri",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "keyVaultKeyUri"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "locations",
+    "kind": "property",
+    "detail": "locations (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_locations",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "locations"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "privateEndpointConnections",
+    "kind": "property",
+    "detail": "privateEndpointConnections",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `PrivateEndpointConnection[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_privateEndpointConnections",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "privateEndpointConnections"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "provisioningState",
+    "kind": "property",
+    "detail": "provisioningState",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_provisioningState",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "provisioningState"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "publicNetworkAccess",
+    "kind": "property",
+    "detail": "publicNetworkAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Disabled' | 'Enabled'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_publicNetworkAccess",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "publicNetworkAccess"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "readLocations",
+    "kind": "property",
+    "detail": "readLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_readLocations",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "readLocations"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "restoreParameters",
+    "kind": "property",
+    "detail": "restoreParameters",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `RestoreParameters`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_restoreParameters",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "restoreParameters"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "virtualNetworkRules",
+    "kind": "property",
+    "detail": "virtualNetworkRules",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `VirtualNetworkRule[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_virtualNetworkRules",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "virtualNetworkRules"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "writeLocations",
+    "kind": "property",
+    "detail": "writeLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_writeLocations",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "writeLocations"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -754,6 +754,84 @@
     }
   },
   {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -728,6 +728,84 @@
     }
   },
   {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -252,3 +252,29 @@ resource dashesInPropertyNames 'Microsoft.ContainerService/managedClusters@2020-
 }
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
+
+resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+  name: 'test'
+  location: 'l'
+  properties: {
+    //createMode: 'Default'
+
+  }
+}
+// #completionTest(90) -> createMode
+var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.properties.cr
+// #completionTest(94) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
+
+resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+  name: 'test'
+  location: 'l'
+  properties: {
+    createMode: 'Default'
+
+  }
+}
+// #completionTest(69) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
+// #completionTest(73) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -326,3 +326,32 @@ resource dashesInPropertyNames 'Microsoft.ContainerService/managedClusters@2020-
 }
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
+
+resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+  name: 'test'
+  location: 'l'
+  properties: {
+    //createMode: 'Default'
+
+  }
+}
+// #completionTest(90) -> createMode
+var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.properties.cr
+// #completionTest(94) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
+//@[48:77) [BCP076 (Error)] Cannot index over expression of type "Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview". Arrays or objects are required. |nestedDiscriminatorMissingKey|
+
+resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+  name: 'test'
+  location: 'l'
+  properties: {
+    createMode: 'Default'
+
+  }
+}
+// #completionTest(69) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
+// #completionTest(73) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
+//@[38:57) [BCP076 (Error)] Cannot index over expression of type "Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview". Arrays or objects are required. |nestedDiscriminator|
+

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -296,3 +296,36 @@ resource dashesInPropertyNames 'Microsoft.ContainerService/managedClusters@2020-
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
 //@[4:23) Variable letsAccessTheDashes. Type: any. Declaration start char: 0, length: 78
+
+resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+//@[9:38) Resource nestedDiscriminatorMissingKey. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 190
+  name: 'test'
+  location: 'l'
+  properties: {
+    //createMode: 'Default'
+
+  }
+}
+// #completionTest(90) -> createMode
+var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.properties.cr
+//@[4:44) Variable nestedDiscriminatorMissingKeyCompletions. Type: any. Declaration start char: 0, length: 90
+// #completionTest(94) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
+//@[4:45) Variable nestedDiscriminatorMissingKeyCompletions2. Type: error. Declaration start char: 0, length: 94
+
+resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+//@[9:28) Resource nestedDiscriminator. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 178
+  name: 'test'
+  location: 'l'
+  properties: {
+    createMode: 'Default'
+
+  }
+}
+// #completionTest(69) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
+//@[4:34) Variable nestedDiscriminatorCompletions. Type: any. Declaration start char: 0, length: 69
+// #completionTest(73) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
+//@[4:35) Variable nestedDiscriminatorCompletions2. Type: error. Declaration start char: 0, length: 73
+

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -1404,4 +1404,184 @@ var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
 //@[76:77)   Dot |.|
 //@[77:78)   IdentifierSyntax
 //@[77:78)    Identifier |s|
-//@[78:78) EndOfFile ||
+//@[78:82) NewLine |\r\n\r\n|
+
+resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+//@[0:190) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:38)  IdentifierSyntax
+//@[9:38)   Identifier |nestedDiscriminatorMissingKey|
+//@[39:97)  StringSyntax
+//@[39:97)   StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[98:99)  Assignment |=|
+//@[100:190)  ObjectSyntax
+//@[100:101)   LeftBrace |{|
+//@[101:103)   NewLine |\r\n|
+  name: 'test'
+//@[2:14)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:14)    StringSyntax
+//@[8:14)     StringComplete |'test'|
+//@[14:16)   NewLine |\r\n|
+  location: 'l'
+//@[2:15)   ObjectPropertySyntax
+//@[2:10)    IdentifierSyntax
+//@[2:10)     Identifier |location|
+//@[10:11)    Colon |:|
+//@[12:15)    StringSyntax
+//@[12:15)     StringComplete |'l'|
+//@[15:17)   NewLine |\r\n|
+  properties: {
+//@[2:51)   ObjectPropertySyntax
+//@[2:12)    IdentifierSyntax
+//@[2:12)     Identifier |properties|
+//@[12:13)    Colon |:|
+//@[14:51)    ObjectSyntax
+//@[14:15)     LeftBrace |{|
+//@[15:17)     NewLine |\r\n|
+    //createMode: 'Default'
+//@[27:31)     NewLine |\r\n\r\n|
+
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(90) -> createMode
+//@[36:38) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.properties.cr
+//@[0:90) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:44)  IdentifierSyntax
+//@[4:44)   Identifier |nestedDiscriminatorMissingKeyCompletions|
+//@[45:46)  Assignment |=|
+//@[47:90)  PropertyAccessSyntax
+//@[47:87)   PropertyAccessSyntax
+//@[47:76)    VariableAccessSyntax
+//@[47:76)     IdentifierSyntax
+//@[47:76)      Identifier |nestedDiscriminatorMissingKey|
+//@[76:77)    Dot |.|
+//@[77:87)    IdentifierSyntax
+//@[77:87)     Identifier |properties|
+//@[87:88)   Dot |.|
+//@[88:90)   IdentifierSyntax
+//@[88:90)    Identifier |cr|
+//@[90:92) NewLine |\r\n|
+// #completionTest(94) -> createMode
+//@[36:38) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
+//@[0:94) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:45)  IdentifierSyntax
+//@[4:45)   Identifier |nestedDiscriminatorMissingKeyCompletions2|
+//@[46:47)  Assignment |=|
+//@[48:94)  PropertyAccessSyntax
+//@[48:91)   ArrayAccessSyntax
+//@[48:77)    VariableAccessSyntax
+//@[48:77)     IdentifierSyntax
+//@[48:77)      Identifier |nestedDiscriminatorMissingKey|
+//@[77:78)    LeftSquare |[|
+//@[78:90)    StringSyntax
+//@[78:90)     StringComplete |'properties'|
+//@[90:91)    RightSquare |]|
+//@[91:92)   Dot |.|
+//@[92:94)   IdentifierSyntax
+//@[92:94)    Identifier |cr|
+//@[94:98) NewLine |\r\n\r\n|
+
+resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+//@[0:178) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:28)  IdentifierSyntax
+//@[9:28)   Identifier |nestedDiscriminator|
+//@[29:87)  StringSyntax
+//@[29:87)   StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[88:89)  Assignment |=|
+//@[90:178)  ObjectSyntax
+//@[90:91)   LeftBrace |{|
+//@[91:93)   NewLine |\r\n|
+  name: 'test'
+//@[2:14)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:14)    StringSyntax
+//@[8:14)     StringComplete |'test'|
+//@[14:16)   NewLine |\r\n|
+  location: 'l'
+//@[2:15)   ObjectPropertySyntax
+//@[2:10)    IdentifierSyntax
+//@[2:10)     Identifier |location|
+//@[10:11)    Colon |:|
+//@[12:15)    StringSyntax
+//@[12:15)     StringComplete |'l'|
+//@[15:17)   NewLine |\r\n|
+  properties: {
+//@[2:49)   ObjectPropertySyntax
+//@[2:12)    IdentifierSyntax
+//@[2:12)     Identifier |properties|
+//@[12:13)    Colon |:|
+//@[14:49)    ObjectSyntax
+//@[14:15)     LeftBrace |{|
+//@[15:17)     NewLine |\r\n|
+    createMode: 'Default'
+//@[4:25)     ObjectPropertySyntax
+//@[4:14)      IdentifierSyntax
+//@[4:14)       Identifier |createMode|
+//@[14:15)      Colon |:|
+//@[16:25)      StringSyntax
+//@[16:25)       StringComplete |'Default'|
+//@[25:29)     NewLine |\r\n\r\n|
+
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(69) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
+//@[0:69) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:34)  IdentifierSyntax
+//@[4:34)   Identifier |nestedDiscriminatorCompletions|
+//@[35:36)  Assignment |=|
+//@[37:69)  PropertyAccessSyntax
+//@[37:67)   PropertyAccessSyntax
+//@[37:56)    VariableAccessSyntax
+//@[37:56)     IdentifierSyntax
+//@[37:56)      Identifier |nestedDiscriminator|
+//@[56:57)    Dot |.|
+//@[57:67)    IdentifierSyntax
+//@[57:67)     Identifier |properties|
+//@[67:68)   Dot |.|
+//@[68:69)   IdentifierSyntax
+//@[68:69)    Identifier |a|
+//@[69:71) NewLine |\r\n|
+// #completionTest(73) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
+//@[0:73) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:35)  IdentifierSyntax
+//@[4:35)   Identifier |nestedDiscriminatorCompletions2|
+//@[36:37)  Assignment |=|
+//@[38:73)  PropertyAccessSyntax
+//@[38:71)   ArrayAccessSyntax
+//@[38:57)    VariableAccessSyntax
+//@[38:57)     IdentifierSyntax
+//@[38:57)      Identifier |nestedDiscriminator|
+//@[57:58)    LeftSquare |[|
+//@[58:70)    StringSyntax
+//@[58:70)     StringComplete |'properties'|
+//@[70:71)    RightSquare |]|
+//@[71:72)   Dot |.|
+//@[72:73)   IdentifierSyntax
+//@[72:73)    Identifier |a|
+//@[73:75) NewLine |\r\n|
+
+//@[0:0) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -953,4 +953,123 @@ var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
 //@[59:76) Identifier |autoScalerProfile|
 //@[76:77) Dot |.|
 //@[77:78) Identifier |s|
-//@[78:78) EndOfFile ||
+//@[78:82) NewLine |\r\n\r\n|
+
+resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+//@[0:8) Identifier |resource|
+//@[9:38) Identifier |nestedDiscriminatorMissingKey|
+//@[39:97) StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[98:99) Assignment |=|
+//@[100:101) LeftBrace |{|
+//@[101:103) NewLine |\r\n|
+  name: 'test'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) StringComplete |'test'|
+//@[14:16) NewLine |\r\n|
+  location: 'l'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:15) StringComplete |'l'|
+//@[15:17) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    //createMode: 'Default'
+//@[27:31) NewLine |\r\n\r\n|
+
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(90) -> createMode
+//@[36:38) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.properties.cr
+//@[0:3) Identifier |var|
+//@[4:44) Identifier |nestedDiscriminatorMissingKeyCompletions|
+//@[45:46) Assignment |=|
+//@[47:76) Identifier |nestedDiscriminatorMissingKey|
+//@[76:77) Dot |.|
+//@[77:87) Identifier |properties|
+//@[87:88) Dot |.|
+//@[88:90) Identifier |cr|
+//@[90:92) NewLine |\r\n|
+// #completionTest(94) -> createMode
+//@[36:38) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
+//@[0:3) Identifier |var|
+//@[4:45) Identifier |nestedDiscriminatorMissingKeyCompletions2|
+//@[46:47) Assignment |=|
+//@[48:77) Identifier |nestedDiscriminatorMissingKey|
+//@[77:78) LeftSquare |[|
+//@[78:90) StringComplete |'properties'|
+//@[90:91) RightSquare |]|
+//@[91:92) Dot |.|
+//@[92:94) Identifier |cr|
+//@[94:98) NewLine |\r\n\r\n|
+
+resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+//@[0:8) Identifier |resource|
+//@[9:28) Identifier |nestedDiscriminator|
+//@[29:87) StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[88:89) Assignment |=|
+//@[90:91) LeftBrace |{|
+//@[91:93) NewLine |\r\n|
+  name: 'test'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) StringComplete |'test'|
+//@[14:16) NewLine |\r\n|
+  location: 'l'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:15) StringComplete |'l'|
+//@[15:17) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    createMode: 'Default'
+//@[4:14) Identifier |createMode|
+//@[14:15) Colon |:|
+//@[16:25) StringComplete |'Default'|
+//@[25:29) NewLine |\r\n\r\n|
+
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(69) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
+//@[0:3) Identifier |var|
+//@[4:34) Identifier |nestedDiscriminatorCompletions|
+//@[35:36) Assignment |=|
+//@[37:56) Identifier |nestedDiscriminator|
+//@[56:57) Dot |.|
+//@[57:67) Identifier |properties|
+//@[67:68) Dot |.|
+//@[68:69) Identifier |a|
+//@[69:71) NewLine |\r\n|
+// #completionTest(73) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
+//@[0:3) Identifier |var|
+//@[4:35) Identifier |nestedDiscriminatorCompletions2|
+//@[36:37) Assignment |=|
+//@[38:57) Identifier |nestedDiscriminator|
+//@[57:58) LeftSquare |[|
+//@[58:70) StringComplete |'properties'|
+//@[70:71) RightSquare |]|
+//@[71:72) Dot |.|
+//@[72:73) Identifier |a|
+//@[73:75) NewLine |\r\n|
+
+//@[0:0) EndOfFile ||

--- a/src/Bicep.Core/Syntax/ObjectSyntaxExtensions.cs
+++ b/src/Bicep.Core/Syntax/ObjectSyntaxExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Bicep.Core.Extensions;
@@ -10,17 +9,58 @@ namespace Bicep.Core.Syntax
 {
     public static class ObjectSyntaxExtensions
     {
+        /// <summary>
+        /// Converts a syntactically valid object syntax node to a hashset of property name strings. Will throw if you provide a node with duplicate properties.
+        /// </summary>
+        /// <param name="syntax">The object syntax node</param>
         public static ImmutableHashSet<string> ToKnownPropertyNames(this ObjectSyntax syntax) => 
             syntax.Properties.Select(p => p.TryGetKeyText()).ToImmutableHashSetExcludingNull(LanguageConstants.IdentifierComparer);
 
         /// <summary>
-        /// Converts a valid object syntax node to a property dictionary. May throw if you provide a node with duplicate properties.
+        /// Converts a syntactically valid object syntax node to a dictionary mapping property name strings to property value expressions. Will throw if you provide a node with duplicate properties.
         /// </summary>
         /// <param name="syntax">The object syntax node</param>
         public static ImmutableDictionary<string, SyntaxBase> ToKnownPropertyValueDictionary(this ObjectSyntax syntax) =>
             syntax.Properties.ToImmutableDictionaryExcludingNull(p => p.TryGetKeyText(), p => p.Value, LanguageConstants.IdentifierComparer);
 
+        /// <summary>
+        /// Converts a syntactically valid object syntax node to a dictionary mapping property name strings to property syntax nodes. Will throw if you provide a node with duplicate properties.
+        /// </summary>
+        /// <param name="syntax">The object syntax node</param>
         public static ImmutableDictionary<string, ObjectPropertySyntax> ToNamedPropertyDictionary(this ObjectSyntax syntax) =>	
             syntax.Properties.ToImmutableDictionaryExcludingNull(p => p.TryGetKeyText(), LanguageConstants.IdentifierComparer);
+
+        /// <summary>
+        /// Returns the specified property by name on any valid or invalid object syntax node if there is exactly one property by that name.
+        /// Returns null if the property does not exist or if multiple properties by that name exist. This method is intended for a single
+        /// one-off property lookup and avoids allocation of a dictionary. If you need to make multiple look ups, use another extension in this class.
+        /// </summary>
+        /// <param name="syntax">The object syntax node</param>
+        /// <param name="propertyName">The property name</param>
+        public static ObjectPropertySyntax? SafeGetPropertyByName(this ObjectSyntax syntax, string propertyName)
+        {
+            ObjectPropertySyntax? result = null;
+
+            var matchingValidProperties = syntax.Properties
+                .Where(p => p.TryGetKeyText() is { } validName && string.Equals(validName, propertyName, LanguageConstants.IdentifierComparison));
+
+            foreach (var property in matchingValidProperties)
+            {
+                if (result == null)
+                {
+                    // we have not yet seen a name match
+                    // store it
+                    result = property;
+                }
+                else
+                {
+                    // we have already seen a name match, which means we have a duplicate property
+                    // no point proceeding any further
+                    return null;
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeAssignment.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeAssignment.cs
@@ -1,22 +1,37 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using Bicep.Core.Syntax;
+
 namespace Bicep.Core.TypeSystem
 {
     public class DeclaredTypeAssignment
     {
-        public DeclaredTypeAssignment(ITypeReference reference, DeclaredTypeFlags flags)
+        public DeclaredTypeAssignment(ITypeReference reference, SyntaxBase? declaringSyntax, DeclaredTypeFlags flags)
         {
             this.Reference = reference;
+            this.DeclaringSyntax = declaringSyntax;
             this.Flags = flags;
         }
 
-        public DeclaredTypeAssignment(ITypeReference reference)
-            : this(reference, DeclaredTypeFlags.None)
+        public DeclaredTypeAssignment(ITypeReference reference, SyntaxBase? declaringSyntax)
+            : this(reference, declaringSyntax, DeclaredTypeFlags.None)
         {
         }
 
         public ITypeReference Reference { get; }
 
         public DeclaredTypeFlags Flags { get; }
+
+        /// <summary>
+        /// Gets the node whose declared type this assignment represents. This is primarily used to resolve nested discriminated object types.
+        /// </summary>
+        /// <remarks>When declared type is requested for a node that is part of a declaration body (INamedDeclarationSyntax, ObjectSyntax, ArraySyntax,
+        /// ObjectPropertySyntax, etc.), you may see DeclaringSyntax to be set to the same node. When requesting declared type for a VariableAccessSyntax,
+        /// PropertyAccessSyntax or ArrayAccessSyntax node, it will point to a corresponding node within the referenced declaration. The value may
+        /// be null if there is not enough information in the declaration body.</remarks>
+        public SyntaxBase? DeclaringSyntax { get; }
+
+        public DeclaredTypeAssignment ReplaceDeclaringSyntax(SyntaxBase? newSyntax) => new DeclaredTypeAssignment(this.Reference, newSyntax, this.Flags);
     }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -72,7 +72,7 @@ namespace Bicep.Core.TypeSystem
                     return GetVariableAccessType(variableAccess);
 
                 case TargetScopeSyntax targetScopeSyntax:
-                    return new DeclaredTypeAssignment(targetScopeSyntax.GetDeclaredType(), DeclaredTypeFlags.Constant);
+                    return new DeclaredTypeAssignment(targetScopeSyntax.GetDeclaredType(), targetScopeSyntax, DeclaredTypeFlags.Constant);
 
                 case PropertyAccessSyntax propertyAccess:
                     return GetPropertyAccessType(propertyAccess);
@@ -80,10 +80,12 @@ namespace Bicep.Core.TypeSystem
                 case ArrayAccessSyntax arrayAccess:
                     return GetArrayAccessType(arrayAccess);
 
-                case VariableDeclarationSyntax _:
+                case VariableDeclarationSyntax variable:
+                    return new DeclaredTypeAssignment(this.typeManager.GetTypeInfo(syntax), variable);
+
                 case FunctionCallSyntax _:
                 case InstanceFunctionCallSyntax _:
-                    return new DeclaredTypeAssignment(this.typeManager.GetTypeInfo(syntax));
+                    return new DeclaredTypeAssignment(this.typeManager.GetTypeInfo(syntax), declaringSyntax: null);
 
                 case ArraySyntax array:
                     return GetArrayType(array);
@@ -101,23 +103,23 @@ namespace Bicep.Core.TypeSystem
             return null;
         }
 
-        private DeclaredTypeAssignment GetParameterType(ParameterDeclarationSyntax syntax) => new DeclaredTypeAssignment(syntax.GetDeclaredType());
+        private DeclaredTypeAssignment GetParameterType(ParameterDeclarationSyntax syntax) => new DeclaredTypeAssignment(syntax.GetDeclaredType(), syntax);
 
-        private DeclaredTypeAssignment GetResourceType(ResourceDeclarationSyntax syntax) => new DeclaredTypeAssignment(syntax.GetDeclaredType(this.resourceTypeProvider));
+        private DeclaredTypeAssignment GetResourceType(ResourceDeclarationSyntax syntax) => new DeclaredTypeAssignment(syntax.GetDeclaredType(this.resourceTypeProvider), syntax);
 
         private DeclaredTypeAssignment GetModuleType(ModuleDeclarationSyntax syntax)
         {
             if (!(bindings.TryGetValue(syntax, out var symbol) && symbol is ModuleSymbol moduleSymbol))
             {
-                return new DeclaredTypeAssignment(ErrorType.Empty());
+                return new DeclaredTypeAssignment(ErrorType.Empty(), syntax);
             }
 
             if (!moduleSymbol.TryGetSemanticModel(out var moduleSemanticModel, out var failureDiagnostic))
             {
-                return new DeclaredTypeAssignment(ErrorType.Create(failureDiagnostic));
+                return new DeclaredTypeAssignment(ErrorType.Create(failureDiagnostic), syntax);
             }
 
-            return new DeclaredTypeAssignment(syntax.GetDeclaredType(targetScope, moduleSemanticModel));
+            return new DeclaredTypeAssignment(syntax.GetDeclaredType(targetScope, moduleSemanticModel), syntax);
         }
 
         private DeclaredTypeAssignment? GetVariableAccessType(VariableAccessSyntax syntax)
@@ -147,7 +149,7 @@ namespace Bicep.Core.TypeSystem
 
                 case NamespaceSymbol namespaceSymbol:
                     // the syntax node is referencing a namespace - use its type
-                    return new DeclaredTypeAssignment(namespaceSymbol.Type);
+                    return new DeclaredTypeAssignment(namespaceSymbol.Type, declaringSyntax: null);
             }
 
             return null;
@@ -160,26 +162,38 @@ namespace Bicep.Core.TypeSystem
                 return null;
             }
 
-            var baseExpressionType = GetDeclaredTypeAssignment(syntax.BaseExpression);
-            return GetObjectPropertyType(baseExpressionType?.Reference.Type, syntax.PropertyName.IdentifierName);
+            var baseExpressionAssignment = GetDeclaredTypeAssignment(syntax.BaseExpression);
+            
+            // it's ok to rely on useSyntax=true because those types have already been established
+            return GetObjectPropertyType(
+                baseExpressionAssignment?.Reference.Type,
+                baseExpressionAssignment?.DeclaringSyntax as ObjectSyntax,
+                syntax.PropertyName.IdentifierName,
+                useSyntax: true);
         }
 
         private DeclaredTypeAssignment? GetArrayAccessType(ArrayAccessSyntax syntax)
         {
-            var baseExpressionDeclaredType = GetDeclaredTypeAssignment(syntax.BaseExpression);
+            var baseExpressionAssignment = GetDeclaredTypeAssignment(syntax.BaseExpression);
             var indexAssignedType = this.typeManager.GetTypeInfo(syntax.IndexExpression);
 
             // TODO: Currently array access is broken with discriminated object types - revisit when that is fixed
-            switch (baseExpressionDeclaredType?.Reference.Type)
+            switch (baseExpressionAssignment?.Reference.Type)
             {
                 case ArrayType arrayType when TypeValidator.AreTypesAssignable(indexAssignedType, LanguageConstants.Int):
                     // we are accessing an array by an expression of a numeric type
                     // return the item type of the array
-                    return new DeclaredTypeAssignment(arrayType.Item.Type);
+                    // TODO: We can flow the syntax nodes through declared type assignments if we are able to evaluate the array index - skipping for now
+                    return new DeclaredTypeAssignment(arrayType.Item.Type, declaringSyntax: null);
 
-                case ObjectType objectType when syntax.IndexExpression is StringSyntax potentialLiteralValue && potentialLiteralValue.TryGetLiteralValue() is string propertyName:
+                case ObjectType objectType when syntax.IndexExpression is StringSyntax potentialLiteralValue && potentialLiteralValue.TryGetLiteralValue() is { } propertyName:
                     // string literal indexing over an object is the same as dot property access
-                    return this.GetObjectPropertyType(objectType, propertyName);
+                    // it's ok to rely on useSyntax=true because those types have already been established
+                    return this.GetObjectPropertyType(
+                        objectType,
+                        baseExpressionAssignment.DeclaringSyntax as ObjectSyntax,
+                        propertyName,
+                        useSyntax: true);
             }
 
             return null;
@@ -196,7 +210,7 @@ namespace Bicep.Core.TypeSystem
             {
                 // this array is a value of the property
                 // the declared type should be the same as the array and we should propagate the flags
-                return GetDeclaredTypeAssignment(parent);
+                return GetDeclaredTypeAssignment(parent)?.ReplaceDeclaringSyntax(syntax);
             }
 
             return null;
@@ -213,7 +227,7 @@ namespace Bicep.Core.TypeSystem
                     var parentType = GetDeclaredTypeAssignment(parent)?.Reference.Type;
                     if (parentType is ArrayType arrayType)
                     {
-                        return new DeclaredTypeAssignment(arrayType.Item.Type);
+                        return new DeclaredTypeAssignment(arrayType.Item.Type, syntax);
                     }
 
                     break;
@@ -227,7 +241,7 @@ namespace Bicep.Core.TypeSystem
             // local function
             DeclaredTypeAssignment? CreateAssignment(ITypeReference? typeRef, DeclaredTypeFlags flags = DeclaredTypeFlags.None) => typeRef == null
                 ? null
-                : new DeclaredTypeAssignment(typeRef, flags);
+                : new DeclaredTypeAssignment(typeRef, syntax, flags);
 
             var parent = this.hierarchy.GetParent(syntax);
             if (parent == null)
@@ -280,36 +294,56 @@ namespace Bicep.Core.TypeSystem
         {
             var propertyName = syntax.TryGetKeyText();
             var parent = this.hierarchy.GetParent(syntax);
-            if (propertyName == null || parent == null)
+            if (propertyName == null || !(parent is ObjectSyntax parentObject))
             {
-                // the property name is an interpolated string (expression) OR the parent is missing
+                // the property name is an interpolated string (expression) OR the parent is missing OR the parent is not ObjectSyntax
                 // cannot establish declared type
                 // TODO: Improve this when we have constant folding
                 return null;
             }
 
             var assignment = GetDeclaredTypeAssignment(parent);
-            return GetObjectPropertyType(assignment?.Reference.Type, propertyName);
+
+            // we are in the process of establishing the declared type for the syntax nodes,
+            // so we must set useSyntax to false to avoid a stack overflow
+            return GetObjectPropertyType(assignment?.Reference.Type, parentObject, propertyName, useSyntax: false);
         }
 
-        private DeclaredTypeAssignment? GetObjectPropertyType(TypeSymbol? type, string propertyName)
+        private DeclaredTypeAssignment? GetObjectPropertyType(TypeSymbol? type, ObjectSyntax? objectSyntax, string propertyName, bool useSyntax)
         {
             // local function
             DeclaredTypeFlags ConvertFlags(TypePropertyFlags flags) => flags.HasFlag(TypePropertyFlags.Constant) ? DeclaredTypeFlags.Constant : DeclaredTypeFlags.None;
 
+            // the declared types on the declaration side of things will take advantage of properties
+            // set on objects to resolve discriminators at all levels
+            // to take advantage of this, we should first try looking up the property's declared type
+            var declaringProperty = objectSyntax?.SafeGetPropertyByName(propertyName);
+            if (useSyntax && declaringProperty != null)
+            {
+                // it is important to get the property value's decl type instead of the property's decl type
+                // (the property has the unresolved discriminated object type and the value will have it resolved)
+                var declaredPropertyAssignment = this.GetDeclaredTypeAssignment(declaringProperty.Value);
+                if (declaredPropertyAssignment != null)
+                {
+                    return declaredPropertyAssignment;
+                }
+            }
+
+            // could not get the declared type via syntax
+            // let's use the type info instead
             switch (type)
             {
                 case ObjectType objectType:
                     // lookup declared property
                     if (objectType.Properties.TryGetValue(propertyName, out var property))
                     {
-                        return new DeclaredTypeAssignment(property.TypeReference.Type, ConvertFlags(property.Flags));
+                        return new DeclaredTypeAssignment(property.TypeReference.Type, declaringProperty, ConvertFlags(property.Flags));
                     }
 
                     // if there are additional properties, try those
                     if (objectType.AdditionalPropertiesType != null)
                     {
-                        return new DeclaredTypeAssignment(objectType.AdditionalPropertiesType.Type, ConvertFlags(objectType.AdditionalPropertiesFlags));
+                        return new DeclaredTypeAssignment(objectType.AdditionalPropertiesType.Type, declaringProperty, ConvertFlags(objectType.AdditionalPropertiesFlags));
                     }
 
                     break;
@@ -318,7 +352,7 @@ namespace Bicep.Core.TypeSystem
                     if (string.Equals(propertyName, discriminated.DiscriminatorProperty.Name, LanguageConstants.IdentifierComparison))
                     {
                         // the property is the discriminator property - use its type
-                        return new DeclaredTypeAssignment(discriminated.DiscriminatorProperty.TypeReference.Type);
+                        return new DeclaredTypeAssignment(discriminated.DiscriminatorProperty.TypeReference.Type, declaringProperty);
                     }
 
                     break;


### PR DESCRIPTION
We are now resolving discriminated object types when they are not at the top level of the resource body.