### PR TITLE
Update CONTRIBUTING.md - using VSCode Extension with WSL2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,4 @@ FodyWeavers.xsd
 
 # Language Server bits
 bicepLanguageServer/
+src/vscode-bicep/bicepLanguageServer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ The Bicep solution is comprised of the following main components:
 * On the first run, you'll need to ensure you have installed all the npm packages required by the Bicep VSCode extension with the following:
   * `cd src/vscode-bicep`
   * `npm i`
-* In the [VSCode Run View](https://code.visualstudio.com/Docs/editor/debugging), select the "Bicep VSCode Extension" task, and press the "Start" button. This will launch a new VSCode window with the Bicep extension and LanguageServer containing your changes. When running on WSL, set the `BICEP_LANGUAGE_SERVER_PATH` environment variable found in `launch.json` manually following [WSL environment setup scripts](https://code.visualstudio.com/docs/remote/wsl#_advanced-environment-setup-script).
+* In the [VSCode Run View](https://code.visualstudio.com/Docs/editor/debugging), select the "Bicep VSCode Extension" task, and press the "Start" button. This will launch a new VSCode window with the Bicep extension and LanguageServer containing your changes. When running on WSL, create a symbolic link in `src/vscode-bicep` named `bicepLanguageServer` to `../Bicep.LangServer/bin/Debug/net5.0`.
 * If you want the ability to put breakpoints and step through the C# code, you can also use the "Attach" run configuration once the extension host has launched, and select the Bicep LanguageServer process by searching for "bicep".
 
 ### Running the Bicep CLI


### PR DESCRIPTION
Current instruction, how to contribute using WSL was not good. It was causing issues with "stock" Bicep extension installed.

When we set the env variable in the .vscode-server/server-env-setup - it was also used by the "stock" extension. Now, when the current development version uses .NET5 and the stock still uses dotnet core 3.1, bicep language server couldn't load.

Removing the environment variable and symbolic linking Lang server build output resolves this issue.

However, I'm not entirely sure if and how it will affect setting up breakpoints.