### PR TITLE
Suggestion to use implicit Depends On for the DomainJoin extension

### DIFF
--- a/docs/examples/201/vm-domain-join/main.bicep
+++ b/docs/examples/201/vm-domain-join/main.bicep
@@ -124,11 +124,8 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-06-01' = {
 }
 
 resource virtualMachineExtension 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
-  name: '${dnsLabelPrefix}/joindomain'
+  name: '${virtualMachine.name}/joindomain'
   location: location
-  dependsOn: [
-    virtualMachine
-  ]
   properties: {
     publisher: 'Microsoft.Compute'
     type: 'JsonADDomainExtension'


### PR DESCRIPTION
Suggestion to use implicit Depends On for the DomainJoin extension by specifying the name property of the Virtual Machine Resource.