### PR TITLE
Formatting rule for TargetScopeSyntax

### DIFF
--- a/docs/examples/101/create-rg-lock-role-assignment/applylock.bicep
+++ b/docs/examples/101/create-rg-lock-role-assignment/applylock.bicep
@@ -1,4 +1,4 @@
-targetScope='resourceGroup'
+targetScope = 'resourceGroup'
 
 param principalId string
 param roleDefinitionId string

--- a/docs/examples/101/create-rg-lock-role-assignment/main.bicep
+++ b/docs/examples/101/create-rg-lock-role-assignment/main.bicep
@@ -1,4 +1,4 @@
-targetScope='subscription'
+targetScope = 'subscription'
 
 param rgName string
 param rgLocation string

--- a/docs/examples/101/mg-policy/main.bicep
+++ b/docs/examples/101/mg-policy/main.bicep
@@ -1,4 +1,4 @@
-targetScope='managementGroup'
+targetScope = 'managementGroup'
 
 param targetMG string
 param allowedLocations array = [

--- a/src/Bicep.Core.Samples/Files/InvalidTargetScopes_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidTargetScopes_LF/main.formatted.bicep
@@ -1,7 +1,7 @@
 targetScope
 
 // #completionTest(12) -> empty
-targetScope
+targetScope 
 
 // #completionTest(13,14) -> targetScopes
-targetScope=
+targetScope = 

--- a/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.formatted.bicep
@@ -1,4 +1,4 @@
-targetScope='tenant'
+targetScope = 'tenant'
 
 module myManagementGroupMod 'modules/managementgroup.bicep' = {
   name: 'myManagementGroupMod'

--- a/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterTestsBase.cs
+++ b/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterTestsBase.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 using Bicep.Core.PrettyPrint;
 using Bicep.Core.PrettyPrint.Options;
+using Bicep.Core.Syntax;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
 
 namespace Bicep.Core.UnitTests.PrettyPrint
 {
@@ -12,5 +15,21 @@ namespace Bicep.Core.UnitTests.PrettyPrint
             IndentKindOption.Space,
             2,
             false);
+
+        protected void TestPrintProgram(string programText, string expectedOutput, PrettyPrintOptions? options = null)
+        {
+            ProgramSyntax? programSyntax = ParserHelper.Parse(programText);
+            options ??= CommonOptions;
+
+            string output = PrettyPrinter.PrintProgram(programSyntax, options);
+
+            output.Should().Be(expectedOutput);
+
+            programSyntax = ParserHelper.Parse(expectedOutput);
+            output = PrettyPrinter.PrintProgram(programSyntax, options);
+
+            // The formatter should produce consistent results.
+            output.Should().Be(expectedOutput);
+        }
     }
 }

--- a/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterValidSyntaxTests.cs
+++ b/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterValidSyntaxTests.cs
@@ -117,7 +117,7 @@ aaa: bbb
 			}
 		]
 	}
-}",
+}".Replace("\r\n", Environment.NewLine),
             new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Tab, 5, false));
 
         [TestMethod]

--- a/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterValidSyntaxTests.cs
+++ b/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterValidSyntaxTests.cs
@@ -3,9 +3,6 @@
 using System;
 using Bicep.Core.PrettyPrint;
 using Bicep.Core.PrettyPrint.Options;
-using Bicep.Core.Syntax;
-using Bicep.Core.UnitTests.Utils;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bicep.Core.UnitTests.PrettyPrint
@@ -14,10 +11,9 @@ namespace Bicep.Core.UnitTests.PrettyPrint
     public class PrettyPrinterValidSyntaxTests : PrettyPrinterTestsBase
     {
         [TestMethod]
-
-        public void PrintProgram_TooManyNewlines_RemovesExtraNewlines()
-        {
-            const string programText = @"
+        public void PrintProgram_TooManyNewlines_RemovesExtraNewlines() => this.TestPrintProgram(
+// Raw.
+@"
 
 
 
@@ -67,12 +63,8 @@ ccc: ddd
   
 
 
-";
-            ProgramSyntax programSyntax = ParserHelper.Parse(programText);
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, CommonOptions);
-
-            output.Should().Be(
+",
+// Formatted.
 @"param foo int
 
 var bar = 1 + mod(foo, 3)
@@ -95,13 +87,11 @@ var baz = {
     ccc: ddd
   }
 }");
-        }
 
         [TestMethod]
-        public void PrintSyntax_IndentKindOptionTab_ShouldIndentUsingTabs()
-        {
-            var programSyntax = ParserHelper.Parse(@"
-var foo = {
+        public void PrintSyntax_IndentKindOptionTab_ShouldIndentUsingTabs() => this.TestPrintProgram(
+// Raw.
+@"var foo = {
 xxx: true
 yyy: {
 mmm: false
@@ -113,12 +103,8 @@ aaa: bbb
 }
 ]
 }
-}");
-            var options = new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Tab, 5, false);
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, options);
-
-            output.Should().Be(
+}",
+// Formatted.
 @"var foo = {
 	xxx: true
 	yyy: {
@@ -131,110 +117,81 @@ aaa: bbb
 			}
 		]
 	}
-}");
-        }
+}",
+            new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Tab, 5, false));
 
         [TestMethod]
-        public void PrintProgram_RequestInsertFinalNewline_ShouldInsertNewlineAtTheEnd()
-        {
-            var programSyntax = ParserHelper.Parse(string.Concat(new[]
+        public void PrintProgram_RequestInsertFinalNewline_ShouldInsertNewlineAtTheEnd() => this.TestPrintProgram(
+            string.Concat(new[]
             {
                 "var foo = bar\n",
                 "var bar = foo"
-            }));
-
-            var options = new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, true);
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, options);
-
-            output.Should().Be(string.Concat(new[]
+            }),
+            string.Concat(new[]
             {
                 "var foo = bar\n",
                 "var bar = foo\n"
-            }));
-        }
+            }),
+            new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, true));
 
         [TestMethod]
-        public void PrintProgram_DoesNotRequestInsertFinalNewline_ShouldTrimNewlineAtTheEnd()
-        {
-            var programSyntax = ParserHelper.Parse(string.Concat(new[]
+        public void PrintProgram_DoesNotRequestInsertFinalNewline_ShouldTrimNewlineAtTheEnd() => this.TestPrintProgram(
+            string.Concat(new[]
             {
                 "var foo = bar\n",
                 "var bar = foo\n"
-            }));
-
-            var options = new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false);
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, options);
-
-            output.Should().Be(string.Concat(new[]
+            }),
+            string.Concat(new[]
             {
                 "var foo = bar\n",
                 "var bar = foo"
-            }));
-        }
+            }),
+            new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false));
 
 
         [DataTestMethod]
         [DataRow(NewlineOption.LF, "\r", "\n")]
         [DataRow(NewlineOption.CRLF, "\r", "\r\n")]
         [DataRow(NewlineOption.CR, "\n", "\r")]
-        public void PrintProgram_NewLineOptionNotAuto_ShouldUseSpecifiedNewline(NewlineOption newlineOption, string originalNewline, string expectedNewline)
-        {
-            var programSyntax = ParserHelper.Parse(string.Join(originalNewline, new[]
+        public void PrintProgram_NewLineOptionNotAuto_ShouldUseSpecifiedNewline(NewlineOption newlineOption, string originalNewline, string expectedNewline) => this.TestPrintProgram(
+            string.Join(originalNewline, new[]
             {
                 "var foo = bar",
                 "var bar = foo",
                 "var baz = bar"
-            }));
-
-            var options = new PrettyPrintOptions(newlineOption, IndentKindOption.Space, 2, false);
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, options);
-
-            output.Should().Be(string.Join(expectedNewline, new[]
+            }),
+            string.Join(expectedNewline, new[]
             {
                 "var foo = bar",
                 "var bar = foo",
                 "var baz = bar"
-            }));
-        }
+            }),
+            new PrettyPrintOptions(newlineOption, IndentKindOption.Space, 2, false));
 
         [TestMethod]
-        public void PrintProgram_NewLineOptionAuto_ShouldInferNewlineKindFromTheFirstNewline()
-        {
-            var programSyntax = ParserHelper.Parse(string.Concat(new[]
+        public void PrintProgram_NewLineOptionAuto_ShouldInferNewlineKindFromTheFirstNewline() => this.TestPrintProgram(
+            string.Concat(new[]
             {
                 "var foo = bar\r",
                 "var bar = foo\n"
-            }));
-
-            var options = new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Space, 2, true);
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, options);
-
-            output.Should().Be(string.Concat(new[]
+            }),
+            string.Concat(new[]
             {
                 "var foo = bar\r",
                 "var bar = foo\r"
-            }));
-        }
+            }),
+            new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Space, 2, true));
 
         [TestMethod]
-        public void PrintProgram_NewLineOptionAutoWithNoNewlineInProgram_ShouldUseEnvironmentNewline()
-        {
-            var programSyntax = ParserHelper.Parse("var foo = bar");
-            var options = new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Space, 2, true);
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, options);
-
-            output.Should().Be($"var foo = bar{Environment.NewLine}");
-        }
+        public void PrintProgram_NewLineOptionAutoWithNoNewlineInProgram_ShouldUseEnvironmentNewline() => this.TestPrintProgram(
+            "var foo = bar",
+            $"var foo = bar{Environment.NewLine}",
+            new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Space, 2, true));
 
         [TestMethod]
-        public void PrintProgram_CommentAfterOpenSyntax_ShouldMoveToNextLineAndIndent()
-        {
-            var programSyntax = ParserHelper.Parse(@"
+        public void PrintProgram_CommentAfterOpenSyntax_ShouldMoveToNextLineAndIndent() => this.TestPrintProgram(
+// Raw.
+@"
 param foo object = { // I can be anywhere
 }
 
@@ -263,11 +220,8 @@ param bar array = [ // I can be anywhere
 param bar array = [     /*I can be anywhere */          // I can be anywhere
   true
   false
-]");
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, CommonOptions);
-
-            output.Should().Be(
+]",
+// Formatted.
 @"param foo object = {
   // I can be anywhere
 }
@@ -304,13 +258,11 @@ param bar array = [
   true
   false
 ]");
-        }
 
         [TestMethod]
-        public void PrintProgram_CommentBeforeCloseSyntax_ShouldMoveOneLineAboveAndIndent()
-        {
-            var programSyntax = ParserHelper.Parse(@"
-param foo object = { /* I can be anywhere */ }
+        public void PrintProgram_CommentBeforeCloseSyntax_ShouldMoveOneLineAboveAndIndent() => this.TestPrintProgram(
+// Raw.
+@"param foo object = { /* I can be anywhere */ }
 
 param foo object = {
   /* I can be anywhere */ }
@@ -344,11 +296,8 @@ param bar array = [
 param bar array = [
   true
   false
-   /* I can be anywhere */       /* I can be anywhere */]");
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, CommonOptions);
-
-            output.Should().Be(
+   /* I can be anywhere */       /* I can be anywhere */]",
+// Formatted.
 @"param foo object = {
   /* I can be anywhere */
 }
@@ -395,12 +344,10 @@ param bar array = [
   false
   /* I can be anywhere */ /* I can be anywhere */
 ]");
-        }
 
         [TestMethod]
-        public void PrintProgram_EmptyBlocks_ShouldFormatCorrectly()
-        {
-            var programSyntax = ParserHelper.Parse(
+        public void PrintProgram_EmptyBlocks_ShouldFormatCorrectly() => this.TestPrintProgram(
+//Raw.
 @"param foo object = {}
 param foo object = {
 }
@@ -425,11 +372,8 @@ param bar array = [
   
 
 
-]");
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, CommonOptions);
-
-            output.Should().Be(
+]",
+// Formatted.
 @"param foo object = {}
 param foo object = {}
 param foo object = {}
@@ -439,34 +383,29 @@ param bar array = []
 param bar array = []
 param bar array = []
 param bar array = []");
-        }
 
         [TestMethod]
-        public void PrintProgram_MultilineComment_ShouldReplaceNewlinesInTheCommentToo()
-        {
-            var programSyntax = ParserHelper.Parse(string.Join("\n", new[]
+        public void PrintProgram_MultilineComment_ShouldReplaceNewlinesInTheCommentToo() => this.TestPrintProgram(
+            string.Join("\n", new[]
             {
                 "var foo = bar",
                 "/* a multiline\ncomment\n */",
                 "var baz = foo"
-            }));
-
-            var options = new PrettyPrintOptions(NewlineOption.CRLF, IndentKindOption.Space, 2, false);
-
-            var output = PrettyPrinter.PrintProgram(programSyntax, options);
-
-            output.Should().Be(string.Join("\r\n", new[]
+            }),
+            string.Join("\r\n", new[]
             {
                 "var foo = bar",
                 "/* a multiline\r\ncomment\r\n */",
                 "var baz = foo"
-            }));
-        }
+            }),
+            new PrettyPrintOptions(NewlineOption.CRLF, IndentKindOption.Space, 2, false)
+            );
 
         [TestMethod]
-        public void PrintProgram_SimpleProgram_ShouldFormatCorrectly()
-        {
-            var programSyntax = ParserHelper.Parse(@"
+        public void PrintProgram_SimpleProgram_ShouldFormatCorrectly() => this.TestPrintProgram(
+// Raw.
+@"targetScope=                    'managementGroup'
+
 param string banana
 param  string apple {
 
@@ -536,12 +475,11 @@ output       myOutput1 int    =     1 +    num *    3
 
 
 }
+",
+// Formatted.
+@"targetScope = 'managementGroup'
 
-");
-            var output = PrettyPrinter.PrintProgram(programSyntax, CommonOptions);
-
-            output.Should().Be(
-@"param string banana
+param string banana
 param string apple {
   allowed: [
     'Static'
@@ -592,16 +530,12 @@ output myOutput2 string = yes ? 'yes' : 'no'
 output myOutput3 object = yes ? {
   value: 42
 } : {}");
-        }
 
-        /*
-         sljfaljsfasfljasf 
-
-        */
         [TestMethod]
         public void PrintProgram_CommentBomb_ShouldFormatCorrectly()
         {
-            var programSyntax = ParserHelper.Parse(
+            this.TestPrintProgram(
+// Raw.
 @" // I can be anywhere
 /*
  * I can
@@ -609,7 +543,7 @@ output myOutput3 object = yes ? {
  */
 
 /* I can be any
-where */   module /* I can be anywhere */ foo  /* I can be anywhere */  './myModule' = /* I can be anywhere *//* I can be anywhere */{
+where */   module /* I can be anywhere */ foo  /* I can be anywhere */  './myModule' = /* I can be anywhere */{
 name/* I can be any where */ : value // I can be anywhere
 }
 
@@ -658,10 +592,8 @@ null
 /* I can be anywhere *//* I can be anywhere */] // I can be any where
 }
      /* I can be anywhere */
-");
-            var output = PrettyPrinter.PrintProgram(programSyntax, CommonOptions);
-
-            output.Should().Be(
+",
+// Formatted.
 @"// I can be anywhere
 /*
  * I can
@@ -669,7 +601,7 @@ null
  */
 
 /* I can be any
-where */module /* I can be anywhere */ foo /* I can be anywhere */ './myModule' = /* I can be anywhere */ /* I can be anywhere */ {
+where */module /* I can be anywhere */ foo /* I can be anywhere */ './myModule' = /* I can be anywhere */ {
   name /* I can be any where */: value // I can be anywhere
 }
 


### PR DESCRIPTION
- Added a rule to format `TargetScopeSyntax` with `Spread` operator
- Handled a nasty edge case that formatting a `SkippedTriviaSyntax` with leading whitespace trivia after a comment will keep inserting whitespaces
- Refactored the formatter unit tests to remove duplicate code