### PR TITLE
Now can get dot property access completions without typing the first letter of the property

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.bicep
@@ -32,6 +32,8 @@ var one = {
 }
 // #completionTest(15) -> empty
 var two = one.f
+// #completionTest(17) -> empty
+var twotwo = one.
 
 // resource completion cycles
 resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
@@ -40,6 +42,8 @@ resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   location: 'l'
   sku: {
     name: 'Premium_LRS'
+    // #completionTest(15) -> empty
+    tier: res2.
   }
   kind: 'StorageV2'
 }
@@ -48,6 +52,10 @@ resource res2 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   location: 'l'
   sku: {
     name: 'Premium_LRS'
+  }
+  properties: {
+    // #completionTest(21) -> empty
+    accessTier: res1.
   }
   kind: 'StorageV2'
 }

--- a/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.diagnostics.bicep
@@ -49,6 +49,10 @@ var one = {
 // #completionTest(15) -> empty
 var two = one.f
 //@[10:13) [BCP080 (Error)] The expression is involved in a cycle ("one" -> "two"). |one|
+// #completionTest(17) -> empty
+var twotwo = one.
+//@[13:16) [BCP080 (Error)] The expression is involved in a cycle ("one" -> "two"). |one|
+//@[17:17) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 // resource completion cycles
 resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
@@ -58,6 +62,10 @@ resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   location: 'l'
   sku: {
     name: 'Premium_LRS'
+    // #completionTest(15) -> empty
+    tier: res2.
+//@[10:14) [BCP080 (Error)] The expression is involved in a cycle ("res2" -> "res1"). |res2|
+//@[15:15) [BCP020 (Error)] Expected a function or property name at this location. ||
   }
   kind: 'StorageV2'
 }
@@ -67,6 +75,12 @@ resource res2 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   location: 'l'
   sku: {
     name: 'Premium_LRS'
+  }
+  properties: {
+    // #completionTest(21) -> empty
+    accessTier: res1.
+//@[16:20) [BCP080 (Error)] The expression is involved in a cycle ("res1" -> "res2"). |res1|
+//@[21:21) [BCP020 (Error)] Expected a function or property name at this location. ||
   }
   kind: 'StorageV2'
 }

--- a/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.symbols.bicep
@@ -45,24 +45,33 @@ var one = {
 // #completionTest(15) -> empty
 var two = one.f
 //@[4:7) Variable two. Type: error. Declaration start char: 0, length: 15
+// #completionTest(17) -> empty
+var twotwo = one.
+//@[4:10) Variable twotwo. Type: error. Declaration start char: 0, length: 17
 
 // resource completion cycles
 resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-//@[9:13) Resource res1. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 196
+//@[9:13) Resource res1. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 250
   // #completionTest(14) -> empty
   name: res2.n
   location: 'l'
   sku: {
     name: 'Premium_LRS'
+    // #completionTest(15) -> empty
+    tier: res2.
   }
   kind: 'StorageV2'
 }
 resource res2 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-//@[9:13) Resource res2. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 164
+//@[9:13) Resource res2. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 246
   name: res1.name
   location: 'l'
   sku: {
     name: 'Premium_LRS'
+  }
+  properties: {
+    // #completionTest(21) -> empty
+    accessTier: res1.
   }
   kind: 'StorageV2'
 }

--- a/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.syntax.bicep
@@ -240,19 +240,35 @@ var two = one.f
 //@[13:14)   Dot |.|
 //@[14:15)   IdentifierSyntax
 //@[14:15)    Identifier |f|
-//@[15:19) NewLine |\r\n\r\n|
+//@[15:17) NewLine |\r\n|
+// #completionTest(17) -> empty
+//@[31:33) NewLine |\r\n|
+var twotwo = one.
+//@[0:17) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:10)  IdentifierSyntax
+//@[4:10)   Identifier |twotwo|
+//@[11:12)  Assignment |=|
+//@[13:17)  PropertyAccessSyntax
+//@[13:16)   VariableAccessSyntax
+//@[13:16)    IdentifierSyntax
+//@[13:16)     Identifier |one|
+//@[16:17)   Dot |.|
+//@[17:17)   IdentifierSyntax
+//@[17:17)    SkippedTriviaSyntax
+//@[17:21) NewLine |\r\n\r\n|
 
 // resource completion cycles
 //@[29:31) NewLine |\r\n|
 resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-//@[0:196) ResourceDeclarationSyntax
+//@[0:250) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:13)  IdentifierSyntax
 //@[9:13)   Identifier |res1|
 //@[14:60)  StringSyntax
 //@[14:60)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
 //@[61:62)  Assignment |=|
-//@[63:196)  ObjectSyntax
+//@[63:250)  ObjectSyntax
 //@[63:64)   LeftBrace |{|
 //@[64:66)   NewLine |\r\n|
   // #completionTest(14) -> empty
@@ -279,11 +295,11 @@ resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 //@[12:15)     StringComplete |'l'|
 //@[15:17)   NewLine |\r\n|
   sku: {
-//@[2:38)   ObjectPropertySyntax
+//@[2:92)   ObjectPropertySyntax
 //@[2:5)    IdentifierSyntax
 //@[2:5)     Identifier |sku|
 //@[5:6)    Colon |:|
-//@[7:38)    ObjectSyntax
+//@[7:92)    ObjectSyntax
 //@[7:8)     LeftBrace |{|
 //@[8:10)     NewLine |\r\n|
     name: 'Premium_LRS'
@@ -294,6 +310,21 @@ resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 //@[10:23)      StringSyntax
 //@[10:23)       StringComplete |'Premium_LRS'|
 //@[23:25)     NewLine |\r\n|
+    // #completionTest(15) -> empty
+//@[35:37)     NewLine |\r\n|
+    tier: res2.
+//@[4:15)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |tier|
+//@[8:9)      Colon |:|
+//@[10:15)      PropertyAccessSyntax
+//@[10:14)       VariableAccessSyntax
+//@[10:14)        IdentifierSyntax
+//@[10:14)         Identifier |res2|
+//@[14:15)       Dot |.|
+//@[15:15)       IdentifierSyntax
+//@[15:15)        SkippedTriviaSyntax
+//@[15:17)     NewLine |\r\n|
   }
 //@[2:3)     RightBrace |}|
 //@[3:5)   NewLine |\r\n|
@@ -309,14 +340,14 @@ resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 //@[0:1)   RightBrace |}|
 //@[1:3) NewLine |\r\n|
 resource res2 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-//@[0:164) ResourceDeclarationSyntax
+//@[0:246) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:13)  IdentifierSyntax
 //@[9:13)   Identifier |res2|
 //@[14:60)  StringSyntax
 //@[14:60)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
 //@[61:62)  Assignment |=|
-//@[63:164)  ObjectSyntax
+//@[63:246)  ObjectSyntax
 //@[63:64)   LeftBrace |{|
 //@[64:66)   NewLine |\r\n|
   name: res1.name
@@ -356,6 +387,32 @@ resource res2 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 //@[10:23)      StringSyntax
 //@[10:23)       StringComplete |'Premium_LRS'|
 //@[23:25)     NewLine |\r\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\r\n|
+  properties: {
+//@[2:80)   ObjectPropertySyntax
+//@[2:12)    IdentifierSyntax
+//@[2:12)     Identifier |properties|
+//@[12:13)    Colon |:|
+//@[14:80)    ObjectSyntax
+//@[14:15)     LeftBrace |{|
+//@[15:17)     NewLine |\r\n|
+    // #completionTest(21) -> empty
+//@[35:37)     NewLine |\r\n|
+    accessTier: res1.
+//@[4:21)     ObjectPropertySyntax
+//@[4:14)      IdentifierSyntax
+//@[4:14)       Identifier |accessTier|
+//@[14:15)      Colon |:|
+//@[16:21)      PropertyAccessSyntax
+//@[16:20)       VariableAccessSyntax
+//@[16:20)        IdentifierSyntax
+//@[16:20)         Identifier |res1|
+//@[20:21)       Dot |.|
+//@[21:21)       IdentifierSyntax
+//@[21:21)        SkippedTriviaSyntax
+//@[21:23)     NewLine |\r\n|
   }
 //@[2:3)     RightBrace |}|
 //@[3:5)   NewLine |\r\n|

--- a/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidCycles_CRLF/main.tokens.bicep
@@ -152,7 +152,16 @@ var two = one.f
 //@[10:13) Identifier |one|
 //@[13:14) Dot |.|
 //@[14:15) Identifier |f|
-//@[15:19) NewLine |\r\n\r\n|
+//@[15:17) NewLine |\r\n|
+// #completionTest(17) -> empty
+//@[31:33) NewLine |\r\n|
+var twotwo = one.
+//@[0:3) Identifier |var|
+//@[4:10) Identifier |twotwo|
+//@[11:12) Assignment |=|
+//@[13:16) Identifier |one|
+//@[16:17) Dot |.|
+//@[17:21) NewLine |\r\n\r\n|
 
 // resource completion cycles
 //@[29:31) NewLine |\r\n|
@@ -187,6 +196,14 @@ resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 //@[8:9) Colon |:|
 //@[10:23) StringComplete |'Premium_LRS'|
 //@[23:25) NewLine |\r\n|
+    // #completionTest(15) -> empty
+//@[35:37) NewLine |\r\n|
+    tier: res2.
+//@[4:8) Identifier |tier|
+//@[8:9) Colon |:|
+//@[10:14) Identifier |res2|
+//@[14:15) Dot |.|
+//@[15:17) NewLine |\r\n|
   }
 //@[2:3) RightBrace |}|
 //@[3:5) NewLine |\r\n|
@@ -227,6 +244,22 @@ resource res2 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 //@[8:9) Colon |:|
 //@[10:23) StringComplete |'Premium_LRS'|
 //@[23:25) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    // #completionTest(21) -> empty
+//@[35:37) NewLine |\r\n|
+    accessTier: res1.
+//@[4:14) Identifier |accessTier|
+//@[14:15) Colon |:|
+//@[16:20) Identifier |res1|
+//@[20:21) Dot |.|
+//@[21:23) NewLine |\r\n|
   }
 //@[2:3) RightBrace |}|
 //@[3:5) NewLine |\r\n|

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.bicep
@@ -107,6 +107,11 @@ var badExpressionInPropertyAccess = resourceGroup()[!'location']
 
 var propertyAccessOnVariable = x.foo
 
+// missing property in property access
+var oneValidDeclaration = {}
+var missingPropertyName = oneValidDeclaration.
+var missingPropertyInsideAnExpression = oneValidDeclaration. + oneValidDeclaration.
+
 // function used like a variable
 var funcvarvar = concat + base64 || !uniqueString
 param funcvarparam bool = concat

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
@@ -206,6 +206,14 @@ var badExpressionInPropertyAccess = resourceGroup()[!'location']
 var propertyAccessOnVariable = x.foo
 //@[31:32) [BCP062 (Error)] The referenced declaration with name "x" is not valid. |x|
 
+// missing property in property access
+var oneValidDeclaration = {}
+var missingPropertyName = oneValidDeclaration.
+//@[46:46) [BCP020 (Error)] Expected a function or property name at this location. ||
+var missingPropertyInsideAnExpression = oneValidDeclaration. + oneValidDeclaration.
+//@[61:61) [BCP020 (Error)] Expected a function or property name at this location. ||
+//@[83:83) [BCP020 (Error)] Expected a function or property name at this location. ||
+
 // function used like a variable
 var funcvarvar = concat + base64 || !uniqueString
 //@[17:23) [BCP063 (Error)] The name "concat" is not a parameter, variable, resource or module. |concat|

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.symbols.bicep
@@ -168,6 +168,14 @@ var badExpressionInPropertyAccess = resourceGroup()[!'location']
 var propertyAccessOnVariable = x.foo
 //@[4:28) Variable propertyAccessOnVariable. Type: error. Declaration start char: 0, length: 36
 
+// missing property in property access
+var oneValidDeclaration = {}
+//@[4:23) Variable oneValidDeclaration. Type: object. Declaration start char: 0, length: 28
+var missingPropertyName = oneValidDeclaration.
+//@[4:23) Variable missingPropertyName. Type: error. Declaration start char: 0, length: 46
+var missingPropertyInsideAnExpression = oneValidDeclaration. + oneValidDeclaration.
+//@[4:37) Variable missingPropertyInsideAnExpression. Type: error. Declaration start char: 0, length: 83
+
 // function used like a variable
 var funcvarvar = concat + base64 || !uniqueString
 //@[4:14) Variable funcvarvar. Type: error. Declaration start char: 0, length: 49

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
@@ -1023,6 +1023,56 @@ var propertyAccessOnVariable = x.foo
 //@[33:36)    Identifier |foo|
 //@[36:38) NewLine |\n\n|
 
+// missing property in property access
+//@[38:39) NewLine |\n|
+var oneValidDeclaration = {}
+//@[0:28) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:23)  IdentifierSyntax
+//@[4:23)   Identifier |oneValidDeclaration|
+//@[24:25)  Assignment |=|
+//@[26:28)  ObjectSyntax
+//@[26:27)   LeftBrace |{|
+//@[27:28)   RightBrace |}|
+//@[28:29) NewLine |\n|
+var missingPropertyName = oneValidDeclaration.
+//@[0:46) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:23)  IdentifierSyntax
+//@[4:23)   Identifier |missingPropertyName|
+//@[24:25)  Assignment |=|
+//@[26:46)  PropertyAccessSyntax
+//@[26:45)   VariableAccessSyntax
+//@[26:45)    IdentifierSyntax
+//@[26:45)     Identifier |oneValidDeclaration|
+//@[45:46)   Dot |.|
+//@[46:46)   IdentifierSyntax
+//@[46:46)    SkippedTriviaSyntax
+//@[46:47) NewLine |\n|
+var missingPropertyInsideAnExpression = oneValidDeclaration. + oneValidDeclaration.
+//@[0:83) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:37)  IdentifierSyntax
+//@[4:37)   Identifier |missingPropertyInsideAnExpression|
+//@[38:39)  Assignment |=|
+//@[40:83)  BinaryOperationSyntax
+//@[40:61)   PropertyAccessSyntax
+//@[40:59)    VariableAccessSyntax
+//@[40:59)     IdentifierSyntax
+//@[40:59)      Identifier |oneValidDeclaration|
+//@[59:60)    Dot |.|
+//@[61:61)    IdentifierSyntax
+//@[61:61)     SkippedTriviaSyntax
+//@[61:62)   Plus |+|
+//@[63:83)   PropertyAccessSyntax
+//@[63:82)    VariableAccessSyntax
+//@[63:82)     IdentifierSyntax
+//@[63:82)      Identifier |oneValidDeclaration|
+//@[82:83)    Dot |.|
+//@[83:83)    IdentifierSyntax
+//@[83:83)     SkippedTriviaSyntax
+//@[83:85) NewLine |\n\n|
+
 // function used like a variable
 //@[32:33) NewLine |\n|
 var funcvarvar = concat + base64 || !uniqueString

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.tokens.bicep
@@ -678,6 +678,33 @@ var propertyAccessOnVariable = x.foo
 //@[33:36) Identifier |foo|
 //@[36:38) NewLine |\n\n|
 
+// missing property in property access
+//@[38:39) NewLine |\n|
+var oneValidDeclaration = {}
+//@[0:3) Identifier |var|
+//@[4:23) Identifier |oneValidDeclaration|
+//@[24:25) Assignment |=|
+//@[26:27) LeftBrace |{|
+//@[27:28) RightBrace |}|
+//@[28:29) NewLine |\n|
+var missingPropertyName = oneValidDeclaration.
+//@[0:3) Identifier |var|
+//@[4:23) Identifier |missingPropertyName|
+//@[24:25) Assignment |=|
+//@[26:45) Identifier |oneValidDeclaration|
+//@[45:46) Dot |.|
+//@[46:47) NewLine |\n|
+var missingPropertyInsideAnExpression = oneValidDeclaration. + oneValidDeclaration.
+//@[0:3) Identifier |var|
+//@[4:37) Identifier |missingPropertyInsideAnExpression|
+//@[38:39) Assignment |=|
+//@[40:59) Identifier |oneValidDeclaration|
+//@[59:60) Dot |.|
+//@[61:62) Plus |+|
+//@[63:82) Identifier |oneValidDeclaration|
+//@[82:83) Dot |.|
+//@[83:85) NewLine |\n\n|
+
 // function used like a variable
 //@[32:33) NewLine |\n|
 var funcvarvar = concat + base64 || !uniqueString

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAOutputs.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAOutputs.json
@@ -16,7 +16,7 @@
       "newText": "arrayOutput"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -36,7 +36,7 @@
       "newText": "objOutput"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -56,7 +56,7 @@
       "newText": "stringOutputA"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -76,7 +76,7 @@
       "newText": "stringOutputB"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelPropertyAccess.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelPropertyAccess.json
@@ -16,7 +16,7 @@
       "newText": "name"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -36,7 +36,7 @@
       "newText": "outputs"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -351,6 +351,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
@@ -377,6 +390,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -387,6 +413,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
     }
   },
   {
@@ -413,6 +452,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
     }
   },
   {
@@ -663,6 +715,19 @@
     }
   },
   {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
     "label": "max",
     "kind": "function",
     "detail": "max()",
@@ -777,6 +842,32 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/autoScalerPropertiesRequireEscaping.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/autoScalerPropertiesRequireEscaping.json
@@ -22,7 +22,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -42,7 +42,7 @@
       "newText": "expander"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -68,7 +68,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -94,7 +94,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -120,7 +120,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -146,7 +146,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -172,7 +172,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -198,7 +198,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -224,7 +224,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -250,7 +250,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -276,7 +276,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -302,7 +302,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -328,7 +328,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -354,7 +354,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -380,7 +380,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -406,7 +406,7 @@
       }
     ],
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -377,6 +377,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
@@ -403,6 +416,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -413,6 +439,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
     }
   },
   {
@@ -439,6 +478,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
     }
   },
   {
@@ -689,6 +741,19 @@
     }
   },
   {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
     "label": "max",
     "kind": "function",
     "detail": "max()",
@@ -803,6 +868,32 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccess.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccess.json
@@ -16,7 +16,7 @@
       "newText": "arguments"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -36,7 +36,7 @@
       "newText": "azCliVersion"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -56,7 +56,7 @@
       "newText": "cleanupPreference"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -76,7 +76,7 @@
       "newText": "containerSettings"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -96,7 +96,7 @@
       "newText": "environmentVariables"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -116,7 +116,7 @@
       "newText": "forceUpdateTag"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -136,7 +136,7 @@
       "newText": "outputs"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -156,7 +156,7 @@
       "newText": "primaryScriptUri"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -176,7 +176,7 @@
       "newText": "provisioningState"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -196,7 +196,7 @@
       "newText": "retentionInterval"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -216,7 +216,7 @@
       "newText": "scriptContent"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -236,7 +236,7 @@
       "newText": "status"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -256,7 +256,7 @@
       "newText": "storageAccountSettings"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -276,7 +276,7 @@
       "newText": "supportingScriptUris"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -296,7 +296,7 @@
       "newText": "timeout"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createMode.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createMode.json
@@ -16,7 +16,7 @@
       "newText": "createMode"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeProperties.json
@@ -16,7 +16,7 @@
       "newText": "apiProperties"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -36,7 +36,7 @@
       "newText": "backupPolicy"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -56,7 +56,7 @@
       "newText": "capabilities"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -76,7 +76,7 @@
       "newText": "connectorOffer"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -96,7 +96,7 @@
       "newText": "consistencyPolicy"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -116,7 +116,7 @@
       "newText": "cors"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -136,7 +136,7 @@
       "newText": "createMode"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -156,7 +156,7 @@
       "newText": "databaseAccountOfferType"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -176,7 +176,7 @@
       "newText": "disableKeyBasedMetadataWriteAccess"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -196,7 +196,7 @@
       "newText": "documentEndpoint"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -216,7 +216,7 @@
       "newText": "enableAnalyticalStorage"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -236,7 +236,7 @@
       "newText": "enableAutomaticFailover"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -256,7 +256,7 @@
       "newText": "enableCassandraConnector"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -276,7 +276,7 @@
       "newText": "enableFreeTier"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -296,7 +296,7 @@
       "newText": "enableMultipleWriteLocations"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -316,7 +316,7 @@
       "newText": "failoverPolicies"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -336,7 +336,7 @@
       "newText": "instanceId"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -356,7 +356,7 @@
       "newText": "ipRules"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -376,7 +376,7 @@
       "newText": "isVirtualNetworkFilterEnabled"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -396,7 +396,7 @@
       "newText": "keyVaultKeyUri"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -416,7 +416,7 @@
       "newText": "locations"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -436,7 +436,7 @@
       "newText": "privateEndpointConnections"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -456,7 +456,7 @@
       "newText": "provisioningState"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -476,7 +476,7 @@
       "newText": "publicNetworkAccess"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -496,7 +496,7 @@
       "newText": "readLocations"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -516,7 +516,7 @@
       "newText": "restoreParameters"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -536,7 +536,7 @@
       "newText": "virtualNetworkRules"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -556,7 +556,7 @@
       "newText": "writeLocations"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -364,6 +364,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
@@ -390,6 +403,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -403,6 +429,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
@@ -413,6 +452,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
     }
   },
   {
@@ -676,6 +728,19 @@
     }
   },
   {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
     "label": "max",
     "kind": "function",
     "detail": "max()",
@@ -790,6 +855,32 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyAccess.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyAccess.json
@@ -16,7 +16,7 @@
       "newText": "kind"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -338,6 +338,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
@@ -364,6 +377,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -374,6 +400,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
     }
   },
   {
@@ -400,6 +439,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
     }
   },
   {
@@ -650,6 +702,19 @@
     }
   },
   {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
     "label": "max",
     "kind": "function",
     "detail": "max()",
@@ -764,6 +829,32 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/powershellPropertyAccess.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/powershellPropertyAccess.json
@@ -16,7 +16,7 @@
       "newText": "arguments"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -36,7 +36,7 @@
       "newText": "azPowerShellVersion"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -56,7 +56,7 @@
       "newText": "cleanupPreference"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -76,7 +76,7 @@
       "newText": "containerSettings"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -96,7 +96,7 @@
       "newText": "environmentVariables"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -116,7 +116,7 @@
       "newText": "forceUpdateTag"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -136,7 +136,7 @@
       "newText": "outputs"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -156,7 +156,7 @@
       "newText": "primaryScriptUri"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -176,7 +176,7 @@
       "newText": "provisioningState"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -196,7 +196,7 @@
       "newText": "retentionInterval"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -216,7 +216,7 @@
       "newText": "scriptContent"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -236,7 +236,7 @@
       "newText": "status"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -256,7 +256,7 @@
       "newText": "storageAccountSettings"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -276,7 +276,7 @@
       "newText": "supportingScriptUris"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -296,7 +296,7 @@
       "newText": "timeout"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -172,6 +172,8 @@ resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@202
 }
 // #completionTest(76) -> missingDiscriminatorPropertyAccess
 var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
+// #completionTest(76) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
@@ -184,6 +186,8 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 }
 // #completionTest(75) -> cliPropertyAccess
 var discriminatorKeySetOneCompletions = discriminatorKeySetOne.properties.a
+// #completionTest(75) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzurePowerShell'
@@ -196,9 +200,13 @@ resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-0
 }
 // #completionTest(75) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletions = discriminatorKeySetTwo.properties.a
+// #completionTest(75) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
 
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['properties'].a
+// #completionTest(90) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
@@ -252,6 +260,8 @@ resource dashesInPropertyNames 'Microsoft.ContainerService/managedClusters@2020-
 }
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
+// #completionTest(78) -> autoScalerPropertiesRequireEscaping
+var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
 
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
@@ -263,8 +273,8 @@ resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@20
 }
 // #completionTest(90) -> createMode
 var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.properties.cr
-// #completionTest(94) -> createMode
-var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
+// #completionTest(92) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].
 
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
@@ -278,3 +288,7 @@ resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-p
 var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
 // #completionTest(73) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
+// #completionTest(69) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
+// #completionTest(72) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -229,6 +229,9 @@ resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@202
 // #completionTest(76) -> missingDiscriminatorPropertyAccess
 var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
 //@[75:76) [BCP053 (Error)] The type "Microsoft.Resources/deploymentScripts@2020-10-01" does not contain property "p". Available properties include "apiVersion", "eTag", "extendedLocation", "id", "identity", "kind", "location", "managedBy", "managedByExtended", "name", "plan", "properties", "scale", "sku", "tags", "type", "zones". |p|
+// #completionTest(76) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
+//@[76:76) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[85:264) [BCP035 (Error)] The specified object is missing the following required properties: "name". |{\r\n  kind: 'AzureCLI'\r\n  // #completionTest(0,1,2) -> deploymentScriptTopLevel\r\n\r\n  properties: {\r\n    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties\r\n    \r\n  }\r\n}|
@@ -242,6 +245,9 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 }
 // #completionTest(75) -> cliPropertyAccess
 var discriminatorKeySetOneCompletions = discriminatorKeySetOne.properties.a
+// #completionTest(75) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
+//@[75:75) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[85:270) [BCP035 (Error)] The specified object is missing the following required properties: "name". |{\r\n  kind: 'AzurePowerShell'\r\n  // #completionTest(0,1,2) -> deploymentScriptTopLevel\r\n\r\n  properties: {\r\n    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties\r\n    \r\n  }\r\n}|
@@ -255,10 +261,17 @@ resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-0
 }
 // #completionTest(75) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletions = discriminatorKeySetTwo.properties.a
+// #completionTest(75) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
+//@[75:75) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['properties'].a
 //@[52:74) [BCP076 (Error)] Cannot index over expression of type "Microsoft.Resources/deploymentScripts@2020-10-01". Arrays or objects are required. |discriminatorKeySetTwo|
+// #completionTest(90) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
+//@[53:75) [BCP076 (Error)] Cannot index over expression of type "Microsoft.Resources/deploymentScripts@2020-10-01". Arrays or objects are required. |discriminatorKeySetTwo|
+//@[90:90) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[85:132) [BCP035 (Error)] The specified object is missing the following required properties: "name". |{\r\n  kind: 'AzureCLI'\r\n\r\n  propertes: {\r\n  }\r\n}|
@@ -326,6 +339,9 @@ resource dashesInPropertyNames 'Microsoft.ContainerService/managedClusters@2020-
 }
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
+// #completionTest(78) -> autoScalerPropertiesRequireEscaping
+var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
+//@[78:78) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
@@ -337,9 +353,10 @@ resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@20
 }
 // #completionTest(90) -> createMode
 var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.properties.cr
-// #completionTest(94) -> createMode
-var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
+// #completionTest(92) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].
 //@[48:77) [BCP076 (Error)] Cannot index over expression of type "Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview". Arrays or objects are required. |nestedDiscriminatorMissingKey|
+//@[92:92) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
@@ -354,4 +371,11 @@ var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
 // #completionTest(73) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
 //@[38:57) [BCP076 (Error)] Cannot index over expression of type "Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview". Arrays or objects are required. |nestedDiscriminator|
+// #completionTest(69) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
+//@[69:69) [BCP020 (Error)] Expected a function or property name at this location. ||
+// #completionTest(72) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
+//@[38:57) [BCP076 (Error)] Cannot index over expression of type "Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview". Arrays or objects are required. |nestedDiscriminator|
+//@[72:72) [BCP020 (Error)] Expected a function or property name at this location. ||
 

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -203,6 +203,9 @@ resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@202
 // #completionTest(76) -> missingDiscriminatorPropertyAccess
 var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
 //@[4:43) Variable discriminatorKeyValueMissingCompletions. Type: error. Declaration start char: 0, length: 76
+// #completionTest(76) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
+//@[4:44) Variable discriminatorKeyValueMissingCompletions2. Type: error. Declaration start char: 0, length: 76
 
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) Resource discriminatorKeySetOne. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 264
@@ -217,6 +220,9 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 // #completionTest(75) -> cliPropertyAccess
 var discriminatorKeySetOneCompletions = discriminatorKeySetOne.properties.a
 //@[4:37) Variable discriminatorKeySetOneCompletions. Type: any. Declaration start char: 0, length: 75
+// #completionTest(75) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
+//@[4:38) Variable discriminatorKeySetOneCompletions2. Type: error. Declaration start char: 0, length: 75
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) Resource discriminatorKeySetTwo. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 270
@@ -231,10 +237,16 @@ resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-0
 // #completionTest(75) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletions = discriminatorKeySetTwo.properties.a
 //@[4:37) Variable discriminatorKeySetTwoCompletions. Type: any. Declaration start char: 0, length: 75
+// #completionTest(75) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
+//@[4:38) Variable discriminatorKeySetTwoCompletions2. Type: error. Declaration start char: 0, length: 75
 
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['properties'].a
 //@[4:49) Variable discriminatorKeySetTwoCompletionsArrayIndexer. Type: error. Declaration start char: 0, length: 90
+// #completionTest(90) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
+//@[4:50) Variable discriminatorKeySetTwoCompletionsArrayIndexer2. Type: error. Declaration start char: 0, length: 90
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) Resource incorrectPropertiesKey. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 132
@@ -296,6 +308,9 @@ resource dashesInPropertyNames 'Microsoft.ContainerService/managedClusters@2020-
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
 //@[4:23) Variable letsAccessTheDashes. Type: any. Declaration start char: 0, length: 78
+// #completionTest(78) -> autoScalerPropertiesRequireEscaping
+var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
+//@[4:24) Variable letsAccessTheDashes2. Type: any. Declaration start char: 0, length: 78
 
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[9:38) Resource nestedDiscriminatorMissingKey. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 190
@@ -309,9 +324,9 @@ resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@20
 // #completionTest(90) -> createMode
 var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.properties.cr
 //@[4:44) Variable nestedDiscriminatorMissingKeyCompletions. Type: any. Declaration start char: 0, length: 90
-// #completionTest(94) -> createMode
-var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
-//@[4:45) Variable nestedDiscriminatorMissingKeyCompletions2. Type: error. Declaration start char: 0, length: 94
+// #completionTest(92) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].
+//@[4:45) Variable nestedDiscriminatorMissingKeyCompletions2. Type: error. Declaration start char: 0, length: 92
 
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[9:28) Resource nestedDiscriminator. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 178
@@ -328,4 +343,10 @@ var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
 // #completionTest(73) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
 //@[4:35) Variable nestedDiscriminatorCompletions2. Type: error. Declaration start char: 0, length: 73
+// #completionTest(69) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
+//@[4:35) Variable nestedDiscriminatorCompletions3. Type: error. Declaration start char: 0, length: 69
+// #completionTest(72) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
+//@[4:35) Variable nestedDiscriminatorCompletions4. Type: error. Declaration start char: 0, length: 72
 

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -1004,6 +1004,22 @@ var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
 //@[74:75)   Dot |.|
 //@[75:76)   IdentifierSyntax
 //@[75:76)    Identifier |p|
+//@[76:78) NewLine |\r\n|
+// #completionTest(76) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
+//@[0:76) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:44)  IdentifierSyntax
+//@[4:44)   Identifier |discriminatorKeyValueMissingCompletions2|
+//@[45:46)  Assignment |=|
+//@[47:76)  PropertyAccessSyntax
+//@[47:75)   VariableAccessSyntax
+//@[47:75)    IdentifierSyntax
+//@[47:75)     Identifier |discriminatorKeyValueMissing|
+//@[75:76)   Dot |.|
+//@[76:76)   IdentifierSyntax
+//@[76:76)    SkippedTriviaSyntax
 //@[76:80) NewLine |\r\n\r\n|
 
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
@@ -1065,6 +1081,26 @@ var discriminatorKeySetOneCompletions = discriminatorKeySetOne.properties.a
 //@[73:74)   Dot |.|
 //@[74:75)   IdentifierSyntax
 //@[74:75)    Identifier |a|
+//@[75:77) NewLine |\r\n|
+// #completionTest(75) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
+//@[0:75) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:38)  IdentifierSyntax
+//@[4:38)   Identifier |discriminatorKeySetOneCompletions2|
+//@[39:40)  Assignment |=|
+//@[41:75)  PropertyAccessSyntax
+//@[41:74)   PropertyAccessSyntax
+//@[41:63)    VariableAccessSyntax
+//@[41:63)     IdentifierSyntax
+//@[41:63)      Identifier |discriminatorKeySetOne|
+//@[63:64)    Dot |.|
+//@[64:74)    IdentifierSyntax
+//@[64:74)     Identifier |properties|
+//@[74:75)   Dot |.|
+//@[75:75)   IdentifierSyntax
+//@[75:75)    SkippedTriviaSyntax
 //@[75:79) NewLine |\r\n\r\n|
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
@@ -1126,6 +1162,26 @@ var discriminatorKeySetTwoCompletions = discriminatorKeySetTwo.properties.a
 //@[73:74)   Dot |.|
 //@[74:75)   IdentifierSyntax
 //@[74:75)    Identifier |a|
+//@[75:77) NewLine |\r\n|
+// #completionTest(75) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
+//@[0:75) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:38)  IdentifierSyntax
+//@[4:38)   Identifier |discriminatorKeySetTwoCompletions2|
+//@[39:40)  Assignment |=|
+//@[41:75)  PropertyAccessSyntax
+//@[41:74)   PropertyAccessSyntax
+//@[41:63)    VariableAccessSyntax
+//@[41:63)     IdentifierSyntax
+//@[41:63)      Identifier |discriminatorKeySetTwo|
+//@[63:64)    Dot |.|
+//@[64:74)    IdentifierSyntax
+//@[64:74)     Identifier |properties|
+//@[74:75)   Dot |.|
+//@[75:75)   IdentifierSyntax
+//@[75:75)    SkippedTriviaSyntax
 //@[75:79) NewLine |\r\n\r\n|
 
 // #completionTest(90) -> powershellPropertyAccess
@@ -1148,6 +1204,27 @@ var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['prop
 //@[88:89)   Dot |.|
 //@[89:90)   IdentifierSyntax
 //@[89:90)    Identifier |a|
+//@[90:92) NewLine |\r\n|
+// #completionTest(90) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
+//@[0:90) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:50)  IdentifierSyntax
+//@[4:50)   Identifier |discriminatorKeySetTwoCompletionsArrayIndexer2|
+//@[51:52)  Assignment |=|
+//@[53:90)  PropertyAccessSyntax
+//@[53:89)   ArrayAccessSyntax
+//@[53:75)    VariableAccessSyntax
+//@[53:75)     IdentifierSyntax
+//@[53:75)      Identifier |discriminatorKeySetTwo|
+//@[75:76)    LeftSquare |[|
+//@[76:88)    StringSyntax
+//@[76:88)     StringComplete |'properties'|
+//@[88:89)    RightSquare |]|
+//@[89:90)   Dot |.|
+//@[90:90)   IdentifierSyntax
+//@[90:90)    SkippedTriviaSyntax
 //@[90:94) NewLine |\r\n\r\n|
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
@@ -1404,6 +1481,30 @@ var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
 //@[76:77)   Dot |.|
 //@[77:78)   IdentifierSyntax
 //@[77:78)    Identifier |s|
+//@[78:80) NewLine |\r\n|
+// #completionTest(78) -> autoScalerPropertiesRequireEscaping
+//@[61:63) NewLine |\r\n|
+var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
+//@[0:78) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:24)  IdentifierSyntax
+//@[4:24)   Identifier |letsAccessTheDashes2|
+//@[25:26)  Assignment |=|
+//@[27:78)  PropertyAccessSyntax
+//@[27:77)   PropertyAccessSyntax
+//@[27:59)    PropertyAccessSyntax
+//@[27:48)     VariableAccessSyntax
+//@[27:48)      IdentifierSyntax
+//@[27:48)       Identifier |dashesInPropertyNames|
+//@[48:49)     Dot |.|
+//@[49:59)     IdentifierSyntax
+//@[49:59)      Identifier |properties|
+//@[59:60)    Dot |.|
+//@[60:77)    IdentifierSyntax
+//@[60:77)     Identifier |autoScalerProfile|
+//@[77:78)   Dot |.|
+//@[78:78)   IdentifierSyntax
+//@[78:78)    SkippedTriviaSyntax
 //@[78:82) NewLine |\r\n\r\n|
 
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
@@ -1470,15 +1571,15 @@ var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.pro
 //@[88:90)   IdentifierSyntax
 //@[88:90)    Identifier |cr|
 //@[90:92) NewLine |\r\n|
-// #completionTest(94) -> createMode
+// #completionTest(92) -> createMode
 //@[36:38) NewLine |\r\n|
-var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
-//@[0:94) VariableDeclarationSyntax
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].
+//@[0:92) VariableDeclarationSyntax
 //@[0:3)  Identifier |var|
 //@[4:45)  IdentifierSyntax
 //@[4:45)   Identifier |nestedDiscriminatorMissingKeyCompletions2|
 //@[46:47)  Assignment |=|
-//@[48:94)  PropertyAccessSyntax
+//@[48:92)  PropertyAccessSyntax
 //@[48:91)   ArrayAccessSyntax
 //@[48:77)    VariableAccessSyntax
 //@[48:77)     IdentifierSyntax
@@ -1488,9 +1589,9 @@ var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['p
 //@[78:90)     StringComplete |'properties'|
 //@[90:91)    RightSquare |]|
 //@[91:92)   Dot |.|
-//@[92:94)   IdentifierSyntax
-//@[92:94)    Identifier |cr|
-//@[94:98) NewLine |\r\n\r\n|
+//@[92:92)   IdentifierSyntax
+//@[92:92)    SkippedTriviaSyntax
+//@[92:96) NewLine |\r\n\r\n|
 
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[0:178) ResourceDeclarationSyntax
@@ -1583,5 +1684,46 @@ var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
 //@[72:73)   IdentifierSyntax
 //@[72:73)    Identifier |a|
 //@[73:75) NewLine |\r\n|
+// #completionTest(69) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
+//@[0:69) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:35)  IdentifierSyntax
+//@[4:35)   Identifier |nestedDiscriminatorCompletions3|
+//@[36:37)  Assignment |=|
+//@[38:69)  PropertyAccessSyntax
+//@[38:68)   PropertyAccessSyntax
+//@[38:57)    VariableAccessSyntax
+//@[38:57)     IdentifierSyntax
+//@[38:57)      Identifier |nestedDiscriminator|
+//@[57:58)    Dot |.|
+//@[58:68)    IdentifierSyntax
+//@[58:68)     Identifier |properties|
+//@[68:69)   Dot |.|
+//@[69:69)   IdentifierSyntax
+//@[69:69)    SkippedTriviaSyntax
+//@[69:71) NewLine |\r\n|
+// #completionTest(72) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
+//@[0:72) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:35)  IdentifierSyntax
+//@[4:35)   Identifier |nestedDiscriminatorCompletions4|
+//@[36:37)  Assignment |=|
+//@[38:72)  PropertyAccessSyntax
+//@[38:71)   ArrayAccessSyntax
+//@[38:57)    VariableAccessSyntax
+//@[38:57)     IdentifierSyntax
+//@[38:57)      Identifier |nestedDiscriminator|
+//@[57:58)    LeftSquare |[|
+//@[58:70)    StringSyntax
+//@[58:70)     StringComplete |'properties'|
+//@[70:71)    RightSquare |]|
+//@[71:72)   Dot |.|
+//@[72:72)   IdentifierSyntax
+//@[72:72)    SkippedTriviaSyntax
+//@[72:74) NewLine |\r\n|
 
 //@[0:0) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -678,6 +678,15 @@ var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
 //@[46:74) Identifier |discriminatorKeyValueMissing|
 //@[74:75) Dot |.|
 //@[75:76) Identifier |p|
+//@[76:78) NewLine |\r\n|
+// #completionTest(76) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
+//@[0:3) Identifier |var|
+//@[4:44) Identifier |discriminatorKeyValueMissingCompletions2|
+//@[45:46) Assignment |=|
+//@[47:75) Identifier |discriminatorKeyValueMissing|
+//@[75:76) Dot |.|
 //@[76:80) NewLine |\r\n\r\n|
 
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
@@ -721,6 +730,17 @@ var discriminatorKeySetOneCompletions = discriminatorKeySetOne.properties.a
 //@[63:73) Identifier |properties|
 //@[73:74) Dot |.|
 //@[74:75) Identifier |a|
+//@[75:77) NewLine |\r\n|
+// #completionTest(75) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
+//@[0:3) Identifier |var|
+//@[4:38) Identifier |discriminatorKeySetOneCompletions2|
+//@[39:40) Assignment |=|
+//@[41:63) Identifier |discriminatorKeySetOne|
+//@[63:64) Dot |.|
+//@[64:74) Identifier |properties|
+//@[74:75) Dot |.|
 //@[75:79) NewLine |\r\n\r\n|
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
@@ -764,6 +784,17 @@ var discriminatorKeySetTwoCompletions = discriminatorKeySetTwo.properties.a
 //@[63:73) Identifier |properties|
 //@[73:74) Dot |.|
 //@[74:75) Identifier |a|
+//@[75:77) NewLine |\r\n|
+// #completionTest(75) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
+//@[0:3) Identifier |var|
+//@[4:38) Identifier |discriminatorKeySetTwoCompletions2|
+//@[39:40) Assignment |=|
+//@[41:63) Identifier |discriminatorKeySetTwo|
+//@[63:64) Dot |.|
+//@[64:74) Identifier |properties|
+//@[74:75) Dot |.|
 //@[75:79) NewLine |\r\n\r\n|
 
 // #completionTest(90) -> powershellPropertyAccess
@@ -778,6 +809,18 @@ var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['prop
 //@[87:88) RightSquare |]|
 //@[88:89) Dot |.|
 //@[89:90) Identifier |a|
+//@[90:92) NewLine |\r\n|
+// #completionTest(90) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
+//@[0:3) Identifier |var|
+//@[4:50) Identifier |discriminatorKeySetTwoCompletionsArrayIndexer2|
+//@[51:52) Assignment |=|
+//@[53:75) Identifier |discriminatorKeySetTwo|
+//@[75:76) LeftSquare |[|
+//@[76:88) StringComplete |'properties'|
+//@[88:89) RightSquare |]|
+//@[89:90) Dot |.|
 //@[90:94) NewLine |\r\n\r\n|
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
@@ -953,6 +996,19 @@ var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
 //@[59:76) Identifier |autoScalerProfile|
 //@[76:77) Dot |.|
 //@[77:78) Identifier |s|
+//@[78:80) NewLine |\r\n|
+// #completionTest(78) -> autoScalerPropertiesRequireEscaping
+//@[61:63) NewLine |\r\n|
+var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
+//@[0:3) Identifier |var|
+//@[4:24) Identifier |letsAccessTheDashes2|
+//@[25:26) Assignment |=|
+//@[27:48) Identifier |dashesInPropertyNames|
+//@[48:49) Dot |.|
+//@[49:59) Identifier |properties|
+//@[59:60) Dot |.|
+//@[60:77) Identifier |autoScalerProfile|
+//@[77:78) Dot |.|
 //@[78:82) NewLine |\r\n\r\n|
 
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
@@ -998,9 +1054,9 @@ var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.pro
 //@[87:88) Dot |.|
 //@[88:90) Identifier |cr|
 //@[90:92) NewLine |\r\n|
-// #completionTest(94) -> createMode
+// #completionTest(92) -> createMode
 //@[36:38) NewLine |\r\n|
-var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].cr
+var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].
 //@[0:3) Identifier |var|
 //@[4:45) Identifier |nestedDiscriminatorMissingKeyCompletions2|
 //@[46:47) Assignment |=|
@@ -1009,8 +1065,7 @@ var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['p
 //@[78:90) StringComplete |'properties'|
 //@[90:91) RightSquare |]|
 //@[91:92) Dot |.|
-//@[92:94) Identifier |cr|
-//@[94:98) NewLine |\r\n\r\n|
+//@[92:96) NewLine |\r\n\r\n|
 
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[0:8) Identifier |resource|
@@ -1071,5 +1126,28 @@ var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
 //@[71:72) Dot |.|
 //@[72:73) Identifier |a|
 //@[73:75) NewLine |\r\n|
+// #completionTest(69) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
+//@[0:3) Identifier |var|
+//@[4:35) Identifier |nestedDiscriminatorCompletions3|
+//@[36:37) Assignment |=|
+//@[38:57) Identifier |nestedDiscriminator|
+//@[57:58) Dot |.|
+//@[58:68) Identifier |properties|
+//@[68:69) Dot |.|
+//@[69:71) NewLine |\r\n|
+// #completionTest(72) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
+//@[0:3) Identifier |var|
+//@[4:35) Identifier |nestedDiscriminatorCompletions4|
+//@[36:37) Assignment |=|
+//@[38:57) Identifier |nestedDiscriminator|
+//@[57:58) LeftSquare |[|
+//@[58:70) StringComplete |'properties'|
+//@[70:71) RightSquare |]|
+//@[71:72) Dot |.|
+//@[72:74) NewLine |\r\n|
 
 //@[0:0) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevel.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevel.json
@@ -16,7 +16,7 @@
       "newText": "fifth"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -36,7 +36,7 @@
       "newText": "first"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -56,7 +56,7 @@
       "newText": "fourth"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -76,7 +76,7 @@
       "newText": "second"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -96,7 +96,7 @@
       "newText": "sixth"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   },
   {
@@ -116,7 +116,7 @@
       "newText": "third"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/oneArrayItemProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/oneArrayItemProperties.json
@@ -16,7 +16,7 @@
       "newText": "two"
     },
     "commitCharacters": [
-      ":"
+      "."
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
@@ -494,6 +494,19 @@
     }
   },
   {
+    "label": "mixedArrayTypeCompletions2",
+    "kind": "variable",
+    "detail": "mixedArrayTypeCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mixedArrayTypeCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "mixedArrayTypeCompletions2"
+    }
+  },
+  {
     "label": "myConcat",
     "kind": "variable",
     "detail": "myConcat",
@@ -559,6 +572,19 @@
     }
   },
   {
+    "label": "objectVarTopLevelCompletions2",
+    "kind": "variable",
+    "detail": "objectVarTopLevelCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_objectVarTopLevelCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "objectVarTopLevelCompletions2"
+    }
+  },
+  {
     "label": "oneArrayItemCompletions",
     "kind": "variable",
     "detail": "oneArrayItemCompletions",
@@ -569,6 +595,19 @@
     "textEdit": {
       "range": {},
       "newText": "oneArrayItemCompletions"
+    }
+  },
+  {
+    "label": "oneArrayItemCompletions2",
+    "kind": "variable",
+    "detail": "oneArrayItemCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_oneArrayItemCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "oneArrayItemCompletions2"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
@@ -118,10 +118,16 @@ var objectLiteralType = {
 
 // #completionTest(54) -> objectVarTopLevel
 var objectVarTopLevelCompletions = objectLiteralType.f
+// #completionTest(54) -> objectVarTopLevel
+var objectVarTopLevelCompletions2 = objectLiteralType.
 
 // this does not produce any completions because mixed array items are of type "any"
 // #completionTest(60) -> mixedArrayProperties
 var mixedArrayTypeCompletions = objectLiteralType.fifth[0].o
+// #completionTest(60) -> mixedArrayProperties
+var mixedArrayTypeCompletions2 = objectLiteralType.fifth[0].
 
 // #completionTest(58) -> oneArrayItemProperties
 var oneArrayItemCompletions = objectLiteralType.sixth[0].t
+// #completionTest(58) -> oneArrayItemProperties
+var oneArrayItemCompletions2 = objectLiteralType.sixth[0].

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -177,11 +177,20 @@ var objectLiteralType = {
 // #completionTest(54) -> objectVarTopLevel
 var objectVarTopLevelCompletions = objectLiteralType.f
 //@[53:54) [BCP053 (Error)] The type "object" does not contain property "f". Available properties include "fifth", "first", "fourth", "second", "sixth", "third". |f|
+// #completionTest(54) -> objectVarTopLevel
+var objectVarTopLevelCompletions2 = objectLiteralType.
+//@[54:54) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 // this does not produce any completions because mixed array items are of type "any"
 // #completionTest(60) -> mixedArrayProperties
 var mixedArrayTypeCompletions = objectLiteralType.fifth[0].o
+// #completionTest(60) -> mixedArrayProperties
+var mixedArrayTypeCompletions2 = objectLiteralType.fifth[0].
+//@[60:60) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 // #completionTest(58) -> oneArrayItemProperties
 var oneArrayItemCompletions = objectLiteralType.sixth[0].t
 //@[57:58) [BCP053 (Error)] The type "object" does not contain property "t". Available properties include "two". |t|
+// #completionTest(58) -> oneArrayItemProperties
+var oneArrayItemCompletions2 = objectLiteralType.sixth[0].
+//@[58:58) [BCP020 (Error)] Expected a function or property name at this location. ||

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
@@ -151,12 +151,21 @@ var objectLiteralType = {
 // #completionTest(54) -> objectVarTopLevel
 var objectVarTopLevelCompletions = objectLiteralType.f
 //@[4:32) Variable objectVarTopLevelCompletions. Type: error. Declaration start char: 0, length: 54
+// #completionTest(54) -> objectVarTopLevel
+var objectVarTopLevelCompletions2 = objectLiteralType.
+//@[4:33) Variable objectVarTopLevelCompletions2. Type: error. Declaration start char: 0, length: 54
 
 // this does not produce any completions because mixed array items are of type "any"
 // #completionTest(60) -> mixedArrayProperties
 var mixedArrayTypeCompletions = objectLiteralType.fifth[0].o
 //@[4:29) Variable mixedArrayTypeCompletions. Type: any. Declaration start char: 0, length: 60
+// #completionTest(60) -> mixedArrayProperties
+var mixedArrayTypeCompletions2 = objectLiteralType.fifth[0].
+//@[4:30) Variable mixedArrayTypeCompletions2. Type: any. Declaration start char: 0, length: 60
 
 // #completionTest(58) -> oneArrayItemProperties
 var oneArrayItemCompletions = objectLiteralType.sixth[0].t
 //@[4:27) Variable oneArrayItemCompletions. Type: error. Declaration start char: 0, length: 58
+// #completionTest(58) -> oneArrayItemProperties
+var oneArrayItemCompletions2 = objectLiteralType.sixth[0].
+//@[4:28) Variable oneArrayItemCompletions2. Type: error. Declaration start char: 0, length: 58

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
@@ -669,6 +669,22 @@ var objectVarTopLevelCompletions = objectLiteralType.f
 //@[52:53)   Dot |.|
 //@[53:54)   IdentifierSyntax
 //@[53:54)    Identifier |f|
+//@[54:55) NewLine |\n|
+// #completionTest(54) -> objectVarTopLevel
+//@[43:44) NewLine |\n|
+var objectVarTopLevelCompletions2 = objectLiteralType.
+//@[0:54) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:33)  IdentifierSyntax
+//@[4:33)   Identifier |objectVarTopLevelCompletions2|
+//@[34:35)  Assignment |=|
+//@[36:54)  PropertyAccessSyntax
+//@[36:53)   VariableAccessSyntax
+//@[36:53)    IdentifierSyntax
+//@[36:53)     Identifier |objectLiteralType|
+//@[53:54)   Dot |.|
+//@[54:54)   IdentifierSyntax
+//@[54:54)    SkippedTriviaSyntax
 //@[54:56) NewLine |\n\n|
 
 // this does not produce any completions because mixed array items are of type "any"
@@ -697,6 +713,31 @@ var mixedArrayTypeCompletions = objectLiteralType.fifth[0].o
 //@[58:59)   Dot |.|
 //@[59:60)   IdentifierSyntax
 //@[59:60)    Identifier |o|
+//@[60:61) NewLine |\n|
+// #completionTest(60) -> mixedArrayProperties
+//@[46:47) NewLine |\n|
+var mixedArrayTypeCompletions2 = objectLiteralType.fifth[0].
+//@[0:60) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:30)  IdentifierSyntax
+//@[4:30)   Identifier |mixedArrayTypeCompletions2|
+//@[31:32)  Assignment |=|
+//@[33:60)  PropertyAccessSyntax
+//@[33:59)   ArrayAccessSyntax
+//@[33:56)    PropertyAccessSyntax
+//@[33:50)     VariableAccessSyntax
+//@[33:50)      IdentifierSyntax
+//@[33:50)       Identifier |objectLiteralType|
+//@[50:51)     Dot |.|
+//@[51:56)     IdentifierSyntax
+//@[51:56)      Identifier |fifth|
+//@[56:57)    LeftSquare |[|
+//@[57:58)    NumericLiteralSyntax
+//@[57:58)     Number |0|
+//@[58:59)    RightSquare |]|
+//@[59:60)   Dot |.|
+//@[60:60)   IdentifierSyntax
+//@[60:60)    SkippedTriviaSyntax
 //@[60:62) NewLine |\n\n|
 
 // #completionTest(58) -> oneArrayItemProperties
@@ -723,4 +764,29 @@ var oneArrayItemCompletions = objectLiteralType.sixth[0].t
 //@[56:57)   Dot |.|
 //@[57:58)   IdentifierSyntax
 //@[57:58)    Identifier |t|
+//@[58:59) NewLine |\n|
+// #completionTest(58) -> oneArrayItemProperties
+//@[48:49) NewLine |\n|
+var oneArrayItemCompletions2 = objectLiteralType.sixth[0].
+//@[0:58) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:28)  IdentifierSyntax
+//@[4:28)   Identifier |oneArrayItemCompletions2|
+//@[29:30)  Assignment |=|
+//@[31:58)  PropertyAccessSyntax
+//@[31:57)   ArrayAccessSyntax
+//@[31:54)    PropertyAccessSyntax
+//@[31:48)     VariableAccessSyntax
+//@[31:48)      IdentifierSyntax
+//@[31:48)       Identifier |objectLiteralType|
+//@[48:49)     Dot |.|
+//@[49:54)     IdentifierSyntax
+//@[49:54)      Identifier |sixth|
+//@[54:55)    LeftSquare |[|
+//@[55:56)    NumericLiteralSyntax
+//@[55:56)     Number |0|
+//@[56:57)    RightSquare |]|
+//@[57:58)   Dot |.|
+//@[58:58)   IdentifierSyntax
+//@[58:58)    SkippedTriviaSyntax
 //@[58:58) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
@@ -448,6 +448,15 @@ var objectVarTopLevelCompletions = objectLiteralType.f
 //@[35:52) Identifier |objectLiteralType|
 //@[52:53) Dot |.|
 //@[53:54) Identifier |f|
+//@[54:55) NewLine |\n|
+// #completionTest(54) -> objectVarTopLevel
+//@[43:44) NewLine |\n|
+var objectVarTopLevelCompletions2 = objectLiteralType.
+//@[0:3) Identifier |var|
+//@[4:33) Identifier |objectVarTopLevelCompletions2|
+//@[34:35) Assignment |=|
+//@[36:53) Identifier |objectLiteralType|
+//@[53:54) Dot |.|
 //@[54:56) NewLine |\n\n|
 
 // this does not produce any completions because mixed array items are of type "any"
@@ -466,6 +475,20 @@ var mixedArrayTypeCompletions = objectLiteralType.fifth[0].o
 //@[57:58) RightSquare |]|
 //@[58:59) Dot |.|
 //@[59:60) Identifier |o|
+//@[60:61) NewLine |\n|
+// #completionTest(60) -> mixedArrayProperties
+//@[46:47) NewLine |\n|
+var mixedArrayTypeCompletions2 = objectLiteralType.fifth[0].
+//@[0:3) Identifier |var|
+//@[4:30) Identifier |mixedArrayTypeCompletions2|
+//@[31:32) Assignment |=|
+//@[33:50) Identifier |objectLiteralType|
+//@[50:51) Dot |.|
+//@[51:56) Identifier |fifth|
+//@[56:57) LeftSquare |[|
+//@[57:58) Number |0|
+//@[58:59) RightSquare |]|
+//@[59:60) Dot |.|
 //@[60:62) NewLine |\n\n|
 
 // #completionTest(58) -> oneArrayItemProperties
@@ -482,4 +505,18 @@ var oneArrayItemCompletions = objectLiteralType.sixth[0].t
 //@[55:56) RightSquare |]|
 //@[56:57) Dot |.|
 //@[57:58) Identifier |t|
+//@[58:59) NewLine |\n|
+// #completionTest(58) -> oneArrayItemProperties
+//@[48:49) NewLine |\n|
+var oneArrayItemCompletions2 = objectLiteralType.sixth[0].
+//@[0:3) Identifier |var|
+//@[4:28) Identifier |oneArrayItemCompletions2|
+//@[29:30) Assignment |=|
+//@[31:48) Identifier |objectLiteralType|
+//@[48:49) Dot |.|
+//@[49:54) Identifier |sixth|
+//@[54:55) LeftSquare |[|
+//@[55:56) Number |0|
+//@[56:57) RightSquare |]|
+//@[57:58) Dot |.|
 //@[58:58) EndOfFile ||

--- a/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
@@ -135,7 +135,7 @@ namespace Bicep.Core.Emit
                         return;
                     }
 
-                    // update the cache if property can't be skipped for inining
+                    // update the cache if property can't be skipped for inlining
                     shouldInlineCache[currentDeclaration] |= !propertyType.Flags.HasFlag(TypePropertyFlags.SkipInlining);
                     return;
             }

--- a/src/Bicep.Core/Parser/Parser.cs
+++ b/src/Bicep.Core/Parser/Parser.cs
@@ -308,7 +308,8 @@ namespace Bicep.Core.Parser
                 {
                     // dot operator
                     Token dot = this.reader.Read();
-                    IdentifierSyntax identifier = this.Identifier(b => b.ExpectedFunctionOrPropertyName());
+
+                    IdentifierSyntax identifier = this.IdentifierOrSkip(b => b.ExpectedFunctionOrPropertyName());
 
                     if (Check(TokenType.LeftParen))
                     {
@@ -482,6 +483,19 @@ namespace Bicep.Core.Parser
             var identifier = Expect(TokenType.Identifier, errorFunc);
 
             return new IdentifierSyntax(identifier);
+        }
+
+        private IdentifierSyntax IdentifierOrSkip(DiagnosticBuilder.ErrorBuilderDelegate errorFunc)
+        {
+            if (this.Check(TokenType.Identifier))
+            {
+                var identifier = Expect(TokenType.Identifier, errorFunc);
+                return new IdentifierSyntax(identifier);
+            }
+
+            var span = new TextSpan(this.reader.Peek().Span.Position, 0);
+            var skipped = new SkippedTriviaSyntax(span, ImmutableArray<SyntaxBase>.Empty, errorFunc(DiagnosticBuilder.ForPosition(span)).AsEnumerable());
+            return new IdentifierSyntax(skipped);
         }
 
         private IdentifierSyntax IdentifierWithRecovery(DiagnosticBuilder.ErrorBuilderDelegate errorFunc, params TokenType[] terminatingTypes)

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -592,12 +592,17 @@ namespace Bicep.Core.TypeSystem
                         // can only access properties of objects
                         return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.PropertyName).ObjectRequiredForPropertyAccess(baseType));
                     }
-                    else
-                    {
-                        // We can assign to an object, but we don't have a type for that object.
-                        // The best we can do is allow it and return the 'any' type.
-                        return LanguageConstants.Any;
-                    }
+
+                    // We can assign to an object, but we don't have a type for that object.
+                    // The best we can do is allow it and return the 'any' type.
+                    return LanguageConstants.Any;
+                }
+
+                if (!syntax.PropertyName.IsValid)
+                {
+                    // the property is not valid
+                    // there's already a parse error for it, so we don't need to add a type error as well
+                    return ErrorType.Empty();
                 }
 
                 return GetNamedPropertyType(objectType, syntax.PropertyName, syntax.PropertyName.IdentifierName, diagnostics);

--- a/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
@@ -48,7 +48,7 @@ namespace Bicep.LanguageServer.Handlers
             DocumentSelector = DocumentSelectorFactory.Create(),
             AllCommitCharacters = new Container<string>(),
             ResolveProvider = false,
-            TriggerCharacters = new Container<string>(":", " ")
+            TriggerCharacters = new Container<string>(":", " ", ".")
         };
     }
 }


### PR DESCRIPTION
- Now can get dot property access completions without typing the first letter of the property. Chose a simpler and less risky approach instead of rewriting all the parser expression recovery logic right before 0.2 release 😊
- Added `.` to the global trigger characters. This means typing `.` will now automatically open the property access completions.
- Added `.` as the commit character on property access completions. This allows a single press of the `.` character when the property list is open to accept the completion, type the `.` and auto trigger the next set of property access completions. See the gif below:

![DotCommit](https://user-images.githubusercontent.com/22460039/98336872-8e800780-1fbc-11eb-8f40-0498ffad30f9.gif)


This should be the final PR that closes #465.