### PR TITLE
Declare dependency on VSCode v1.52.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       # we're deliberately taking a dependency on an older version of vscode for back-compatibility
       - dependency-name: "@types/vscode"
         versions:
-        - ">1.14.0"
+        - ">1.52.0"
   - package-ecosystem: "npm"
     directory: "/src/playground"
     schedule:

--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -1223,9 +1223,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.14.0.tgz",
-            "integrity": "sha512-0PFarl1nOck6V+vTMycb7b3mrc2ybDkkg3bA8u/8DUyY0/KhYUw3qxCQjxT2c66ferlpOeA05ETgddSmup69fA==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+            "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
             "dev": true
         },
         "@types/webpack": {

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -10,7 +10,7 @@
   "preview": true,
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
   "engines": {
-    "vscode": "^1.14.0"
+    "vscode": "^1.52.0"
   },
   "categories": [
     "Azure",
@@ -96,7 +96,7 @@
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.14",
     "@types/triple-beam": "^1.3.2",
-    "@types/vscode": "^1.14.0",
+    "@types/vscode": "^1.52.0",
     "@types/webpack": "^4.41.25",
     "@typescript-eslint/eslint-plugin": "^4.10.0",
     "@typescript-eslint/parser": "^4.10.0",

--- a/src/vscode-bicep/src/test/unit/logger.test.ts
+++ b/src/vscode-bicep/src/test/unit/logger.test.ts
@@ -25,16 +25,18 @@ const mockWinstonLogger = ({
   log: jest.fn(),
 } as unknown) as winston.Logger;
 
-const mockState: vscode.Memento = { get: jest.fn(), update: jest.fn() };
+const mockWorkspaceState: vscode.Memento = { get: jest.fn(), update: jest.fn() };
+const mockGlobalstate = { ...mockWorkspaceState, setKeysForSync: jest.fn(), };
 const mockContext: vscode.ExtensionContext = {
   subscriptions: [],
-  workspaceState: mockState,
-  globalState: mockState,
+  workspaceState: mockWorkspaceState,
+  globalState: mockGlobalstate,
   asAbsolutePath: jest.fn(),
   extensionPath: "",
   storagePath: "",
-  logPath: "",
-};
+  logPath: ""
+} as any;
+
 const mockOutputChannel: vscode.OutputChannel = {
   name: "",
   append: jest.fn(),

--- a/src/vscode-bicep/src/test/unit/logger.test.ts
+++ b/src/vscode-bicep/src/test/unit/logger.test.ts
@@ -25,17 +25,20 @@ const mockWinstonLogger = ({
   log: jest.fn(),
 } as unknown) as winston.Logger;
 
-const mockWorkspaceState: vscode.Memento = { get: jest.fn(), update: jest.fn() };
-const mockGlobalstate = { ...mockWorkspaceState, setKeysForSync: jest.fn(), };
-const mockContext: vscode.ExtensionContext = {
+const mockWorkspaceState: vscode.Memento = {
+  get: jest.fn(),
+  update: jest.fn(),
+};
+const mockGlobalstate = { ...mockWorkspaceState, setKeysForSync: jest.fn() };
+const mockContext = ({
   subscriptions: [],
   workspaceState: mockWorkspaceState,
   globalState: mockGlobalstate,
   asAbsolutePath: jest.fn(),
   extensionPath: "",
   storagePath: "",
-  logPath: ""
-} as any;
+  logPath: "",
+} as unknown) as vscode.ExtensionContext;
 
 const mockOutputChannel: vscode.OutputChannel = {
   name: "",


### PR DESCRIPTION
This fixes the underlying issue for #1161, but we still need to address the testing to avoid future breakages.

The reason for this upgrade is that https://www.npmjs.com/package/vscode-languageclient has a hard dependency on VSCode 1.52.0+