### PR TITLE
Added a function overload builder

### DIFF
--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -129,8 +129,5 @@ namespace Bicep.Core.Semantics
 
             return FunctionMatchResult.Match;
         }
-
-        public static FunctionOverload CreatePartialFixed(string name, TypeSymbol returnType, IEnumerable<TypeSymbol> fixedArgumentTypes, TypeSymbol variableArgumentType) => 
-            new FunctionOverload(name, returnType, fixedArgumentTypes.Count(), null, fixedArgumentTypes, variableArgumentType);
     }
 }

--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -132,14 +132,5 @@ namespace Bicep.Core.Semantics
 
         public static FunctionOverload CreatePartialFixed(string name, TypeSymbol returnType, IEnumerable<TypeSymbol> fixedArgumentTypes, TypeSymbol variableArgumentType) => 
             new FunctionOverload(name, returnType, fixedArgumentTypes.Count(), null, fixedArgumentTypes, variableArgumentType);
-
-        public static FunctionOverload CreateWithVarArgs(string name, TypeSymbol returnType, int minimumArgumentCount, TypeSymbol argumentType) =>
-            new FunctionOverload(
-                name,
-                returnType,
-                minimumArgumentCount,
-                maximumArgumentCount: null,
-                Enumerable.Repeat(argumentType, minimumArgumentCount),
-                argumentType);
     }
 }

--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -130,12 +130,6 @@ namespace Bicep.Core.Semantics
             return FunctionMatchResult.Match;
         }
 
-        public static FunctionOverload CreateFixed(string name, TypeSymbol returnType, params TypeSymbol[] argumentTypes) => 
-            new FunctionOverload(name, returnType, argumentTypes.Length, argumentTypes.Length, argumentTypes, variableParameterType: null);
-
-        public static FunctionOverload CreateFixed(string name, ReturnTypeBuilderDelegate returnTypeBuilder, params TypeSymbol[] argumentTypes) => 
-            new FunctionOverload(name, returnTypeBuilder, returnTypeBuilder(Enumerable.Empty<FunctionArgumentSyntax>()), argumentTypes.Length, argumentTypes.Length, argumentTypes, variableParameterType: null);
-
         public static FunctionOverload CreatePartialFixed(string name, TypeSymbol returnType, IEnumerable<TypeSymbol> fixedArgumentTypes, TypeSymbol variableArgumentType) => 
             new FunctionOverload(name, returnType, fixedArgumentTypes.Count(), null, fixedArgumentTypes, variableArgumentType);
 

--- a/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
@@ -71,7 +71,10 @@ namespace Bicep.Core.Semantics
             return this;
         }
 
-        public FunctionOverloadBuilder WithFixedParameters(params TypeSymbol[] parameterTypes)
+        public FunctionOverloadBuilder WithFixedParameters(params TypeSymbol[] parameterTypes) => 
+            this.WithOptionalFixedParameters(parameterTypes.Length, parameterTypes);
+
+        public FunctionOverloadBuilder WithOptionalFixedParameters(int minimumArgumentCount, params TypeSymbol[] parameterTypes)
         {
             this.fixedParameterTypes.Clear();
             foreach (TypeSymbol parameterType in parameterTypes)
@@ -79,8 +82,17 @@ namespace Bicep.Core.Semantics
                 this.fixedParameterTypes.Add(parameterType);
             }
 
-            this.minimumArgumentCount = parameterTypes.Length;
+            this.minimumArgumentCount = minimumArgumentCount;
             this.maximumArgumentCount = parameterTypes.Length;
+
+            return this;
+        }
+
+        public FunctionOverloadBuilder WithFixedParametersAndOptionalVariableParameters(TypeSymbol variableArgumentType, params TypeSymbol[] fixedArgumentTypes)
+        {
+            this.WithFixedParameters(fixedArgumentTypes);
+            this.maximumArgumentCount = null;
+            this.variableParameterType = variableArgumentType;
 
             return this;
         }

--- a/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Semantics
+{
+    public sealed class FunctionOverloadBuilder
+    {
+        private readonly string name;
+
+        private string? description;
+
+        private TypeSymbol returnType;
+
+        private readonly ImmutableArray<TypeSymbol>.Builder fixedParameterTypes;
+
+        private int minimumArgumentCount;
+
+        private int? maximumArgumentCount;
+
+        private TypeSymbol? variableParameterType;
+
+        private FunctionOverload.ReturnTypeBuilderDelegate returnTypeBuilder;
+
+        private FunctionFlags flags;
+
+        public FunctionOverloadBuilder(string name)
+        {
+            this.name = name;
+            this.returnType = LanguageConstants.Any;
+            this.fixedParameterTypes = ImmutableArray.CreateBuilder<TypeSymbol>();
+            this.returnTypeBuilder = args => LanguageConstants.Any;
+            this.variableParameterType = null;
+        }
+
+        public FunctionOverload Build() =>
+            new FunctionOverload(
+                this.name,
+                this.returnTypeBuilder,
+                this.returnType,
+                this.minimumArgumentCount,
+                this.maximumArgumentCount,
+                this.fixedParameterTypes.ToImmutable(),
+                this.variableParameterType,
+                this.flags);
+
+        public FunctionOverloadBuilder WithDescription(string description)
+        {
+            this.description = description;
+
+            return this;
+        }
+
+        public FunctionOverloadBuilder WithReturnType(TypeSymbol returnType)
+        {
+            this.returnType = returnType;
+            this.returnTypeBuilder = args => returnType;
+
+            return this;
+        }
+
+        public FunctionOverloadBuilder WithDynamicReturnType(FunctionOverload.ReturnTypeBuilderDelegate returnTypeBuilder)
+        {
+            this.returnType = returnTypeBuilder(Enumerable.Empty<FunctionArgumentSyntax>());
+            this.returnTypeBuilder = returnTypeBuilder;
+
+            return this;
+        }
+
+        public FunctionOverloadBuilder WithFixedParameters(params TypeSymbol[] parameterTypes)
+        {
+            foreach (TypeSymbol parameterType in parameterTypes)
+            {
+                this.fixedParameterTypes.Add(parameterType);
+            }
+
+            // TODO: Ensure these values are accurate regardless of call order on With* methods.
+            this.minimumArgumentCount = parameterTypes.Length;
+            this.maximumArgumentCount = parameterTypes.Length;
+
+            return this;
+        }
+
+        public FunctionOverloadBuilder WithFlags(FunctionFlags flags)
+        {
+            this.flags = flags;
+
+            return this;
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
@@ -73,14 +73,29 @@ namespace Bicep.Core.Semantics
 
         public FunctionOverloadBuilder WithFixedParameters(params TypeSymbol[] parameterTypes)
         {
+            this.fixedParameterTypes.Clear();
             foreach (TypeSymbol parameterType in parameterTypes)
             {
                 this.fixedParameterTypes.Add(parameterType);
             }
 
-            // TODO: Ensure these values are accurate regardless of call order on With* methods.
             this.minimumArgumentCount = parameterTypes.Length;
             this.maximumArgumentCount = parameterTypes.Length;
+
+            return this;
+        }
+
+        public FunctionOverloadBuilder WithVariableParameters(int minimumArgumentCount, TypeSymbol parameterType)
+        {
+            this.fixedParameterTypes.Clear();
+            for (int i = 0; i < minimumArgumentCount; i++)
+            {
+                this.fixedParameterTypes.Add(parameterType);
+            }
+
+            this.minimumArgumentCount = minimumArgumentCount;
+            this.maximumArgumentCount = null;
+            this.variableParameterType = parameterType;
 
             return this;
         }

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceSymbol.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceSymbol.cs
@@ -170,10 +170,25 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             // TODO: This is based on docs. Verify
-            yield return FunctionOverload.CreateWithVarArgs("resourceId", LanguageConstants.String, 2, LanguageConstants.String);
-            yield return FunctionOverload.CreateWithVarArgs("subscriptionResourceId", LanguageConstants.String, 2, LanguageConstants.String);
-            yield return FunctionOverload.CreateWithVarArgs("tenantResourceId", LanguageConstants.String, 2, LanguageConstants.String);
-            yield return FunctionOverload.CreateWithVarArgs("extensionResourceId", LanguageConstants.String, 3, LanguageConstants.String);
+            yield return new FunctionOverloadBuilder("resourceId")
+                .WithReturnType(LanguageConstants.String)
+                .WithVariableParameters(2, LanguageConstants.String)
+                .Build();
+
+            yield return new FunctionOverloadBuilder("subscriptionResourceId")
+                .WithReturnType(LanguageConstants.String)
+                .WithVariableParameters(2, LanguageConstants.String)
+                .Build();
+
+            yield return new FunctionOverloadBuilder("tenantResourceId")
+                .WithReturnType(LanguageConstants.String)
+                .WithVariableParameters(2, LanguageConstants.String)
+                .Build();
+
+            yield return new FunctionOverloadBuilder("extensionResourceId")
+                .WithReturnType(LanguageConstants.String)
+                .WithVariableParameters(3, LanguageConstants.String)
+                .Build();
 
             // TODO: Not sure about return type
             yield return new FunctionOverload("providers", LanguageConstants.Array, 1, 2, Enumerable.Repeat(LanguageConstants.String, 2), null);

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceSymbol.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceSymbol.cs
@@ -133,17 +133,17 @@ namespace Bicep.Core.Semantics.Namespaces
             // This list should be kept in-sync with ScopeHelper.CanConvertToArmJson().
 
             var allScopes = ResourceScopeType.TenantScope | ResourceScopeType.ManagementGroupScope | ResourceScopeType.SubscriptionScope | ResourceScopeType.ResourceGroupScope;
-            yield return (FunctionOverload.CreateFixed("tenant", GetRestrictedTenantReturnValue), allScopes);
+            yield return (new FunctionOverloadBuilder("tenant").WithDynamicReturnType(GetRestrictedTenantReturnValue).WithFixedParameters().Build(), allScopes);
 
-            yield return (FunctionOverload.CreateFixed("managementGroup", GetRestrictedManagementGroupReturnValue), ResourceScopeType.ManagementGroupScope);
-            yield return (FunctionOverload.CreateFixed("managementGroup", GetRestrictedManagementGroupReturnValue, LanguageConstants.String), ResourceScopeType.TenantScope | ResourceScopeType.ManagementGroupScope);
+            yield return (new FunctionOverloadBuilder("managementGroup").WithDynamicReturnType(GetRestrictedManagementGroupReturnValue).WithFixedParameters().Build(), ResourceScopeType.ManagementGroupScope);
+            yield return (new FunctionOverloadBuilder("managementGroup").WithDynamicReturnType(GetRestrictedManagementGroupReturnValue).WithFixedParameters(LanguageConstants.String).Build(), ResourceScopeType.TenantScope | ResourceScopeType.ManagementGroupScope);
 
-            yield return (FunctionOverload.CreateFixed("subscription", GetSubscriptionReturnValue), ResourceScopeType.SubscriptionScope | ResourceScopeType.ResourceGroupScope);
-            yield return (FunctionOverload.CreateFixed("subscription", GetRestrictedSubscriptionReturnValue, LanguageConstants.String), allScopes);
+            yield return (new FunctionOverloadBuilder("subscription").WithDynamicReturnType(GetSubscriptionReturnValue).WithFixedParameters().Build(), ResourceScopeType.SubscriptionScope | ResourceScopeType.ResourceGroupScope);
+            yield return (new FunctionOverloadBuilder("subscription").WithDynamicReturnType(GetRestrictedSubscriptionReturnValue).WithFixedParameters(LanguageConstants.String).Build(), allScopes);
 
-            yield return (FunctionOverload.CreateFixed("resourceGroup", GetResourceGroupReturnValue), ResourceScopeType.ResourceGroupScope);
-            yield return (FunctionOverload.CreateFixed("resourceGroup", GetRestrictedResourceGroupReturnValue, LanguageConstants.String), ResourceScopeType.SubscriptionScope | ResourceScopeType.ResourceGroupScope);
-            yield return (FunctionOverload.CreateFixed("resourceGroup", GetRestrictedResourceGroupReturnValue, LanguageConstants.String, LanguageConstants.String), ResourceScopeType.SubscriptionScope | ResourceScopeType.ResourceGroupScope);
+            yield return (new FunctionOverloadBuilder("resourceGroup").WithDynamicReturnType(GetResourceGroupReturnValue).WithFixedParameters().Build(), ResourceScopeType.ResourceGroupScope);
+            yield return (new FunctionOverloadBuilder("resourceGroup").WithDynamicReturnType(GetRestrictedResourceGroupReturnValue).WithFixedParameters(LanguageConstants.String).Build(), ResourceScopeType.SubscriptionScope | ResourceScopeType.ResourceGroupScope);
+            yield return (new FunctionOverloadBuilder("resourceGroup").WithDynamicReturnType(GetRestrictedResourceGroupReturnValue).WithFixedParameters(LanguageConstants.String, LanguageConstants.String).Build(), ResourceScopeType.SubscriptionScope | ResourceScopeType.ResourceGroupScope);
         }
 
         private static IEnumerable<FunctionOverload> GetAzOverloads(ResourceScopeType resourceScope)
@@ -159,9 +159,15 @@ namespace Bicep.Core.Semantics.Namespaces
             }
 
             // TODO: Add schema for return type
-            yield return FunctionOverload.CreateFixed("deployment", GetDeploymentReturnType(resourceScope));
+            yield return new FunctionOverloadBuilder("deployment")
+                .WithReturnType(GetDeploymentReturnType(resourceScope))
+                .WithFixedParameters()
+                .Build();
 
-            yield return FunctionOverload.CreateFixed("environment", GetEnvironmentReturnType());
+            yield return new FunctionOverloadBuilder("environment")
+                .WithReturnType(GetEnvironmentReturnType())
+                .WithFixedParameters()
+                .Build();
 
             // TODO: This is based on docs. Verify
             yield return FunctionOverload.CreateWithVarArgs("resourceId", LanguageConstants.String, 2, LanguageConstants.String);

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceSymbol.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceSymbol.cs
@@ -133,6 +133,7 @@ namespace Bicep.Core.Semantics.Namespaces
             // This list should be kept in-sync with ScopeHelper.CanConvertToArmJson().
 
             var allScopes = ResourceScopeType.TenantScope | ResourceScopeType.ManagementGroupScope | ResourceScopeType.SubscriptionScope | ResourceScopeType.ResourceGroupScope;
+            
             yield return (new FunctionOverloadBuilder("tenant").WithDynamicReturnType(GetRestrictedTenantReturnValue).WithFixedParameters().Build(), allScopes);
 
             yield return (new FunctionOverloadBuilder("managementGroup").WithDynamicReturnType(GetRestrictedManagementGroupReturnValue).WithFixedParameters().Build(), ResourceScopeType.ManagementGroupScope);
@@ -155,6 +156,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 {
                     yield return functionOverload;
                 }
+
                 // TODO: add banned function to explain why a given function isn't available
             }
 
@@ -191,14 +193,24 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             // TODO: Not sure about return type
-            yield return new FunctionOverload("providers", LanguageConstants.Array, 1, 2, Enumerable.Repeat(LanguageConstants.String, 2), null);
+            yield return new FunctionOverloadBuilder("providers")
+                .WithReturnType(LanguageConstants.Array)
+                .WithOptionalFixedParameters(1, LanguageConstants.String, LanguageConstants.String)
+                .Build();
 
             // TODO: return type is string[]
-            yield return new FunctionOverload("pickZones", LanguageConstants.Array, 3, 5, new[] {LanguageConstants.String, LanguageConstants.String, LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Int}, null);
+            yield return new FunctionOverloadBuilder("pickZones")
+                .WithReturnType(LanguageConstants.Array)
+                .WithOptionalFixedParameters(3, LanguageConstants.String, LanguageConstants.String, LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Int)
+                .Build();
 
-            // the use of FunctionPlacementConstraints.Resources prevents use of these functions anywhere where they can't be directly inlined into a resource body
-            yield return new FunctionOverload("reference", LanguageConstants.Object, 1, 3, Enumerable.Repeat(LanguageConstants.String, 3), null, FunctionFlags.RequiresInlining);
-            yield return new FunctionWildcardOverload("list*", LanguageConstants.Any, 2, 3, new[] { LanguageConstants.String, LanguageConstants.String, LanguageConstants.Object }, null, new Regex("^list[a-zA-Z]*"), FunctionFlags.RequiresInlining);
+            yield return new FunctionOverloadBuilder("reference")
+                .WithReturnType(LanguageConstants.Object)
+                .WithOptionalFixedParameters(1, LanguageConstants.String, LanguageConstants.String, LanguageConstants.String)
+                .WithFlags(FunctionFlags.RequiresInlining)
+                .Build();
+
+            yield return new FunctionWildcardOverload("list*", LanguageConstants.Any, 2, 3, new[] {LanguageConstants.String, LanguageConstants.String, LanguageConstants.Object}, null, new Regex("^list[a-zA-Z]*"), FunctionFlags.RequiresInlining);
         }
 
         public AzNamespaceSymbol(ResourceScopeType resourceScope)

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
@@ -19,26 +19,26 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithReturnType(LanguageConstants.Array)
                 .WithVariableParameters(1, LanguageConstants.Array)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("concat")
                 .WithReturnType(LanguageConstants.String)
                 .WithVariableParameters(1, UnionType.Create(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Bool))
                 .Build(),
-            
-            FunctionOverload.CreatePartialFixed("format", LanguageConstants.String, new[]
-            {
-                LanguageConstants.String
-            }, LanguageConstants.Any),
+
+            new FunctionOverloadBuilder("format")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParametersAndOptionalVariableParameters(LanguageConstants.Any, LanguageConstants.String)
+                .Build(),
 
             new FunctionOverloadBuilder("base64")
                 .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
-            
-            new FunctionOverload("padLeft", LanguageConstants.String, 2, 3, new[]
-            {
-                UnionType.Create(LanguageConstants.String, LanguageConstants.Int), LanguageConstants.Int, LanguageConstants.String
-            }, null),
+
+            new FunctionOverloadBuilder("padLeft")
+                .WithReturnType(LanguageConstants.String)
+                .WithOptionalFixedParameters(2, UnionType.Create(LanguageConstants.String, LanguageConstants.Int), LanguageConstants.Int, LanguageConstants.String)
+                .Build(),
 
             new FunctionOverloadBuilder("replace")
                 .WithReturnType(LanguageConstants.String)
@@ -54,12 +54,12 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("length")
                 .WithReturnType(LanguageConstants.Int)
                 .WithFixedParameters(UnionType.Create(LanguageConstants.String, LanguageConstants.Object, LanguageConstants.Array))
                 .Build(),
-            
+
             new FunctionOverloadBuilder("split")
                 .WithReturnType(LanguageConstants.Array)
                 .WithFixedParameters(LanguageConstants.String, UnionType.Create(LanguageConstants.String, LanguageConstants.Array))
@@ -86,7 +86,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("trim")
-                .WithReturnType( LanguageConstants.String)
+                .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
 
@@ -95,7 +95,10 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
                 .Build(),
 
-            new FunctionOverload("substring", LanguageConstants.String, 2, 3, new[] {LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Int}, null),
+            new FunctionOverloadBuilder("substring")
+                .WithReturnType(LanguageConstants.String)
+                .WithOptionalFixedParameters(2, LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Int)
+                .Build(),
 
             new FunctionOverloadBuilder("take")
                 .WithReturnType(LanguageConstants.Array)
@@ -121,17 +124,17 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithReturnType(LanguageConstants.Bool)
                 .WithFixedParameters(UnionType.Create(LanguageConstants.Null, LanguageConstants.Object, LanguageConstants.Array, LanguageConstants.String))
                 .Build(),
-            
+
             new FunctionOverloadBuilder("contains")
                 .WithReturnType(LanguageConstants.Bool)
                 .WithFixedParameters(LanguageConstants.Object, LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("contains")
                 .WithReturnType(LanguageConstants.Bool)
                 .WithFixedParameters(LanguageConstants.Array, LanguageConstants.Any)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("contains")
                 .WithReturnType(LanguageConstants.Bool)
                 .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
@@ -166,12 +169,12 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("last")
                 .WithReturnType(LanguageConstants.Any)
                 .WithFixedParameters(LanguageConstants.Array)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("last")
                 .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.String)
@@ -186,17 +189,17 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithReturnType(LanguageConstants.Int)
                 .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("startsWith")
                 .WithReturnType(LanguageConstants.Bool)
                 .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("endsWith")
                 .WithReturnType(LanguageConstants.Bool)
                 .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
                 .Build(),
-            
+
             // TODO: Needs to support number type as well
             new FunctionOverloadBuilder("min")
                 .WithReturnType(LanguageConstants.Int)
@@ -207,7 +210,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithReturnType(LanguageConstants.Int)
                 .WithFixedParameters(LanguageConstants.Array)
                 .Build(),
-            
+
             // TODO: Needs to support number type as well
             new FunctionOverloadBuilder("max")
                 .WithReturnType(LanguageConstants.Int)
@@ -223,37 +226,37 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithReturnType(LanguageConstants.Array)
                 .WithFixedParameters(LanguageConstants.Int, LanguageConstants.Int)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("base64ToString")
                 .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("base64ToJson")
                 .WithReturnType(LanguageConstants.Any)
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("uriComponentToString")
                 .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("uriComponent")
                 .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("dataUriToString")
                 .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("dataUri")
                 .WithReturnType(LanguageConstants.String)
                 .WithFixedParameters(LanguageConstants.Any)
                 .Build(),
-            
+
             new FunctionOverloadBuilder("array")
                 .WithReturnType(LanguageConstants.Array)
                 .WithFixedParameters(LanguageConstants.Any)
@@ -280,11 +283,23 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithFixedParameters(LanguageConstants.String)
                 .Build(),
 
-            new FunctionOverload("dateTimeAdd", LanguageConstants.String, 2, 3, Enumerable.Repeat(LanguageConstants.String, 3), null),
+            new FunctionOverloadBuilder("dateTimeAdd")
+                .WithReturnType(LanguageConstants.String)
+                .WithOptionalFixedParameters(2, LanguageConstants.String, LanguageConstants.String, LanguageConstants.String)
+                .Build(),
 
             // newGuid and utcNow are only allowed in parameter default values
-            new FunctionOverload("utcNow", LanguageConstants.String, 0, 1, Enumerable.Repeat(LanguageConstants.String, 1), null, FunctionFlags.ParamDefaultsOnly),
-            new FunctionOverload("newGuid", LanguageConstants.String, 0, 0, Enumerable.Empty<TypeSymbol>(), null, FunctionFlags.ParamDefaultsOnly),
+            new FunctionOverloadBuilder("utcNow")
+                .WithReturnType(LanguageConstants.String)
+                .WithOptionalFixedParameters(0, LanguageConstants.String)
+                .WithFlags(FunctionFlags.ParamDefaultsOnly)
+                .Build(),
+
+            new FunctionOverloadBuilder("newGuid")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters()
+                .WithFlags(FunctionFlags.ParamDefaultsOnly)
+                .Build(),
         }.ToImmutableArray();
 
         // TODO: Add copyIndex here when we support loops.

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
@@ -15,8 +15,16 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithFixedParameters(LanguageConstants.Any)
                 .Build(),
 
-            FunctionOverload.CreateWithVarArgs("concat", LanguageConstants.Array, 1, LanguageConstants.Array),
-            FunctionOverload.CreateWithVarArgs("concat", LanguageConstants.String, 1, UnionType.Create(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Bool)),
+            new FunctionOverloadBuilder("concat")
+                .WithReturnType(LanguageConstants.Array)
+                .WithVariableParameters(1, LanguageConstants.Array)
+                .Build(),
+            
+            new FunctionOverloadBuilder("concat")
+                .WithReturnType(LanguageConstants.String)
+                .WithVariableParameters(1, UnionType.Create(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Bool))
+                .Build(),
+            
             FunctionOverload.CreatePartialFixed("format", LanguageConstants.String, new[]
             {
                 LanguageConstants.String
@@ -67,9 +75,15 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithFixedParameters(UnionType.Create(LanguageConstants.String, LanguageConstants.Int))
                 .Build(),
 
-            FunctionOverload.CreateWithVarArgs("uniqueString", LanguageConstants.String, 1, LanguageConstants.String),
+            new FunctionOverloadBuilder("uniqueString")
+                .WithReturnType(LanguageConstants.String)
+                .WithVariableParameters(1, LanguageConstants.String)
+                .Build(),
 
-            FunctionOverload.CreateWithVarArgs("guid", LanguageConstants.String, 1, LanguageConstants.String),
+            new FunctionOverloadBuilder("guid")
+                .WithReturnType(LanguageConstants.String)
+                .WithVariableParameters(1, LanguageConstants.String)
+                .Build(),
 
             new FunctionOverloadBuilder("trim")
                 .WithReturnType( LanguageConstants.String)
@@ -122,14 +136,26 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithReturnType(LanguageConstants.Bool)
                 .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
                 .Build(),
-            
-            FunctionOverload.CreateWithVarArgs("intersection", LanguageConstants.Object, 2, LanguageConstants.Object),
-            
-            FunctionOverload.CreateWithVarArgs("intersection", LanguageConstants.Array, 2, LanguageConstants.Array),
-            
-            FunctionOverload.CreateWithVarArgs("union", LanguageConstants.Object, 2, LanguageConstants.Object),
-            
-            FunctionOverload.CreateWithVarArgs("union", LanguageConstants.Array, 2, LanguageConstants.Array),
+
+            new FunctionOverloadBuilder("intersection")
+                .WithReturnType(LanguageConstants.Object)
+                .WithVariableParameters(2, LanguageConstants.Object)
+                .Build(),
+
+            new FunctionOverloadBuilder("intersection")
+                .WithReturnType(LanguageConstants.Array)
+                .WithVariableParameters(2, LanguageConstants.Array)
+                .Build(),
+
+            new FunctionOverloadBuilder("union")
+                .WithReturnType(LanguageConstants.Object)
+                .WithVariableParameters(2, LanguageConstants.Object)
+                .Build(),
+
+            new FunctionOverloadBuilder("union")
+                .WithReturnType(LanguageConstants.Array)
+                .WithVariableParameters(2, LanguageConstants.Array)
+                .Build(),
 
             new FunctionOverloadBuilder("first")
                 .WithReturnType(LanguageConstants.Any)
@@ -172,7 +198,10 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
             
             // TODO: Needs to support number type as well
-            FunctionOverload.CreateWithVarArgs("min", LanguageConstants.Int, 1, LanguageConstants.Int),
+            new FunctionOverloadBuilder("min")
+                .WithReturnType(LanguageConstants.Int)
+                .WithVariableParameters(1, LanguageConstants.Int)
+                .Build(),
 
             new FunctionOverloadBuilder("min")
                 .WithReturnType(LanguageConstants.Int)
@@ -180,7 +209,10 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
             
             // TODO: Needs to support number type as well
-            FunctionOverload.CreateWithVarArgs("max", LanguageConstants.Int, 1, LanguageConstants.Int),
+            new FunctionOverloadBuilder("max")
+                .WithReturnType(LanguageConstants.Int)
+                .WithVariableParameters(1, LanguageConstants.Int)
+                .Build(),
 
             new FunctionOverloadBuilder("max")
                 .WithReturnType(LanguageConstants.Int)
@@ -226,8 +258,11 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithReturnType(LanguageConstants.Array)
                 .WithFixedParameters(LanguageConstants.Any)
                 .Build(),
-            
-            FunctionOverload.CreateWithVarArgs("coalesce", LanguageConstants.Any, 1, LanguageConstants.Any),
+
+            new FunctionOverloadBuilder("coalesce")
+                .WithReturnType(LanguageConstants.Any)
+                .WithVariableParameters(1, LanguageConstants.Any)
+                .Build(),
 
             // TODO: Requires number type
             //new FunctionOverloadBuilder("float")

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
@@ -10,7 +10,10 @@ namespace Bicep.Core.Semantics.Namespaces
     {
         private static readonly ImmutableArray<FunctionOverload> SystemOverloads = new[]
         {
-            FunctionOverload.CreateFixed("any", LanguageConstants.Any, LanguageConstants.Any),
+            new FunctionOverloadBuilder("any")
+                .WithReturnType(LanguageConstants.Any)
+                .WithFixedParameters(LanguageConstants.Any)
+                .Build(),
 
             FunctionOverload.CreateWithVarArgs("concat", LanguageConstants.Array, 1, LanguageConstants.Array),
             FunctionOverload.CreateWithVarArgs("concat", LanguageConstants.String, 1, UnionType.Create(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Bool)),
@@ -18,69 +21,230 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 LanguageConstants.String
             }, LanguageConstants.Any),
-            FunctionOverload.CreateFixed("base64", LanguageConstants.String, LanguageConstants.String),
+
+            new FunctionOverloadBuilder("base64")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+            
             new FunctionOverload("padLeft", LanguageConstants.String, 2, 3, new[]
             {
                 UnionType.Create(LanguageConstants.String, LanguageConstants.Int), LanguageConstants.Int, LanguageConstants.String
             }, null),
-            FunctionOverload.CreateFixed("replace", LanguageConstants.String, LanguageConstants.String, LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("toLower", LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("toUpper", LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("length", LanguageConstants.Int, UnionType.Create(LanguageConstants.String, LanguageConstants.Object, LanguageConstants.Array)),
-            FunctionOverload.CreateFixed("split", LanguageConstants.Array, LanguageConstants.String, UnionType.Create(LanguageConstants.String, LanguageConstants.Array)),
-            FunctionOverload.CreateFixed("string", LanguageConstants.String, LanguageConstants.Any),
-            FunctionOverload.CreateFixed("int", LanguageConstants.Int, UnionType.Create(LanguageConstants.String, LanguageConstants.Int)),
-            FunctionOverload.CreateWithVarArgs("uniqueString", LanguageConstants.String, 1, LanguageConstants.String),
-            FunctionOverload.CreateWithVarArgs("guid", LanguageConstants.String, 1, LanguageConstants.String),
-            FunctionOverload.CreateFixed("trim", LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("uri", LanguageConstants.String, LanguageConstants.String, LanguageConstants.String),
-            new FunctionOverload("substring", LanguageConstants.String, 2, 3, new[] {LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Int}, null),
-            FunctionOverload.CreateFixed("take", LanguageConstants.Array, LanguageConstants.Array, LanguageConstants.Int),
-            FunctionOverload.CreateFixed("take", LanguageConstants.String, LanguageConstants.String, LanguageConstants.Int),
-            FunctionOverload.CreateFixed("skip", LanguageConstants.Array, LanguageConstants.Array, LanguageConstants.Int),
-            FunctionOverload.CreateFixed("skip", LanguageConstants.String, LanguageConstants.String, LanguageConstants.Int),
-            FunctionOverload.CreateFixed("empty", LanguageConstants.Bool, UnionType.Create(LanguageConstants.Null, LanguageConstants.Object, LanguageConstants.Array, LanguageConstants.String)),
-            FunctionOverload.CreateFixed("contains", LanguageConstants.Bool, LanguageConstants.Object, LanguageConstants.String),
-            FunctionOverload.CreateFixed("contains", LanguageConstants.Bool, LanguageConstants.Array, LanguageConstants.Any),
-            FunctionOverload.CreateFixed("contains", LanguageConstants.Bool, LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateWithVarArgs("intersection", LanguageConstants.Object, 2, LanguageConstants.Object),
-            FunctionOverload.CreateWithVarArgs("intersection", LanguageConstants.Array, 2, LanguageConstants.Array),
-            FunctionOverload.CreateWithVarArgs("union", LanguageConstants.Object, 2, LanguageConstants.Object),
-            FunctionOverload.CreateWithVarArgs("union", LanguageConstants.Array, 2, LanguageConstants.Array),
-            FunctionOverload.CreateFixed("first", LanguageConstants.Any, LanguageConstants.Array),
-            FunctionOverload.CreateFixed("first", LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("last", LanguageConstants.Any, LanguageConstants.Array),
-            FunctionOverload.CreateFixed("last", LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("indexOf", LanguageConstants.Int, LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("lastIndexOf", LanguageConstants.Int, LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("startsWith", LanguageConstants.Bool, LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("endsWith", LanguageConstants.Bool, LanguageConstants.String, LanguageConstants.String),
 
+            new FunctionOverloadBuilder("replace")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String, LanguageConstants.String, LanguageConstants.String)
+                .Build(),
+
+            new FunctionOverloadBuilder("toLower")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+
+            new FunctionOverloadBuilder("toUpper")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("length")
+                .WithReturnType(LanguageConstants.Int)
+                .WithFixedParameters(UnionType.Create(LanguageConstants.String, LanguageConstants.Object, LanguageConstants.Array))
+                .Build(),
+            
+            new FunctionOverloadBuilder("split")
+                .WithReturnType(LanguageConstants.Array)
+                .WithFixedParameters(LanguageConstants.String, UnionType.Create(LanguageConstants.String, LanguageConstants.Array))
+                .Build(),
+
+            new FunctionOverloadBuilder("string")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.Any)
+                .Build(),
+
+            new FunctionOverloadBuilder("int")
+                .WithReturnType(LanguageConstants.Int)
+                .WithFixedParameters(UnionType.Create(LanguageConstants.String, LanguageConstants.Int))
+                .Build(),
+
+            FunctionOverload.CreateWithVarArgs("uniqueString", LanguageConstants.String, 1, LanguageConstants.String),
+
+            FunctionOverload.CreateWithVarArgs("guid", LanguageConstants.String, 1, LanguageConstants.String),
+
+            new FunctionOverloadBuilder("trim")
+                .WithReturnType( LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+
+            new FunctionOverloadBuilder("uri")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
+                .Build(),
+
+            new FunctionOverload("substring", LanguageConstants.String, 2, 3, new[] {LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Int}, null),
+
+            new FunctionOverloadBuilder("take")
+                .WithReturnType(LanguageConstants.Array)
+                .WithFixedParameters(LanguageConstants.Array, LanguageConstants.Int)
+                .Build(),
+
+            new FunctionOverloadBuilder("take")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String, LanguageConstants.Int)
+                .Build(),
+
+            new FunctionOverloadBuilder("skip")
+                .WithReturnType(LanguageConstants.Array)
+                .WithFixedParameters(LanguageConstants.Array, LanguageConstants.Int)
+                .Build(),
+
+            new FunctionOverloadBuilder("skip")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String, LanguageConstants.Int)
+                .Build(),
+
+            new FunctionOverloadBuilder("empty")
+                .WithReturnType(LanguageConstants.Bool)
+                .WithFixedParameters(UnionType.Create(LanguageConstants.Null, LanguageConstants.Object, LanguageConstants.Array, LanguageConstants.String))
+                .Build(),
+            
+            new FunctionOverloadBuilder("contains")
+                .WithReturnType(LanguageConstants.Bool)
+                .WithFixedParameters(LanguageConstants.Object, LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("contains")
+                .WithReturnType(LanguageConstants.Bool)
+                .WithFixedParameters(LanguageConstants.Array, LanguageConstants.Any)
+                .Build(),
+            
+            new FunctionOverloadBuilder("contains")
+                .WithReturnType(LanguageConstants.Bool)
+                .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
+                .Build(),
+            
+            FunctionOverload.CreateWithVarArgs("intersection", LanguageConstants.Object, 2, LanguageConstants.Object),
+            
+            FunctionOverload.CreateWithVarArgs("intersection", LanguageConstants.Array, 2, LanguageConstants.Array),
+            
+            FunctionOverload.CreateWithVarArgs("union", LanguageConstants.Object, 2, LanguageConstants.Object),
+            
+            FunctionOverload.CreateWithVarArgs("union", LanguageConstants.Array, 2, LanguageConstants.Array),
+
+            new FunctionOverloadBuilder("first")
+                .WithReturnType(LanguageConstants.Any)
+                .WithFixedParameters(LanguageConstants.Array)
+                .Build(),
+
+            new FunctionOverloadBuilder("first")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("last")
+                .WithReturnType(LanguageConstants.Any)
+                .WithFixedParameters(LanguageConstants.Array)
+                .Build(),
+            
+            new FunctionOverloadBuilder("last")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+
+            new FunctionOverloadBuilder("indexOf")
+                .WithReturnType(LanguageConstants.Int)
+                .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
+                .Build(),
+
+            new FunctionOverloadBuilder("lastIndexOf")
+                .WithReturnType(LanguageConstants.Int)
+                .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("startsWith")
+                .WithReturnType(LanguageConstants.Bool)
+                .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("endsWith")
+                .WithReturnType(LanguageConstants.Bool)
+                .WithFixedParameters(LanguageConstants.String, LanguageConstants.String)
+                .Build(),
+            
             // TODO: Needs to support number type as well
             FunctionOverload.CreateWithVarArgs("min", LanguageConstants.Int, 1, LanguageConstants.Int),
-            FunctionOverload.CreateFixed("min", LanguageConstants.Int, LanguageConstants.Array),
 
+            new FunctionOverloadBuilder("min")
+                .WithReturnType(LanguageConstants.Int)
+                .WithFixedParameters(LanguageConstants.Array)
+                .Build(),
+            
             // TODO: Needs to support number type as well
             FunctionOverload.CreateWithVarArgs("max", LanguageConstants.Int, 1, LanguageConstants.Int),
-            FunctionOverload.CreateFixed("max", LanguageConstants.Int, LanguageConstants.Array),
 
-            FunctionOverload.CreateFixed("range", LanguageConstants.Array, LanguageConstants.Int, LanguageConstants.Int),
-            FunctionOverload.CreateFixed("base64ToString", LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("base64ToJson", LanguageConstants.Any, LanguageConstants.String),
-            FunctionOverload.CreateFixed("uriComponentToString", LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("uriComponent", LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("dataUriToString", LanguageConstants.String, LanguageConstants.String),
-            FunctionOverload.CreateFixed("dataUri", LanguageConstants.String, LanguageConstants.Any),
-            FunctionOverload.CreateFixed("array", LanguageConstants.Array, LanguageConstants.Any),
+            new FunctionOverloadBuilder("max")
+                .WithReturnType(LanguageConstants.Int)
+                .WithFixedParameters(LanguageConstants.Array)
+                .Build(),
+
+            new FunctionOverloadBuilder("range")
+                .WithReturnType(LanguageConstants.Array)
+                .WithFixedParameters(LanguageConstants.Int, LanguageConstants.Int)
+                .Build(),
+            
+            new FunctionOverloadBuilder("base64ToString")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("base64ToJson")
+                .WithReturnType(LanguageConstants.Any)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("uriComponentToString")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("uriComponent")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("dataUriToString")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+            
+            new FunctionOverloadBuilder("dataUri")
+                .WithReturnType(LanguageConstants.String)
+                .WithFixedParameters(LanguageConstants.Any)
+                .Build(),
+            
+            new FunctionOverloadBuilder("array")
+                .WithReturnType(LanguageConstants.Array)
+                .WithFixedParameters(LanguageConstants.Any)
+                .Build(),
+            
             FunctionOverload.CreateWithVarArgs("coalesce", LanguageConstants.Any, 1, LanguageConstants.Any),
 
             // TODO: Requires number type
-            //FunctionInfo.CreateFixed("float",LanguageConstants.Number,LanguageConstants.Any),
+            //new FunctionOverloadBuilder("float")
+            //    .WithReturnType(LanguageConstants.Number)
+            //    .WithFixedParameters(LanguageConstants.Any)
+            //    .Build(),
 
-            FunctionOverload.CreateFixed("bool", LanguageConstants.Bool, LanguageConstants.Any),
+            new FunctionOverloadBuilder("bool")
+                .WithReturnType(LanguageConstants.Bool)
+                .WithFixedParameters(LanguageConstants.Any)
+                .Build(),
 
-            FunctionOverload.CreateFixed("json", LanguageConstants.Any, LanguageConstants.String),
-            
+            new FunctionOverloadBuilder("json")
+                .WithReturnType(LanguageConstants.Any)
+                .WithFixedParameters(LanguageConstants.String)
+                .Build(),
+
             new FunctionOverload("dateTimeAdd", LanguageConstants.String, 2, 3, Enumerable.Repeat(LanguageConstants.String, 3), null),
 
             // newGuid and utcNow are only allowed in parameter default values


### PR DESCRIPTION
Refactored code that constructs all the function overloads to be more fluent. To support signature help (#284), I will need to update function metadata to have descriptions on indvidual overloads as well as add names and descriptions to each parameters. The previous pattern wouldn't support the additional information very well.

There are no functional changes in this PR.