### PR TITLE
binskim workaround

### DIFF
--- a/.pipelines/Bicep.yml
+++ b/.pipelines/Bicep.yml
@@ -80,7 +80,9 @@ steps:
   displayName: Copy bicep to output
   inputs:
     sourceFolder: '$(Build.SourcesDirectory)/src/Bicep.Cli/bin/$(BuildConfiguration)/$(TargetFramework)/${{ parameters.rid }}/publish/'
-    contents: '**'
+    contents: |
+      **
+      !**/*.pdb
     targetFolder: '$(Build.SourcesDirectory)/out/bicep-$(BuildConfiguration)-${{ parameters.rid }}/'
 
 - ${{ if eq(parameters.rid, 'win-x64') }}:

--- a/.pipelines/Common.yml
+++ b/.pipelines/Common.yml
@@ -12,8 +12,8 @@ stages:
     variables:
       ob_outputDirectory: '$(Build.SourcesDirectory)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
       # https://aka.ms/obpipelines/sdl
-      ob_sdl_binskim_enabled: false # you can disable sdl tools in non-official build 
-      ob_sdl_binskim_break: true # always break the build on binskim issues. You can disable it by setting to 'false'
+      ob_sdl_binskim_enabled: true # you can disable sdl tools in non-official build 
+      ob_sdl_binskim_break: false # always break the build on binskim issues. You can disable it by setting to 'false'
       ob_sdl_binskim_scanOutputDirectoryOnly: true
       ob_sdl_roslyn_break: true
       # ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\.gdn\job.gdnsuppress
@@ -29,8 +29,8 @@ stages:
     variables:
       ob_outputDirectory: '$(Build.SourcesDirectory)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
       # https://aka.ms/obpipelines/sdl
-      ob_sdl_binskim_enabled: false # you can disable sdl tools in non-official build 
-      ob_sdl_binskim_break: true # always break the build on binskim issues. You can disable it by setting to 'false'
+      ob_sdl_binskim_enabled: true # you can disable sdl tools in non-official build 
+      ob_sdl_binskim_break: false # always break the build on binskim issues. You can disable it by setting to 'false'
       ob_sdl_binskim_scanOutputDirectoryOnly: true
       ob_sdl_roslyn_break: true
       # ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\.gdn\job.gdnsuppress
@@ -46,8 +46,8 @@ stages:
     variables:
       ob_outputDirectory: '$(Build.SourcesDirectory)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
       # https://aka.ms/obpipelines/sdl
-      ob_sdl_binskim_enabled: false # you can disable sdl tools in non-official build 
-      ob_sdl_binskim_break: true # always break the build on binskim issues. You can disable it by setting to 'false'
+      ob_sdl_binskim_enabled: true # you can disable sdl tools in non-official build 
+      ob_sdl_binskim_break: false # always break the build on binskim issues. You can disable it by setting to 'false'
       ob_sdl_binskim_scanOutputDirectoryOnly: true
       ob_sdl_roslyn_break: true
       # ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\.gdn\job.gdnsuppress


### PR DESCRIPTION
BinSkim chokes on self-contained single-file executables due to missing singlefilehost.pdb symbols. For now, we will work around this issue by not copying the symbols at all to the output for bicep.exe. This will be reverted in the future once BinSkim is fixed.