### PR TITLE
Switched from submodule to type nugets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "bicep-types-az"]
-	path = bicep-types-az
-	url = https://github.com/Azure/bicep-types-az.git

--- a/Bicep.sln
+++ b/Bicep.sln
@@ -33,23 +33,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.LangServer.Integratio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.Cli.IntegrationTests", "src\Bicep.Cli.IntegrationTests\Bicep.Cli.IntegrationTests.csproj", "{34D7A843-55CB-4A3A-B268-2D4ABB7044D3}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Types", "Types", "{4BF029F4-21C7-4751-B3B1-0586AD17525D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.SerializedTypes", "bicep-types-az\src\Bicep.SerializedTypes\Bicep.SerializedTypes.csproj", "{29A01BDE-25AB-44BA-8657-D5C66CBD519D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.SerializedTypes.Az", "bicep-types-az\src\Bicep.SerializedTypes.Az\Bicep.SerializedTypes.Az.csproj", "{39F6D713-EF43-4A23-B101-9CF06C8471C8}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.SerializedTypes.Az.UnitTests", "bicep-types-az\src\Bicep.SerializedTypes.Az.UnitTests\Bicep.SerializedTypes.Az.UnitTests.csproj", "{97A5C9AD-5043-42C7-B823-FE7C2C6D9C48}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.SerializedTypes.UnitTests", "bicep-types-az\src\Bicep.SerializedTypes.UnitTests\Bicep.SerializedTypes.UnitTests.csproj", "{F7EF3463-D8D3-4C76-A743-D1BAF1D72AA0}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{61643BA1-BE82-4430-A3D3-CB7A16E747E3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.Decompiler", "src\Bicep.Decompiler\Bicep.Decompiler.csproj", "{4CD48B4A-6297-49FC-90AC-5DF9213C1527}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.Decompiler", "src\Bicep.Decompiler\Bicep.Decompiler.csproj", "{4CD48B4A-6297-49FC-90AC-5DF9213C1527}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.Decompiler.IntegrationTests", "src\Bicep.Decompiler.IntegrationTests\Bicep.Decompiler.IntegrationTests.csproj", "{695560CE-C6C3-4FCD-A488-09F06E608297}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.Decompiler.IntegrationTests", "src\Bicep.Decompiler.IntegrationTests\Bicep.Decompiler.IntegrationTests.csproj", "{695560CE-C6C3-4FCD-A488-09F06E608297}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.Decompiler.UnitTests", "src\Bicep.Decompiler.UnitTests\Bicep.Decompiler.UnitTests.csproj", "{F3AF01F6-24E8-4129-80B6-84AC070B5C7D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.Decompiler.UnitTests", "src\Bicep.Decompiler.UnitTests\Bicep.Decompiler.UnitTests.csproj", "{F3AF01F6-24E8-4129-80B6-84AC070B5C7D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -101,22 +91,6 @@ Global
 		{34D7A843-55CB-4A3A-B268-2D4ABB7044D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{34D7A843-55CB-4A3A-B268-2D4ABB7044D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{34D7A843-55CB-4A3A-B268-2D4ABB7044D3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{29A01BDE-25AB-44BA-8657-D5C66CBD519D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{29A01BDE-25AB-44BA-8657-D5C66CBD519D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{29A01BDE-25AB-44BA-8657-D5C66CBD519D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{29A01BDE-25AB-44BA-8657-D5C66CBD519D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{39F6D713-EF43-4A23-B101-9CF06C8471C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{39F6D713-EF43-4A23-B101-9CF06C8471C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{39F6D713-EF43-4A23-B101-9CF06C8471C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{39F6D713-EF43-4A23-B101-9CF06C8471C8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{97A5C9AD-5043-42C7-B823-FE7C2C6D9C48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{97A5C9AD-5043-42C7-B823-FE7C2C6D9C48}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{97A5C9AD-5043-42C7-B823-FE7C2C6D9C48}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{97A5C9AD-5043-42C7-B823-FE7C2C6D9C48}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F7EF3463-D8D3-4C76-A743-D1BAF1D72AA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F7EF3463-D8D3-4C76-A743-D1BAF1D72AA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F7EF3463-D8D3-4C76-A743-D1BAF1D72AA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F7EF3463-D8D3-4C76-A743-D1BAF1D72AA0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4CD48B4A-6297-49FC-90AC-5DF9213C1527}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4CD48B4A-6297-49FC-90AC-5DF9213C1527}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4CD48B4A-6297-49FC-90AC-5DF9213C1527}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -145,10 +119,6 @@ Global
 		{29A1AE2B-D47D-41DD-9824-279475D9B6C2} = {B02251C3-B01E-40EB-B145-2B03F25FE653}
 		{0DE47D02-2BBE-4352-9E38-79A374F9C41E} = {76F6CBAF-FE81-4B56-B0DB-DE6FD7174771}
 		{34D7A843-55CB-4A3A-B268-2D4ABB7044D3} = {B02251C3-B01E-40EB-B145-2B03F25FE653}
-		{29A01BDE-25AB-44BA-8657-D5C66CBD519D} = {4BF029F4-21C7-4751-B3B1-0586AD17525D}
-		{39F6D713-EF43-4A23-B101-9CF06C8471C8} = {4BF029F4-21C7-4751-B3B1-0586AD17525D}
-		{97A5C9AD-5043-42C7-B823-FE7C2C6D9C48} = {4BF029F4-21C7-4751-B3B1-0586AD17525D}
-		{F7EF3463-D8D3-4C76-A743-D1BAF1D72AA0} = {4BF029F4-21C7-4751-B3B1-0586AD17525D}
 		{4CD48B4A-6297-49FC-90AC-5DF9213C1527} = {61643BA1-BE82-4430-A3D3-CB7A16E747E3}
 		{695560CE-C6C3-4FCD-A488-09F06E608297} = {61643BA1-BE82-4430-A3D3-CB7A16E747E3}
 		{F3AF01F6-24E8-4129-80B6-84AC070B5C7D} = {61643BA1-BE82-4430-A3D3-CB7A16E747E3}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We are very happy to accept community contributions to Bicep, whether those are 
 * You are free to work on Bicep on any platform using any editor, but you may find it quickest to get started using [VSCode](https://code.visualstudio.com/Download) with the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 * Fork this repo (see [this forking guide](https://guides.github.com/activities/forking/) for more information).
 * Checkout the repo locally with `git clone git@github.com:{your_username}/bicep.git`.
-* Change into the bicep repo directory and run `git submodule update --init --recursive`.
+* If `git status` shows untracked files in the `bicep-types-az` directory, remove the directory via `rm -r bicep-types-az` on Linux/Mac or `rmdir /S bicep-types-az` on Windows. (This is only needed once.)
 * Build the .NET solution with `dotnet build`.
 
 ## Developing

--- a/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
@@ -7,13 +7,12 @@ using System.Linq;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Resources;
 using Bicep.Core.Semantics;
-using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
-using Bicep.SerializedTypes;
-using Bicep.SerializedTypes.Az;
+using Azure.Bicep.Types;
+using Azure.Bicep.Types.Az;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -196,7 +195,7 @@ resource unexpectedPropertiesProperty 'Mock.Rp/mockType@2020-01-01' = {
         {
             var serializedTypes = CreateSerializedTypes(resourceTypeReference);
             var deserializedType = TypeSerializer.Deserialize(serializedTypes);
-            var resourceType = deserializedType.OfType<SerializedTypes.Concrete.ResourceType>().Single();
+            var resourceType = deserializedType.OfType<Azure.Bicep.Types.Concrete.ResourceType>().Single();
 
             var mockTypeLocation = new TypeLocation();
             var mockTypeLoader = new Mock<ITypeLoader>();
@@ -212,35 +211,35 @@ resource unexpectedPropertiesProperty 'Mock.Rp/mockType@2020-01-01' = {
 
         private static string CreateSerializedTypes(ResourceTypeReference resourceTypeReference)
         {
-            var typeFactory = new SerializedTypes.Concrete.TypeFactory(Enumerable.Empty<SerializedTypes.Concrete.TypeBase>());
-            var stringType = typeFactory.Create(() => new SerializedTypes.Concrete.BuiltInType { Kind = SerializedTypes.Concrete.BuiltInTypeKind.String });
-            var apiVersionType = typeFactory.Create(() => new SerializedTypes.Concrete.StringLiteralType { Value = resourceTypeReference.ApiVersion });
-            var typeType = typeFactory.Create(() => new SerializedTypes.Concrete.StringLiteralType { Value = resourceTypeReference.FullyQualifiedType });
-            var propertiesType = typeFactory.Create(() => new SerializedTypes.Concrete.ObjectType
+            var typeFactory = new Azure.Bicep.Types.Concrete.TypeFactory(Enumerable.Empty<Azure.Bicep.Types.Concrete.TypeBase>());
+            var stringType = typeFactory.Create(() => new Azure.Bicep.Types.Concrete.BuiltInType { Kind = Azure.Bicep.Types.Concrete.BuiltInTypeKind.String });
+            var apiVersionType = typeFactory.Create(() => new Azure.Bicep.Types.Concrete.StringLiteralType { Value = resourceTypeReference.ApiVersion });
+            var typeType = typeFactory.Create(() => new Azure.Bicep.Types.Concrete.StringLiteralType { Value = resourceTypeReference.FullyQualifiedType });
+            var propertiesType = typeFactory.Create(() => new Azure.Bicep.Types.Concrete.ObjectType
             {
                 Name = "Properties",
-                Properties = new Dictionary<string, SerializedTypes.Concrete.ObjectProperty>
+                Properties = new Dictionary<string, Azure.Bicep.Types.Concrete.ObjectProperty>
                 {
-                    ["readwrite"] = new SerializedTypes.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = SerializedTypes.Concrete.ObjectPropertyFlags.None },
-                    ["readonly"] = new SerializedTypes.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = SerializedTypes.Concrete.ObjectPropertyFlags.ReadOnly },
-                    ["writeonly"] = new SerializedTypes.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = SerializedTypes.Concrete.ObjectPropertyFlags.WriteOnly },
-                    ["required"] = new SerializedTypes.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = SerializedTypes.Concrete.ObjectPropertyFlags.Required },
+                    ["readwrite"] = new Azure.Bicep.Types.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = Azure.Bicep.Types.Concrete.ObjectPropertyFlags.None },
+                    ["readonly"] = new Azure.Bicep.Types.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = Azure.Bicep.Types.Concrete.ObjectPropertyFlags.ReadOnly },
+                    ["writeonly"] = new Azure.Bicep.Types.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = Azure.Bicep.Types.Concrete.ObjectPropertyFlags.WriteOnly },
+                    ["required"] = new Azure.Bicep.Types.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = Azure.Bicep.Types.Concrete.ObjectPropertyFlags.Required },
                 }
             });
-            var bodyType = typeFactory.Create(() => new SerializedTypes.Concrete.ObjectType
+            var bodyType = typeFactory.Create(() => new Azure.Bicep.Types.Concrete.ObjectType
             {
                 Name = resourceTypeReference.FormatName(),
-                Properties = new Dictionary<string, SerializedTypes.Concrete.ObjectProperty>
+                Properties = new Dictionary<string, Azure.Bicep.Types.Concrete.ObjectProperty>
                 {
-                    ["name"] = new SerializedTypes.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = SerializedTypes.Concrete.ObjectPropertyFlags.DeployTimeConstant | SerializedTypes.Concrete.ObjectPropertyFlags.Required },
-                    ["type"] = new SerializedTypes.Concrete.ObjectProperty { Type = typeFactory.GetReference(typeType), Flags = SerializedTypes.Concrete.ObjectPropertyFlags.DeployTimeConstant | SerializedTypes.Concrete.ObjectPropertyFlags.ReadOnly },
-                    ["apiVersion"] = new SerializedTypes.Concrete.ObjectProperty { Type = typeFactory.GetReference(apiVersionType), Flags = SerializedTypes.Concrete.ObjectPropertyFlags.DeployTimeConstant | SerializedTypes.Concrete.ObjectPropertyFlags.ReadOnly },
-                    ["id"] = new SerializedTypes.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = SerializedTypes.Concrete.ObjectPropertyFlags.DeployTimeConstant | SerializedTypes.Concrete.ObjectPropertyFlags.ReadOnly },
-                    ["properties"] = new SerializedTypes.Concrete.ObjectProperty { Type = typeFactory.GetReference(propertiesType), Flags = SerializedTypes.Concrete.ObjectPropertyFlags.Required },
+                    ["name"] = new Azure.Bicep.Types.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = Azure.Bicep.Types.Concrete.ObjectPropertyFlags.DeployTimeConstant | Azure.Bicep.Types.Concrete.ObjectPropertyFlags.Required },
+                    ["type"] = new Azure.Bicep.Types.Concrete.ObjectProperty { Type = typeFactory.GetReference(typeType), Flags = Azure.Bicep.Types.Concrete.ObjectPropertyFlags.DeployTimeConstant | Azure.Bicep.Types.Concrete.ObjectPropertyFlags.ReadOnly },
+                    ["apiVersion"] = new Azure.Bicep.Types.Concrete.ObjectProperty { Type = typeFactory.GetReference(apiVersionType), Flags = Azure.Bicep.Types.Concrete.ObjectPropertyFlags.DeployTimeConstant | Azure.Bicep.Types.Concrete.ObjectPropertyFlags.ReadOnly },
+                    ["id"] = new Azure.Bicep.Types.Concrete.ObjectProperty { Type = typeFactory.GetReference(stringType), Flags = Azure.Bicep.Types.Concrete.ObjectPropertyFlags.DeployTimeConstant | Azure.Bicep.Types.Concrete.ObjectPropertyFlags.ReadOnly },
+                    ["properties"] = new Azure.Bicep.Types.Concrete.ObjectProperty { Type = typeFactory.GetReference(propertiesType), Flags = Azure.Bicep.Types.Concrete.ObjectPropertyFlags.Required },
                 },
             });
 
-            typeFactory.Create(() => new SerializedTypes.Concrete.ResourceType
+            typeFactory.Create(() => new Azure.Bicep.Types.Concrete.ResourceType
             {
                 Name = resourceTypeReference.FormatName(),
                 Body = typeFactory.GetReference(bodyType),

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -5,17 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../bicep-types-az/src/Bicep.SerializedTypes/Bicep.SerializedTypes.csproj" />
-    <ProjectReference Include="../../bicep-types-az/src/Bicep.SerializedTypes.Az/Bicep.SerializedTypes.Az.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="Azure.Deployments.Expression" Version="1.0.112" />
+    <PackageReference Include="Azure.Bicep.Types" Version="0.1.4" />
+    <PackageReference Include="Azure.Bicep.Types.Az" Version="0.1.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 using System.Collections.Generic;
 using System.Linq;
+using Azure.Bicep.Types.Az;
 using Bicep.Core.Resources;
-using Bicep.SerializedTypes.Az;
 
 namespace Bicep.Core.TypeSystem.Az
 {

--- a/src/playground/package-lock.json
+++ b/src/playground/package-lock.json
@@ -5127,9 +5127,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -6548,12 +6548,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {


### PR DESCRIPTION
- Removed submodule
- Replaced direct project references with package references
- Ran `npm audit fix` on the VS code extension project to fix a vulnerability.

In addition to tests, manually validated type-related functionality in the VS code extension and in the playground.

This is one of the many changes needed for #457. 