### PR TITLE
e2e tests now run in ADO pipeline

### DIFF
--- a/.pipelines/Common.yml
+++ b/.pipelines/Common.yml
@@ -71,6 +71,9 @@ stages:
       # ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\.gdn\job.gdnsuppress
     
     steps:
+    - script: sudo apt-get update && sudo apt-get install -y xvfb libgtk2.0-0 libxss-dev libgconf-2-4 libasound2
+      displayName: Install dependencies
+    
     - task: NodeTool@0 
       displayName: Setup Node.js
       inputs:
@@ -104,10 +107,17 @@ stages:
       displayName: Run unit tests
       workingDirectory: $(Build.SourcesDirectory)/src/vscode-bicep
 
-    # xvfb is missing in the container image
-    # - script: xvfb-run -a npm run test:e2e
-    #   displayName: Run E2E tests
-    #   workingDirectory: $(Build.SourcesDirectory)/src/vscode-bicep
+    - script: /usr/bin/Xvfb :99 -screen 0 1024x768x24 & sleep 2
+      displayName: Start Xvfb
+    
+    - script: node ./out/test/e2e/runTests.js 
+      displayName: Run E2E tests
+      workingDirectory: $(Build.SourcesDirectory)/src/vscode-bicep
+      env:
+        DISPLAY: ':99.0'
+    
+    - script: killall Xvfb
+      displayName: Kill Xvfb
 
     - script: npm run package
       displayName: Create VSIX

--- a/src/vscode-bicep/src/test/e2e/runTests.ts
+++ b/src/vscode-bicep/src/test/e2e/runTests.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import * as path from "path";
 import * as cp from "child_process";
+import * as fs from "fs";
 import {
   runTests,
   downloadAndUnzipVSCode,
@@ -18,6 +19,8 @@ async function go() {
     // some of our builds run as root in a container, which requires passing
     // the user data folder path to vs code itself
     const userDataDir = path.resolve(__dirname, "user-data");
+
+    fs.mkdirSync(userDataDir, { recursive: true });
 
     // Install .NET Install Tool as a dependency.
     cp.spawnSync(

--- a/src/vscode-bicep/src/test/e2e/runTests.ts
+++ b/src/vscode-bicep/src/test/e2e/runTests.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as path from "path";
 import * as cp from "child_process";
-import * as fs from "fs";
+import * as os from "os";
 import {
   runTests,
   downloadAndUnzipVSCode,
@@ -19,25 +19,32 @@ async function go() {
     // some of our builds run as root in a container, which requires passing
     // the user data folder path to vs code itself
     const userDataDir = path.resolve(__dirname, "user-data");
+    const userDataArgument = `--user-data-dir="${userDataDir}"`;
 
-    fs.mkdirSync(userDataDir, { recursive: true });
+    const isRoot = os.userInfo().username == "root";
+
+    const extensionInstallArguments = [
+      "--install-extension",
+      "ms-dotnettools.vscode-dotnet-runtime",
+    ];
+
+    if (isRoot) {
+      extensionInstallArguments.push(userDataArgument);
+    }
 
     // Install .NET Install Tool as a dependency.
-    cp.spawnSync(
-      cliPath,
-      [
-        "--install-extension",
-        "ms-dotnettools.vscode-dotnet-runtime",
-        `--user-data-dir="${userDataDir}"`,
-      ],
-      { encoding: "utf-8", stdio: "inherit" }
-    );
+    cp.spawnSync(cliPath, extensionInstallArguments, {
+      encoding: "utf-8",
+      stdio: "inherit",
+    });
 
     await runTests({
       vscodeExecutablePath,
       extensionDevelopmentPath: path.resolve(__dirname, "../../.."),
       extensionTestsPath: path.resolve(__dirname, "index"),
-      launchArgs: ["--enable-proposed-api", `--user-data-dir="${userDataDir}"`],
+      launchArgs: isRoot
+        ? ["--enable-proposed-api", userDataArgument]
+        : ["--enable-proposed-api"],
     });
 
     process.exit(0);

--- a/src/vscode-bicep/src/test/e2e/runTests.ts
+++ b/src/vscode-bicep/src/test/e2e/runTests.ts
@@ -15,10 +15,18 @@ async function go() {
       vscodeExecutablePath
     );
 
+    // some of our builds run as root in a container, which requires passing
+    // the user data folder path to vs code itself
+    const userDataDir = path.resolve(__dirname, "user-data");
+
     // Install .NET Install Tool as a dependency.
     cp.spawnSync(
       cliPath,
-      ["--install-extension", "ms-dotnettools.vscode-dotnet-runtime"],
+      [
+        "--install-extension",
+        "ms-dotnettools.vscode-dotnet-runtime",
+        `--user-data-dir="${userDataDir}"`,
+      ],
       { encoding: "utf-8", stdio: "inherit" }
     );
 
@@ -26,7 +34,7 @@ async function go() {
       vscodeExecutablePath,
       extensionDevelopmentPath: path.resolve(__dirname, "../../.."),
       extensionTestsPath: path.resolve(__dirname, "index"),
-      launchArgs: ["--enable-proposed-api"],
+      launchArgs: ["--enable-proposed-api", `--user-data-dir="${userDataDir}"`],
     });
 
     process.exit(0);


### PR DESCRIPTION
This change allows our tests to run inside the ADO pipeline we will use for official builds:
- Installed missing dependencies (build steps run as root inside the containers, so we can just install whatever is missing)
- Added steps to start and kill Xvfb server because ADO build agents are headless (unlike the machines used by GitHub actions)
- Added `--user-data-dir` to VS code calls when the user name is root. This was needed because VS code runs as root under ADO. 

This is needed for #457 

The tests themselves are partially failing in ADO due to a race condition. @shenglol is working on a fix. (We have observed this type of failures in GH actions as well - just less frequently.)