### PR TITLE
Revert "disabled setup signing"

### DIFF
--- a/.pipelines/Bicep.yml
+++ b/.pipelines/Bicep.yml
@@ -108,13 +108,13 @@ steps:
       projects: ./src/installer-win/installer.proj
       arguments: '--configuration $(BuildConfiguration)'
 
-  # - task: onebranch.pipeline.signing@1
-  #   displayName: Sign Windows Setup
-  #   inputs:
-  #     command: 'sign'
-  #     signing_profile: 'external_distribution'
-  #     files_to_sign: '**/*.exe'
-  #     search_root: '$(Build.SourcesDirectory)/src/installer-win/bin/release/net46/'
+  - task: onebranch.pipeline.signing@1
+    displayName: Sign Windows Setup
+    inputs:
+      command: 'sign'
+      signing_profile: 'external_distribution'
+      files_to_sign: '**/*.exe'
+      search_root: '$(Build.SourcesDirectory)/src/installer-win/bin/release/net46/'
 
   - task: CopyFiles@2
     displayName: Copy Windows Setup to output


### PR DESCRIPTION
The official build I ran last night actually passed, so I'm reverting the workaround.

Reverts Azure/bicep#1082