### PR TITLE
E2E tests are now working in the ADO pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,11 +175,16 @@ jobs:
         run: npm run test:e2e
         if: runner.os != 'Linux'
         working-directory: ./src/vscode-bicep
-        
+
       # In headless Linux CI machines xvfb is required to run VS Code, so need a separate path for Linux.
       - name: Run E2E tests (Linux)
         run: xvfb-run -a npm run test:e2e
         if: runner.os == 'Linux'
+        working-directory: ./src/vscode-bicep
+
+      - name: Show extension logs of E2E tests
+        run: cat ./bicep.log
+        if: ${{ always() }}
         working-directory: ./src/vscode-bicep
 
       - name: Upload Code Coverage

--- a/.pipelines/Common.yml
+++ b/.pipelines/Common.yml
@@ -115,7 +115,12 @@ stages:
       workingDirectory: $(Build.SourcesDirectory)/src/vscode-bicep
       env:
         DISPLAY: ':99.0'
-    
+
+    - script: cat ./bicep.log
+      displayName: Show extension logs of E2E tests
+      condition: always()
+      workingDirectory: $(Build.SourcesDirectory)/src/vscode-bicep
+
     - script: killall Xvfb
       displayName: Kill Xvfb
 

--- a/src/vscode-bicep/.vscode/launch.json
+++ b/src/vscode-bicep/.vscode/launch.json
@@ -31,7 +31,8 @@
       "outFiles": ["${workspaceRoot}/out/test/e2e/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}",
       "env": {
-        "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net5.0/Bicep.LangServer.dll"
+        "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net5.0/Bicep.LangServer.dll",
+        "NODE_ENV": "test"
       }
     }
   ]

--- a/src/vscode-bicep/.vscodeignore
+++ b/src/vscode-bicep/.vscodeignore
@@ -11,3 +11,4 @@ tsconfig.json
 gulpfile.js
 jest.config.*.js
 vsc-extension-quickstart.md
+bicep.log

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -91,6 +91,8 @@ async function launchLanguageService(
 }
 
 async function ensureDotnetRuntimeInstalled(): Promise<string> {
+  getLogger().info("Acquiring dotnet runtime...");
+
   const result = await vscode.commands.executeCommand<{ dotnetPath: string }>(
     "dotnet.acquire",
     {
@@ -100,7 +102,10 @@ async function ensureDotnetRuntimeInstalled(): Promise<string> {
   );
 
   if (!result) {
-    throw new Error(`Failed to install .NET runtime v${dotnetRuntimeVersion}.`);
+    const errorMessage = `Failed to install .NET runtime v${dotnetRuntimeVersion}.`;
+
+    getLogger().error(errorMessage);
+    throw new Error(errorMessage);
   }
 
   return path.resolve(result.dotnetPath);

--- a/src/vscode-bicep/src/test/unit/logger.test.ts
+++ b/src/vscode-bicep/src/test/unit/logger.test.ts
@@ -8,6 +8,9 @@ jest.mock("winston", () => ({
     errors: jest.fn(),
     printf: jest.fn(),
   },
+  transports: {
+    File: jest.fn(),
+  },
 }));
 
 import * as vscode from "vscode";


### PR DESCRIPTION
It turns out we need to pass `--user-data-dir` a relative path. I also added a CI step to show extension logs after the e2e tests step to make it easier to debug.