### PR TITLE
Fixed functions signatures in vararg functions

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Semantics/NamespaceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/NamespaceTests.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Bicep.Core.Extensions;
+using Bicep.Core.Samples;
+using Bicep.Core.Semantics;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.IntegrationTests.Semantics
+{
+    [TestClass]
+    public class NamespaceTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetNamespaces), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetDisplayName))]
+        public void FunctionsShouldHaveExpectedSignatures(NamespaceSymbol @namespace)
+        {
+            var knownOverloads = @namespace.Type.MethodResolver.GetKnownFunctions().Values
+                .SelectMany(function => function.Overloads)
+                .OrderBy(overload => overload.Name)
+                .Select(Convert);
+
+            var actual = JToken.FromObject(knownOverloads, DataSetSerialization.CreateSerializer());
+            var actualLocation = FileHelper.SaveResultFile(this.TestContext, $"{this.TestContext.TestName}_{@namespace.Name}.json", actual.ToString(Formatting.Indented));
+
+            var fileName = $"{@namespace.Name}.json";
+            
+            var expectedStr = DataSets.Functions.TryGetValue(fileName);
+            if (expectedStr == null)
+            {
+                throw new AssertFailedException($"The function baseline file for namespace '{@namespace.Name}' does not exist.");
+            }
+
+            var expected = JToken.Parse(expectedStr);
+            var expectedPath = Path.Combine("src", "Bicep.Core.Samples", "Files", DataSet.TestFunctionsDirectory, fileName);
+            actual.Should().EqualWithJsonDiffOutput(TestContext, expected, expectedPath, actualLocation);
+        }
+
+        private static IEnumerable<object[]> GetNamespaces()
+        {
+            // local function
+            static object[] CreateRow(NamespaceSymbol @namespace) => new object[] {@namespace};
+
+            var compilation = CompilationHelper.CreateCompilation(new TestResourceTypeProvider(), ("main.bicep", string.Empty));
+
+            return compilation.GetEntrypointSemanticModel().Root.ImportedNamespaces.Values.Select(CreateRow);
+        }
+
+        public static string GetDisplayName(MethodInfo info, object[] data)
+        {
+            data.Should().HaveCount(1);
+            var candiddate = data.Single();
+            candiddate.Should().BeAssignableTo<NamespaceSymbol>();
+
+            return $"{info.Name}_{((NamespaceSymbol) candiddate).Name}";
+        }
+
+        private OverloadItem Convert(FunctionOverload overload) =>
+            new OverloadItem(
+                overload.Name,
+                overload.FixedParameterTypes.Select(type => type.Name).ToImmutableArray(),
+                overload.MinimumArgumentCount,
+                overload.MaximumArgumentCount,
+                overload.VariableParameterType?.Name,
+                overload.Flags,
+                overload.TypeSignature,
+                overload.ParameterTypeSignatures);
+
+        private record OverloadItem(
+            string Name,
+            ImmutableArray<string> FixedParameterTypes,
+            int MinimumArgumentCount,
+            int? MaximumArgumentCount,
+            string? VariableParameterType,
+            FunctionFlags Flags,
+            string TypeSignature,
+            ImmutableArray<string> ParameterTypeSignatures);
+    }
+}

--- a/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
@@ -176,23 +176,6 @@ namespace Bicep.Core.IntegrationTests.Semantics
         }
 
         private static IEnumerable<object[]> GetData() => DataSets.AllDataSets.ToDynamicTestData();
-
-        private static bool FilterSymbol(Symbol symbol)
-        {
-            switch (symbol.Kind)
-            {
-                // namespace and function symbols don't have locations
-                // type symbols will have their own tests
-                case SymbolKind.Namespace:
-                case SymbolKind.Function:
-                case SymbolKind.Type:
-                    return false;
-
-                // allow everything else
-                default:
-                    return true;
-            }
-        }
     }
 }
 

--- a/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
+++ b/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
@@ -22,12 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Files\InvalidResources_CRLF\Completions\cliPropertyAccessIndexesPlusSymbols.json">
-      <LogicalName>$([System.String]::new('Bicep.Core.Samples/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/src/Bicep.Core.Samples/DataSet.cs
+++ b/src/Bicep.Core.Samples/DataSet.cs
@@ -25,8 +25,10 @@ namespace Bicep.Core.Samples
         public const string TestFileMainSyntax = "main.syntax.bicep";
         public const string TestFileMainFormatted = "main.formatted.bicep";
         public const string TestFileMainCompiled = "main.json";
-        public const string TestCompletionsPrefix = TestCompletionsDirectory + "/";
         public const string TestCompletionsDirectory = "Completions";
+        public const string TestCompletionsPrefix = TestCompletionsDirectory + "/";
+        public const string TestFunctionsDirectory = "Functions";
+        public const string TestFunctionsPrefix = TestFunctionsDirectory + "/";
 
         public static readonly string Prefix = typeof(DataSet).Namespace == null ? string.Empty : typeof(DataSet).Namespace + '/';
 

--- a/src/Bicep.Core.Samples/DataSets.cs
+++ b/src/Bicep.Core.Samples/DataSets.cs
@@ -57,6 +57,8 @@ namespace Bicep.Core.Samples
 
         public static ImmutableDictionary<string, string> Completions => DataSet.ReadDataSetDictionary($"{DataSet.Prefix}{DataSet.TestCompletionsPrefix}");
 
+        public static ImmutableDictionary<string, string> Functions => DataSet.ReadDataSetDictionary($"{DataSet.Prefix}{DataSet.TestFunctionsPrefix}");
+
         private static DataSet CreateDataSet([CallerMemberName] string? dataSetName = null) => new DataSet(dataSetName!);
     }
 }

--- a/src/Bicep.Core.Samples/Files/Functions/az.json
+++ b/src/Bicep.Core.Samples/Files/Functions/az.json
@@ -27,12 +27,12 @@
     "minimumArgumentCount": 3,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, param1: string, param2: string, ...rest: string[]): string",
+    "typeSignature": "(param0: string, param1: string, param2: string, ... : string): string",
     "parameterTypeSignatures": [
       "param0: string",
       "param1: string",
       "param2: string",
-      "...rest: string[]"
+      "... : string"
     ]
   },
   {
@@ -134,11 +134,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, param1: string, ...rest: string[]): string",
+    "typeSignature": "(param0: string, param1: string, ... : string): string",
     "parameterTypeSignatures": [
       "param0: string",
       "param1: string",
-      "...rest: string[]"
+      "... : string"
     ]
   },
   {
@@ -172,11 +172,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, param1: string, ...rest: string[]): string",
+    "typeSignature": "(param0: string, param1: string, ... : string): string",
     "parameterTypeSignatures": [
       "param0: string",
       "param1: string",
-      "...rest: string[]"
+      "... : string"
     ]
   },
   {
@@ -197,11 +197,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, param1: string, ...rest: string[]): string",
+    "typeSignature": "(param0: string, param1: string, ... : string): string",
     "parameterTypeSignatures": [
       "param0: string",
       "param1: string",
-      "...rest: string[]"
+      "... : string"
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/Functions/az.json
+++ b/src/Bicep.Core.Samples/Files/Functions/az.json
@@ -1,0 +1,203 @@
+[
+  {
+    "name": "deployment",
+    "fixedParameterTypes": [],
+    "minimumArgumentCount": 0,
+    "maximumArgumentCount": 0,
+    "flags": "default",
+    "typeSignature": "(): deployment",
+    "parameterTypeSignatures": []
+  },
+  {
+    "name": "environment",
+    "fixedParameterTypes": [],
+    "minimumArgumentCount": 0,
+    "maximumArgumentCount": 0,
+    "flags": "default",
+    "typeSignature": "(): environment",
+    "parameterTypeSignatures": []
+  },
+  {
+    "name": "extensionResourceId",
+    "fixedParameterTypes": [
+      "string",
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 3,
+    "variableParameterType": "string",
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string, param2: string): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string",
+      "param2: string"
+    ]
+  },
+  {
+    "name": "pickZones",
+    "fixedParameterTypes": [
+      "string",
+      "string",
+      "string",
+      "int",
+      "int"
+    ],
+    "minimumArgumentCount": 3,
+    "maximumArgumentCount": 5,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string, param2: string, param3: int, param4: int): array",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string",
+      "param2: string",
+      "param3: int",
+      "param4: int"
+    ]
+  },
+  {
+    "name": "providers",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): array",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "reference",
+    "fixedParameterTypes": [
+      "string",
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 3,
+    "flags": "requiresInlining",
+    "typeSignature": "(param0: string, param1: string, param2: string): object",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string",
+      "param2: string"
+    ]
+  },
+  {
+    "name": "resourceGroup",
+    "fixedParameterTypes": [],
+    "minimumArgumentCount": 0,
+    "maximumArgumentCount": 0,
+    "flags": "default",
+    "typeSignature": "(): resourceGroup",
+    "parameterTypeSignatures": []
+  },
+  {
+    "name": "resourceGroup",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): resourceGroup",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "resourceGroup",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): resourceGroup",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "resourceId",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "variableParameterType": "string",
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "subscription",
+    "fixedParameterTypes": [],
+    "minimumArgumentCount": 0,
+    "maximumArgumentCount": 0,
+    "flags": "default",
+    "typeSignature": "(): subscription",
+    "parameterTypeSignatures": []
+  },
+  {
+    "name": "subscription",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): subscription",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "subscriptionResourceId",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "variableParameterType": "string",
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "tenant",
+    "fixedParameterTypes": [],
+    "minimumArgumentCount": 0,
+    "maximumArgumentCount": 0,
+    "flags": "default",
+    "typeSignature": "(): tenant",
+    "parameterTypeSignatures": []
+  },
+  {
+    "name": "tenantResourceId",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "variableParameterType": "string",
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/Files/Functions/az.json
+++ b/src/Bicep.Core.Samples/Files/Functions/az.json
@@ -27,11 +27,12 @@
     "minimumArgumentCount": 3,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, param1: string, param2: string): string",
+    "typeSignature": "(param0: string, param1: string, param2: string, ...rest: string[]): string",
     "parameterTypeSignatures": [
       "param0: string",
       "param1: string",
-      "param2: string"
+      "param2: string",
+      "...rest: string[]"
     ]
   },
   {
@@ -133,10 +134,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, param1: string): string",
+    "typeSignature": "(param0: string, param1: string, ...rest: string[]): string",
     "parameterTypeSignatures": [
       "param0: string",
-      "param1: string"
+      "param1: string",
+      "...rest: string[]"
     ]
   },
   {
@@ -170,10 +172,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, param1: string): string",
+    "typeSignature": "(param0: string, param1: string, ...rest: string[]): string",
     "parameterTypeSignatures": [
       "param0: string",
-      "param1: string"
+      "param1: string",
+      "...rest: string[]"
     ]
   },
   {
@@ -194,10 +197,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, param1: string): string",
+    "typeSignature": "(param0: string, param1: string, ...rest: string[]): string",
     "parameterTypeSignatures": [
       "param0: string",
-      "param1: string"
+      "param1: string",
+      "...rest: string[]"
     ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/Functions/sys.json
@@ -85,9 +85,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "any",
     "flags": "default",
-    "typeSignature": "(param0: any): any",
+    "typeSignature": "(param0: any, ...rest: any[]): any",
     "parameterTypeSignatures": [
-      "param0: any"
+      "param0: any",
+      "...rest: any[]"
     ]
   },
   {
@@ -98,9 +99,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "array",
     "flags": "default",
-    "typeSignature": "(param0: array): array",
+    "typeSignature": "(param0: array, ...rest: array[]): array",
     "parameterTypeSignatures": [
-      "param0: array"
+      "param0: array",
+      "...rest: array[]"
     ]
   },
   {
@@ -111,9 +113,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "bool | int | string",
     "flags": "default",
-    "typeSignature": "(param0: bool | int | string): string",
+    "typeSignature": "(param0: bool | int | string, ...rest: (bool | int | string)[]): string",
     "parameterTypeSignatures": [
-      "param0: bool | int | string"
+      "param0: bool | int | string",
+      "...rest: (bool | int | string)[]"
     ]
   },
   {
@@ -266,9 +269,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "any",
     "flags": "default",
-    "typeSignature": "(param0: string): string",
+    "typeSignature": "(param0: string, ...rest: any[]): string",
     "parameterTypeSignatures": [
-      "param0: string"
+      "param0: string",
+      "...rest: any[]"
     ]
   },
   {
@@ -279,9 +283,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string): string",
+    "typeSignature": "(param0: string, ...rest: string[]): string",
     "parameterTypeSignatures": [
-      "param0: string"
+      "param0: string",
+      "...rest: string[]"
     ]
   },
   {
@@ -321,10 +326,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "object",
     "flags": "default",
-    "typeSignature": "(param0: object, param1: object): object",
+    "typeSignature": "(param0: object, param1: object, ...rest: object[]): object",
     "parameterTypeSignatures": [
       "param0: object",
-      "param1: object"
+      "param1: object",
+      "...rest: object[]"
     ]
   },
   {
@@ -336,10 +342,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "array",
     "flags": "default",
-    "typeSignature": "(param0: array, param1: array): array",
+    "typeSignature": "(param0: array, param1: array, ...rest: array[]): array",
     "parameterTypeSignatures": [
       "param0: array",
-      "param1: array"
+      "param1: array",
+      "...rest: array[]"
     ]
   },
   {
@@ -417,9 +424,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "int",
     "flags": "default",
-    "typeSignature": "(param0: int): int",
+    "typeSignature": "(param0: int, ...rest: int[]): int",
     "parameterTypeSignatures": [
-      "param0: int"
+      "param0: int",
+      "...rest: int[]"
     ]
   },
   {
@@ -443,9 +451,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "int",
     "flags": "default",
-    "typeSignature": "(param0: int): int",
+    "typeSignature": "(param0: int, ...rest: int[]): int",
     "parameterTypeSignatures": [
-      "param0: int"
+      "param0: int",
+      "...rest: int[]"
     ]
   },
   {
@@ -687,10 +696,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "object",
     "flags": "default",
-    "typeSignature": "(param0: object, param1: object): object",
+    "typeSignature": "(param0: object, param1: object, ...rest: object[]): object",
     "parameterTypeSignatures": [
       "param0: object",
-      "param1: object"
+      "param1: object",
+      "...rest: object[]"
     ]
   },
   {
@@ -702,10 +712,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "array",
     "flags": "default",
-    "typeSignature": "(param0: array, param1: array): array",
+    "typeSignature": "(param0: array, param1: array, ...rest: array[]): array",
     "parameterTypeSignatures": [
       "param0: array",
-      "param1: array"
+      "param1: array",
+      "...rest: array[]"
     ]
   },
   {
@@ -716,9 +727,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string): string",
+    "typeSignature": "(param0: string, ...rest: string[]): string",
     "parameterTypeSignatures": [
-      "param0: string"
+      "param0: string",
+      "...rest: string[]"
     ]
   },
   {

--- a/src/Bicep.Core.Samples/Files/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/Functions/sys.json
@@ -1,0 +1,778 @@
+[
+  {
+    "name": "any",
+    "fixedParameterTypes": [
+      "any"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: any): any",
+    "parameterTypeSignatures": [
+      "param0: any"
+    ]
+  },
+  {
+    "name": "array",
+    "fixedParameterTypes": [
+      "any"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: any): array",
+    "parameterTypeSignatures": [
+      "param0: any"
+    ]
+  },
+  {
+    "name": "base64",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "base64ToJson",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): any",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "base64ToString",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "bool",
+    "fixedParameterTypes": [
+      "any"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: any): bool",
+    "parameterTypeSignatures": [
+      "param0: any"
+    ]
+  },
+  {
+    "name": "coalesce",
+    "fixedParameterTypes": [
+      "any"
+    ],
+    "minimumArgumentCount": 1,
+    "variableParameterType": "any",
+    "flags": "default",
+    "typeSignature": "(param0: any): any",
+    "parameterTypeSignatures": [
+      "param0: any"
+    ]
+  },
+  {
+    "name": "concat",
+    "fixedParameterTypes": [
+      "array"
+    ],
+    "minimumArgumentCount": 1,
+    "variableParameterType": "array",
+    "flags": "default",
+    "typeSignature": "(param0: array): array",
+    "parameterTypeSignatures": [
+      "param0: array"
+    ]
+  },
+  {
+    "name": "concat",
+    "fixedParameterTypes": [
+      "bool | int | string"
+    ],
+    "minimumArgumentCount": 1,
+    "variableParameterType": "bool | int | string",
+    "flags": "default",
+    "typeSignature": "(param0: bool | int | string): string",
+    "parameterTypeSignatures": [
+      "param0: bool | int | string"
+    ]
+  },
+  {
+    "name": "contains",
+    "fixedParameterTypes": [
+      "object",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: object, param1: string): bool",
+    "parameterTypeSignatures": [
+      "param0: object",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "contains",
+    "fixedParameterTypes": [
+      "array",
+      "any"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: array, param1: any): bool",
+    "parameterTypeSignatures": [
+      "param0: array",
+      "param1: any"
+    ]
+  },
+  {
+    "name": "contains",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): bool",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "dataUri",
+    "fixedParameterTypes": [
+      "any"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: any): string",
+    "parameterTypeSignatures": [
+      "param0: any"
+    ]
+  },
+  {
+    "name": "dataUriToString",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "dateTimeAdd",
+    "fixedParameterTypes": [
+      "string",
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 3,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string, param2: string): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string",
+      "param2: string"
+    ]
+  },
+  {
+    "name": "empty",
+    "fixedParameterTypes": [
+      "array | null | object | string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: array | null | object | string): bool",
+    "parameterTypeSignatures": [
+      "param0: array | null | object | string"
+    ]
+  },
+  {
+    "name": "endsWith",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): bool",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "first",
+    "fixedParameterTypes": [
+      "array"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: array): any",
+    "parameterTypeSignatures": [
+      "param0: array"
+    ]
+  },
+  {
+    "name": "first",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "format",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "variableParameterType": "any",
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "guid",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "variableParameterType": "string",
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "indexOf",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): int",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "int",
+    "fixedParameterTypes": [
+      "int | string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: int | string): int",
+    "parameterTypeSignatures": [
+      "param0: int | string"
+    ]
+  },
+  {
+    "name": "intersection",
+    "fixedParameterTypes": [
+      "object",
+      "object"
+    ],
+    "minimumArgumentCount": 2,
+    "variableParameterType": "object",
+    "flags": "default",
+    "typeSignature": "(param0: object, param1: object): object",
+    "parameterTypeSignatures": [
+      "param0: object",
+      "param1: object"
+    ]
+  },
+  {
+    "name": "intersection",
+    "fixedParameterTypes": [
+      "array",
+      "array"
+    ],
+    "minimumArgumentCount": 2,
+    "variableParameterType": "array",
+    "flags": "default",
+    "typeSignature": "(param0: array, param1: array): array",
+    "parameterTypeSignatures": [
+      "param0: array",
+      "param1: array"
+    ]
+  },
+  {
+    "name": "json",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): any",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "last",
+    "fixedParameterTypes": [
+      "array"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: array): any",
+    "parameterTypeSignatures": [
+      "param0: array"
+    ]
+  },
+  {
+    "name": "last",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "lastIndexOf",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): int",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "length",
+    "fixedParameterTypes": [
+      "array | object | string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: array | object | string): int",
+    "parameterTypeSignatures": [
+      "param0: array | object | string"
+    ]
+  },
+  {
+    "name": "max",
+    "fixedParameterTypes": [
+      "int"
+    ],
+    "minimumArgumentCount": 1,
+    "variableParameterType": "int",
+    "flags": "default",
+    "typeSignature": "(param0: int): int",
+    "parameterTypeSignatures": [
+      "param0: int"
+    ]
+  },
+  {
+    "name": "max",
+    "fixedParameterTypes": [
+      "array"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: array): int",
+    "parameterTypeSignatures": [
+      "param0: array"
+    ]
+  },
+  {
+    "name": "min",
+    "fixedParameterTypes": [
+      "int"
+    ],
+    "minimumArgumentCount": 1,
+    "variableParameterType": "int",
+    "flags": "default",
+    "typeSignature": "(param0: int): int",
+    "parameterTypeSignatures": [
+      "param0: int"
+    ]
+  },
+  {
+    "name": "min",
+    "fixedParameterTypes": [
+      "array"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: array): int",
+    "parameterTypeSignatures": [
+      "param0: array"
+    ]
+  },
+  {
+    "name": "newGuid",
+    "fixedParameterTypes": [],
+    "minimumArgumentCount": 0,
+    "maximumArgumentCount": 0,
+    "flags": "paramDefaultsOnly",
+    "typeSignature": "(): string",
+    "parameterTypeSignatures": []
+  },
+  {
+    "name": "padLeft",
+    "fixedParameterTypes": [
+      "int | string",
+      "int",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 3,
+    "flags": "default",
+    "typeSignature": "(param0: int | string, param1: int, param2: string): string",
+    "parameterTypeSignatures": [
+      "param0: int | string",
+      "param1: int",
+      "param2: string"
+    ]
+  },
+  {
+    "name": "range",
+    "fixedParameterTypes": [
+      "int",
+      "int"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: int, param1: int): array",
+    "parameterTypeSignatures": [
+      "param0: int",
+      "param1: int"
+    ]
+  },
+  {
+    "name": "replace",
+    "fixedParameterTypes": [
+      "string",
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 3,
+    "maximumArgumentCount": 3,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string, param2: string): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string",
+      "param2: string"
+    ]
+  },
+  {
+    "name": "skip",
+    "fixedParameterTypes": [
+      "array",
+      "int"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: array, param1: int): array",
+    "parameterTypeSignatures": [
+      "param0: array",
+      "param1: int"
+    ]
+  },
+  {
+    "name": "skip",
+    "fixedParameterTypes": [
+      "string",
+      "int"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: int): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: int"
+    ]
+  },
+  {
+    "name": "split",
+    "fixedParameterTypes": [
+      "string",
+      "array | string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: array | string): array",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: array | string"
+    ]
+  },
+  {
+    "name": "startsWith",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): bool",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "string",
+    "fixedParameterTypes": [
+      "any"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: any): string",
+    "parameterTypeSignatures": [
+      "param0: any"
+    ]
+  },
+  {
+    "name": "substring",
+    "fixedParameterTypes": [
+      "string",
+      "int",
+      "int"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 3,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: int, param2: int): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: int",
+      "param2: int"
+    ]
+  },
+  {
+    "name": "take",
+    "fixedParameterTypes": [
+      "array",
+      "int"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: array, param1: int): array",
+    "parameterTypeSignatures": [
+      "param0: array",
+      "param1: int"
+    ]
+  },
+  {
+    "name": "take",
+    "fixedParameterTypes": [
+      "string",
+      "int"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: int): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: int"
+    ]
+  },
+  {
+    "name": "toLower",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "toUpper",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "trim",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "union",
+    "fixedParameterTypes": [
+      "object",
+      "object"
+    ],
+    "minimumArgumentCount": 2,
+    "variableParameterType": "object",
+    "flags": "default",
+    "typeSignature": "(param0: object, param1: object): object",
+    "parameterTypeSignatures": [
+      "param0: object",
+      "param1: object"
+    ]
+  },
+  {
+    "name": "union",
+    "fixedParameterTypes": [
+      "array",
+      "array"
+    ],
+    "minimumArgumentCount": 2,
+    "variableParameterType": "array",
+    "flags": "default",
+    "typeSignature": "(param0: array, param1: array): array",
+    "parameterTypeSignatures": [
+      "param0: array",
+      "param1: array"
+    ]
+  },
+  {
+    "name": "uniqueString",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "variableParameterType": "string",
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "uri",
+    "fixedParameterTypes": [
+      "string",
+      "string"
+    ],
+    "minimumArgumentCount": 2,
+    "maximumArgumentCount": 2,
+    "flags": "default",
+    "typeSignature": "(param0: string, param1: string): string",
+    "parameterTypeSignatures": [
+      "param0: string",
+      "param1: string"
+    ]
+  },
+  {
+    "name": "uriComponent",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "uriComponentToString",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  },
+  {
+    "name": "utcNow",
+    "fixedParameterTypes": [
+      "string"
+    ],
+    "minimumArgumentCount": 0,
+    "maximumArgumentCount": 1,
+    "flags": "paramDefaultsOnly",
+    "typeSignature": "(param0: string): string",
+    "parameterTypeSignatures": [
+      "param0: string"
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/Files/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/Functions/sys.json
@@ -85,10 +85,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "any",
     "flags": "default",
-    "typeSignature": "(param0: any, ...rest: any[]): any",
+    "typeSignature": "(param0: any, ... : any): any",
     "parameterTypeSignatures": [
       "param0: any",
-      "...rest: any[]"
+      "... : any"
     ]
   },
   {
@@ -99,10 +99,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "array",
     "flags": "default",
-    "typeSignature": "(param0: array, ...rest: array[]): array",
+    "typeSignature": "(param0: array, ... : array): array",
     "parameterTypeSignatures": [
       "param0: array",
-      "...rest: array[]"
+      "... : array"
     ]
   },
   {
@@ -113,10 +113,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "bool | int | string",
     "flags": "default",
-    "typeSignature": "(param0: bool | int | string, ...rest: (bool | int | string)[]): string",
+    "typeSignature": "(param0: bool | int | string, ... : bool | int | string): string",
     "parameterTypeSignatures": [
       "param0: bool | int | string",
-      "...rest: (bool | int | string)[]"
+      "... : bool | int | string"
     ]
   },
   {
@@ -269,10 +269,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "any",
     "flags": "default",
-    "typeSignature": "(param0: string, ...rest: any[]): string",
+    "typeSignature": "(param0: string, ... : any): string",
     "parameterTypeSignatures": [
       "param0: string",
-      "...rest: any[]"
+      "... : any"
     ]
   },
   {
@@ -283,10 +283,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, ...rest: string[]): string",
+    "typeSignature": "(param0: string, ... : string): string",
     "parameterTypeSignatures": [
       "param0: string",
-      "...rest: string[]"
+      "... : string"
     ]
   },
   {
@@ -326,11 +326,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "object",
     "flags": "default",
-    "typeSignature": "(param0: object, param1: object, ...rest: object[]): object",
+    "typeSignature": "(param0: object, param1: object, ... : object): object",
     "parameterTypeSignatures": [
       "param0: object",
       "param1: object",
-      "...rest: object[]"
+      "... : object"
     ]
   },
   {
@@ -342,11 +342,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "array",
     "flags": "default",
-    "typeSignature": "(param0: array, param1: array, ...rest: array[]): array",
+    "typeSignature": "(param0: array, param1: array, ... : array): array",
     "parameterTypeSignatures": [
       "param0: array",
       "param1: array",
-      "...rest: array[]"
+      "... : array"
     ]
   },
   {
@@ -424,10 +424,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "int",
     "flags": "default",
-    "typeSignature": "(param0: int, ...rest: int[]): int",
+    "typeSignature": "(param0: int, ... : int): int",
     "parameterTypeSignatures": [
       "param0: int",
-      "...rest: int[]"
+      "... : int"
     ]
   },
   {
@@ -451,10 +451,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "int",
     "flags": "default",
-    "typeSignature": "(param0: int, ...rest: int[]): int",
+    "typeSignature": "(param0: int, ... : int): int",
     "parameterTypeSignatures": [
       "param0: int",
-      "...rest: int[]"
+      "... : int"
     ]
   },
   {
@@ -696,11 +696,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "object",
     "flags": "default",
-    "typeSignature": "(param0: object, param1: object, ...rest: object[]): object",
+    "typeSignature": "(param0: object, param1: object, ... : object): object",
     "parameterTypeSignatures": [
       "param0: object",
       "param1: object",
-      "...rest: object[]"
+      "... : object"
     ]
   },
   {
@@ -712,11 +712,11 @@
     "minimumArgumentCount": 2,
     "variableParameterType": "array",
     "flags": "default",
-    "typeSignature": "(param0: array, param1: array, ...rest: array[]): array",
+    "typeSignature": "(param0: array, param1: array, ... : array): array",
     "parameterTypeSignatures": [
       "param0: array",
       "param1: array",
-      "...rest: array[]"
+      "... : array"
     ]
   },
   {
@@ -727,10 +727,10 @@
     "minimumArgumentCount": 1,
     "variableParameterType": "string",
     "flags": "default",
-    "typeSignature": "(param0: string, ...rest: string[]): string",
+    "typeSignature": "(param0: string, ... : string): string",
     "parameterTypeSignatures": [
       "param0: string",
-      "...rest: string[]"
+      "... : string"
     ]
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
@@ -249,7 +249,7 @@ var takeTooMany = take([
 
 // wrong argument types
 var concatWrongTypes = concat({
-//@[30:33) [BCP048 (Error)] Cannot resolve function overload.\n  Overload 1 of 2, "(param0: array): array", gave the following error:\n    Argument of type "object" is not assignable to parameter of type "array".\n  Overload 2 of 2, "(param0: bool | int | string): string", gave the following error:\n    Argument of type "object" is not assignable to parameter of type "bool | int | string". |{\n}|
+//@[30:33) [BCP048 (Error)] Cannot resolve function overload.\n  Overload 1 of 2, "(param0: array, ...rest: array[]): array", gave the following error:\n    Argument of type "object" is not assignable to parameter of type "array".\n  Overload 2 of 2, "(param0: bool | int | string, ...rest: (bool | int | string)[]): string", gave the following error:\n    Argument of type "object" is not assignable to parameter of type "bool | int | string". |{\n}|
 })
 var concatWrongTypesContradiction = concat('s', [
 //@[48:51) [BCP070 (Error)] Argument of type "array" is not assignable to parameter of type "bool | int | string". |[\n]|

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
@@ -249,7 +249,7 @@ var takeTooMany = take([
 
 // wrong argument types
 var concatWrongTypes = concat({
-//@[30:33) [BCP048 (Error)] Cannot resolve function overload.\n  Overload 1 of 2, "(param0: array, ...rest: array[]): array", gave the following error:\n    Argument of type "object" is not assignable to parameter of type "array".\n  Overload 2 of 2, "(param0: bool | int | string, ...rest: (bool | int | string)[]): string", gave the following error:\n    Argument of type "object" is not assignable to parameter of type "bool | int | string". |{\n}|
+//@[30:33) [BCP048 (Error)] Cannot resolve function overload.\n  Overload 1 of 2, "(param0: array, ... : array): array", gave the following error:\n    Argument of type "object" is not assignable to parameter of type "array".\n  Overload 2 of 2, "(param0: bool | int | string, ... : bool | int | string): string", gave the following error:\n    Argument of type "object" is not assignable to parameter of type "bool | int | string". |{\n}|
 })
 var concatWrongTypesContradiction = concat('s', [
 //@[48:51) [BCP070 (Error)] Argument of type "array" is not assignable to parameter of type "bool | int | string". |[\n]|

--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -39,15 +39,19 @@ namespace Bicep.Core.Semantics
             this.VariableParameterType = variableParameterType;
             this.Flags = flags;
 
-            this.ParameterTypeSignatures = fixedTypes
-                .Select((parameterType, i) => $"param{i}: {parameterType}")
-                .ToImmutableArray();
+            var builder = ImmutableArray.CreateBuilder<string>();
+            for (int i = 0; i < fixedTypes.Length; i++)
+            {
+                builder.Add($"param{i}: {fixedTypes[i]}");
+            }
 
             if (variableParameterType != null)
             {
                 var restParameterType = variableParameterType.TypeKind == TypeKind.Union ? $"({variableParameterType})[]": $"{variableParameterType}[]";
-                this.ParameterTypeSignatures.Add($"...rest: {restParameterType}");
+                builder.Add($"...rest: {restParameterType}");
             }
+
+            this.ParameterTypeSignatures = builder.ToImmutable();
 
             this.TypeSignature = $"({string.Join(", ", this.ParameterTypeSignatures)}): {returnType}";
         }

--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -47,8 +47,7 @@ namespace Bicep.Core.Semantics
 
             if (variableParameterType != null)
             {
-                var restParameterType = variableParameterType.TypeKind == TypeKind.Union ? $"({variableParameterType})[]": $"{variableParameterType}[]";
-                builder.Add($"...rest: {restParameterType}");
+                builder.Add($"... : {variableParameterType}");
             }
 
             this.ParameterTypeSignatures = builder.ToImmutable();

--- a/src/Bicep.Core/TypeSystem/FunctionResolver.cs
+++ b/src/Bicep.Core/TypeSystem/FunctionResolver.cs
@@ -50,7 +50,7 @@ namespace Bicep.Core.TypeSystem
 
         public ImmutableDictionary<string, FunctionSymbol> GetKnownFunctions()
             => this.FunctionCache.Values.ToImmutableDictionaryExcludingNullValues(symbol => symbol.Name, LanguageConstants.IdentifierComparer);
-        
+
         private Symbol? TryGetBannedFunction(IdentifierSyntax identifierSyntax)
         {
             if (BannedFunctions.TryGetValue(identifierSyntax.IdentifierName, out var banned))


### PR DESCRIPTION
Fixed function signatures reported in error messages for functions that allow a variable number of arguments.

We didn't have good coverage for this, so the first commit adds a set of tests to assert on various properties of function overloads in default namespaces. The second commit fixes the bug. The third commit revises the format of the signature because the original broken one was confusing.