### PR TITLE
array access completions plus assorted fixes

### DIFF
--- a/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
+++ b/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
@@ -22,6 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Files\InvalidResources_CRLF\Completions\cliPropertyAccessIndexesPlusSymbols.json">
+      <LogicalName>$([System.String]::new('Bicep.Core.Samples/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.bicep
@@ -202,6 +202,16 @@ var azFunctions = az.a
 // #completionTest(24) -> sysFunctions
 var sysFunctions = sys.a
 
+// missing method name
+var missingMethodName = az.()
+
+// missing indexer
+var missingIndexerOnLiteralArray = [][][]
+var missingIndexerOnIdentifier = nonExistentIdentifier[][1][]
+
+// empty parens - should produce expected expression diagnostic
+var emptyParens = ()
+
 // keywords can't be called like functions
 var nullness = null()
 var truth = true()

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
@@ -359,6 +359,23 @@ var azFunctions = az.a
 var sysFunctions = sys.a
 //@[23:24) [BCP052 (Error)] The type "sys" does not contain property "a". |a|
 
+// missing method name
+var missingMethodName = az.()
+//@[27:27) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// missing indexer
+var missingIndexerOnLiteralArray = [][][]
+//@[38:38) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+//@[40:40) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+var missingIndexerOnIdentifier = nonExistentIdentifier[][1][]
+//@[33:54) [BCP057 (Error)] The name "nonExistentIdentifier" does not exist in the current context. |nonExistentIdentifier|
+//@[55:55) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+//@[60:60) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+
+// empty parens - should produce expected expression diagnostic
+var emptyParens = ()
+//@[19:20) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. |)|
+
 // keywords can't be called like functions
 var nullness = null()
 //@[19:20) [BCP019 (Error)] Expected a new line character at this location. |(|

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.symbols.bicep
@@ -301,6 +301,20 @@ var azFunctions = az.a
 var sysFunctions = sys.a
 //@[4:16) Variable sysFunctions. Type: error. Declaration start char: 0, length: 24
 
+// missing method name
+var missingMethodName = az.()
+//@[4:21) Variable missingMethodName. Type: error. Declaration start char: 0, length: 29
+
+// missing indexer
+var missingIndexerOnLiteralArray = [][][]
+//@[4:32) Variable missingIndexerOnLiteralArray. Type: error. Declaration start char: 0, length: 41
+var missingIndexerOnIdentifier = nonExistentIdentifier[][1][]
+//@[4:30) Variable missingIndexerOnIdentifier. Type: error. Declaration start char: 0, length: 61
+
+// empty parens - should produce expected expression diagnostic
+var emptyParens = ()
+//@[4:15) Variable emptyParens. Type: error. Declaration start char: 0, length: 20
+
 // keywords can't be called like functions
 var nullness = null()
 //@[4:12) Variable nullness. Type: null. Declaration start char: 0, length: 19

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
@@ -2102,6 +2102,82 @@ var sysFunctions = sys.a
 //@[23:24)    Identifier |a|
 //@[24:26) NewLine |\n\n|
 
+// missing method name
+//@[22:23) NewLine |\n|
+var missingMethodName = az.()
+//@[0:29) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:21)  IdentifierSyntax
+//@[4:21)   Identifier |missingMethodName|
+//@[22:23)  Assignment |=|
+//@[24:29)  InstanceFunctionCallSyntax
+//@[24:26)   VariableAccessSyntax
+//@[24:26)    IdentifierSyntax
+//@[24:26)     Identifier |az|
+//@[26:27)   Dot |.|
+//@[27:27)   IdentifierSyntax
+//@[27:27)    SkippedTriviaSyntax
+//@[27:28)   LeftParen |(|
+//@[28:29)   RightParen |)|
+//@[29:31) NewLine |\n\n|
+
+// missing indexer
+//@[18:19) NewLine |\n|
+var missingIndexerOnLiteralArray = [][][]
+//@[0:41) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:32)  IdentifierSyntax
+//@[4:32)   Identifier |missingIndexerOnLiteralArray|
+//@[33:34)  Assignment |=|
+//@[35:41)  ArrayAccessSyntax
+//@[35:39)   ArrayAccessSyntax
+//@[35:37)    ArraySyntax
+//@[35:36)     LeftSquare |[|
+//@[36:37)     RightSquare |]|
+//@[37:38)    LeftSquare |[|
+//@[38:38)    SkippedTriviaSyntax
+//@[38:39)    RightSquare |]|
+//@[39:40)   LeftSquare |[|
+//@[40:40)   SkippedTriviaSyntax
+//@[40:41)   RightSquare |]|
+//@[41:42) NewLine |\n|
+var missingIndexerOnIdentifier = nonExistentIdentifier[][1][]
+//@[0:61) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:30)  IdentifierSyntax
+//@[4:30)   Identifier |missingIndexerOnIdentifier|
+//@[31:32)  Assignment |=|
+//@[33:61)  ArrayAccessSyntax
+//@[33:59)   ArrayAccessSyntax
+//@[33:56)    ArrayAccessSyntax
+//@[33:54)     VariableAccessSyntax
+//@[33:54)      IdentifierSyntax
+//@[33:54)       Identifier |nonExistentIdentifier|
+//@[54:55)     LeftSquare |[|
+//@[55:55)     SkippedTriviaSyntax
+//@[55:56)     RightSquare |]|
+//@[56:57)    LeftSquare |[|
+//@[57:58)    NumericLiteralSyntax
+//@[57:58)     Number |1|
+//@[58:59)    RightSquare |]|
+//@[59:60)   LeftSquare |[|
+//@[60:60)   SkippedTriviaSyntax
+//@[60:61)   RightSquare |]|
+//@[61:63) NewLine |\n\n|
+
+// empty parens - should produce expected expression diagnostic
+//@[63:64) NewLine |\n|
+var emptyParens = ()
+//@[0:20) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:15)  IdentifierSyntax
+//@[4:15)   Identifier |emptyParens|
+//@[16:17)  Assignment |=|
+//@[18:20)  SkippedTriviaSyntax
+//@[18:19)   LeftParen |(|
+//@[19:20)   RightParen |)|
+//@[20:22) NewLine |\n\n|
+
 // keywords can't be called like functions
 //@[42:43) NewLine |\n|
 var nullness = null()

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.tokens.bicep
@@ -1324,6 +1324,55 @@ var sysFunctions = sys.a
 //@[23:24) Identifier |a|
 //@[24:26) NewLine |\n\n|
 
+// missing method name
+//@[22:23) NewLine |\n|
+var missingMethodName = az.()
+//@[0:3) Identifier |var|
+//@[4:21) Identifier |missingMethodName|
+//@[22:23) Assignment |=|
+//@[24:26) Identifier |az|
+//@[26:27) Dot |.|
+//@[27:28) LeftParen |(|
+//@[28:29) RightParen |)|
+//@[29:31) NewLine |\n\n|
+
+// missing indexer
+//@[18:19) NewLine |\n|
+var missingIndexerOnLiteralArray = [][][]
+//@[0:3) Identifier |var|
+//@[4:32) Identifier |missingIndexerOnLiteralArray|
+//@[33:34) Assignment |=|
+//@[35:36) LeftSquare |[|
+//@[36:37) RightSquare |]|
+//@[37:38) LeftSquare |[|
+//@[38:39) RightSquare |]|
+//@[39:40) LeftSquare |[|
+//@[40:41) RightSquare |]|
+//@[41:42) NewLine |\n|
+var missingIndexerOnIdentifier = nonExistentIdentifier[][1][]
+//@[0:3) Identifier |var|
+//@[4:30) Identifier |missingIndexerOnIdentifier|
+//@[31:32) Assignment |=|
+//@[33:54) Identifier |nonExistentIdentifier|
+//@[54:55) LeftSquare |[|
+//@[55:56) RightSquare |]|
+//@[56:57) LeftSquare |[|
+//@[57:58) Number |1|
+//@[58:59) RightSquare |]|
+//@[59:60) LeftSquare |[|
+//@[60:61) RightSquare |]|
+//@[61:63) NewLine |\n\n|
+
+// empty parens - should produce expected expression diagnostic
+//@[63:64) NewLine |\n|
+var emptyParens = ()
+//@[0:3) Identifier |var|
+//@[4:15) Identifier |emptyParens|
+//@[16:17) Assignment |=|
+//@[18:19) LeftParen |(|
+//@[19:20) RightParen |)|
+//@[20:22) NewLine |\n\n|
+
 // keywords can't be called like functions
 //@[42:43) NewLine |\n|
 var nullness = null()

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -364,6 +364,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
@@ -465,6 +478,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
     }
   },
   {
@@ -819,6 +845,19 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -907,6 +946,19 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -390,6 +390,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
@@ -491,6 +504,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
     }
   },
   {
@@ -845,6 +871,19 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -933,6 +972,19 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -1,28 +1,257 @@
 [
   {
-    "label": "'AzureCLI'",
-    "kind": "enumMember",
-    "detail": "'AzureCLI'",
+    "label": "'arguments'",
+    "kind": "property",
+    "detail": "arguments",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
     "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzureCLI'",
+    "preselect": false,
+    "sortText": "1_'arguments'",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "'AzureCLI'"
+      "newText": "'arguments'"
     }
   },
   {
-    "label": "'AzurePowerShell'",
-    "kind": "enumMember",
-    "detail": "'AzurePowerShell'",
+    "label": "'azCliVersion'",
+    "kind": "property",
+    "detail": "azCliVersion (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
     "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzurePowerShell'",
+    "preselect": false,
+    "sortText": "1_'azCliVersion'",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "'AzurePowerShell'"
+      "newText": "'azCliVersion'"
+    }
+  },
+  {
+    "label": "'cleanupPreference'",
+    "kind": "property",
+    "detail": "cleanupPreference",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Always' | 'OnExpiration' | 'OnSuccess'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'cleanupPreference'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'cleanupPreference'"
+    }
+  },
+  {
+    "label": "'containerSettings'",
+    "kind": "property",
+    "detail": "containerSettings",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ContainerConfiguration`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'containerSettings'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'containerSettings'"
+    }
+  },
+  {
+    "label": "'environmentVariables'",
+    "kind": "property",
+    "detail": "environmentVariables",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `EnvironmentVariable[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'environmentVariables'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'environmentVariables'"
+    }
+  },
+  {
+    "label": "'forceUpdateTag'",
+    "kind": "property",
+    "detail": "forceUpdateTag",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'forceUpdateTag'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'forceUpdateTag'"
+    }
+  },
+  {
+    "label": "'outputs'",
+    "kind": "property",
+    "detail": "outputs",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Dictionary<string,Object>`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'outputs'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'outputs'"
+    }
+  },
+  {
+    "label": "'primaryScriptUri'",
+    "kind": "property",
+    "detail": "primaryScriptUri",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'primaryScriptUri'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'primaryScriptUri'"
+    }
+  },
+  {
+    "label": "'provisioningState'",
+    "kind": "property",
+    "detail": "provisioningState",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Canceled' | 'Creating' | 'Failed' | 'ProvisioningResources' | 'Running' | 'Succeeded'`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'provisioningState'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'provisioningState'"
+    }
+  },
+  {
+    "label": "'retentionInterval'",
+    "kind": "property",
+    "detail": "retentionInterval (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'retentionInterval'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'retentionInterval'"
+    }
+  },
+  {
+    "label": "'scriptContent'",
+    "kind": "property",
+    "detail": "scriptContent",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'scriptContent'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'scriptContent'"
+    }
+  },
+  {
+    "label": "'status'",
+    "kind": "property",
+    "detail": "status",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ScriptStatus`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'status'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'status'"
+    }
+  },
+  {
+    "label": "'storageAccountSettings'",
+    "kind": "property",
+    "detail": "storageAccountSettings",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `StorageAccountConfiguration`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'storageAccountSettings'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'storageAccountSettings'"
+    }
+  },
+  {
+    "label": "'supportingScriptUris'",
+    "kind": "property",
+    "detail": "supportingScriptUris",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'supportingScriptUris'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'supportingScriptUris'"
+    }
+  },
+  {
+    "label": "'timeout'",
+    "kind": "property",
+    "detail": "timeout",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'timeout'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'timeout'"
     }
   },
   {
@@ -377,19 +606,6 @@
     }
   },
   {
-    "label": "discriminatorKeySetOneCompletions3",
-    "kind": "variable",
-    "detail": "discriminatorKeySetOneCompletions3",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetOneCompletions3",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetOneCompletions3"
-    }
-  },
-  {
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
@@ -452,6 +668,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -1,28 +1,19 @@
 [
   {
-    "label": "'AzureCLI'",
-    "kind": "enumMember",
-    "detail": "'AzureCLI'",
+    "label": "'createMode'",
+    "kind": "property",
+    "detail": "createMode (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Default' | 'Restore'`  \n"
+    },
     "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzureCLI'",
+    "preselect": false,
+    "sortText": "1_'createMode'",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "'AzureCLI'"
-    }
-  },
-  {
-    "label": "'AzurePowerShell'",
-    "kind": "enumMember",
-    "detail": "'AzurePowerShell'",
-    "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzurePowerShell'",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "'AzurePowerShell'"
+      "newText": "'createMode'"
     }
   },
   {
@@ -452,6 +443,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
     }
   },
   {
@@ -959,19 +963,6 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKeyCompletions2"
-    }
-  },
-  {
-    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "kind": "variable",
-    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -1,28 +1,478 @@
 [
   {
-    "label": "'AzureCLI'",
-    "kind": "enumMember",
-    "detail": "'AzureCLI'",
+    "label": "'apiProperties'",
+    "kind": "property",
+    "detail": "apiProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ApiProperties`  \n"
+    },
     "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzureCLI'",
+    "preselect": false,
+    "sortText": "1_'apiProperties'",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "'AzureCLI'"
+      "newText": "'apiProperties'"
     }
   },
   {
-    "label": "'AzurePowerShell'",
-    "kind": "enumMember",
-    "detail": "'AzurePowerShell'",
+    "label": "'backupPolicy'",
+    "kind": "property",
+    "detail": "backupPolicy",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `BackupPolicy`  \n"
+    },
     "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzurePowerShell'",
+    "preselect": false,
+    "sortText": "1_'backupPolicy'",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "'AzurePowerShell'"
+      "newText": "'backupPolicy'"
+    }
+  },
+  {
+    "label": "'capabilities'",
+    "kind": "property",
+    "detail": "capabilities",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Capability[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'capabilities'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'capabilities'"
+    }
+  },
+  {
+    "label": "'connectorOffer'",
+    "kind": "property",
+    "detail": "connectorOffer",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Small'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'connectorOffer'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'connectorOffer'"
+    }
+  },
+  {
+    "label": "'consistencyPolicy'",
+    "kind": "property",
+    "detail": "consistencyPolicy",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ConsistencyPolicy`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'consistencyPolicy'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'consistencyPolicy'"
+    }
+  },
+  {
+    "label": "'cors'",
+    "kind": "property",
+    "detail": "cors",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `CorsPolicy[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'cors'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'cors'"
+    }
+  },
+  {
+    "label": "'createMode'",
+    "kind": "property",
+    "detail": "createMode (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Default'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'createMode'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'createMode'"
+    }
+  },
+  {
+    "label": "'databaseAccountOfferType'",
+    "kind": "property",
+    "detail": "databaseAccountOfferType (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'databaseAccountOfferType'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'databaseAccountOfferType'"
+    }
+  },
+  {
+    "label": "'disableKeyBasedMetadataWriteAccess'",
+    "kind": "property",
+    "detail": "disableKeyBasedMetadataWriteAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'disableKeyBasedMetadataWriteAccess'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'disableKeyBasedMetadataWriteAccess'"
+    }
+  },
+  {
+    "label": "'documentEndpoint'",
+    "kind": "property",
+    "detail": "documentEndpoint",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'documentEndpoint'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'documentEndpoint'"
+    }
+  },
+  {
+    "label": "'enableAnalyticalStorage'",
+    "kind": "property",
+    "detail": "enableAnalyticalStorage",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableAnalyticalStorage'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableAnalyticalStorage'"
+    }
+  },
+  {
+    "label": "'enableAutomaticFailover'",
+    "kind": "property",
+    "detail": "enableAutomaticFailover",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableAutomaticFailover'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableAutomaticFailover'"
+    }
+  },
+  {
+    "label": "'enableCassandraConnector'",
+    "kind": "property",
+    "detail": "enableCassandraConnector",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableCassandraConnector'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableCassandraConnector'"
+    }
+  },
+  {
+    "label": "'enableFreeTier'",
+    "kind": "property",
+    "detail": "enableFreeTier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableFreeTier'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableFreeTier'"
+    }
+  },
+  {
+    "label": "'enableMultipleWriteLocations'",
+    "kind": "property",
+    "detail": "enableMultipleWriteLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableMultipleWriteLocations'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableMultipleWriteLocations'"
+    }
+  },
+  {
+    "label": "'failoverPolicies'",
+    "kind": "property",
+    "detail": "failoverPolicies",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `FailoverPolicy[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'failoverPolicies'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'failoverPolicies'"
+    }
+  },
+  {
+    "label": "'instanceId'",
+    "kind": "property",
+    "detail": "instanceId",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'instanceId'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'instanceId'"
+    }
+  },
+  {
+    "label": "'ipRules'",
+    "kind": "property",
+    "detail": "ipRules",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `IpAddressOrRange[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'ipRules'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'ipRules'"
+    }
+  },
+  {
+    "label": "'isVirtualNetworkFilterEnabled'",
+    "kind": "property",
+    "detail": "isVirtualNetworkFilterEnabled",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'isVirtualNetworkFilterEnabled'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'isVirtualNetworkFilterEnabled'"
+    }
+  },
+  {
+    "label": "'keyVaultKeyUri'",
+    "kind": "property",
+    "detail": "keyVaultKeyUri",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'keyVaultKeyUri'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'keyVaultKeyUri'"
+    }
+  },
+  {
+    "label": "'locations'",
+    "kind": "property",
+    "detail": "locations (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'locations'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'locations'"
+    }
+  },
+  {
+    "label": "'privateEndpointConnections'",
+    "kind": "property",
+    "detail": "privateEndpointConnections",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `PrivateEndpointConnection[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'privateEndpointConnections'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'privateEndpointConnections'"
+    }
+  },
+  {
+    "label": "'provisioningState'",
+    "kind": "property",
+    "detail": "provisioningState",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'provisioningState'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'provisioningState'"
+    }
+  },
+  {
+    "label": "'publicNetworkAccess'",
+    "kind": "property",
+    "detail": "publicNetworkAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Disabled' | 'Enabled'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'publicNetworkAccess'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'publicNetworkAccess'"
+    }
+  },
+  {
+    "label": "'readLocations'",
+    "kind": "property",
+    "detail": "readLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'readLocations'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'readLocations'"
+    }
+  },
+  {
+    "label": "'restoreParameters'",
+    "kind": "property",
+    "detail": "restoreParameters",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `RestoreParameters`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'restoreParameters'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'restoreParameters'"
+    }
+  },
+  {
+    "label": "'virtualNetworkRules'",
+    "kind": "property",
+    "detail": "virtualNetworkRules",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `VirtualNetworkRule[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'virtualNetworkRules'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'virtualNetworkRules'"
+    }
+  },
+  {
+    "label": "'writeLocations'",
+    "kind": "property",
+    "detail": "writeLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'writeLocations'",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "'writeLocations'"
     }
   },
   {
@@ -455,6 +905,19 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
@@ -855,19 +1318,6 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
-  },
-  {
-    "label": "nestedDiscriminatorArrayIndexCompletions",
-    "kind": "variable",
-    "detail": "nestedDiscriminatorArrayIndexCompletions",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "nestedDiscriminatorArrayIndexCompletions"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -1,28 +1,19 @@
 [
   {
-    "label": "'AzureCLI'",
-    "kind": "enumMember",
-    "detail": "'AzureCLI'",
+    "label": "'kind'",
+    "kind": "property",
+    "detail": "kind (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \n"
+    },
     "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzureCLI'",
+    "preselect": false,
+    "sortText": "1_'kind'",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "'AzureCLI'"
-    }
-  },
-  {
-    "label": "'AzurePowerShell'",
-    "kind": "enumMember",
-    "detail": "'AzurePowerShell'",
-    "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzurePowerShell'",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "'AzurePowerShell'"
+      "newText": "'kind'"
     }
   },
   {
@@ -455,6 +446,19 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions",
@@ -478,19 +482,6 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions2"
-    }
-  },
-  {
-    "label": "discriminatorKeyValueMissingCompletions3",
-    "kind": "variable",
-    "detail": "discriminatorKeyValueMissingCompletions3",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeyValueMissingCompletions3",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeyValueMissingCompletions3"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -351,6 +351,19 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwo",
     "kind": "interface",
     "detail": "discriminatorKeySetTwo",
@@ -452,6 +465,19 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
     }
   },
   {
@@ -806,6 +832,19 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -894,6 +933,19 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -175,6 +175,9 @@ var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
 // #completionTest(76) -> missingDiscriminatorPropertyAccess
 var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 
+// #completionTest(76) -> missingDiscriminatorPropertyIndexPlusSymbols
+var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
+
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -188,6 +191,9 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 var discriminatorKeySetOneCompletions = discriminatorKeySetOne.properties.a
 // #completionTest(75) -> cliPropertyAccess
 var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
+
+// #completionTest(75) -> cliPropertyAccessIndexesPlusSymbols
+var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzurePowerShell'
@@ -276,6 +282,9 @@ var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.pro
 // #completionTest(92) -> createMode
 var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].
 
+// #completionTest(94) -> createModeIndexPlusSymbols
+var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKey.properties['']
+
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
   location: 'l'
@@ -292,3 +301,6 @@ var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
 var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
 // #completionTest(72) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
+
+// #completionTest(79) -> defaultCreateModeIndexes
+var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -233,6 +233,10 @@ var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
 var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 //@[76:76) [BCP020 (Error)] Expected a function or property name at this location. ||
 
+// #completionTest(76) -> missingDiscriminatorPropertyIndexPlusSymbols
+var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
+//@[76:76) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |discriminatorKeySetOne|
   kind: 'AzureCLI'
@@ -248,6 +252,10 @@ var discriminatorKeySetOneCompletions = discriminatorKeySetOne.properties.a
 // #completionTest(75) -> cliPropertyAccess
 var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 //@[75:75) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(75) -> cliPropertyAccessIndexesPlusSymbols
+var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
+//@[75:75) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |discriminatorKeySetTwo|
@@ -267,10 +275,8 @@ var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
 
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['properties'].a
-//@[52:74) [BCP076 (Error)] Cannot index over expression of type "Microsoft.Resources/deploymentScripts@2020-10-01". Arrays or objects are required. |discriminatorKeySetTwo|
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
-//@[53:75) [BCP076 (Error)] Cannot index over expression of type "Microsoft.Resources/deploymentScripts@2020-10-01". Arrays or objects are required. |discriminatorKeySetTwo|
 //@[90:90) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
@@ -355,8 +361,10 @@ resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@20
 var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.properties.cr
 // #completionTest(92) -> createMode
 var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].
-//@[48:77) [BCP076 (Error)] Cannot index over expression of type "Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview". Arrays or objects are required. |nestedDiscriminatorMissingKey|
 //@[92:92) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(94) -> createModeIndexPlusSymbols
+var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKey.properties['']
 
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
@@ -370,12 +378,13 @@ resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-p
 var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
 // #completionTest(73) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
-//@[38:57) [BCP076 (Error)] Cannot index over expression of type "Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview". Arrays or objects are required. |nestedDiscriminator|
 // #completionTest(69) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
 //@[69:69) [BCP020 (Error)] Expected a function or property name at this location. ||
 // #completionTest(72) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
-//@[38:57) [BCP076 (Error)] Cannot index over expression of type "Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview". Arrays or objects are required. |nestedDiscriminator|
 //@[72:72) [BCP020 (Error)] Expected a function or property name at this location. ||
 
+// #completionTest(79) -> defaultCreateModeIndexes
+var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
+//@[78:79) [BCP057 (Error)] The name "a" does not exist in the current context. |a|

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -207,6 +207,10 @@ var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
 var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 //@[4:44) Variable discriminatorKeyValueMissingCompletions2. Type: error. Declaration start char: 0, length: 76
 
+// #completionTest(76) -> missingDiscriminatorPropertyIndexPlusSymbols
+var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
+//@[4:44) Variable discriminatorKeyValueMissingCompletions3. Type: error. Declaration start char: 0, length: 77
+
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) Resource discriminatorKeySetOne. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 264
   kind: 'AzureCLI'
@@ -223,6 +227,10 @@ var discriminatorKeySetOneCompletions = discriminatorKeySetOne.properties.a
 // #completionTest(75) -> cliPropertyAccess
 var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 //@[4:38) Variable discriminatorKeySetOneCompletions2. Type: error. Declaration start char: 0, length: 75
+
+// #completionTest(75) -> cliPropertyAccessIndexesPlusSymbols
+var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
+//@[4:38) Variable discriminatorKeySetOneCompletions3. Type: error. Declaration start char: 0, length: 76
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) Resource discriminatorKeySetTwo. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 270
@@ -243,7 +251,7 @@ var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
 
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['properties'].a
-//@[4:49) Variable discriminatorKeySetTwoCompletionsArrayIndexer. Type: error. Declaration start char: 0, length: 90
+//@[4:49) Variable discriminatorKeySetTwoCompletionsArrayIndexer. Type: any. Declaration start char: 0, length: 90
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
 //@[4:50) Variable discriminatorKeySetTwoCompletionsArrayIndexer2. Type: error. Declaration start char: 0, length: 90
@@ -328,6 +336,10 @@ var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.pro
 var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].
 //@[4:45) Variable nestedDiscriminatorMissingKeyCompletions2. Type: error. Declaration start char: 0, length: 92
 
+// #completionTest(94) -> createModeIndexPlusSymbols
+var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKey.properties['']
+//@[4:49) Variable nestedDiscriminatorMissingKeyIndexCompletions. Type: any. Declaration start char: 0, length: 96
+
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[9:28) Resource nestedDiscriminator. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 178
   name: 'test'
@@ -342,7 +354,7 @@ var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
 //@[4:34) Variable nestedDiscriminatorCompletions. Type: any. Declaration start char: 0, length: 69
 // #completionTest(73) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
-//@[4:35) Variable nestedDiscriminatorCompletions2. Type: error. Declaration start char: 0, length: 73
+//@[4:35) Variable nestedDiscriminatorCompletions2. Type: any. Declaration start char: 0, length: 73
 // #completionTest(69) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
 //@[4:35) Variable nestedDiscriminatorCompletions3. Type: error. Declaration start char: 0, length: 69
@@ -350,3 +362,6 @@ var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
 var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
 //@[4:35) Variable nestedDiscriminatorCompletions4. Type: error. Declaration start char: 0, length: 72
 
+// #completionTest(79) -> defaultCreateModeIndexes
+var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
+//@[4:44) Variable nestedDiscriminatorArrayIndexCompletions. Type: error. Declaration start char: 0, length: 80

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -1022,6 +1022,23 @@ var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 //@[76:76)    SkippedTriviaSyntax
 //@[76:80) NewLine |\r\n\r\n|
 
+// #completionTest(76) -> missingDiscriminatorPropertyIndexPlusSymbols
+//@[70:72) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
+//@[0:77) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:44)  IdentifierSyntax
+//@[4:44)   Identifier |discriminatorKeyValueMissingCompletions3|
+//@[45:46)  Assignment |=|
+//@[47:77)  ArrayAccessSyntax
+//@[47:75)   VariableAccessSyntax
+//@[47:75)    IdentifierSyntax
+//@[47:75)     Identifier |discriminatorKeyValueMissing|
+//@[75:76)   LeftSquare |[|
+//@[76:76)   SkippedTriviaSyntax
+//@[76:77)   RightSquare |]|
+//@[77:81) NewLine |\r\n\r\n|
+
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:264) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
@@ -1102,6 +1119,27 @@ var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 //@[75:75)   IdentifierSyntax
 //@[75:75)    SkippedTriviaSyntax
 //@[75:79) NewLine |\r\n\r\n|
+
+// #completionTest(75) -> cliPropertyAccessIndexesPlusSymbols
+//@[61:63) NewLine |\r\n|
+var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
+//@[0:76) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:38)  IdentifierSyntax
+//@[4:38)   Identifier |discriminatorKeySetOneCompletions3|
+//@[39:40)  Assignment |=|
+//@[41:76)  ArrayAccessSyntax
+//@[41:74)   PropertyAccessSyntax
+//@[41:63)    VariableAccessSyntax
+//@[41:63)     IdentifierSyntax
+//@[41:63)      Identifier |discriminatorKeySetOne|
+//@[63:64)    Dot |.|
+//@[64:74)    IdentifierSyntax
+//@[64:74)     Identifier |properties|
+//@[74:75)   LeftSquare |[|
+//@[75:75)   SkippedTriviaSyntax
+//@[75:76)   RightSquare |]|
+//@[76:80) NewLine |\r\n\r\n|
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:270) ResourceDeclarationSyntax
@@ -1593,6 +1631,28 @@ var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['p
 //@[92:92)    SkippedTriviaSyntax
 //@[92:96) NewLine |\r\n\r\n|
 
+// #completionTest(94) -> createModeIndexPlusSymbols
+//@[52:54) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKey.properties['']
+//@[0:96) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:49)  IdentifierSyntax
+//@[4:49)   Identifier |nestedDiscriminatorMissingKeyIndexCompletions|
+//@[50:51)  Assignment |=|
+//@[52:96)  ArrayAccessSyntax
+//@[52:92)   PropertyAccessSyntax
+//@[52:81)    VariableAccessSyntax
+//@[52:81)     IdentifierSyntax
+//@[52:81)      Identifier |nestedDiscriminatorMissingKey|
+//@[81:82)    Dot |.|
+//@[82:92)    IdentifierSyntax
+//@[82:92)     Identifier |properties|
+//@[92:93)   LeftSquare |[|
+//@[93:95)   StringSyntax
+//@[93:95)    StringComplete |''|
+//@[95:96)   RightSquare |]|
+//@[96:100) NewLine |\r\n\r\n|
+
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[0:178) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
@@ -1724,6 +1784,27 @@ var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
 //@[71:72)   Dot |.|
 //@[72:72)   IdentifierSyntax
 //@[72:72)    SkippedTriviaSyntax
-//@[72:74) NewLine |\r\n|
+//@[72:76) NewLine |\r\n\r\n|
 
-//@[0:0) EndOfFile ||
+// #completionTest(79) -> defaultCreateModeIndexes
+//@[50:52) NewLine |\r\n|
+var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
+//@[0:80) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:44)  IdentifierSyntax
+//@[4:44)   Identifier |nestedDiscriminatorArrayIndexCompletions|
+//@[45:46)  Assignment |=|
+//@[47:80)  ArrayAccessSyntax
+//@[47:77)   PropertyAccessSyntax
+//@[47:66)    VariableAccessSyntax
+//@[47:66)     IdentifierSyntax
+//@[47:66)      Identifier |nestedDiscriminator|
+//@[66:67)    Dot |.|
+//@[67:77)    IdentifierSyntax
+//@[67:77)     Identifier |properties|
+//@[77:78)   LeftSquare |[|
+//@[78:79)   VariableAccessSyntax
+//@[78:79)    IdentifierSyntax
+//@[78:79)     Identifier |a|
+//@[79:80)   RightSquare |]|
+//@[80:80) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -689,6 +689,17 @@ var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 //@[75:76) Dot |.|
 //@[76:80) NewLine |\r\n\r\n|
 
+// #completionTest(76) -> missingDiscriminatorPropertyIndexPlusSymbols
+//@[70:72) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
+//@[0:3) Identifier |var|
+//@[4:44) Identifier |discriminatorKeyValueMissingCompletions3|
+//@[45:46) Assignment |=|
+//@[47:75) Identifier |discriminatorKeyValueMissing|
+//@[75:76) LeftSquare |[|
+//@[76:77) RightSquare |]|
+//@[77:81) NewLine |\r\n\r\n|
+
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:8) Identifier |resource|
 //@[9:31) Identifier |discriminatorKeySetOne|
@@ -742,6 +753,19 @@ var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 //@[64:74) Identifier |properties|
 //@[74:75) Dot |.|
 //@[75:79) NewLine |\r\n\r\n|
+
+// #completionTest(75) -> cliPropertyAccessIndexesPlusSymbols
+//@[61:63) NewLine |\r\n|
+var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
+//@[0:3) Identifier |var|
+//@[4:38) Identifier |discriminatorKeySetOneCompletions3|
+//@[39:40) Assignment |=|
+//@[41:63) Identifier |discriminatorKeySetOne|
+//@[63:64) Dot |.|
+//@[64:74) Identifier |properties|
+//@[74:75) LeftSquare |[|
+//@[75:76) RightSquare |]|
+//@[76:80) NewLine |\r\n\r\n|
 
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:8) Identifier |resource|
@@ -1067,6 +1091,20 @@ var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['p
 //@[91:92) Dot |.|
 //@[92:96) NewLine |\r\n\r\n|
 
+// #completionTest(94) -> createModeIndexPlusSymbols
+//@[52:54) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKey.properties['']
+//@[0:3) Identifier |var|
+//@[4:49) Identifier |nestedDiscriminatorMissingKeyIndexCompletions|
+//@[50:51) Assignment |=|
+//@[52:81) Identifier |nestedDiscriminatorMissingKey|
+//@[81:82) Dot |.|
+//@[82:92) Identifier |properties|
+//@[92:93) LeftSquare |[|
+//@[93:95) StringComplete |''|
+//@[95:96) RightSquare |]|
+//@[96:100) NewLine |\r\n\r\n|
+
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[0:8) Identifier |resource|
 //@[9:28) Identifier |nestedDiscriminator|
@@ -1148,6 +1186,18 @@ var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
 //@[58:70) StringComplete |'properties'|
 //@[70:71) RightSquare |]|
 //@[71:72) Dot |.|
-//@[72:74) NewLine |\r\n|
+//@[72:76) NewLine |\r\n\r\n|
 
-//@[0:0) EndOfFile ||
+// #completionTest(79) -> defaultCreateModeIndexes
+//@[50:52) NewLine |\r\n|
+var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
+//@[0:3) Identifier |var|
+//@[4:44) Identifier |nestedDiscriminatorArrayIndexCompletions|
+//@[45:46) Assignment |=|
+//@[47:66) Identifier |nestedDiscriminator|
+//@[66:67) Dot |.|
+//@[67:77) Identifier |properties|
+//@[77:78) LeftSquare |[|
+//@[78:79) Identifier |a|
+//@[79:80) RightSquare |]|
+//@[80:80) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -1,31 +1,5 @@
 [
   {
-    "label": "'AzureCLI'",
-    "kind": "enumMember",
-    "detail": "'AzureCLI'",
-    "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzureCLI'",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "'AzureCLI'"
-    }
-  },
-  {
-    "label": "'AzurePowerShell'",
-    "kind": "enumMember",
-    "detail": "'AzurePowerShell'",
-    "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzurePowerShell'",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "'AzurePowerShell'"
-    }
-  },
-  {
     "label": "any",
     "kind": "function",
     "detail": "any()",
@@ -65,86 +39,47 @@
     }
   },
   {
-    "label": "badDepends",
-    "kind": "interface",
-    "detail": "badDepends",
+    "label": "az.resourceGroup",
+    "kind": "function",
+    "detail": "az.resourceGroup()",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_badDepends",
-    "insertTextFormat": "plainText",
+    "sortText": "3_az.resourceGroup",
+    "insertTextFormat": "snippet",
     "textEdit": {
       "range": {},
-      "newText": "badDepends"
+      "newText": "az.resourceGroup($0)"
     }
   },
   {
-    "label": "badDepends2",
-    "kind": "interface",
-    "detail": "badDepends2",
+    "label": "badEquals",
+    "kind": "variable",
+    "detail": "badEquals",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_badDepends2",
+    "sortText": "2_badEquals",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "badDepends2"
+      "newText": "badEquals"
     }
   },
   {
-    "label": "badDepends3",
-    "kind": "interface",
-    "detail": "badDepends3",
+    "label": "badEquals2",
+    "kind": "variable",
+    "detail": "badEquals2",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_badDepends3",
+    "sortText": "2_badEquals2",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "badDepends3"
-    }
-  },
-  {
-    "label": "badDepends4",
-    "kind": "interface",
-    "detail": "badDepends4",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badDepends4",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "badDepends4"
-    }
-  },
-  {
-    "label": "badDepends5",
-    "kind": "interface",
-    "detail": "badDepends5",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badDepends5",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "badDepends5"
-    }
-  },
-  {
-    "label": "badInterp",
-    "kind": "interface",
-    "detail": "badInterp",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badInterp",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "badInterp"
+      "newText": "badEquals2"
     }
   },
   {
     "label": "bar",
-    "kind": "interface",
+    "kind": "variable",
     "detail": "bar",
     "deprecated": false,
     "preselect": false,
@@ -192,19 +127,6 @@
     "textEdit": {
       "range": {},
       "newText": "base64ToString($0)"
-    }
-  },
-  {
-    "label": "baz",
-    "kind": "interface",
-    "detail": "baz",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_baz",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "baz"
     }
   },
   {
@@ -260,19 +182,6 @@
     }
   },
   {
-    "label": "dashesInPropertyNames",
-    "kind": "interface",
-    "detail": "dashesInPropertyNames",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_dashesInPropertyNames",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "dashesInPropertyNames"
-    }
-  },
-  {
     "label": "dataUri",
     "kind": "function",
     "detail": "dataUri()",
@@ -325,172 +234,16 @@
     }
   },
   {
-    "label": "discriminatorKeyMissing",
-    "kind": "interface",
-    "detail": "discriminatorKeyMissing",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeyMissing",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeyMissing"
-    }
-  },
-  {
-    "label": "discriminatorKeySetOne",
-    "kind": "interface",
-    "detail": "discriminatorKeySetOne",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetOne",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetOne"
-    }
-  },
-  {
-    "label": "discriminatorKeySetOneCompletions",
+    "label": "doubleString",
     "kind": "variable",
-    "detail": "discriminatorKeySetOneCompletions",
+    "detail": "doubleString",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_discriminatorKeySetOneCompletions",
+    "sortText": "2_doubleString",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "discriminatorKeySetOneCompletions"
-    }
-  },
-  {
-    "label": "discriminatorKeySetOneCompletions2",
-    "kind": "variable",
-    "detail": "discriminatorKeySetOneCompletions2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetOneCompletions2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetOneCompletions2"
-    }
-  },
-  {
-    "label": "discriminatorKeySetOneCompletions3",
-    "kind": "variable",
-    "detail": "discriminatorKeySetOneCompletions3",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetOneCompletions3",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetOneCompletions3"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwo",
-    "kind": "interface",
-    "detail": "discriminatorKeySetTwo",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwo",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwo"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwoCompletions",
-    "kind": "variable",
-    "detail": "discriminatorKeySetTwoCompletions",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwoCompletions",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwoCompletions"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwoCompletions2",
-    "kind": "variable",
-    "detail": "discriminatorKeySetTwoCompletions2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwoCompletions2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwoCompletions2"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "kind": "variable",
-    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "kind": "variable",
-    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
-    }
-  },
-  {
-    "label": "discriminatorKeyValueMissingCompletions",
-    "kind": "variable",
-    "detail": "discriminatorKeyValueMissingCompletions",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeyValueMissingCompletions",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeyValueMissingCompletions"
-    }
-  },
-  {
-    "label": "discriminatorKeyValueMissingCompletions2",
-    "kind": "variable",
-    "detail": "discriminatorKeyValueMissingCompletions2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeyValueMissingCompletions2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeyValueMissingCompletions2"
-    }
-  },
-  {
-    "label": "discriminatorKeyValueMissingCompletions3",
-    "kind": "variable",
-    "detail": "discriminatorKeyValueMissingCompletions3",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeyValueMissingCompletions3",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeyValueMissingCompletions3"
+      "newText": "doubleString"
     }
   },
   {
@@ -559,21 +312,8 @@
     }
   },
   {
-    "label": "fo",
-    "kind": "interface",
-    "detail": "fo",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_fo",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "fo"
-    }
-  },
-  {
     "label": "foo",
-    "kind": "interface",
+    "kind": "variable",
     "detail": "foo",
     "deprecated": false,
     "preselect": false,
@@ -611,32 +351,6 @@
     }
   },
   {
-    "label": "incorrectPropertiesKey",
-    "kind": "interface",
-    "detail": "incorrectPropertiesKey",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_incorrectPropertiesKey",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "incorrectPropertiesKey"
-    }
-  },
-  {
-    "label": "incorrectPropertiesKey2",
-    "kind": "interface",
-    "detail": "incorrectPropertiesKey2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_incorrectPropertiesKey2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "incorrectPropertiesKey2"
-    }
-  },
-  {
     "label": "indexOf",
     "kind": "function",
     "detail": "indexOf()",
@@ -663,19 +377,6 @@
     }
   },
   {
-    "label": "interpVal",
-    "kind": "variable",
-    "detail": "interpVal",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_interpVal",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "interpVal"
-    }
-  },
-  {
     "label": "intersection",
     "kind": "function",
     "detail": "intersection()",
@@ -686,6 +387,19 @@
     "textEdit": {
       "range": {},
       "newText": "intersection($0)"
+    }
+  },
+  {
+    "label": "invalidNamespaceAssignment",
+    "kind": "variable",
+    "detail": "invalidNamespaceAssignment",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidNamespaceAssignment",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidNamespaceAssignment"
     }
   },
   {
@@ -741,32 +455,6 @@
     }
   },
   {
-    "label": "letsAccessTheDashes",
-    "kind": "variable",
-    "detail": "letsAccessTheDashes",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_letsAccessTheDashes",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "letsAccessTheDashes"
-    }
-  },
-  {
-    "label": "letsAccessTheDashes2",
-    "kind": "variable",
-    "detail": "letsAccessTheDashes2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_letsAccessTheDashes2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "letsAccessTheDashes2"
-    }
-  },
-  {
     "label": "max",
     "kind": "function",
     "detail": "max()",
@@ -793,185 +481,159 @@
     }
   },
   {
-    "label": "missingTopLevelProperties",
-    "kind": "interface",
-    "detail": "missingTopLevelProperties",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_missingTopLevelProperties",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "missingTopLevelProperties"
-    }
-  },
-  {
-    "label": "missingTopLevelPropertiesExceptName",
-    "kind": "interface",
-    "detail": "missingTopLevelPropertiesExceptName",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_missingTopLevelPropertiesExceptName",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "missingTopLevelPropertiesExceptName"
-    }
-  },
-  {
-    "label": "missingType",
-    "kind": "interface",
-    "detail": "missingType",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_missingType",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "missingType"
-    }
-  },
-  {
-    "label": "mock",
+    "label": "missingValue",
     "kind": "variable",
-    "detail": "mock",
+    "detail": "missingValue",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_mock",
+    "sortText": "2_missingValue",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "mock"
+      "newText": "missingValue"
     }
   },
   {
-    "label": "nestedDiscriminator",
-    "kind": "interface",
-    "detail": "nestedDiscriminator",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_nestedDiscriminator",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "nestedDiscriminator"
-    }
-  },
-  {
-    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "label": "mixedArrayTypeCompletions",
     "kind": "variable",
-    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "detail": "mixedArrayTypeCompletions",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "sortText": "2_mixedArrayTypeCompletions",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorArrayIndexCompletions"
+      "newText": "mixedArrayTypeCompletions"
     }
   },
   {
-    "label": "nestedDiscriminatorCompletions",
+    "label": "mixedArrayTypeCompletions2",
     "kind": "variable",
-    "detail": "nestedDiscriminatorCompletions",
+    "detail": "mixedArrayTypeCompletions2",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorCompletions",
+    "sortText": "2_mixedArrayTypeCompletions2",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorCompletions"
+      "newText": "mixedArrayTypeCompletions2"
     }
   },
   {
-    "label": "nestedDiscriminatorCompletions2",
+    "label": "myConcat",
     "kind": "variable",
-    "detail": "nestedDiscriminatorCompletions2",
+    "detail": "myConcat",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorCompletions2",
+    "sortText": "2_myConcat",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorCompletions2"
+      "newText": "myConcat"
     }
   },
   {
-    "label": "nestedDiscriminatorCompletions3",
+    "label": "mySum",
     "kind": "variable",
-    "detail": "nestedDiscriminatorCompletions3",
+    "detail": "mySum",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorCompletions3",
+    "sortText": "2_mySum",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorCompletions3"
+      "newText": "mySum"
     }
   },
   {
-    "label": "nestedDiscriminatorCompletions4",
+    "label": "objWithInterp",
     "kind": "variable",
-    "detail": "nestedDiscriminatorCompletions4",
+    "detail": "objWithInterp",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorCompletions4",
+    "sortText": "2_objWithInterp",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorCompletions4"
+      "newText": "objWithInterp"
     }
   },
   {
-    "label": "nestedDiscriminatorMissingKey",
-    "kind": "interface",
-    "detail": "nestedDiscriminatorMissingKey",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_nestedDiscriminatorMissingKey",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "nestedDiscriminatorMissingKey"
-    }
-  },
-  {
-    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "label": "objectLiteralType",
     "kind": "variable",
-    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "detail": "objectLiteralType",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "sortText": "2_objectLiteralType",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorMissingKeyCompletions"
+      "newText": "objectLiteralType"
     }
   },
   {
-    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "label": "objectVarTopLevelCompletions",
     "kind": "variable",
-    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "detail": "objectVarTopLevelCompletions",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "sortText": "2_objectVarTopLevelCompletions",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+      "newText": "objectVarTopLevelCompletions"
     }
   },
   {
-    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "label": "objectVarTopLevelCompletions2",
     "kind": "variable",
-    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "detail": "objectVarTopLevelCompletions2",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "sortText": "2_objectVarTopLevelCompletions2",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+      "newText": "objectVarTopLevelCompletions2"
+    }
+  },
+  {
+    "label": "oneArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "oneArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_oneArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "oneArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "oneArrayItemCompletions",
+    "kind": "variable",
+    "detail": "oneArrayItemCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_oneArrayItemCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "oneArrayItemCompletions"
+    }
+  },
+  {
+    "label": "oneArrayItemCompletions2",
+    "kind": "variable",
+    "detail": "oneArrayItemCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_oneArrayItemCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "oneArrayItemCompletions2"
     }
   },
   {
@@ -1054,15 +716,15 @@
   },
   {
     "label": "resourceGroup",
-    "kind": "function",
-    "detail": "resourceGroup()",
+    "kind": "variable",
+    "detail": "resourceGroup",
     "deprecated": false,
     "preselect": false,
-    "sortText": "3_resourceGroup",
-    "insertTextFormat": "snippet",
+    "sortText": "2_resourceGroup",
+    "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "resourceGroup($0)"
+      "newText": "resourceGroup"
     }
   },
   {
@@ -1079,29 +741,16 @@
     }
   },
   {
-    "label": "resrefpar",
-    "kind": "field",
-    "detail": "resrefpar",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resrefpar",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "resrefpar"
-    }
-  },
-  {
-    "label": "resrefvar",
+    "label": "rgName",
     "kind": "variable",
-    "detail": "resrefvar",
+    "detail": "rgName",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_resrefvar",
+    "sortText": "2_rgName",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "resrefvar"
+      "newText": "rgName"
     }
   },
   {
@@ -1128,32 +777,6 @@
     "textEdit": {
       "range": {},
       "newText": "split($0)"
-    }
-  },
-  {
-    "label": "startedTypingTypeWithQuotes",
-    "kind": "interface",
-    "detail": "startedTypingTypeWithQuotes",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_startedTypingTypeWithQuotes",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "startedTypingTypeWithQuotes"
-    }
-  },
-  {
-    "label": "startedTypingTypeWithoutQuotes",
-    "kind": "interface",
-    "detail": "startedTypingTypeWithoutQuotes",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_startedTypingTypeWithoutQuotes",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "startedTypingTypeWithoutQuotes"
     }
   },
   {
@@ -1274,6 +897,58 @@
     }
   },
   {
+    "label": "test",
+    "kind": "variable",
+    "detail": "test",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_test",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "test"
+    }
+  },
+  {
+    "label": "test2",
+    "kind": "variable",
+    "detail": "test2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_test2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "test2"
+    }
+  },
+  {
+    "label": "test3",
+    "kind": "variable",
+    "detail": "test3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_test3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "test3"
+    }
+  },
+  {
+    "label": "testDupe",
+    "kind": "variable",
+    "detail": "testDupe",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_testDupe",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "testDupe"
+    }
+  },
+  {
     "label": "toLower",
     "kind": "function",
     "detail": "toLower()",
@@ -1310,19 +985,6 @@
     "textEdit": {
       "range": {},
       "newText": "trim($0)"
-    }
-  },
-  {
-    "label": "unfinishedVnet",
-    "kind": "interface",
-    "detail": "unfinishedVnet",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_unfinishedVnet",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "unfinishedVnet"
     }
   },
   {
@@ -1388,6 +1050,32 @@
     "textEdit": {
       "range": {},
       "newText": "uriComponentToString($0)"
+    }
+  },
+  {
+    "label": "x",
+    "kind": "variable",
+    "detail": "x",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_x",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "x"
+    }
+  },
+  {
+    "label": "y",
+    "kind": "variable",
+    "detail": "y",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_y",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "y"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
@@ -559,6 +559,19 @@
     }
   },
   {
+    "label": "objectVarTopLevelArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "objectVarTopLevelArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_objectVarTopLevelArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "objectVarTopLevelArrayIndexCompletions"
+    }
+  },
+  {
     "label": "objectVarTopLevelCompletions",
     "kind": "variable",
     "detail": "objectVarTopLevelCompletions",
@@ -582,6 +595,19 @@
     "textEdit": {
       "range": {},
       "newText": "objectVarTopLevelCompletions2"
+    }
+  },
+  {
+    "label": "oneArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "oneArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_oneArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "oneArrayIndexCompletions"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -1,28 +1,19 @@
 [
   {
-    "label": "'AzureCLI'",
-    "kind": "enumMember",
-    "detail": "'AzureCLI'",
+    "label": "'two'",
+    "kind": "property",
+    "detail": "two",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `int`  \n"
+    },
     "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzureCLI'",
+    "preselect": false,
+    "sortText": "1_'two'",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "'AzureCLI'"
-    }
-  },
-  {
-    "label": "'AzurePowerShell'",
-    "kind": "enumMember",
-    "detail": "'AzurePowerShell'",
-    "deprecated": false,
-    "preselect": true,
-    "sortText": "2_'AzurePowerShell'",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "'AzurePowerShell'"
+      "newText": "'two'"
     }
   },
   {
@@ -65,86 +56,47 @@
     }
   },
   {
-    "label": "badDepends",
-    "kind": "interface",
-    "detail": "badDepends",
+    "label": "az.resourceGroup",
+    "kind": "function",
+    "detail": "az.resourceGroup()",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_badDepends",
-    "insertTextFormat": "plainText",
+    "sortText": "3_az.resourceGroup",
+    "insertTextFormat": "snippet",
     "textEdit": {
       "range": {},
-      "newText": "badDepends"
+      "newText": "az.resourceGroup($0)"
     }
   },
   {
-    "label": "badDepends2",
-    "kind": "interface",
-    "detail": "badDepends2",
+    "label": "badEquals",
+    "kind": "variable",
+    "detail": "badEquals",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_badDepends2",
+    "sortText": "2_badEquals",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "badDepends2"
+      "newText": "badEquals"
     }
   },
   {
-    "label": "badDepends3",
-    "kind": "interface",
-    "detail": "badDepends3",
+    "label": "badEquals2",
+    "kind": "variable",
+    "detail": "badEquals2",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_badDepends3",
+    "sortText": "2_badEquals2",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "badDepends3"
-    }
-  },
-  {
-    "label": "badDepends4",
-    "kind": "interface",
-    "detail": "badDepends4",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badDepends4",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "badDepends4"
-    }
-  },
-  {
-    "label": "badDepends5",
-    "kind": "interface",
-    "detail": "badDepends5",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badDepends5",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "badDepends5"
-    }
-  },
-  {
-    "label": "badInterp",
-    "kind": "interface",
-    "detail": "badInterp",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_badInterp",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "badInterp"
+      "newText": "badEquals2"
     }
   },
   {
     "label": "bar",
-    "kind": "interface",
+    "kind": "variable",
     "detail": "bar",
     "deprecated": false,
     "preselect": false,
@@ -192,19 +144,6 @@
     "textEdit": {
       "range": {},
       "newText": "base64ToString($0)"
-    }
-  },
-  {
-    "label": "baz",
-    "kind": "interface",
-    "detail": "baz",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_baz",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "baz"
     }
   },
   {
@@ -260,19 +199,6 @@
     }
   },
   {
-    "label": "dashesInPropertyNames",
-    "kind": "interface",
-    "detail": "dashesInPropertyNames",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_dashesInPropertyNames",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "dashesInPropertyNames"
-    }
-  },
-  {
     "label": "dataUri",
     "kind": "function",
     "detail": "dataUri()",
@@ -325,172 +251,16 @@
     }
   },
   {
-    "label": "discriminatorKeyMissing",
-    "kind": "interface",
-    "detail": "discriminatorKeyMissing",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeyMissing",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeyMissing"
-    }
-  },
-  {
-    "label": "discriminatorKeySetOne",
-    "kind": "interface",
-    "detail": "discriminatorKeySetOne",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetOne",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetOne"
-    }
-  },
-  {
-    "label": "discriminatorKeySetOneCompletions",
+    "label": "doubleString",
     "kind": "variable",
-    "detail": "discriminatorKeySetOneCompletions",
+    "detail": "doubleString",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_discriminatorKeySetOneCompletions",
+    "sortText": "2_doubleString",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "discriminatorKeySetOneCompletions"
-    }
-  },
-  {
-    "label": "discriminatorKeySetOneCompletions2",
-    "kind": "variable",
-    "detail": "discriminatorKeySetOneCompletions2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetOneCompletions2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetOneCompletions2"
-    }
-  },
-  {
-    "label": "discriminatorKeySetOneCompletions3",
-    "kind": "variable",
-    "detail": "discriminatorKeySetOneCompletions3",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetOneCompletions3",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetOneCompletions3"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwo",
-    "kind": "interface",
-    "detail": "discriminatorKeySetTwo",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwo",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwo"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwoCompletions",
-    "kind": "variable",
-    "detail": "discriminatorKeySetTwoCompletions",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwoCompletions",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwoCompletions"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwoCompletions2",
-    "kind": "variable",
-    "detail": "discriminatorKeySetTwoCompletions2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwoCompletions2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwoCompletions2"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "kind": "variable",
-    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
-    }
-  },
-  {
-    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "kind": "variable",
-    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
-    }
-  },
-  {
-    "label": "discriminatorKeyValueMissingCompletions",
-    "kind": "variable",
-    "detail": "discriminatorKeyValueMissingCompletions",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeyValueMissingCompletions",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeyValueMissingCompletions"
-    }
-  },
-  {
-    "label": "discriminatorKeyValueMissingCompletions2",
-    "kind": "variable",
-    "detail": "discriminatorKeyValueMissingCompletions2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeyValueMissingCompletions2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeyValueMissingCompletions2"
-    }
-  },
-  {
-    "label": "discriminatorKeyValueMissingCompletions3",
-    "kind": "variable",
-    "detail": "discriminatorKeyValueMissingCompletions3",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_discriminatorKeyValueMissingCompletions3",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminatorKeyValueMissingCompletions3"
+      "newText": "doubleString"
     }
   },
   {
@@ -559,21 +329,8 @@
     }
   },
   {
-    "label": "fo",
-    "kind": "interface",
-    "detail": "fo",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_fo",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "fo"
-    }
-  },
-  {
     "label": "foo",
-    "kind": "interface",
+    "kind": "variable",
     "detail": "foo",
     "deprecated": false,
     "preselect": false,
@@ -611,32 +368,6 @@
     }
   },
   {
-    "label": "incorrectPropertiesKey",
-    "kind": "interface",
-    "detail": "incorrectPropertiesKey",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_incorrectPropertiesKey",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "incorrectPropertiesKey"
-    }
-  },
-  {
-    "label": "incorrectPropertiesKey2",
-    "kind": "interface",
-    "detail": "incorrectPropertiesKey2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_incorrectPropertiesKey2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "incorrectPropertiesKey2"
-    }
-  },
-  {
     "label": "indexOf",
     "kind": "function",
     "detail": "indexOf()",
@@ -663,19 +394,6 @@
     }
   },
   {
-    "label": "interpVal",
-    "kind": "variable",
-    "detail": "interpVal",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_interpVal",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "interpVal"
-    }
-  },
-  {
     "label": "intersection",
     "kind": "function",
     "detail": "intersection()",
@@ -686,6 +404,19 @@
     "textEdit": {
       "range": {},
       "newText": "intersection($0)"
+    }
+  },
+  {
+    "label": "invalidNamespaceAssignment",
+    "kind": "variable",
+    "detail": "invalidNamespaceAssignment",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidNamespaceAssignment",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidNamespaceAssignment"
     }
   },
   {
@@ -741,32 +472,6 @@
     }
   },
   {
-    "label": "letsAccessTheDashes",
-    "kind": "variable",
-    "detail": "letsAccessTheDashes",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_letsAccessTheDashes",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "letsAccessTheDashes"
-    }
-  },
-  {
-    "label": "letsAccessTheDashes2",
-    "kind": "variable",
-    "detail": "letsAccessTheDashes2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_letsAccessTheDashes2",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "letsAccessTheDashes2"
-    }
-  },
-  {
     "label": "max",
     "kind": "function",
     "detail": "max()",
@@ -793,185 +498,159 @@
     }
   },
   {
-    "label": "missingTopLevelProperties",
-    "kind": "interface",
-    "detail": "missingTopLevelProperties",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_missingTopLevelProperties",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "missingTopLevelProperties"
-    }
-  },
-  {
-    "label": "missingTopLevelPropertiesExceptName",
-    "kind": "interface",
-    "detail": "missingTopLevelPropertiesExceptName",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_missingTopLevelPropertiesExceptName",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "missingTopLevelPropertiesExceptName"
-    }
-  },
-  {
-    "label": "missingType",
-    "kind": "interface",
-    "detail": "missingType",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_missingType",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "missingType"
-    }
-  },
-  {
-    "label": "mock",
+    "label": "missingValue",
     "kind": "variable",
-    "detail": "mock",
+    "detail": "missingValue",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_mock",
+    "sortText": "2_missingValue",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "mock"
+      "newText": "missingValue"
     }
   },
   {
-    "label": "nestedDiscriminator",
-    "kind": "interface",
-    "detail": "nestedDiscriminator",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_nestedDiscriminator",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "nestedDiscriminator"
-    }
-  },
-  {
-    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "label": "mixedArrayTypeCompletions",
     "kind": "variable",
-    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "detail": "mixedArrayTypeCompletions",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "sortText": "2_mixedArrayTypeCompletions",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorArrayIndexCompletions"
+      "newText": "mixedArrayTypeCompletions"
     }
   },
   {
-    "label": "nestedDiscriminatorCompletions",
+    "label": "mixedArrayTypeCompletions2",
     "kind": "variable",
-    "detail": "nestedDiscriminatorCompletions",
+    "detail": "mixedArrayTypeCompletions2",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorCompletions",
+    "sortText": "2_mixedArrayTypeCompletions2",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorCompletions"
+      "newText": "mixedArrayTypeCompletions2"
     }
   },
   {
-    "label": "nestedDiscriminatorCompletions2",
+    "label": "myConcat",
     "kind": "variable",
-    "detail": "nestedDiscriminatorCompletions2",
+    "detail": "myConcat",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorCompletions2",
+    "sortText": "2_myConcat",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorCompletions2"
+      "newText": "myConcat"
     }
   },
   {
-    "label": "nestedDiscriminatorCompletions3",
+    "label": "mySum",
     "kind": "variable",
-    "detail": "nestedDiscriminatorCompletions3",
+    "detail": "mySum",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorCompletions3",
+    "sortText": "2_mySum",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorCompletions3"
+      "newText": "mySum"
     }
   },
   {
-    "label": "nestedDiscriminatorCompletions4",
+    "label": "objWithInterp",
     "kind": "variable",
-    "detail": "nestedDiscriminatorCompletions4",
+    "detail": "objWithInterp",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorCompletions4",
+    "sortText": "2_objWithInterp",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorCompletions4"
+      "newText": "objWithInterp"
     }
   },
   {
-    "label": "nestedDiscriminatorMissingKey",
-    "kind": "interface",
-    "detail": "nestedDiscriminatorMissingKey",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_nestedDiscriminatorMissingKey",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "nestedDiscriminatorMissingKey"
-    }
-  },
-  {
-    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "label": "objectLiteralType",
     "kind": "variable",
-    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "detail": "objectLiteralType",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "sortText": "2_objectLiteralType",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorMissingKeyCompletions"
+      "newText": "objectLiteralType"
     }
   },
   {
-    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "label": "objectVarTopLevelArrayIndexCompletions",
     "kind": "variable",
-    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "detail": "objectVarTopLevelArrayIndexCompletions",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "sortText": "2_objectVarTopLevelArrayIndexCompletions",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+      "newText": "objectVarTopLevelArrayIndexCompletions"
     }
   },
   {
-    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "label": "objectVarTopLevelCompletions",
     "kind": "variable",
-    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "detail": "objectVarTopLevelCompletions",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "sortText": "2_objectVarTopLevelCompletions",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+      "newText": "objectVarTopLevelCompletions"
+    }
+  },
+  {
+    "label": "objectVarTopLevelCompletions2",
+    "kind": "variable",
+    "detail": "objectVarTopLevelCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_objectVarTopLevelCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "objectVarTopLevelCompletions2"
+    }
+  },
+  {
+    "label": "oneArrayItemCompletions",
+    "kind": "variable",
+    "detail": "oneArrayItemCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_oneArrayItemCompletions",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "oneArrayItemCompletions"
+    }
+  },
+  {
+    "label": "oneArrayItemCompletions2",
+    "kind": "variable",
+    "detail": "oneArrayItemCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_oneArrayItemCompletions2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "oneArrayItemCompletions2"
     }
   },
   {
@@ -1054,15 +733,15 @@
   },
   {
     "label": "resourceGroup",
-    "kind": "function",
-    "detail": "resourceGroup()",
+    "kind": "variable",
+    "detail": "resourceGroup",
     "deprecated": false,
     "preselect": false,
-    "sortText": "3_resourceGroup",
-    "insertTextFormat": "snippet",
+    "sortText": "2_resourceGroup",
+    "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "resourceGroup($0)"
+      "newText": "resourceGroup"
     }
   },
   {
@@ -1079,29 +758,16 @@
     }
   },
   {
-    "label": "resrefpar",
-    "kind": "field",
-    "detail": "resrefpar",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resrefpar",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "resrefpar"
-    }
-  },
-  {
-    "label": "resrefvar",
+    "label": "rgName",
     "kind": "variable",
-    "detail": "resrefvar",
+    "detail": "rgName",
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_resrefvar",
+    "sortText": "2_rgName",
     "insertTextFormat": "plainText",
     "textEdit": {
       "range": {},
-      "newText": "resrefvar"
+      "newText": "rgName"
     }
   },
   {
@@ -1128,32 +794,6 @@
     "textEdit": {
       "range": {},
       "newText": "split($0)"
-    }
-  },
-  {
-    "label": "startedTypingTypeWithQuotes",
-    "kind": "interface",
-    "detail": "startedTypingTypeWithQuotes",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_startedTypingTypeWithQuotes",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "startedTypingTypeWithQuotes"
-    }
-  },
-  {
-    "label": "startedTypingTypeWithoutQuotes",
-    "kind": "interface",
-    "detail": "startedTypingTypeWithoutQuotes",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_startedTypingTypeWithoutQuotes",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "startedTypingTypeWithoutQuotes"
     }
   },
   {
@@ -1274,6 +914,58 @@
     }
   },
   {
+    "label": "test",
+    "kind": "variable",
+    "detail": "test",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_test",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "test"
+    }
+  },
+  {
+    "label": "test2",
+    "kind": "variable",
+    "detail": "test2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_test2",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "test2"
+    }
+  },
+  {
+    "label": "test3",
+    "kind": "variable",
+    "detail": "test3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_test3",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "test3"
+    }
+  },
+  {
+    "label": "testDupe",
+    "kind": "variable",
+    "detail": "testDupe",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_testDupe",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "testDupe"
+    }
+  },
+  {
     "label": "toLower",
     "kind": "function",
     "detail": "toLower()",
@@ -1310,19 +1002,6 @@
     "textEdit": {
       "range": {},
       "newText": "trim($0)"
-    }
-  },
-  {
-    "label": "unfinishedVnet",
-    "kind": "interface",
-    "detail": "unfinishedVnet",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_unfinishedVnet",
-    "insertTextFormat": "plainText",
-    "textEdit": {
-      "range": {},
-      "newText": "unfinishedVnet"
     }
   },
   {
@@ -1388,6 +1067,32 @@
     "textEdit": {
       "range": {},
       "newText": "uriComponentToString($0)"
+    }
+  },
+  {
+    "label": "x",
+    "kind": "variable",
+    "detail": "x",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_x",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "x"
+    }
+  },
+  {
+    "label": "y",
+    "kind": "variable",
+    "detail": "y",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_y",
+    "insertTextFormat": "plainText",
+    "textEdit": {
+      "range": {},
+      "newText": "y"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
@@ -131,3 +131,9 @@ var mixedArrayTypeCompletions2 = objectLiteralType.fifth[0].
 var oneArrayItemCompletions = objectLiteralType.sixth[0].t
 // #completionTest(58) -> oneArrayItemProperties
 var oneArrayItemCompletions2 = objectLiteralType.sixth[0].
+
+// #completionTest(65) -> objectVarTopLevelIndexes
+var objectVarTopLevelArrayIndexCompletions = objectLiteralType[f]
+
+// #completionTest(58) -> twoIndexPlusSymbols
+var oneArrayIndexCompletions = objectLiteralType.sixth[0][]

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -194,3 +194,12 @@ var oneArrayItemCompletions = objectLiteralType.sixth[0].t
 // #completionTest(58) -> oneArrayItemProperties
 var oneArrayItemCompletions2 = objectLiteralType.sixth[0].
 //@[58:58) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(65) -> objectVarTopLevelIndexes
+var objectVarTopLevelArrayIndexCompletions = objectLiteralType[f]
+//@[63:64) [BCP057 (Error)] The name "f" does not exist in the current context. |f|
+
+// #completionTest(58) -> twoIndexPlusSymbols
+var oneArrayIndexCompletions = objectLiteralType.sixth[0][]
+//@[58:58) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
@@ -169,3 +169,12 @@ var oneArrayItemCompletions = objectLiteralType.sixth[0].t
 // #completionTest(58) -> oneArrayItemProperties
 var oneArrayItemCompletions2 = objectLiteralType.sixth[0].
 //@[4:28) Variable oneArrayItemCompletions2. Type: error. Declaration start char: 0, length: 58
+
+// #completionTest(65) -> objectVarTopLevelIndexes
+var objectVarTopLevelArrayIndexCompletions = objectLiteralType[f]
+//@[4:42) Variable objectVarTopLevelArrayIndexCompletions. Type: error. Declaration start char: 0, length: 65
+
+// #completionTest(58) -> twoIndexPlusSymbols
+var oneArrayIndexCompletions = objectLiteralType.sixth[0][]
+//@[4:28) Variable oneArrayIndexCompletions. Type: error. Declaration start char: 0, length: 59
+

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
@@ -789,4 +789,51 @@ var oneArrayItemCompletions2 = objectLiteralType.sixth[0].
 //@[57:58)   Dot |.|
 //@[58:58)   IdentifierSyntax
 //@[58:58)    SkippedTriviaSyntax
-//@[58:58) EndOfFile ||
+//@[58:60) NewLine |\n\n|
+
+// #completionTest(65) -> objectVarTopLevelIndexes
+//@[50:51) NewLine |\n|
+var objectVarTopLevelArrayIndexCompletions = objectLiteralType[f]
+//@[0:65) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:42)  IdentifierSyntax
+//@[4:42)   Identifier |objectVarTopLevelArrayIndexCompletions|
+//@[43:44)  Assignment |=|
+//@[45:65)  ArrayAccessSyntax
+//@[45:62)   VariableAccessSyntax
+//@[45:62)    IdentifierSyntax
+//@[45:62)     Identifier |objectLiteralType|
+//@[62:63)   LeftSquare |[|
+//@[63:64)   VariableAccessSyntax
+//@[63:64)    IdentifierSyntax
+//@[63:64)     Identifier |f|
+//@[64:65)   RightSquare |]|
+//@[65:67) NewLine |\n\n|
+
+// #completionTest(58) -> twoIndexPlusSymbols
+//@[45:46) NewLine |\n|
+var oneArrayIndexCompletions = objectLiteralType.sixth[0][]
+//@[0:59) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:28)  IdentifierSyntax
+//@[4:28)   Identifier |oneArrayIndexCompletions|
+//@[29:30)  Assignment |=|
+//@[31:59)  ArrayAccessSyntax
+//@[31:57)   ArrayAccessSyntax
+//@[31:54)    PropertyAccessSyntax
+//@[31:48)     VariableAccessSyntax
+//@[31:48)      IdentifierSyntax
+//@[31:48)       Identifier |objectLiteralType|
+//@[48:49)     Dot |.|
+//@[49:54)     IdentifierSyntax
+//@[49:54)      Identifier |sixth|
+//@[54:55)    LeftSquare |[|
+//@[55:56)    NumericLiteralSyntax
+//@[55:56)     Number |0|
+//@[56:57)    RightSquare |]|
+//@[57:58)   LeftSquare |[|
+//@[58:58)   SkippedTriviaSyntax
+//@[58:59)   RightSquare |]|
+//@[59:60) NewLine |\n|
+
+//@[0:0) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
@@ -519,4 +519,34 @@ var oneArrayItemCompletions2 = objectLiteralType.sixth[0].
 //@[55:56) Number |0|
 //@[56:57) RightSquare |]|
 //@[57:58) Dot |.|
-//@[58:58) EndOfFile ||
+//@[58:60) NewLine |\n\n|
+
+// #completionTest(65) -> objectVarTopLevelIndexes
+//@[50:51) NewLine |\n|
+var objectVarTopLevelArrayIndexCompletions = objectLiteralType[f]
+//@[0:3) Identifier |var|
+//@[4:42) Identifier |objectVarTopLevelArrayIndexCompletions|
+//@[43:44) Assignment |=|
+//@[45:62) Identifier |objectLiteralType|
+//@[62:63) LeftSquare |[|
+//@[63:64) Identifier |f|
+//@[64:65) RightSquare |]|
+//@[65:67) NewLine |\n\n|
+
+// #completionTest(58) -> twoIndexPlusSymbols
+//@[45:46) NewLine |\n|
+var oneArrayIndexCompletions = objectLiteralType.sixth[0][]
+//@[0:3) Identifier |var|
+//@[4:28) Identifier |oneArrayIndexCompletions|
+//@[29:30) Assignment |=|
+//@[31:48) Identifier |objectLiteralType|
+//@[48:49) Dot |.|
+//@[49:54) Identifier |sixth|
+//@[54:55) LeftSquare |[|
+//@[55:56) Number |0|
+//@[56:57) RightSquare |]|
+//@[57:58) LeftSquare |[|
+//@[58:59) RightSquare |]|
+//@[59:60) NewLine |\n|
+
+//@[0:0) EndOfFile ||

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -673,6 +673,13 @@ namespace Bicep.Core.Diagnostics
                 "BCP116",
                 $"Unsupported scope for module deployment in a \"{LanguageConstants.TargetScopeTypeResourceGroup}\" target scope. Omit this property to inherit the current scope, or specify a valid scope. " +
                 $"Permissible scopes include current resource group: resourceGroup(), named resource group in same subscription: resourceGroup(<name>), named resource group in a different subscription: resourceGroup(<subId>, <name>), or tenant: tenant().");
+
+            public ErrorDiagnostic EmptyIndexerNotAllowed() => new ErrorDiagnostic(
+                TextSpan,
+                "BCP117",
+                "An empty indexer is not allowed. Specify a valid expression."
+            );
+
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -15,7 +15,8 @@ namespace Bicep.Core
         public const int MaxParameterCount = 256;
         public const int MaxIdentifierLength = 255;
 
-        public const string ListSeparator = ", ";
+        public const string ErrorName = "<error>";
+        public const string MissingName = "<missing>";
 
         public const string TargetScopeKeyword = "targetScope";
         public const string ParameterKeyword = "param";

--- a/src/Bicep.Core/Parser/Parser.cs
+++ b/src/Bicep.Core/Parser/Parser.cs
@@ -296,10 +296,22 @@ namespace Bicep.Core.Parser
                 {
                     // array indexer
                     Token openSquare = this.reader.Read();
-                    SyntaxBase indexExpression = this.Expression(allowComplexLiterals);
-                    Token closeSquare = this.Expect(TokenType.RightSquare, b => b.ExpectedCharacter("]"));
 
-                    current = new ArrayAccessSyntax(current, openSquare, indexExpression, closeSquare);
+                    if (this.Check(TokenType.RightSquare))
+                    {
+                        // empty indexer - we are allowing this special case in the parser to help with completions
+                        SyntaxBase skipped = SkipEmpty(b => b.EmptyIndexerNotAllowed());
+                        Token closeSquare = this.Expect(TokenType.RightSquare, b => b.ExpectedCharacter("]"));
+
+                        current = new ArrayAccessSyntax(current, openSquare, skipped, closeSquare);
+                    }
+                    else
+                    {
+                        SyntaxBase indexExpression = this.Expression(allowComplexLiterals);
+                        Token closeSquare = this.Expect(TokenType.RightSquare, b => b.ExpectedCharacter("]"));
+
+                        current = new ArrayAccessSyntax(current, openSquare, indexExpression, closeSquare);
+                    }
 
                     continue;
                 }
@@ -493,8 +505,7 @@ namespace Bicep.Core.Parser
                 return new IdentifierSyntax(identifier);
             }
 
-            var span = new TextSpan(this.reader.Peek().Span.Position, 0);
-            var skipped = new SkippedTriviaSyntax(span, ImmutableArray<SyntaxBase>.Empty, errorFunc(DiagnosticBuilder.ForPosition(span)).AsEnumerable());
+            var skipped = SkipEmpty(errorFunc);
             return new IdentifierSyntax(skipped);
         }
 
@@ -516,6 +527,12 @@ namespace Bicep.Core.Parser
                 default:
                     throw new NotImplementedException($"Unexpected identifier syntax type '{identifierOrSkipped.GetType().Name}'");
             }
+        }
+
+        private SkippedTriviaSyntax SkipEmpty(DiagnosticBuilder.ErrorBuilderDelegate errorFunc)
+        {
+            var span = new TextSpan(this.reader.Peek().Span.Position, 0);
+            return new SkippedTriviaSyntax(span, ImmutableArray<SyntaxBase>.Empty, errorFunc(DiagnosticBuilder.ForPosition(span)).AsEnumerable());
         }
 
         private TypeSyntax Type(DiagnosticBuilder.ErrorBuilderDelegate errorFunc)

--- a/src/Bicep.Core/SemanticModel/ErrorSymbol.cs
+++ b/src/Bicep.Core/SemanticModel/ErrorSymbol.cs
@@ -10,7 +10,12 @@ namespace Bicep.Core.SemanticModel
     /// </summary>
     public class ErrorSymbol : Symbol
     {
-        private readonly ErrorDiagnostic error;
+        private readonly ErrorDiagnostic? error;
+
+        public ErrorSymbol() : base(LanguageConstants.ErrorName)
+        {
+            this.error = null;
+        }
 
         public ErrorSymbol(ErrorDiagnostic error) : base(error.Code)
         {
@@ -23,7 +28,10 @@ namespace Bicep.Core.SemanticModel
 
         public override IEnumerable<ErrorDiagnostic> GetDiagnostics()
         {
-            yield return this.error;
+            if (this.error != null)
+            {
+                yield return this.error;
+            }
         }
     }
 }

--- a/src/Bicep.Core/Syntax/IdentifierSyntax.cs
+++ b/src/Bicep.Core/Syntax/IdentifierSyntax.cs
@@ -37,7 +37,7 @@ namespace Bicep.Core.Syntax
                         return identifier.Text;
 
                     case SkippedTriviaSyntax skipped:
-                        return skipped.Elements.Any() ? "<error>" : "<missing>";
+                        return skipped.Elements.Any() ? LanguageConstants.ErrorName : LanguageConstants.MissingName;
 
                     default:
                         throw new NotImplementedException($"Unexpected child node type '{this.Child.GetType().Name}'.");

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -361,7 +361,7 @@ namespace Bicep.Core.TypeSystem
             return null;
         }
 
-        private TypeSymbol? ResolveDiscriminatedObjects(TypeSymbol type, ObjectSyntax syntax)
+        private static TypeSymbol? ResolveDiscriminatedObjects(TypeSymbol type, ObjectSyntax syntax)
         {
             if (!(type is DiscriminatedObjectType discriminated))
             {

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -501,6 +501,8 @@ namespace Bicep.Core.TypeSystem
                     return ErrorType.Create(errors);
                 }
 
+                baseType = UnwrapType(baseType);
+
                 if (baseType.TypeKind == TypeKind.Any)
                 {
                     // base expression is of type any
@@ -510,8 +512,8 @@ namespace Bicep.Core.TypeSystem
                         return LanguageConstants.Any;
                     }
 
-                    if (TypeValidator.AreTypesAssignable(indexType, LanguageConstants.Int) == true ||
-                        TypeValidator.AreTypesAssignable(indexType, LanguageConstants.String) == true)
+                    if (TypeValidator.AreTypesAssignable(indexType, LanguageConstants.Int) ||
+                        TypeValidator.AreTypesAssignable(indexType, LanguageConstants.String))
                     {
                         // index expression is string | int but base is any
                         return LanguageConstants.Any;
@@ -524,7 +526,7 @@ namespace Bicep.Core.TypeSystem
                 if (baseType is ArrayType baseArray)
                 {
                     // we are indexing over an array
-                    if (TypeValidator.AreTypesAssignable(indexType, LanguageConstants.Int) == true)
+                    if (TypeValidator.AreTypesAssignable(indexType, LanguageConstants.Int))
                     {
                         // the index is of "any" type or integer type
                         // return the item type
@@ -543,11 +545,11 @@ namespace Bicep.Core.TypeSystem
                         return GetExpressionedPropertyType(baseObject, syntax.IndexExpression);
                     }
 
-                    if (TypeValidator.AreTypesAssignable(indexType, LanguageConstants.String) == true)
+                    if (TypeValidator.AreTypesAssignable(indexType, LanguageConstants.String))
                     {
                         switch (syntax.IndexExpression)
                         {
-                            case StringSyntax @string when @string.TryGetLiteralValue() is string literalValue:
+                            case StringSyntax @string when @string.TryGetLiteralValue() is { } literalValue:
                                 // indexing using a string literal so we know the name of the property
                                 return GetNamedPropertyType(baseObject, syntax.IndexExpression, literalValue, diagnostics);
 
@@ -555,6 +557,19 @@ namespace Bicep.Core.TypeSystem
                                 // the property name is itself an expression
                                 return GetExpressionedPropertyType(baseObject, syntax.IndexExpression);
                         }
+                    }
+
+                    return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.IndexExpression).ObjectsRequireStringIndex(indexType));
+                }
+
+                if (baseType is DiscriminatedObjectType)
+                {
+                    if (TypeValidator.AreTypesAssignable(indexType, LanguageConstants.String))
+                    {
+                        // index is assignable to string
+                        // since we're not resolving the discriminator currently, we can just return the "any" type
+                        // TODO: resolve the discriminator
+                        return LanguageConstants.Any;
                     }
 
                     return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.IndexExpression).ObjectsRequireStringIndex(indexType));
@@ -576,39 +591,33 @@ namespace Bicep.Core.TypeSystem
                     return ErrorType.Create(errors);
                 }
 
-                if (baseType is ResourceType resourceType)
-                {
-                    // We're accessing a property on the resource body.
-                    baseType = resourceType.Body.Type;
-                }
+                baseType = UnwrapType(baseType);
 
-                if (baseType is ModuleType moduleType)
+                switch (baseType)
                 {
-                    // We're accessing a property on the module body.
-                    baseType = moduleType.Body.Type;
-                }
+                    case ObjectType objectType:
+                        if (!syntax.PropertyName.IsValid)
+                        {
+                            // the property is not valid
+                            // there's already a parse error for it, so we don't need to add a type error as well
+                            return ErrorType.Empty();
+                        }
 
-                if (!(baseType is ObjectType objectType))
-                {
-                    if (TypeValidator.AreTypesAssignable(baseType, LanguageConstants.Object) != true)
-                    {
+                        return GetNamedPropertyType(objectType, syntax.PropertyName, syntax.PropertyName.IdentifierName, diagnostics);
+
+                    case DiscriminatedObjectType _:
+                        // TODO: We might be able use the declared type here to resolve discriminator to improve the assigned type
+                        return LanguageConstants.Any;
+
+                    case TypeSymbol _ when TypeValidator.AreTypesAssignable(baseType, LanguageConstants.Object):
+                        // We can assign to an object, but we don't have a type for that object.
+                        // The best we can do is allow it and return the 'any' type.
+                        return LanguageConstants.Any;
+
+                    default:
                         // can only access properties of objects
                         return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.PropertyName).ObjectRequiredForPropertyAccess(baseType));
-                    }
-
-                    // We can assign to an object, but we don't have a type for that object.
-                    // The best we can do is allow it and return the 'any' type.
-                    return LanguageConstants.Any;
                 }
-
-                if (!syntax.PropertyName.IsValid)
-                {
-                    // the property is not valid
-                    // there's already a parse error for it, so we don't need to add a type error as well
-                    return ErrorType.Empty();
-                }
-
-                return GetNamedPropertyType(objectType, syntax.PropertyName, syntax.PropertyName.IdentifierName, diagnostics);
             });
 
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
@@ -647,17 +656,7 @@ namespace Bicep.Core.TypeSystem
                     return ErrorType.Create(errors);
                 }
 
-                if (baseType is ResourceType resourceType)
-                {
-                    // We're accessing a property on the resource body.
-                    baseType = resourceType.Body.Type;
-                }
-
-                if (baseType is ModuleType moduleType)
-                {
-                    // We're accessing a property on the module body.
-                    baseType = moduleType.Body.Type;
-                }
+                baseType = UnwrapType(baseType);
 
                 if (!(baseType is ObjectType objectType))
                 {
@@ -984,5 +983,19 @@ namespace Bicep.Core.TypeSystem
                 },
                 accumulated => accumulated);
         }
+        
+        private static TypeSymbol UnwrapType(TypeSymbol baseType) =>
+            baseType switch
+            {
+                ResourceType resourceType =>
+                    // We're accessing a property on the resource body.
+                    resourceType.Body.Type,
+
+                ModuleType moduleType =>
+                    // We're accessing a property on the module body.
+                    moduleType.Body.Type,
+
+                _ => baseType
+            };
     }
 }

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -96,11 +96,11 @@ namespace Bicep.Core.TypeSystem
                     // this function does not validate item types
                     return true;
 
-                case DiscriminatedObjectType targetDiscriminated when sourceType is DiscriminatedObjectType sourceDiscriminated:
+                case DiscriminatedObjectType _ when sourceType is DiscriminatedObjectType:
                     // validation left for later
                     return true;
 
-                case DiscriminatedObjectType targetDiscriminated when sourceType is ObjectType sourceObject:
+                case DiscriminatedObjectType _ when sourceType is ObjectType:
                     // validation left for later
                     return true;
 

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -75,6 +75,11 @@ namespace Bicep.LanguageServer.Completions
         /// <summary>
         /// The current location needs target scope value.
         /// </summary>
-        TargetScope = 1 << 12
+        TargetScope = 1 << 12,
+
+        /// <summary>
+        /// The current location needs an array index.
+        /// </summary>
+        ArrayIndex = 1 << 13
     }
 }

--- a/src/Bicep.LangServer/Completions/SyntaxMatcher.cs
+++ b/src/Bicep.LangServer/Completions/SyntaxMatcher.cs
@@ -38,5 +38,19 @@ namespace Bicep.LanguageServer.Completions
                    nodes[^1] is T3 three &&
                    predicate(one, two, three);
         }
+
+        public static bool IsTailMatch<T1, T2, T3, T4>(IList<SyntaxBase> nodes, Func<T1, T2, T3, T4, bool> predicate)
+            where T1 : SyntaxBase
+            where T2 : SyntaxBase
+            where T3 : SyntaxBase
+            where T4 : SyntaxBase
+        {
+            return nodes.Count >= 4 &&
+                   nodes[^4] is T1 one &&
+                   nodes[^3] is T2 two &&
+                   nodes[^2] is T3 three &&
+                   nodes[^1] is T4 four &&
+                   predicate(one, two, three, four);
+        }
     }
 }


### PR DESCRIPTION
- Added array access completions. This closes #773.
-  Property access on discriminated object types works again. This closes #834. (The fix treats them as `any` type to reduce risk to 0.2. We will improve it in the future.)
- Array access syntax now works properly on resource and module types. This closes #777. 

Array access completions screenshot:
![image](https://user-images.githubusercontent.com/22460039/98464390-77394980-2177-11eb-9625-928ad661428c.png)
