### PR TITLE
added script to update test baselines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,13 @@ The Bicep solution is comprised of the following main components:
 * You can use the following command to run the full Bicep test suite:
     * `dotnet test`
 
+### Updating test baselines
+* Many of the bicep integration tests rely on baseline test assertion files that are checked into the repo. Code changes in some areas will require updates to the baseline assertions. 
+* If you see a test failure with a message containing Windows and *nix copy commands, you have encountered such a test. You have the following options to fix the test:
+  1. Manually execute the provided command in a shell. This makes sense for a single test, but is extremely tedious otherwise.
+  1. Run the `SetBaseline.ps1` script at the repo root to execute the tests in `SetBaseLine` mode, which causes the baselines to be automatically updated in bulk for failing tests. You should see baseline file modifications in Git pending changes. (Make sure your Git pending changes are empty before doing so - your changes could get overwritten!).
+* Inspect the baseline assertion diffs to ensure changes are expected and match the code changes you have made. (If a pull request contains changes to baseline files that can't be explained, it will not be merged.)
+
 ### Running the Bicep VSCode extension
 * On the first run, you'll need to ensure you have installed all the npm packages required by the Bicep VSCode extension with the following:
     * `cd src/vscode-bicep`

--- a/SetBaseline.ps1
+++ b/SetBaseline.ps1
@@ -1,0 +1,1 @@
+dotnet test -- 'TestRunParameters.Parameter(name=\\\"SetBaseLine\\\", value=\\\"true\\\")'

--- a/src/Bicep.Cli.IntegrationTests/ProgramTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/ProgramTests.cs
@@ -138,6 +138,7 @@ namespace Bicep.Cli.IntegrationTests
             var actual = JToken.Parse(File.ReadAllText(compiledFilePath));
 
             actual.Should().EqualWithJsonDiffOutput(
+                TestContext, 
                 JToken.Parse(dataSet.Compiled!),
                 expectedLocation: Path.Combine("src", "Bicep.Core.Samples", "Files", dataSet.Name, DataSet.TestFileMainCompiled),
                 actualLocation: compiledFilePath);
@@ -169,6 +170,7 @@ namespace Bicep.Cli.IntegrationTests
             var actual = JToken.Parse(output);
 
             actual.Should().EqualWithJsonDiffOutput(
+                TestContext, 
                 JToken.Parse(dataSet.Compiled!),
                 expectedLocation: Path.Combine("src", "Bicep.Core.Samples", "Files", dataSet.Name, DataSet.TestFileMainCompiled),
                 actualLocation: compiledFilePath);
@@ -207,6 +209,7 @@ namespace Bicep.Cli.IntegrationTests
                 var actual = JToken.Parse(File.ReadAllText(compiledFilePath));
 
                 actual.Should().EqualWithJsonDiffOutput(
+                    TestContext, 
                     JToken.Parse(dataSet.Compiled!),
                     expectedLocation: Path.Combine("src", "Bicep.Core.Samples", "Files", dataSet.Name, DataSet.TestFileMainCompiled),
                     actualLocation: compiledFilePath);

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -99,7 +99,7 @@ namespace Bicep.Cli
 
         private void Build(IDiagnosticLogger logger, BuildArguments arguments)
         {
-            var bicepPaths = arguments.Files.Select(PathHelper.ResolvePath).ToArray();
+            var bicepPaths = arguments.Files.Select(f => PathHelper.ResolvePath(f)).ToArray();
             if (arguments.OutputToStdOut)
             {
                 BuildManyFilesToStdOut(logger, bicepPaths);

--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -41,6 +41,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             var actual = JToken.Parse(File.ReadAllText(compiledFilePath));
 
             actual.Should().EqualWithJsonDiffOutput(
+                TestContext, 
                 JToken.Parse(dataSet.Compiled!),
                 expectedLocation: OutputHelper.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainCompiled),
                 actualLocation: compiledFilePath);
@@ -83,6 +84,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             var compiledFilePath = FileHelper.SaveResultFile(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainCompiled), actual.ToString(Formatting.Indented));
 
             actual.Should().EqualWithJsonDiffOutput(
+                TestContext, 
                 JToken.Parse(dataSet.Compiled!),
                 expectedLocation: OutputHelper.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainCompiled),
                 actualLocation: compiledFilePath);

--- a/src/Bicep.Core.IntegrationTests/LexerTests.cs
+++ b/src/Bicep.Core.IntegrationTests/LexerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -19,6 +20,7 @@ namespace Bicep.Core.IntegrationTests
     [TestClass]
     public class LexerTests
     {
+        [NotNull]
         public TestContext? TestContext { get; set; }
 
         [DataTestMethod]
@@ -103,9 +105,10 @@ namespace Bicep.Core.IntegrationTests
             }
 
             var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(dataSet, lexer.GetTokens(), getLoggingString);
-            var resultsFile = FileHelper.SaveResultFile(this.TestContext!, Path.Combine(dataSet.Name, DataSet.TestFileMainTokens), sourceTextWithDiags);
+            var resultsFile = FileHelper.SaveResultFile(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainTokens), sourceTextWithDiags);
 
             sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(
+                TestContext, 
                 dataSet.Tokens,
                 expectedLocation: OutputHelper.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainTokens),
                 actualLocation: resultsFile);

--- a/src/Bicep.Core.IntegrationTests/ParserTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParserTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using Bicep.Core.UnitTests.Assertions;
@@ -58,6 +59,7 @@ namespace Bicep.Core.IntegrationTests
             }
         }
 
+        [NotNull]
         public TestContext? TestContext { get; set; }
 
         [DataTestMethod]
@@ -111,9 +113,10 @@ namespace Bicep.Core.IntegrationTests
             TextSpan getSpan(SyntaxCollectorVisitor.SyntaxItem data) => data.Syntax.Span;
 
             var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(dataSet, syntaxList, getSpan, getLoggingString);
-            var resultsFile = FileHelper.SaveResultFile(this.TestContext!, Path.Combine(dataSet.Name, DataSet.TestFileMainSyntax), sourceTextWithDiags);
+            var resultsFile = FileHelper.SaveResultFile(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainSyntax), sourceTextWithDiags);
 
             sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(
+                TestContext, 
                 dataSet.Syntax,
                 expectedLocation: OutputHelper.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainSyntax),
                 actualLocation: resultsFile);

--- a/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
@@ -35,6 +35,7 @@ namespace Bicep.Core.IntegrationTests.PrettyPrint
             var resultsFile = FileHelper.SaveResultFile(this.TestContext!, Path.Combine(dataSet.Name, DataSet.TestFileMainFormatted), formattedOutput!);
 
             formattedOutput.Should().EqualWithLineByLineDiffOutput(
+                TestContext, 
                 formattedOutput!,
                 expectedLocation: OutputHelper.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainFormatted),
                 actualLocation: resultsFile);

--- a/src/Bicep.Core.IntegrationTests/SemanticModel/SemanticModelTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SemanticModel/SemanticModelTests.cs
@@ -46,6 +46,7 @@ namespace Bicep.Core.IntegrationTests.SemanticModel
             File.WriteAllText(resultsFile, sourceTextWithDiags);
 
             sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(
+                TestContext, 
                 dataSet.Diagnostics,
                 expectedLocation: OutputHelper.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainDiagnostics),
                 actualLocation: resultsFile);
@@ -82,6 +83,7 @@ namespace Bicep.Core.IntegrationTests.SemanticModel
             File.WriteAllText(resultsFile, sourceTextWithDiags);
 
             sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(
+                TestContext, 
                 dataSet.Symbols,
                 expectedLocation: OutputHelper.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainSymbols),
                 actualLocation: resultsFile);

--- a/src/Bicep.Core.Samples/ExamplesTests.cs
+++ b/src/Bicep.Core.Samples/ExamplesTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -26,6 +27,7 @@ namespace Bicep.Core.Samples
     [TestClass]
     public class ExamplesTests
     {
+        [NotNull]
         public TestContext? TestContext { get; set; }
 
         public class ExampleData
@@ -110,7 +112,7 @@ namespace Bicep.Core.Samples
         {
             // save all the files in the containing directory to disk so that we can test module resolution
             var parentStream = Path.GetDirectoryName(example.BicepStreamName)!.Replace('\\', '/');
-            var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(TestContext!, typeof(ExamplesTests).Assembly, example.OutputFolderName, parentStream);
+            var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(TestContext, typeof(ExamplesTests).Assembly, example.OutputFolderName, parentStream);
             var bicepFileName = Path.Combine(outputDirectory, Path.GetFileName(example.BicepStreamName));
             var jsonFileName = Path.Combine(outputDirectory, Path.GetFileName(example.JsonStreamName));
             
@@ -145,6 +147,7 @@ namespace Bicep.Core.Samples
                     File.WriteAllText(jsonFileName + ".actual", generated);
 
                     actual.Should().EqualWithJsonDiffOutput(
+                        TestContext, 
                         JToken.Parse(File.ReadAllText(jsonFileName)),
                         example.JsonStreamName,
                         jsonFileName + ".actual");

--- a/src/Bicep.Core.UnitTests/Assertions/BaselineHelper.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/BaselineHelper.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using Bicep.Core.FileSystem;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Assertions
+{
+    public static class BaselineHelper
+    {
+        private static readonly string RepoRoot = GetRepoRoot();
+
+        private const string SetBaseLineSettingName = "SetBaseLine";
+
+        public static bool ShouldSetBaseline(TestContext testContext) =>
+            testContext.Properties.Contains(SetBaseLineSettingName) && string.Equals(testContext.Properties[SetBaseLineSettingName] as string, bool.TrueString, StringComparison.OrdinalIgnoreCase);
+
+        public static void SetBaseline(string actualLocation, string expectedLocation)
+        {
+            actualLocation = PathHelper.ResolveAndNormalizePath(actualLocation, RepoRoot);
+            expectedLocation = PathHelper.ResolveAndNormalizePath(expectedLocation, RepoRoot);
+
+            File.Copy(actualLocation, expectedLocation, overwrite: true);
+        }
+
+        private static string GetRepoRoot()
+        {
+            // just using PowerShell as an easy way to redirect streams
+            using var ps = PowerShell.Create();
+            ps.AddScript("git rev-parse --show-toplevel");
+
+            var output = ps.Invoke();
+            if (!ps.HadErrors && output.Count == 1 && output.Single().BaseObject is string path)
+            {
+                // normalize the path for current platform (git really likes using / on windows)
+                return Path.GetFullPath(path);
+            }
+
+            throw new InvalidOperationException("Unable to determine the repo root path.");
+        }
+    }
+}

--- a/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
+++ b/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="JsonDiffPatch.Net" Version="2.2.0" />
     <PackageReference Include="DiffPlex" Version="1.6.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.3" />
     <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
@@ -19,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Management.Automation" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Core/FileSystem/PathHelper.cs
+++ b/src/Bicep.Core/FileSystem/PathHelper.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 using System;
 using System.IO;
-using System.Text;
 
 namespace Bicep.Core.FileSystem
 {
@@ -20,23 +19,26 @@ namespace Bicep.Core.FileSystem
         /// Converts relative paths to absolute paths relative to current directory. Fully qualified paths are returned as-is.
         /// </summary>
         /// <param name="path">The path.</param>
-        public static string ResolvePath(string path)
+        /// <param name="baseDirectory">The base directory to use when resolving relative paths. Set to null to use CWD.</param>
+        public static string ResolvePath(string path, string? baseDirectory = null)
         {
             if (Path.IsPathFullyQualified(path))
             {
                 return path;
             }
 
-            return Path.Combine(Environment.CurrentDirectory, path);
+            baseDirectory ??= Environment.CurrentDirectory;
+            return Path.Combine(baseDirectory, path);
         }
 
         /// <summary>
         /// Returns a normalized absolute path. Relative paths are converted to absolute paths relative to current directory prior to normalization.
         /// </summary>
         /// <param name="path">The path.</param>
-        public static string ResolveAndNormalizePath(string path)
+        /// <param name="baseDirectory">The base directory to use when resolving relative paths. Set to null to use CWD.</param>
+        public static string ResolveAndNormalizePath(string path, string? baseDirectory = null)
         {
-            var resolvedPath = ResolvePath(path);
+            var resolvedPath = ResolvePath(path, baseDirectory);
 
             return Path.GetFullPath(resolvedPath);
         }

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -56,7 +56,7 @@ namespace Bicep.LangServer.IntegrationTests
             
             var expected = JToken.Parse(expectedStr);
 
-            actual.Should().EqualWithJsonDiffOutput(expected, GetGlobalCompletionSetPath(expectedSetName), actualLocation);
+            actual.Should().EqualWithJsonDiffOutput(TestContext, expected, GetGlobalCompletionSetPath(expectedSetName), actualLocation);
         }
 
         [DataTestMethod]
@@ -125,7 +125,7 @@ namespace Bicep.LangServer.IntegrationTests
                 _ => GetGlobalCompletionSetPath(setName)
             };
 
-            actual.Should().EqualWithJsonDiffOutput(expected, expectedLocation, actualLocation, "because ");
+            actual.Should().EqualWithJsonDiffOutput(TestContext, expected, expectedLocation, actualLocation, "because ");
         }
 
         private static string GetGlobalCompletionSetPath(string setName) => Path.Combine("src", "Bicep.Core.Samples", "Files", DataSet.TestCompletionsDirectory, GetFullSetName(setName));


### PR DESCRIPTION
Our library of integration tests is growing. Those tests rely on checked in baseline assertion files. Anytime any change is made to the code many of these tests fail. They do fail with super helpful error messages that give you a command to update the baseline, but it has become rather tedious.

I added the `SetBaseline.ps1` script at the root of the repo that runs `dotnet test` with an extra RunParameter passed through the command line. In tests, we use that run parameter to automatically copy the actual file to the checked in location. (Tests fail in a SetBaseline run, but should pass next time.)

I also updated the contribution guide to explain how to use this script.

Only tested on Windows.