### PR TITLE
Make playground buttons look like buttons, display tooltips

### DIFF
--- a/src/playground/src/playground.tsx
+++ b/src/playground/src/playground.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { ButtonGroup, Dropdown, Nav, Navbar, NavLink } from 'react-bootstrap';
+import { Button, ButtonGroup, Dropdown, Nav, Navbar, NavLink, OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 import './playground.css';
 import { examples } from './examples';
@@ -48,19 +48,31 @@ export const Playground : React.FC = () => {
   }
 
   const dropdownItems = Object.keys(examples).map(example => (
-    <Dropdown.Item key={example} eventKey={example}>{example}</Dropdown.Item>
+    <Dropdown.Item key={example} eventKey={example} active={false}>{example}</Dropdown.Item>
   ));
+
+  const createTooltip = (text: string) => (
+    <Tooltip id="button-tooltip">
+      {text}
+    </Tooltip>
+  );
 
   return <>
     <input type="file" ref={uploadInputRef} style={{ display: 'none' }} onChange={e => handleDecompileClick(e.currentTarget.files[0])} accept="application/json" multiple={false} />
     <Navbar bg="dark" variant="dark">
       <Navbar.Brand>Bicep Playground</Navbar.Brand>
       <Nav className="ml-auto">
-        <NavLink onClick={handlCopyClick}>{copied ? 'Copied' : 'Copy Link'}</NavLink>
-        <NavLink onClick={() => uploadInputRef.current.click()}>Decompile</NavLink>
+        <OverlayTrigger placement="bottom" overlay={createTooltip('Copy a shareable link to clipboard')}>
+          <Button size="sm" variant="primary" className="mx-1" onClick={handlCopyClick}>{copied ? 'Copied' : 'Copy Link'}</Button>
+        </OverlayTrigger>
+        <OverlayTrigger placement="bottom" overlay={createTooltip('Upload an ARM template JSON file to decompile to Bicep')}>
+          <Button size="sm" variant="primary" className="mx-1" onClick={() => uploadInputRef.current.click()}>Decompile</Button>
+        </OverlayTrigger>
         <Dropdown as={ButtonGroup} onSelect={key => setInitialContent(examples[key])}>
-          <Dropdown.Toggle as={NavLink}>Sample Template</Dropdown.Toggle>
-          <Dropdown.Menu className="dropdown-menu-right">
+          <OverlayTrigger placement="bottom" overlay={createTooltip('Select a sample Bicep file to start')}>
+            <Dropdown.Toggle as={Button} size="sm" variant="primary" className="mx-1">Sample Template</Dropdown.Toggle>
+          </OverlayTrigger>
+          <Dropdown.Menu align="right">
             {dropdownItems}
           </Dropdown.Menu>
         </Dropdown>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/38542602/99987168-fd9f7f00-2d64-11eb-9e21-6cb7e8e05205.png)
After:
![image](https://user-images.githubusercontent.com/38542602/99987361-38a1b280-2d65-11eb-96a1-8365f4557ced.png)
