### PR TITLE
Updated to .net 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,6 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: 3.1.301
       
       - name: Build
         run: dotnet build --configuration ${{ matrix.configuration }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,13 +69,13 @@ jobs:
         if: ${{ matrix.publishLanguageServer == 'true' }}
         with:
           name: Bicep.LangServer
-          path: ./src/Bicep.LangServer/bin/${{ matrix.configuration }}/netcoreapp3.1/publish/*
+          path: ./src/Bicep.LangServer/bin/${{ matrix.configuration }}/net5.0/publish/*
       
       - name: Upload Bicep
         uses: actions/upload-artifact@v2
         with:
           name: bicep-${{ matrix.configuration }}-${{ matrix.rid }}
-          path: ./src/Bicep.Cli/bin/${{ matrix.configuration }}/netcoreapp3.1/${{ matrix.rid }}/publish/*
+          path: ./src/Bicep.Cli/bin/${{ matrix.configuration }}/net5.0/${{ matrix.rid }}/publish/*
           if-no-files-found: error
 
       - name: Upload Code Coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,8 +96,6 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: 3.1.301
       
       - name: Download Bicep CLI
         uses: actions/download-artifact@v2
@@ -185,8 +183,6 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: 3.1.301
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,17 +10,26 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'restore'
-    projects: '**/*.csproj'
-    feedsToUse: 'config'
-    nugetConfigPath: 'NuGet.config'
-    noCache: true
-    verbosityRestore: 'Normal'
-- task: ComponentGovernanceComponentDetection@0
-  inputs:
-    scanType: 'Register'
-    verbosity: 'Verbose'
-    alertWarningLevel: 'High'
-    failOnAlert: true
+  - task: UseDotNet@2
+    displayName: Setup .NET Core
+    continueOnError: true
+    inputs:
+      packageType: 'sdk'
+      useGlobalJson: true
+      performMultiLevelLookup: true
+
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: 'restore'
+      projects: '**/*.csproj'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+      noCache: true
+      verbosityRestore: 'Normal'
+
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      scanType: 'Register'
+      verbosity: 'Verbose'
+      alertWarningLevel: 'High'
+      failOnAlert: true

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "sdk": {
     "allowPrerelease": false,
-    "version": "3.1.301",
+    "version": "5.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Bicep.Cli.IntegrationTests/Bicep.Cli.IntegrationTests.csproj
+++ b/src/Bicep.Cli.IntegrationTests/Bicep.Cli.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj
+++ b/src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Bicep.Cli/Bicep.Cli.csproj
+++ b/src/Bicep.Cli/Bicep.Cli.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>bicep</AssemblyName>
     <StartupObject>Bicep.Cli.Program</StartupObject>
+    <!-- .net 5 by default does not package up the native dependencies -->
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bicep.Cli/Bicep.Cli.csproj
+++ b/src/Bicep.Cli/Bicep.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>bicep</AssemblyName>
     <StartupObject>Bicep.Cli.Program</StartupObject>
   </PropertyGroup>

--- a/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
+++ b/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
+++ b/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
+++ b/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
+++ b/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="JsonDiffPatch.Net" Version="2.2.0" />
     <PackageReference Include="DiffPlex" Version="1.6.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.3" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.0" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Management.Automation" Version="7.0.3" />
+    <PackageReference Include="System.Management.Automation" Version="7.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
@@ -16,7 +16,7 @@ namespace Bicep.Core.UnitTests.Utils
         {
             string filePath = Path.Combine(testContext.TestRunResultsDirectory, testContext.TestName, fileName);
 
-            Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath) ?? throw new AssertFailedException($"There is no directory path for file '{filePath}'."));
             testContext.AddResultFile(filePath);
 
             return filePath;
@@ -45,7 +45,7 @@ namespace Bicep.Core.UnitTests.Utils
                 }
 
                 var filePath = Path.Combine(outputDirectory, relativePath);
-                var directoryPath = Path.GetDirectoryName(filePath);
+                var directoryPath = Path.GetDirectoryName(filePath) ?? throw new AssertFailedException($"There is no directory path for file '{filePath}'.");
                 Directory.CreateDirectory(directoryPath);
 
                 var fileStream = File.Create(filePath);

--- a/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
+++ b/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
+++ b/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bicep.Core;
+using Bicep.Core.Extensions;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parser;
 using Bicep.Core.SemanticModel;
@@ -46,7 +47,7 @@ namespace Bicep.LangServer.UnitTests
             snippetCompletions.Should().OnlyContain(c => LanguageConstants.DeclarationKeywords.Contains(c.Label));
             snippetCompletions.Should().OnlyContain(c => c.Documentation!.HasMarkupContent && c.Documentation.MarkupContent!.Kind == MarkupKind.Markdown);
 
-            var snippetsByDetail = snippetCompletions.ToDictionary(c => c.Detail);
+            var snippetsByDetail = snippetCompletions.Where(c => c.Detail != null).ToImmutableDictionaryExcludingNull(c => c.Detail, StringComparer.Ordinal);
 
             var replacementsByDetail = new Dictionary<string, IList<string>>
             {

--- a/src/Bicep.LangServer/Bicep.LangServer.csproj
+++ b/src/Bicep.LangServer/Bicep.LangServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Bicep.LanguageServer</RootNamespace>
   </PropertyGroup>
 

--- a/src/Bicep.Wasm/Bicep.Wasm.csproj
+++ b/src/Bicep.Wasm/Bicep.Wasm.csproj
@@ -1,13 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Bicep.Wasm/Program.cs
+++ b/src/Bicep.Wasm/Program.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -16,7 +18,7 @@ namespace Bicep.Wasm
         {
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
-            var jsRuntime = builder.Services.BuildServiceProvider().GetService<IJSRuntime>();
+            var jsRuntime = builder.Services.BuildServiceProvider().GetService<IJSRuntime>() ?? throw new InvalidOperationException("Unable to obtain JS runtime.");
             await jsRuntime.InvokeAsync<object>("BicepInitialize", DotNetObjectReference.Create(new Interop(jsRuntime)));
 
             await builder.Build().RunAsync();

--- a/src/playground/src/lspInterop.ts
+++ b/src/playground/src/lspInterop.ts
@@ -9,7 +9,7 @@ export function initializeInterop(self): Promise<boolean> {
       resolve(true);
     }
   
-    const test = require('../../Bicep.Wasm/bin/Release/netstandard2.1/wwwroot/_framework/blazor.webassembly.js');  
+    const test = require('../../Bicep.Wasm/bin/Release/net5.0/wwwroot/_framework/blazor.webassembly.js');  
   });
 }
 

--- a/src/playground/webpack.config.js
+++ b/src/playground/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = {
   plugins: [
     new CopyPlugin({
       patterns: [
-        { from: '../Bicep.Wasm/bin/Release/netstandard2.1/wwwroot/_framework', to: './_framework/' },
+        { from: '../Bicep.Wasm/bin/Release/net5.0/wwwroot/_framework', to: './_framework/' },
       ],
     }),
     new HtmlWebpackPlugin({

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -12,7 +12,7 @@ import {
 } from "vscode-azureextensionui";
 import { ErrorAction, Message, CloseAction } from "vscode-languageclient/node";
 
-const dotnetRuntimeVersion = "3.1";
+const dotnetRuntimeVersion = "5.0";
 const packagedServerPath = "bicepLanguageServer/Bicep.LangServer.dll";
 const extensionId = "ms-azuretools.vscode-bicep";
 


### PR DESCRIPTION
- Updated to .net 5
- Removed hard-coded .net version in build.yml. It should not fallback to global.json.
- Left core libraries targeting netstandard 2.1
- Upgraded some of the nugets that easily upgraded. The web assembly nugets didn't want to upgrade because of the previous line. We will need to investigate.
- Did not touch any self-contained file settings yet. We can experiment once this goes in.
- Enabled `IncludeNativeLibrariesForSelfExtract` so we truly get single files for bicep cli instead of the executable plus native libraries.

Testing done on merge validation build artifacts:
- Validated cli on wsl2 and windows (machine without .net 5 installed). Bicep build command worked.
- Validated windows setup (machine without .net 5 installed). Bicep build command worked.
- Installed extension from VSIX in VS code. Runtime was acquired successfully and language server was functional.

This closes #873.