### PR TITLE
Remove some limitations for decompiling nested/linked templates

### DIFF
--- a/docs/decompiling.md
+++ b/docs/decompiling.md
@@ -32,5 +32,5 @@ See [Export Template](https://aka.ms/armexport) for guidance. Use `bicep decompi
 ## Current Limitations
 The following are temporary limiations on the `bicep decompile` command:
 * Templates using copy loops or conditionals cannot be decompiled
-* Nested templates cannot be decompiled
-* Cross-scope linked templates cannot be decompiled
+* Nested templates can only be decompiled if they are using ['inner' expression evaluation scope](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/linked-templates#expression-evaluation-scope-in-nested-templates).
+* The 'scope' property is unsupported for extension resource declarations.

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -148,7 +148,7 @@ var rgName = resourceGroup().name
 
 // this does not work at the resource group scope
 var invalidLocationVar = deployment().location
-//@[38:46) [BCP053 (Error)] The type "environment" does not contain property "location". Available properties include "name", "properties". |location|
+//@[38:46) [BCP053 (Error)] The type "deployment" does not contain property "location". Available properties include "name", "properties". |location|
 
 var invalidEnvironmentVar = environment().aosdufhsad
 //@[42:52) [BCP053 (Error)] The type "environment" does not contain property "aosdufhsad". Available properties include "activeDirectoryDataLake", "authentication", "batch", "gallery", "graph", "graphAudience", "locations", "media", "name", "portal", "resourceManager", "sqlManagement", "suffixes", "vmImageAliasDoc". |aosdufhsad|

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceSymbol.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceSymbol.cs
@@ -121,7 +121,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 properties = properties.Concat(locationProperty.AsEnumerable());
             }
 
-            return new NamedObjectType("environment", TypeSymbolValidationFlags.Default, properties, null);
+            return new NamedObjectType("deployment", TypeSymbolValidationFlags.Default, properties, null);
         }
 
         private static IEnumerable<(FunctionOverload functionOverload, ResourceScopeType allowedScopes)> GetScopeFunctions()

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -38,7 +38,7 @@ namespace Bicep.Core.Semantics
 
         public SyntaxTree SyntaxTree { get; }
 
-        public Binder Binder { get; }
+        public IBinder Binder { get; }
 
         public ISymbolContext SymbolContext { get; }
 

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -133,26 +133,19 @@ namespace Bicep.Core.IntegrationTests
             return new InMemoryFileResolver(fileDict);
         }
 
-        [TestMethod]
-        public void Decompiler_raises_errors_for_unsupported_features()
+        [DataTestMethod]
+        [DataRow("NonWorking/conditional.json", "[75:17]: The 'condition' property is not supported")]
+        [DataRow("NonWorking/copyloop.json", "[11:9]: The 'copy' property is not supported")]
+        [DataRow("NonWorking/unknownprops.json", "[15:29]: Unrecognized top-level resource property 'madeUpProperty'")]
+        [DataRow("NonWorking/nested-outer.json", "[11:23]: Nested template decompilation requires 'inner' expression evaluation scope. See 'https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/linked-templates#expression-evaluation-scope-in-nested-templates' for more information Microsoft.Resources/deployments pid-00000000-0000-0000-0000-000000000000")]
+        public void Decompiler_raises_errors_for_unsupported_features(string resourcePath, string expectedMessage)
         {
-            var resourcePath = "";
             Action onDecompile = () => {
                 var fileResolver = ReadResourceFile(resourcePath);
                 TemplateDecompiler.DecompileFileWithModules(TestResourceTypeProvider.Create(),fileResolver, new Uri($"file:///{resourcePath}"));
             };
 
-            using (new AssertionScope())
-            {
-                resourcePath = "NonWorking/conditional.json";
-                onDecompile.Should().Throw<ConversionFailedException>().WithMessage("[75:17]: The 'condition' property is not supported");
-
-                resourcePath = "NonWorking/copyloop.json";
-                onDecompile.Should().Throw<ConversionFailedException>().WithMessage("[11:9]: The 'copy' property is not supported");
-
-                resourcePath = "NonWorking/unknownprops.json";
-                onDecompile.Should().Throw<ConversionFailedException>().WithMessage("[15:29]: Unrecognized top-level resource property 'madeUpProperty'");
-            }
+            onDecompile.Should().Throw<ConversionFailedException>().WithMessage(expectedMessage);
         }
 
         [DataTestMethod]

--- a/src/Bicep.Decompiler.IntegrationTests/NonWorking/nested-outer.json
+++ b/src/Bicep.Decompiler.IntegrationTests/NonWorking/nested-outer.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+      {
+        "apiVersion": "2020-05-01",
+        "name": "pid-00000000-0000-0000-0000-000000000000",
+        "type": "Microsoft.Resources/deployments",
+        "properties": {
+          "mode": "Incremental",
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "resources": []
+          }
+        }
+      }
+    ]
+  }
+  

--- a/src/Bicep.Decompiler.IntegrationTests/Working/modules/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/modules/main.bicep
@@ -44,3 +44,26 @@ module moduleWithDodgyUri '?' /*TODO: replace with correct path to [concat(param
     arrayParam: arrayVar
   }
 }
+
+module moduleWithRg 'nested/module1.bicep' = {
+  name: 'moduleWithRg'
+  scope: resourceGroup('test${module1Url}')
+  params: {}
+//@[2:8) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "arrayParam", "location", "objectParam". |params|
+}
+
+module moduleWithRgAndSub 'nested/module1.bicep' = {
+  name: 'moduleWithRgAndSub'
+  scope: resourceGroup('${module1Url}test', 'test${module1Url}')
+  params: {}
+//@[2:8) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "arrayParam", "location", "objectParam". |params|
+}
+
+module moduleWithSub 'nested/module1.bicep' = {
+  name: 'moduleWithSub'
+  scope: subscription('${module1Url}test')
+//@[9:42) [BCP036 (Error)] The property "scope" expected a value of type "resourceGroup" but the provided value is of type "subscription". |subscription('${module1Url}test')|
+//@[9:42) [BCP116 (Error)] Unsupported scope for module deployment in a "resourceGroup" target scope. Omit this property to inherit the current scope, or specify a valid scope. Permissible scopes include current resource group: resourceGroup(), named resource group in same subscription: resourceGroup(<name>), named resource group in a different subscription: resourceGroup(<subId>, <name>), or tenant: tenant(). |subscription('${module1Url}test')|
+  params: {}
+//@[2:8) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "arrayParam", "location", "objectParam". |params|
+}

--- a/src/Bicep.Decompiler.IntegrationTests/Working/modules/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/modules/main.json
@@ -96,6 +96,46 @@
                     }
                 }
             }
+        },
+        {
+            "name": "moduleWithRg",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2015-01-01",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[variables('module1Url')]",
+                    "contentVersion": "1.0.0.0"
+                }
+            },
+            "resourceGroup": "[concat('test', variables('module1Url'))]"
+        },
+        {
+            "name": "moduleWithRgAndSub",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2015-01-01",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[variables('module1Url')]",
+                    "contentVersion": "1.0.0.0"
+                }
+            },
+            "resourceGroup": "[concat('test', variables('module1Url'))]",
+            "subscriptionId": "[concat(variables('module1Url'), 'test')]"
+        },
+        {
+            "name": "moduleWithSub",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2015-01-01",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[variables('module1Url')]",
+                    "contentVersion": "1.0.0.0"
+                }
+            },
+            "subscriptionId": "[concat(variables('module1Url'), 'test')]"
         }
     ],
 

--- a/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/azuredeploy.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/azuredeploy.bicep
@@ -1,0 +1,78 @@
+param location string {
+  metadata: {
+    description: 'Region where you resources are located'
+  }
+  default: resourceGroup().location
+}
+param NetworkWatcherName string {
+  metadata: {
+    description: 'Name of the Network Watcher attached to your subscription. Format: NetworkWatcher_<region_name>'
+  }
+  default: 'NetworkWatcher_${location}'
+}
+param FlowLogName string {
+  metadata: {
+    description: 'Chosen name of your Flow log resource'
+  }
+  default: 'FlowLog1'
+}
+param existingNSG string {
+  metadata: {
+    description: 'Resource ID of the target NSG'
+  }
+}
+param RetentionDays int {
+  minValue: 0
+  maxValue: 365
+  metadata: {
+    description: 'Retention period in days. Default is zero which stands for permanent retention. Can be any Integer from 0 to 365'
+  }
+  default: 0
+}
+param FlowLogsversion string {
+  allowed: [
+    '1'
+    '2'
+  ]
+  metadata: {
+    description: 'FlowLogs Version. Correct values are 1 or 2 (default)'
+  }
+  default: '2'
+}
+param storageAccountType string {
+  allowed: [
+    'Standard_LRS'
+    'Standard_GRS'
+    'Standard_ZRS'
+  ]
+  metadata: {
+    description: 'Storage Account type'
+  }
+  default: 'Standard_LRS'
+}
+
+var storageAccountName_var = 'flowlogs${uniqueString(resourceGroup().id)}'
+
+resource storageAccountName 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: storageAccountName_var
+  location: location
+  sku: {
+    name: storageAccountType
+  }
+  kind: 'StorageV2'
+  properties: {}
+}
+
+module deployFlowLogs './nested_deployFlowLogs.bicep' = {
+  name: 'deployFlowLogs'
+  scope: resourceGroup('NetworkWatcherRG')
+  params: {
+    location: location
+    NetworkWatcherName: NetworkWatcherName
+    FlowLogName: FlowLogName
+    existingNSG: existingNSG
+    RetentionDays: RetentionDays
+    FlowLogsversion: FlowLogsversion
+    storageAccountResourceId: storageAccountName.id
+  }
+}

--- a/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/azuredeploy.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/azuredeploy.json
@@ -1,0 +1,169 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "location": {
+        "type": "string",
+        "defaultValue": "[resourceGroup().location]",
+        "metadata": {
+          "description": "Region where you resources are located"
+        }
+      },
+      "NetworkWatcherName": {
+        "type": "string",
+        "defaultValue": "[concat('NetworkWatcher_', parameters('location'))]",
+        "metadata": {
+          "description": "Name of the Network Watcher attached to your subscription. Format: NetworkWatcher_<region_name>"
+        }
+      },
+      "FlowLogName": {
+        "type": "string",
+        "defaultValue": "FlowLog1",
+        "metadata": {
+          "description": "Chosen name of your Flow log resource"
+        }
+      },
+      "existingNSG": {
+        "type": "string",
+        "metadata": {
+          "description": "Resource ID of the target NSG"
+        }
+      },
+      "RetentionDays": {
+        "type": "int",
+        "defaultValue": 0,
+        "minValue": 0,
+        "maxValue": 365,
+        "metadata": {
+          "description": "Retention period in days. Default is zero which stands for permanent retention. Can be any Integer from 0 to 365"
+        }
+      },
+      "FlowLogsversion": {
+        "type": "string",
+        "defaultValue": "2",
+        "allowedValues": [
+          "1",
+          "2"
+        ],
+        "metadata": {
+          "description": "FlowLogs Version. Correct values are 1 or 2 (default)"
+        }
+      },
+      "storageAccountType": {
+        "type": "string",
+        "defaultValue": "Standard_LRS",
+        "allowedValues": [
+          "Standard_LRS",
+          "Standard_GRS",
+          "Standard_ZRS"
+        ],
+        "metadata": {
+          "description": "Storage Account type"
+        }
+      }
+    },
+    "variables": {
+      "storageAccountName": "[concat('flowlogs', uniquestring(resourceGroup().id))]"
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Storage/storageAccounts",
+        "apiVersion": "2019-06-01",
+        "name": "[variables('storageAccountName')]",
+        "location": "[parameters('location')]",
+        "sku": {
+          "name": "[parameters('storageAccountType')]"
+        },
+        "kind": "StorageV2",
+        "properties": {
+        }
+      },
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2020-06-01",
+        "name": "deployFlowLogs",
+        "resourceGroup": "NetworkWatcherRG",
+        "dependsOn": [
+          "[variables('storageAccountName')]"
+        ],
+        "properties": {
+          "mode": "Incremental",
+          "expressionEvaluationOptions": {
+            "scope": "inner"
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "location": {
+                "type": "string"
+              },
+              "NetworkWatcherName": {
+                "type": "string"
+              },
+              "FlowLogName": {
+                "type": "string"
+              },
+              "existingNSG": {
+                "type": "string"
+              },
+              "RetentionDays": {
+                "type": "int"
+              },
+              "FlowLogsversion": {
+                "type": "string"
+              },
+              "storageAccountResourceId": {
+                "type": "string"
+              }
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Network/networkWatchers/flowLogs",
+                "apiVersion": "2020-06-01",
+                "name": "[concat(parameters('NetworkWatcherName'), '/', parameters('FlowLogName'))]",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "targetResourceId": "[parameters('existingNSG')]",
+                  "storageId": "[parameters('storageAccountResourceId')]",
+                  "enabled": true,
+                  "retentionPolicy": {
+                    "days": "[parameters('RetentionDays')]",
+                    "enabled": true
+                  },
+                  "format": {
+                    "type": "JSON",
+                    "version": "[parameters('FlowLogsversion')]"
+                  }
+                }
+              }
+            ]
+          },
+          "parameters": {
+            "location": {
+              "value": "[parameters('location')]"
+            },
+            "NetworkWatcherName": {
+              "value": "[parameters('NetworkWatcherName')]"
+            },
+            "FlowLogName": {
+              "value": "[parameters('FlowLogName')]"
+            },
+            "existingNSG": {
+              "value": "[parameters('existingNSG')]"
+            },
+            "RetentionDays": {
+              "value": "[parameters('RetentionDays')]"
+            },
+            "FlowLogsversion": {
+              "value": "[parameters('FlowLogsversion')]"
+            },
+            "storageAccountResourceId": {
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+            }
+          }
+        }
+      }
+    ]
+  }
+  

--- a/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/nested_deployFlowLogs.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/nested_deployFlowLogs.bicep
@@ -1,0 +1,26 @@
+param location string
+param NetworkWatcherName string
+param FlowLogName string
+param existingNSG string
+param RetentionDays int
+param FlowLogsversion string
+param storageAccountResourceId string
+
+resource NetworkWatcherName_FlowLogName 'Microsoft.Network/networkWatchers/flowLogs@2020-06-01' = {
+  name: '${NetworkWatcherName}/${FlowLogName}'
+  location: location
+  properties: {
+    targetResourceId: existingNSG
+    storageId: storageAccountResourceId
+    enabled: true
+    retentionPolicy: {
+      days: RetentionDays
+      enabled: true
+    }
+    format: {
+      type: 'JSON'
+      version: FlowLogsversion
+//@[15:30) [BCP036 (Warning)] The property "version" expected a value of type "int" but the provided value is of type "string". |FlowLogsversion|
+    }
+  }
+}

--- a/src/Bicep.Decompiler/ArmHelpers/TemplateHelpers.cs
+++ b/src/Bicep.Decompiler/ArmHelpers/TemplateHelpers.cs
@@ -15,6 +15,22 @@ namespace Bicep.Decompiler.ArmHelpers
         public static JProperty? GetProperty(JObject parent, string name)
             => parent.Property(name, StringComparison.OrdinalIgnoreCase);
 
+        public static JToken? GetNestedProperty(JObject parent, params string[] names)
+        {
+            JToken? current = parent;
+            foreach (var name in names)
+            {
+                if (current is not JObject currentObject)
+                {
+                    return null;
+                }
+
+                current = GetProperty(currentObject, name)?.Value;
+            }
+
+            return current;
+        }
+
         public static bool HasProperty(JObject parent, string name)
             => GetProperty(parent, name) != null;
 

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -17,31 +17,36 @@ using System.Diagnostics.CodeAnalysis;
 using Azure.Deployments.Expression.Engines;
 using Bicep.Core.FileSystem;
 using Bicep.Decompiler.Exceptions;
+using Bicep.Core.Workspaces;
+using System.Collections.Immutable;
+using Bicep.Core.Extensions;
 
 namespace Bicep.Decompiler
 {
     public class TemplateConverter
     {
         private readonly INamingResolver nameResolver;
+        private readonly Workspace workspace;
         private readonly IFileResolver fileResolver;
         private readonly Uri fileUri;
         private readonly JObject template;
 
-        private TemplateConverter(IFileResolver fileResolver, Uri fileUri, string content)
+        private TemplateConverter(Workspace workspace, IFileResolver fileResolver, Uri fileUri, JObject template)
         {
+            this.workspace = workspace;
             this.fileResolver = fileResolver;
             this.fileUri = fileUri;
-            this.template = JObject.Parse(content, new JsonLoadSettings
-            {
-                CommentHandling = CommentHandling.Ignore,
-                LineInfoHandling = LineInfoHandling.Load,
-            });
+            this.template = template;
             this.nameResolver = new UniqueNamingResolver();
         }
 
-        public static ProgramSyntax DecompileTemplate(IFileResolver fileResolver, Uri fileUri, string content)
+        public static ProgramSyntax DecompileTemplate(Workspace workspace, IFileResolver fileResolver, Uri fileUri, string content)
         {
-            var instance = new TemplateConverter(fileResolver, fileUri, content);
+            var instance = new TemplateConverter(workspace, fileResolver, fileUri, JObject.Parse(content, new JsonLoadSettings
+            {
+                CommentHandling = CommentHandling.Ignore,
+                LineInfoHandling = LineInfoHandling.Load,
+            }));
 
             return instance.Parse();
         }
@@ -607,16 +612,10 @@ namespace Bicep.Decompiler
                 ParseJToken(value.Value));
         }
 
-        private SyntaxBase GetModuleFilePath(JObject resource)
+        private SyntaxBase GetModuleFilePath(JObject resource, string templateLink)
         {
             StringSyntax createFakeModulePath(string templateLinkExpression)
                 => SyntaxHelpers.CreateStringLiteralWithComment("?", $"TODO: replace with correct path to {templateLinkExpression}");
-
-            var templateLink = resource["properties"]?["templateLink"]?["uri"]?.Value<string>();
-            if (templateLink == null)
-            {
-                throw new ConversionFailedException($"Unable to find ${resource["name"]}.properties.templateLink.uri. Decompilation of nested templates is not currently supported.", resource);
-            }
 
             var templateLinkExpression = InlineVariables(ExpressionHelpers.ParseExpression(templateLink));
 
@@ -778,10 +777,49 @@ namespace Bicep.Decompiler
 
             var identifier = nameResolver.TryLookupResourceName(typeString, ExpressionHelpers.ParseExpression(nameString)) ?? throw new ArgumentException($"Unable to find resource {typeString} {nameString}");
             
+            var nestedTemplate = TemplateHelpers.GetNestedProperty(resource, "properties", "template");
+            if (nestedTemplate is not null)
+            {
+                if (nestedTemplate is not JObject nestedTemplateObject)
+                {
+                    throw new ConversionFailedException($"Expected template objectfor {typeString} {nameString}", nestedTemplate);
+                }
+
+                var expressionEvaluationScope = TemplateHelpers.GetNestedProperty(resource, "properties", "expressionEvaluationOptions", "scope")?.ToString();
+                if (!StringComparer.OrdinalIgnoreCase.Equals(expressionEvaluationScope, "inner"))
+                {
+                    throw new ConversionFailedException($"Nested template decompilation requires 'inner' expression evaluation scope. See 'https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/linked-templates#expression-evaluation-scope-in-nested-templates' for more information {typeString} {nameString}", nestedTemplate);
+                }
+            
+                var filePath = $"./nested_{identifier}.bicep";
+                var nestedModuleUri = fileResolver.TryResolveModulePath(fileUri, filePath) ?? throw new ConversionFailedException($"Unable to module uri for {typeString} {nameString}", nestedTemplate);
+                if (workspace.TryGetSyntaxTree(nestedModuleUri, out _))
+                {
+                    throw new ConversionFailedException($"Unable to generate duplicate module to path ${nestedModuleUri} for {typeString} {nameString}", nestedTemplate);
+                }
+
+                var nestedConverter = new TemplateConverter(workspace, fileResolver, nestedModuleUri, nestedTemplateObject);
+                var nestedSyntaxTree = new SyntaxTree(nestedModuleUri, ImmutableArray<int>.Empty, nestedConverter.Parse());
+                workspace.UpsertSyntaxTrees(nestedSyntaxTree.AsEnumerable());
+
+                return new ModuleDeclarationSyntax(
+                    SyntaxHelpers.CreateToken(TokenType.Identifier, "module"),
+                    SyntaxHelpers.CreateIdentifier(identifier),
+                    SyntaxHelpers.CreateStringLiteral(filePath),
+                    SyntaxHelpers.CreateToken(TokenType.Assignment, "="),
+                    SyntaxHelpers.CreateObject(properties));
+            }
+
+            var templateLink = TemplateHelpers.GetNestedProperty(resource, "properties", "templateLink", "uri");
+            if (templateLink?.Value<string>() is not string templateLinkString)
+            {
+                throw new ConversionFailedException($"Unable to find {resource["name"]}.properties.templateLink.uri for linked template.", resource);
+            }
+            
             return new ModuleDeclarationSyntax(
                 SyntaxHelpers.CreateToken(TokenType.Identifier, "module"),
                 SyntaxHelpers.CreateIdentifier(identifier),
-                GetModuleFilePath(resource),
+                GetModuleFilePath(resource, templateLinkString),
                 SyntaxHelpers.CreateToken(TokenType.Assignment, "="),
                 SyntaxHelpers.CreateObject(properties));
         }

--- a/src/Bicep.Decompiler/TemplateDecompiler.cs
+++ b/src/Bicep.Decompiler/TemplateDecompiler.cs
@@ -57,7 +57,7 @@ namespace Bicep.Decompiler
                     throw new InvalidOperationException($"Failed to read {currentJsonUri}");
                 }
 
-                var program = TemplateConverter.DecompileTemplate(fileResolver, currentJsonUri, jsonInput);
+                var program = TemplateConverter.DecompileTemplate(workspace, fileResolver, currentJsonUri, jsonInput);
                 var syntaxTree = new SyntaxTree(bicepUri, ImmutableArray<int>.Empty, program);
                 workspace.UpsertSyntaxTrees(syntaxTree.AsEnumerable());
 


### PR DESCRIPTION
* Allow decompilation of nested templates with expression evaluation scope set to 'inner'. 'outer' is still blocked.
* Allow decompilation of linked/nested templates targeting a different RG/Subscription scope. Higher scopes are still blocked.
* Fix the type name for the `deployment()` return type (was incorrectly specified as "environment").
* Allow DependsOnRemovalRewriter to remove dependencies from module declarations