### PR TITLE
Set intellisense defaults

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -44,7 +44,6 @@
       "[bicep]": {
         "editor.tabSize": 2,
         "editor.insertSpaces": true,
-        "editor.suggest.statusBar.visible": true,
         "editor.suggestSelection": "first",
         "editor.suggest.snippetsPreventQuickSuggestions": false,
         "editor.suggest.showWords": false

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -43,7 +43,11 @@
     "configurationDefaults": {
       "[bicep]": {
         "editor.tabSize": 2,
-        "editor.insertSpaces": true
+        "editor.insertSpaces": true,
+        "editor.suggest.statusBar.visible": true,
+        "editor.suggestSelection": "first",
+        "editor.suggest.snippetsPreventQuickSuggestions": false,
+        "editor.suggest.showWords": false
       }
     },
     "configuration": {


### PR DESCRIPTION
Set the following IntelliSense defaults for Bicep language in the VS code extension:
- Choose first selection in completion list (we have observed strange VS code behavior with other settings)
- Allow completions to work inside an active snippet
- Disables text-based completions.

This fixes #882