### PR TITLE
Include language server bits in release assets.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,3 +309,19 @@ jobs:
           asset_path: ./bicep-setup-win-x64/bicep-setup-win-x64.exe
           asset_name: bicep-setup-win-x64.exe
           asset_content_type: binary/octet-stream
+      
+      - name: Zip language server
+        uses: papeloto/action-zip@v1
+        with:
+          files: ./Bicep.LangServer
+          dest: ./bicep-langserver.zip
+      
+      - name: Upload bicep-langserver.zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./bicep-langserver.zip
+          asset_name: bicep-langserver.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
The runtime-agnostic language server bits were already being produced by our builds but were not included in releases. This fixes #1141.

New asset contents were verified in my own fork. This is what they looked like:
![image](https://user-images.githubusercontent.com/22460039/102161423-2682d380-3e3c-11eb-8ce2-eaa74592c497.png)
