### PR TITLE
Update version to be of format "vX.Y.Z" instead of "v-X.Y.Z-alpha"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          release_name: ${{ github.ref }} (alpha)
           draft: true
           prerelease: false
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.2-alpha",
+  "version": "0.2",
   "publicReleaseRefSpec": [
     "^refs/tags/v\\d+\\.\\d+\\.\\d+"
   ]


### PR DESCRIPTION
This is necessitated by https://github.com/microsoft/vscode-vsce/issues/148 as the VSCode marketplace doesn't support pre-release version identifiers.