### PR TITLE
Stop triggering build on tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: Build
 
 on:
   push:
-    tags:
-    - 'latest'
-    - 'v*'
     branches: [ main ]
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
We no longer need the build to be triggered when a version tag gets pushed. I missed this from the previous PR.