### PR TITLE
Fixed baseline script

### DIFF
--- a/SetBaseline.ps1
+++ b/SetBaseline.ps1
@@ -1,1 +1,1 @@
-dotnet test -- 'TestRunParameters.Parameter(name=\\\"SetBaseLine\\\", value=\\\"true\\\")'
+dotnet test -- 'TestRunParameters.Parameter(name=\"SetBaseLine\", value=\"true\")'


### PR DESCRIPTION
This script originally worked for me but it now stopped working on the same machine due to the following error:

```
The test run parameter argument 'TestRunParameters.Parameter(name=\"SetBaseLine\", value=\"true\")' is invalid. Please use the format below.
     Format: TestRunParameters.Parameter(name=\"<name>\", value=\"<value>\")
```

Removing the extra escaping fixed the issue although I am baffled why the behavior has changed. Perhaps .net 5 changed something here?