### PR TITLE
Implement retrying logic for VSCode E2E tests

### DIFF
--- a/src/vscode-bicep/src/test/e2e/hover.test.ts
+++ b/src/vscode-bicep/src/test/e2e/hover.test.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 
 import { expectDefined, expectRange } from "../utils/assert";
-import { sleep } from "../utils/time";
+import { retryWhile, sleep } from "../utils/time";
 import { executeHoverProviderCommand } from "./commands";
 import { readExampleFile } from "./examples";
 
@@ -29,7 +29,7 @@ describe("hover", (): void => {
   });
 
   it("should reveal type signature when hovering over a parameter name", async () => {
-    const hovers = await executeHoverProviderCommand(
+    const hovers = await executeHoverProviderCommandWithRetry(
       document.uri,
       new vscode.Position(1, 7)
     );
@@ -44,7 +44,7 @@ describe("hover", (): void => {
   });
 
   it("should reveal type signature when hovering over a variable name", async () => {
-    const hovers = await executeHoverProviderCommand(
+    const hovers = await executeHoverProviderCommandWithRetry(
       document.uri,
       new vscode.Position(53, 10)
     );
@@ -59,7 +59,7 @@ describe("hover", (): void => {
   });
 
   it("should reveal type signature when hovering over a resource symbolic name", async () => {
-    const hovers = await executeHoverProviderCommand(
+    const hovers = await executeHoverProviderCommandWithRetry(
       document.uri,
       new vscode.Position(111, 10)
     );
@@ -74,7 +74,7 @@ describe("hover", (): void => {
   });
 
   it("should reveal type signature when hovering over an output name", async () => {
-    const hovers = await executeHoverProviderCommand(
+    const hovers = await executeHoverProviderCommandWithRetry(
       document.uri,
       new vscode.Position(186, 14)
     );
@@ -89,7 +89,7 @@ describe("hover", (): void => {
   });
 
   it("should reveal type signature when hovering over a function name", async () => {
-    const hovers = await executeHoverProviderCommand(
+    const hovers = await executeHoverProviderCommandWithRetry(
       document.uri,
       new vscode.Position(19, 60)
     );
@@ -102,6 +102,16 @@ describe("hover", (): void => {
       contents: ["function uniqueString(string): string"],
     });
   });
+
+  function executeHoverProviderCommandWithRetry(
+    documentUri: vscode.Uri,
+    position: vscode.Position
+  ) {
+    return retryWhile(
+      async () => await executeHoverProviderCommand(documentUri, position),
+      (hovers) => hovers === undefined || hovers.length === 0
+    );
+  }
 
   function expectHovers(
     hovers: vscode.Hover[] | undefined,

--- a/src/vscode-bicep/src/test/e2e/setup.ts
+++ b/src/vscode-bicep/src/test/e2e/setup.ts
@@ -5,3 +5,5 @@ process.env.NODE_ENV = "test";
 // Workaround for https://github.com/microsoft/vscode-test/issues/37.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 jest.mock("vscode", () => (global as any).vscode, { virtual: true });
+
+jest.setTimeout(20000);

--- a/src/vscode-bicep/src/test/utils/time.ts
+++ b/src/vscode-bicep/src/test/utils/time.ts
@@ -3,3 +3,20 @@
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export async function retryWhile<T>(
+  func: () => Promise<T>,
+  predicate: (result: T) => boolean,
+  retryOptions = {
+    interval: 2000,
+    count: 3,
+  }
+): Promise<T> {
+  let result = await func();
+
+  while (predicate(result) && retryOptions.count--) {
+    result = await func();
+  }
+
+  return result;
+}

--- a/src/vscode-bicep/src/test/utils/time.ts
+++ b/src/vscode-bicep/src/test/utils/time.ts
@@ -7,15 +7,19 @@ export function sleep(ms: number): Promise<void> {
 export async function retryWhile<T>(
   func: () => Promise<T>,
   predicate: (result: T) => boolean,
-  retryOptions = {
-    interval: 2000,
-    count: 3,
-  }
+  retryOptions?: Readonly<{
+    interval?: number;
+    count?: number;
+  }>
 ): Promise<T> {
   let result = await func();
 
-  while (predicate(result) && retryOptions.count--) {
+  const interval = retryOptions?.interval ?? 2000;
+  let count = retryOptions?.count ?? 3;
+
+  while (predicate(result) && count--) {
     result = await func();
+    await sleep(interval);
   }
 
   return result;


### PR DESCRIPTION
Hopefully this can make the E2E tests pass in the ADO pipeline.