### PR TITLE
removed nullness overrides in tests

### DIFF
--- a/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.IntegrationTests.PrettyPrint
             var formattedOutput = PrettyPrinter.PrintProgram(program, options);
             formattedOutput.Should().NotBeNull();
 
-            var resultsFile = FileHelper.SaveResultFile(this.TestContext!, Path.Combine(dataSet.Name, DataSet.TestFileMainFormatted), formattedOutput!);
+            var resultsFile = FileHelper.SaveResultFile(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainFormatted), formattedOutput!);
 
             formattedOutput.Should().EqualWithLineByLineDiffOutput(
                 TestContext, 

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -41,12 +41,12 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task EmptyFileShouldProduceDeclarationCompletions()
         {
             const string expectedSetName = "declarations";
-            var uri = DocumentUri.From($"/{this.TestContext!.TestName}");
+            var uri = DocumentUri.From($"/{this.TestContext.TestName}");
 
             using var client = await IntegrationTestHelper.StartServerWithTextAsync(string.Empty, uri);
 
             var actual = await GetActualCompletions(client, uri, new Position(0, 0));
-            var actualLocation = FileHelper.SaveResultFile(this.TestContext!, $"{this.TestContext.TestName}_{expectedSetName}", actual.ToString(Formatting.Indented));
+            var actualLocation = FileHelper.SaveResultFile(this.TestContext, $"{this.TestContext.TestName}_{expectedSetName}", actual.ToString(Formatting.Indented));
             
             var expectedStr = DataSets.Completions.TryGetValue(GetFullSetName(expectedSetName));
             if (expectedStr == null)
@@ -116,7 +116,7 @@ namespace Bicep.LangServer.IntegrationTests
             }
 
             var actual = JToken.Parse(single.Key);
-            var actualLocation = FileHelper.SaveResultFile(this.TestContext!, $"{dataSet.Name}_{setName}_Actual.json", actual.ToString(Formatting.Indented));
+            var actualLocation = FileHelper.SaveResultFile(this.TestContext, $"{dataSet.Name}_{setName}_Actual.json", actual.ToString(Formatting.Indented));
 
             var expected = expectedInfo.Value.content;
             var expectedLocation = expectedInfo.Value.scope switch

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Syntax;
@@ -25,6 +26,7 @@ namespace Bicep.LangServer.UnitTests
     {
         private static readonly MockRepository Repository = new MockRepository(MockBehavior.Strict);
 
+        [NotNull]
         public TestContext? TestContext { get; set; }
 
         private static IFileResolver CreateEmptyFileResolver()
@@ -42,7 +44,7 @@ namespace Bicep.LangServer.UnitTests
             var manager = new BicepCompilationManager(server.Object, new BicepCompilationProvider(TestResourceTypeProvider.Create(), CreateEmptyFileResolver()), new Workspace());
 
             const int version = 42;
-            var uri = DocumentUri.File(this.TestContext!.TestName);
+            var uri = DocumentUri.File(this.TestContext.TestName);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -86,7 +88,7 @@ namespace Bicep.LangServer.UnitTests
             var manager = new BicepCompilationManager(server.Object, new BicepCompilationProvider(TestResourceTypeProvider.Create(), CreateEmptyFileResolver()), new Workspace());
 
             const int version = 42;
-            var uri = DocumentUri.File(this.TestContext!.TestName);
+            var uri = DocumentUri.File(this.TestContext.TestName);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -153,7 +155,7 @@ namespace Bicep.LangServer.UnitTests
             var manager = new BicepCompilationManager(server.Object, new BicepCompilationProvider(TestResourceTypeProvider.Create(), CreateEmptyFileResolver()), new Workspace());
 
             const int version = 42;
-            var uri = DocumentUri.File(this.TestContext!.TestName);
+            var uri = DocumentUri.File(this.TestContext.TestName);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -215,7 +217,7 @@ namespace Bicep.LangServer.UnitTests
 
             var manager = new BicepCompilationManager(server.Object, new BicepCompilationProvider(TestResourceTypeProvider.Create(), CreateEmptyFileResolver()), new Workspace());
 
-            var uri = DocumentUri.File(this.TestContext!.TestName);
+            var uri = DocumentUri.File(this.TestContext.TestName);
 
             manager.GetCompilation(uri).Should().BeNull();
         }
@@ -231,7 +233,7 @@ namespace Bicep.LangServer.UnitTests
 
             var manager = new BicepCompilationManager(server.Object, new BicepCompilationProvider(TestResourceTypeProvider.Create(), CreateEmptyFileResolver()), new Workspace());
 
-            var uri = DocumentUri.File(this.TestContext!.TestName);
+            var uri = DocumentUri.File(this.TestContext.TestName);
 
             manager.CloseCompilation(uri);
 
@@ -264,7 +266,7 @@ namespace Bicep.LangServer.UnitTests
             var manager = new BicepCompilationManager(server.Object, provider.Object, new Workspace());
 
             const int version = 74;
-            var uri = DocumentUri.File(this.TestContext!.TestName);
+            var uri = DocumentUri.File(this.TestContext.TestName);
 
             // upsert should fail because of the mock fatal exception
             manager.UpsertCompilation(uri, version, "fake");
@@ -312,7 +314,7 @@ namespace Bicep.LangServer.UnitTests
             const string expectedMessage = "Internal bicep exception.";
 
             const int version = 74;
-            var uri = DocumentUri.File(this.TestContext!.TestName);
+            var uri = DocumentUri.File(this.TestContext.TestName);
             
             // start by failing
             bool failUpsert = true;


### PR DESCRIPTION
While working on something else, I found some unnecessary nullness overrides on `TestContext` in a few of our tests. With the `NotNull` annotation, they are no longer necessary, so I removed them to prevent them from spreading via copy/paste in the future.