### PR TITLE
Do not show completions inside comments

### DIFF
--- a/src/Bicep.Core/Navigation/SyntaxTriviaExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxTriviaExtensions.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Navigation
+{
+    public static class SyntaxTriviaExtensions
+    {
+        public static SyntaxTrivia? TryFindMostSpecificTriviaInclusive(this SyntaxBase root, int offset, Func<SyntaxTrivia, bool> predicate) => 
+            TryFindMostSpecificTriviaInternal(root, offset, predicate, inclusive: true);
+
+        public static SyntaxTrivia? TryFindMostSpecificTriviaExclusive(this SyntaxBase root, int offset, Func<SyntaxTrivia, bool> predicate) => 
+            TryFindMostSpecificTriviaInternal(root, offset, predicate, inclusive: false);
+
+        private static SyntaxTrivia? TryFindMostSpecificTriviaInternal(SyntaxBase root, int offset, Func<SyntaxTrivia, bool> predicate, bool inclusive)
+        {
+            var visitor = new NavigationSearchVisitor(offset, predicate, inclusive);
+            visitor.Visit(root);
+
+            return visitor.Result;
+        }
+
+        private sealed class NavigationSearchVisitor : SyntaxVisitor
+        {
+            private readonly int offset;
+            private readonly Func<SyntaxTrivia, bool> predicate;
+            private readonly bool inclusive;
+
+            public NavigationSearchVisitor(int offset, Func<SyntaxTrivia, bool> predicate, bool inclusive)
+            {
+                this.offset = offset;
+                this.predicate = predicate;
+                this.inclusive = inclusive;
+            }
+
+            public SyntaxTrivia? Result { get; private set; }
+
+            public override void VisitSyntaxTrivia(SyntaxTrivia node)
+            {
+                // check if offset is inside the node's span
+                if (CheckNodeContainsOffset(node))
+                {
+                    // the node span contains the offset
+                    // check the predicate
+                    if (this.predicate(node))
+                    {
+                        // store the potential result
+                        this.Result = node;
+                    }
+                }
+            }
+
+            private bool CheckNodeContainsOffset(SyntaxTrivia node) => this.inclusive
+                    ? node.Span.ContainsInclusive(offset)
+                    : node.Span.Contains(offset);
+        }
+    }
+}

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -369,6 +369,28 @@ output length int =
                 });
         }
 
+        [DataTestMethod]
+        [DataRow("// |")]
+        [DataRow("/* |")]
+        [DataRow("param foo // |")]
+        [DataRow("param foo /* |")]
+        [DataRow("param /*| */ foo")]
+        [DataRow(@"/*
+*
+* |
+*/")]
+        public void CommentShouldNotGiveAnyCompletions(string codeFragment)
+        {
+        var grouping = SyntaxFactory.CreateFromText(codeFragment);
+        var compilation = new Compilation(TestResourceTypeProvider.Create(), grouping);
+        var provider = new BicepCompletionProvider();
+
+        var offset = codeFragment.IndexOf('|');
+
+        var completions = provider.GetFilteredCompletions(compilation, BicepCompletionContext.Create(grouping.EntryPoint, offset));
+
+        completions.Should().BeEmpty();
+        }
         private static void AssertExpectedDeclarationTypeCompletions(List<CompletionItem> completions)
         {
             completions.Should().SatisfyRespectively(

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -74,6 +74,15 @@ namespace Bicep.LanguageServer.Completions
                 // this indicates a bug
                 throw new ArgumentException($"The specified offset {offset} is outside the span of the specified {nameof(ProgramSyntax)} node.");
             }
+            
+            // the check at the beginning guarantees we have at least 1 node
+            var replacementRange = GetReplacementRange(syntaxTree, matchingNodes[^1], offset);
+
+            var matchingTriviaType = FindTriviaMatchingOffset(syntaxTree.ProgramSyntax, offset)?.Type;
+            if (matchingTriviaType is not null && (matchingTriviaType == SyntaxTriviaType.MultiLineComment || matchingTriviaType == SyntaxTriviaType.SingleLineComment)) {
+                //we're in a comment, no hints here
+                return new BicepCompletionContext(BicepCompletionContextKind.None, replacementRange, null, null, null, null, null, null, null);
+            }
 
             var declarationInfo = FindLastNodeOfType<INamedDeclarationSyntax, SyntaxBase>(matchingNodes);
             var objectInfo = FindLastNodeOfType<ObjectSyntax, ObjectSyntax>(matchingNodes);
@@ -101,9 +110,6 @@ namespace Bicep.LanguageServer.Completions
                 // check if we're inside an expression
                 kind |= ConvertFlag(IsInnerExpressionContext(matchingNodes), BicepCompletionContextKind.Expression);
             }
-
-            // the check at the beginning guarantees we have at least 1 node
-            var replacementRange = GetReplacementRange(syntaxTree, matchingNodes[^1], offset);
 
             return new BicepCompletionContext(kind, replacementRange, declarationInfo.node, objectInfo.node, propertyInfo.node, arrayInfo.node, propertyAccessInfo.node, arrayAccessInfo.node, targetScopeInfo.node);
         }
@@ -133,6 +139,16 @@ namespace Bicep.LanguageServer.Completions
             return nodes;
         }
 
+        /// <summary>
+        /// Returnes trivia which span contains the specified offset.
+        /// </summary>
+        /// <param name="syntax">The program node</param>
+        /// <param name="offset">The offset</param>
+        private static SyntaxTrivia? FindTriviaMatchingOffset(ProgramSyntax syntax, int offset)
+        {
+            return syntax.TryFindMostSpecificTriviaInclusive(offset, current => true);
+        }
+        
         private static BicepCompletionContextKind ConvertFlag(bool value, BicepCompletionContextKind flag) => value ? flag : BicepCompletionContextKind.None;
 
         private static BicepCompletionContextKind GetDeclarationTypeFlags(IList<SyntaxBase> matchingNodes, int offset)


### PR DESCRIPTION
* Detecting if we're inside a comment by checking if current offset is in a `SyntaxTrivia` and that trivia is a comment type
* If so, do not try to build completions, as it's pointless - return `BicepCompletionContextKind.None`

Fixes #970 
Fixes #576 