### PR TITLE
Force textual diffs on .bicep files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.bicep -text
+*.bicep -text diff
 *.ts text eol=lf


### PR DESCRIPTION
On certain `.bicep` files, git incorrectly detects them as binary, resulting in GitHub diffs displaying "Binary file not shown." instead of the diff.