### PR TITLE
Fix string concatenation in Redis example

### DIFF
--- a/docs/examples/101/redis-cache/main.bicep
+++ b/docs/examples/101/redis-cache/main.bicep
@@ -4,7 +4,7 @@ param redisCacheFamily string
 param redisCacheCapacity int
 param location string
 
-var redisCacheName = concat(environmentName, uniqueString(resourceGroup().id))
+var redisCacheName = '${environmentName}${uniqueString(resourceGroup().id)}'
 
 resource redisCache 'Microsoft.Cache/redis@2019-07-01' = {
   name: redisCacheName

--- a/docs/examples/101/redis-cache/main.json
+++ b/docs/examples/101/redis-cache/main.json
@@ -20,7 +20,7 @@
   },
   "functions": [],
   "variables": {
-    "redisCacheName": "[concat(parameters('environmentName'), uniqueString(resourceGroup().id))]"
+    "redisCacheName": "[format('{0}{1}', parameters('environmentName'), uniqueString(resourceGroup().id))]"
   },
   "resources": [
     {


### PR DESCRIPTION
This PR fixes an incorrect use of the `concat` function in the Redis Cache example, as per https://github.com/Azure/bicep/pull/976.