### PR TITLE
Run VSIX tests on all platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.bicep -text
+*.ts text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,11 +135,6 @@ jobs:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
           submodules: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: 12.x
-
       - name: npm ci
         run: npm ci
         working-directory: ./src/vscode-bicep

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,9 +117,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: build-bicep
 
-    env:
-      CI: true
-
     strategy:
       fail-fast: false
       matrix:
@@ -156,15 +153,21 @@ jobs:
           
       - name: Run unit tests
         run: npm run test:unit
+        env:
+          CI: true
         working-directory: ./src/vscode-bicep
 
       - name: Run E2E tests
         run: npm run test:e2e
+        env:
+          CI: true
         if: runner.os != 'Linux'
         working-directory: ./src/vscode-bicep
         
       - name: Run E2E tests (Linux)
         run: xvfb-run -a npm run test:e2e
+        env:
+          CI: true
         if: runner.os == 'Linux'
         working-directory: ./src/vscode-bicep
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,11 @@ jobs:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
           submodules: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 10.x
+
       - name: npm ci
         run: npm ci
         working-directory: ./src/vscode-bicep

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'windows-latest', 'ubuntu-latest', 'macos-latest' ]
+        include:
+        - os: 'windows-latest'
+          rid: 'win-x64'
+        - os: 'ubuntu-latest'
+          rid: 'linux-x64'
+        - os: 'macos-latest'
+          rid: 'osx-x64'
 
     steps:
       - uses: actions/checkout@v2
@@ -131,7 +138,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: 14.x
+          node-version: 12.x
 
       - name: npm ci
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,16 @@ jobs:
 
   build-vsix:
     name: 'Build VSIX'
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ matrix.os }}
     needs: build-bicep
+
+    env:
+      CI: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'windows-latest', 'ubuntu-latest', 'macos-latest' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -126,7 +134,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: 10.x
+          node-version: 14.x
 
       - name: npm ci
         run: npm ci
@@ -149,23 +157,32 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
         working-directory: ./src/vscode-bicep
-        
+
       - name: Run E2E tests
+        run: npm run test:e2e
+        if: runner.os != 'Linux'
+        working-directory: ./src/vscode-bicep
+        
+      - name: Run E2E tests (Linux)
         run: xvfb-run -a npm run test:e2e
+        if: runner.os == 'Linux'
         working-directory: ./src/vscode-bicep
 
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v1
+        if: runner.os == 'Linux'
         with:
           flags: typescript
           directory: ./src/vscode-bicep/coverage
 
       - name: Create VSIX
         run: npm run package
+        if: runner.os == 'Linux'
         working-directory: ./src/vscode-bicep
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v2
+        if: runner.os == 'Linux'
         with:
           name: vscode-bicep.vsix
           path: ./src/vscode-bicep/vscode-bicep.vsix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: build-bicep
 
+    env:
+      CI: true
+
     strategy:
       fail-fast: false
       matrix:
@@ -160,27 +163,21 @@ jobs:
           
       - name: Run unit tests
         run: npm run test:unit
-        env:
-          CI: true
         working-directory: ./src/vscode-bicep
 
       - name: Run E2E tests
         run: npm run test:e2e
-        env:
-          CI: true
         if: runner.os != 'Linux'
         working-directory: ./src/vscode-bicep
         
+      # In headless Linux CI machines xvfb is required to run VS Code, so need a separate path for Linux.
       - name: Run E2E tests (Linux)
         run: xvfb-run -a npm run test:e2e
-        env:
-          CI: true
         if: runner.os == 'Linux'
         working-directory: ./src/vscode-bicep
 
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v1
-        if: runner.os == 'Linux'
         with:
           flags: typescript
           directory: ./src/vscode-bicep/coverage

--- a/src/vscode-bicep/src/test/e2e/runTests.ts
+++ b/src/vscode-bicep/src/test/e2e/runTests.ts
@@ -10,7 +10,7 @@ import {
 
 async function go() {
   try {
-    const vscodeExecutablePath = await downloadAndUnzipVSCode("1.46.1");
+    const vscodeExecutablePath = await downloadAndUnzipVSCode("stable");
     const cliPath = resolveCliPathFromVSCodeExecutablePath(
       vscodeExecutablePath
     );

--- a/src/vscode-bicep/src/test/e2e/runTests.ts
+++ b/src/vscode-bicep/src/test/e2e/runTests.ts
@@ -10,7 +10,7 @@ import {
 
 async function go() {
   try {
-    const vscodeExecutablePath = await downloadAndUnzipVSCode("stable");
+    const vscodeExecutablePath = await downloadAndUnzipVSCode("1.46.1");
     const cliPath = resolveCliPathFromVSCodeExecutablePath(
       vscodeExecutablePath
     );
@@ -28,6 +28,8 @@ async function go() {
       extensionTestsPath: path.resolve(__dirname, "index"),
       launchArgs: ["--enable-proposed-api"],
     });
+
+    process.exit(0);
   } catch (err) {
     console.error(err);
     process.exit(1);


### PR DESCRIPTION
Updated `build.yml` to run VSIX tests on Windows and macOS as well. This closes #912 .