### PR TITLE
Fix official VSIX version to unblock publishing to VS gallery

### DIFF
--- a/.pipelines/Bicep.yml
+++ b/.pipelines/Bicep.yml
@@ -1,4 +1,6 @@
 parameters:
+  - name: official
+    type: boolean
   - name: rid
     type: string
 

--- a/.pipelines/Bicep.yml
+++ b/.pipelines/Bicep.yml
@@ -16,7 +16,7 @@ steps:
   inputs:
     command: build
     projects: $(BuildSolution)
-    arguments: '--configuration $(BuildConfiguration)'
+    arguments: '--configuration $(BuildConfiguration) /p:PublicRelease=${{ parameters.official }}'
 
 - task: DotNetCoreCLI@2
   displayName: Test
@@ -40,7 +40,7 @@ steps:
       command: 'publish'
       publishWebProjects: false
       projects: ./src/Bicep.LangServer/Bicep.LangServer.csproj
-      arguments: '--configuration $(BuildConfiguration)'
+      arguments: '--configuration $(BuildConfiguration) /p:PublicRelease=${{ parameters.official }}'
       zipAfterPublish: false
 
   - task: onebranch.pipeline.signing@1
@@ -64,7 +64,7 @@ steps:
     command: 'publish'
     publishWebProjects: false
     projects: ./src/Bicep.Cli/Bicep.Cli.csproj
-    arguments: '--configuration $(BuildConfiguration) --self-contained true -p:PublishTrimmed=true -p:PublishSingleFile=true -r ${{ parameters.rid }}'
+    arguments: '--configuration $(BuildConfiguration) --self-contained true -p:PublishTrimmed=true -p:PublishSingleFile=true -r ${{ parameters.rid }} /p:PublicRelease=${{ parameters.official }}'
     zipAfterPublish: false
 
 - ${{ if eq(parameters.rid, 'win-x64') }}:
@@ -106,7 +106,7 @@ steps:
     inputs:
       command: build
       projects: ./src/installer-win/installer.proj
-      arguments: '--configuration $(BuildConfiguration)'
+      arguments: '--configuration $(BuildConfiguration) /p:PublicRelease=${{ parameters.official }}'
 
   - task: onebranch.pipeline.signing@1
     displayName: Sign Windows Setup

--- a/.pipelines/Common.yml
+++ b/.pipelines/Common.yml
@@ -20,6 +20,7 @@ stages:
     steps:
     - template: Bicep.yml
       parameters:
+        official: ${{ parameters.official }}
         rid: win-x64
   
   - job: bicep_linux
@@ -37,6 +38,7 @@ stages:
     steps:
     - template: Bicep.yml
       parameters:
+        official: ${{ parameters.official }}
         rid: linux-x64
 
   - job: bicep_osx
@@ -54,6 +56,7 @@ stages:
     steps:
     - template: Bicep.yml
       parameters:
+        official: ${{ parameters.official }}
         rid: osx-x64
 
   - job: vsix

--- a/.pipelines/Common.yml
+++ b/.pipelines/Common.yml
@@ -125,6 +125,9 @@ stages:
       displayName: Kill Xvfb
 
     - script: npm run package
+      env:
+        # ensure that we generate a VS gallery compatible version number on official builds
+        PublicRelease: ${{ parameters.official }}
       displayName: Create VSIX
       workingDirectory: $(Build.SourcesDirectory)/src/vscode-bicep
     

--- a/version.json
+++ b/version.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.2",
-  "publicReleaseRefSpec": [
-    "^refs/tags/v\\d+\\.\\d+\\.\\d+"
-  ]
+  "version": "0.2"
 }


### PR DESCRIPTION
The official build from https://github.com/Azure/bicep/releases/tag/v0.2.317 produced a VSIX file with a version that is rejected by the VS gallery due. This was due to the official build not setting the `PublicRelease` flag in nbgv correctly.

Validated the change in the official build pipeline. Unfortunately, we will need to produce another release after this change is merged.