### PR TITLE
Add a clean command

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/CleanTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/CleanTests.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using Bicep.Cli.UnitTests;
+using Bicep.Core.Extensions;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Cli.IntegrationTests
+{
+    [TestClass]
+    public class CleanTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        private static Program CreateProgram(TextWriter outputWriter, TextWriter errorWriter)
+        {
+            return new Program(TestResourceTypeProvider.Create(), outputWriter, errorWriter);
+        }
+
+        [TestMethod]
+        public void ZeroDirectoriesToCleanShouldProduceError()
+        {
+            var (output, error, result) = TextWriterHelper.InvokeWriterAction((@out, err) =>
+            {
+                var p = CreateProgram(@out, err);
+                return p.Run(new[] { "clean" });
+            });
+
+            result.Should().Be(1);
+            output.Should().BeEmpty();
+
+            error.Should().NotBeEmpty();
+            error.Should().Be($"At least one directory must be specified to the clean command.{Environment.NewLine}");
+        }
+
+        [TestMethod]
+        public void CleanSingleDirectoryShouldRemoveOneTemplate()
+        {
+            var directoryName = Path.Combine(TestContext.TestRunResultsDirectory, TestContext.TestName);
+            Directory.CreateDirectory(directoryName);
+
+            var bicepName = Path.Combine(directoryName, "main.bicep");
+            File.WriteAllText(bicepName, "");
+
+            var jsonName = Path.Combine(directoryName, "main.json");
+            File.WriteAllText(jsonName, "{}");
+
+            var (output, error, result) = TextWriterHelper.InvokeWriterAction((@out, err) =>
+            {
+                var p = CreateProgram(@out, err);
+                return p.Run(new[] { "clean", directoryName });
+            });
+
+            using (new AssertionScope())
+            {
+                result.Should().Be(0);
+                output.Should().BeEmpty();
+                error.Should().BeEmpty();
+            }
+
+            File.Exists(bicepName).Should().BeTrue();
+            File.Exists(jsonName).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void CleanSingleDirectoryShouldRemoveManyTemplates()
+        {
+            var directoryName = Path.Combine(TestContext.TestRunResultsDirectory, TestContext.TestName);
+            Directory.CreateDirectory(directoryName);
+
+            var bicepName = Path.Combine(directoryName, "main.bicep");
+            File.WriteAllText(bicepName, "");
+
+            var jsonName = Path.Combine(directoryName, "main.json");
+            File.WriteAllText(jsonName, "{}");
+
+            var secondBicepName = Path.Combine(directoryName, "secondMain.bicep");
+            File.WriteAllText(secondBicepName, "");
+
+            var secondJsonName = Path.Combine(directoryName, "secondMain.json");
+            File.WriteAllText(secondJsonName, "{}");
+
+            var (output, error, result) = TextWriterHelper.InvokeWriterAction((@out, err) =>
+            {
+                var p = CreateProgram(@out, err);
+                return p.Run(new[] { "clean", directoryName });
+            });
+
+            using (new AssertionScope())
+            {
+                result.Should().Be(0);
+                output.Should().BeEmpty();
+                error.Should().BeEmpty();
+            }
+
+            File.Exists(bicepName).Should().BeTrue();
+            File.Exists(jsonName).Should().BeFalse();
+            File.Exists(secondBicepName).Should().BeTrue();
+            File.Exists(secondJsonName).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void CleanMultipleDirectoriesShouldRemoveOneTemplate()
+        {
+            string firstDirectory = Path.Combine(TestContext.TestRunResultsDirectory, TestContext.TestName);
+            string secondDirectory = Path.Combine(firstDirectory, TestContext.TestName);
+
+            string[] directories = new string[] { firstDirectory, secondDirectory };
+            List<string> files = new List<string>();
+            string fileName;
+
+            foreach (string dir in directories)
+            {
+                Directory.CreateDirectory(dir);
+
+                fileName = Path.Combine(dir, "main.bicep");
+                File.WriteAllText(fileName, "{}");
+                files.Add(fileName);
+
+                fileName = Path.Combine(dir, "main.json");
+                File.WriteAllText(fileName, "{}");
+                files.Add(fileName);
+            }
+   
+
+            var (output, error, result) = TextWriterHelper.InvokeWriterAction((@out, err) =>
+            {
+                var p = CreateProgram(@out, err);
+
+                string[] args = "clean".AsEnumerable().Concat(directories).ToArray();
+                return p.Run(args);
+            });
+
+            using (new AssertionScope())
+            {
+                result.Should().Be(0);
+                output.Should().BeEmpty();
+                error.Should().BeEmpty();
+            }
+
+            foreach (string file in files)
+            {
+                if(Path.GetExtension(file).Equals(".json"))
+                {
+                    File.Exists(file).Should().BeFalse();
+                }
+                else
+                {
+                   File.Exists(file).Should().BeTrue();
+                }
+            }
+        }
+
+    }
+}

--- a/src/Bicep.Cli.UnitTests/ArgumentParserTests.cs
+++ b/src/Bicep.Cli.UnitTests/ArgumentParserTests.cs
@@ -24,6 +24,7 @@ namespace Bicep.Cli.UnitTests
             actual.Should().Contain("options");
             actual.Should().Contain("--stdout");
             actual.Should().Contain("bicep decompile");
+            actual.Should().Contain("bicep clean");
         }
 
         [TestMethod]
@@ -200,6 +201,33 @@ namespace Bicep.Cli.UnitTests
 
             arguments!.Should().NotBeNull();
             arguments!.Files.Should().Equal("file1", "file2", "file3");
+        }
+
+        [TestMethod]
+        public void CleanNoDirectories_ShouldThrow()
+        {
+            Action noDirectories = () => ArgumentParser.TryParse(new[] { "clean" });
+
+            noDirectories.Should().Throw<CommandLineException>().WithMessage("At least one directory must be specified to the clean command.");
+        }
+
+        [TestMethod]
+        public void CleanOneDirectory_ShouldReturnOneDirectory()
+        {
+            var arguments = (CleanArguments?)ArgumentParser.TryParse(new[] { "clean", "/directory1" });
+
+            // using classic assert so R# understands the value is not null
+            Assert.IsNotNull(arguments);
+            arguments!.BicepDirectories.Should().Equal("/directory1");
+        }
+
+        [TestMethod]
+        public void CleanMultipleDirectories_ShouldReturnAllDirectories()
+        {
+            var arguments = (CleanArguments?)ArgumentParser.TryParse(new[] { "clean", "/directory1", "/directory2", "/directory3" });
+
+            Assert.IsNotNull(arguments);
+            arguments!.BicepDirectories.Should().Equal("/directory1", "/directory2", "/directory3");
         }
     }
 }

--- a/src/Bicep.Cli/CommandLine/ArgumentParser.cs
+++ b/src/Bicep.Cli/CommandLine/ArgumentParser.cs
@@ -23,6 +23,8 @@ namespace Bicep.Cli.CommandLine
                     return ParseBuild(args[1..]);
                 case CliConstants.CommandDecompile:
                     return ParseDecompile(args[1..]);
+                case CliConstants.CommandClean:
+                    return ParseClean(args[1..]);
                 case CliConstants.ArgumentHelp:
                 case CliConstants.ArgumentHelpShort:
                     return new HelpArguments();
@@ -75,6 +77,12 @@ Usage:
     Arguments:
       <files>     The list of one or more .json files to decompile
 
+  {exeName} clean [options] [<directories>...]
+    Clean the directory by removing all the built templates
+
+    Arguments:
+      <directories>     The list of one or more directories to clean
+
   {exeName} [options]
     Options:
       --version  -v   Shows bicep version information
@@ -93,6 +101,11 @@ Usage:
         private static DecompileArguments ParseDecompile(string[] files)
         {
             return new DecompileArguments(files);
+        }
+
+        private static CleanArguments ParseClean(string[] files)
+        {
+            return new CleanArguments(files);
         }
     }
 }

--- a/src/Bicep.Cli/CommandLine/Arguments/CleanArguments.cs
+++ b/src/Bicep.Cli/CommandLine/Arguments/CleanArguments.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Bicep.Cli.CommandLine.Arguments
+{
+    public class CleanArguments : ArgumentsBase
+    {
+        public ImmutableArray<string> BicepDirectories { get; }
+
+        public CleanArguments(IEnumerable<string> arguments)
+        {
+            this.BicepDirectories = arguments.ToImmutableArray();
+
+            if (!this.BicepDirectories.Any())
+            {
+                throw new CommandLineException($"At least one directory must be specified to the {CliConstants.CommandClean} command.");
+            }
+        }
+
+    }
+}
+

--- a/src/Bicep.Cli/CommandLine/CliConstants.cs
+++ b/src/Bicep.Cli/CommandLine/CliConstants.cs
@@ -6,6 +6,7 @@ namespace Bicep.Cli.CommandLine
     {
         public const string CommandBuild = "build";
         public const string CommandDecompile = "decompile";
+        public const string CommandClean = "clean";
         public const string ArgumentStdOut = "--stdout";
         public const string ArgumentVersion = "--version";
         public const string ArgumentVersionShort = "-v";


### PR DESCRIPTION
This Pull Request introduces a new command : clean.

The goal of this command is to remove all the built Json Templates and clean the directory. 

It may be useful if we want to push only the bicep files inside an organisation.

**Example :** 

We have a directory that contains a file "`main.bicep`"
by running` bicep.exe build ./main.bicep` it will generate a `./main.json`
By running `bicep clean .`/ , it will delete the `main.json`
