### PR TITLE
Loops - parsing and semantic checks

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -18,9 +18,9 @@ parameterDefaultValue -> "=" expression
 
 variableDecl -> decorator* "variable" IDENTIFIER(name) "=" expression NL
 
-resourceDecl -> decorator* "resource" IDENTIFIER(name) interpString(type) "existing"? "=" (ifCondition | object) NL
+resourceDecl -> decorator* "resource" IDENTIFIER(name) interpString(type) "existing"? "=" (ifCondition | object | forExpression) NL
 
-moduleDecl -> decorator* "module" IDENTIFIER(name) interpString(type) "=" (ifCondition | object) NL
+moduleDecl -> decorator* "module" IDENTIFIER(name) interpString(type) "=" (ifCondition | object | forExpression) NL
 
 outputDecl -> decorator* "output" IDENTIFIER(name) IDENTIFIER(type) "=" expression NL
 
@@ -78,6 +78,7 @@ primaryExpression ->
   literalValue |
   interpString |
   array |
+  forExpression |
   object |
   parenthesizedExpression
 
@@ -90,6 +91,8 @@ argumentList -> expression ("," expression)*
 parenthesizedExpression -> "(" expression ")"
 
 ifCondition -> "if" parenthesizedExpression object
+
+forExpression -> "[" "for" IDENTIFIER "in" expression ":" expression(body) "]"
 
 interpString ->  interpStringLeftPiece ( expression interpStringMiddlePiece )* expression interpStringRightPiece | literalString
 interpStringLeftPiece -> "'" STRINGCHAR* "${"

--- a/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
@@ -109,7 +109,8 @@ namespace Bicep.Core.IntegrationTests.Semantics
                         s is ModuleSymbol ||
                         s is OutputSymbol ||
                         s is FunctionSymbol ||
-                        s is NamespaceSymbol);
+                        s is NamespaceSymbol ||
+                        s is LocalSymbol);
                 }
                 else
                 {
@@ -122,7 +123,8 @@ namespace Bicep.Core.IntegrationTests.Semantics
                         s is ModuleSymbol ||
                         s is OutputSymbol ||
                         s is FunctionSymbol ||
-                        s is NamespaceSymbol);
+                        s is NamespaceSymbol ||
+                        s is LocalSymbol);
                 }
 
                 var foundRefs = model.FindReferences(symbol!);

--- a/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
@@ -110,7 +110,7 @@ namespace Bicep.Core.IntegrationTests.Semantics
                         s is OutputSymbol ||
                         s is FunctionSymbol ||
                         s is NamespaceSymbol ||
-                        s is LocalSymbol);
+                        s is LocalVariableSymbol);
                 }
                 else
                 {
@@ -124,7 +124,7 @@ namespace Bicep.Core.IntegrationTests.Semantics
                         s is OutputSymbol ||
                         s is FunctionSymbol ||
                         s is NamespaceSymbol ||
-                        s is LocalSymbol);
+                        s is LocalVariableSymbol);
                 }
 
                 var foundRefs = model.FindReferences(symbol!);

--- a/src/Bicep.Core.Samples/DataSetsExtensions.cs
+++ b/src/Bicep.Core.Samples/DataSetsExtensions.cs
@@ -4,9 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Azure.Bicep.Types.Az;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,6 +17,8 @@ namespace Bicep.Core.Samples
 {
     public static class DataSetsExtensions
     {
+        private static readonly ITypeLoader TypeLoader = new TypeLoader();
+
         public static IEnumerable<object[]> ToDynamicTestData(this IEnumerable<DataSet> source) => source.Select(ToDynamicTestData);
 
         public static object[] ToDynamicTestData(this DataSet ds) => new object[] {ds};
@@ -31,7 +35,7 @@ namespace Bicep.Core.Samples
             var fileUri = PathHelper.FilePathToFileUrl(Path.Combine(outputDirectory, DataSet.TestFileMain));
             var syntaxTreeGrouping = SyntaxTreeGroupingBuilder.Build(new FileResolver(), new Workspace(), fileUri);
 
-            return new Compilation(TestResourceTypeProvider.Create(), syntaxTreeGrouping);
+            return new Compilation(new AzResourceTypeProvider(TypeLoader), syntaxTreeGrouping);
         }
     }
 }

--- a/src/Bicep.Core.Samples/Files/AKS_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/AKS_LF/main.diagnostics.bicep
@@ -37,6 +37,7 @@ resource aks 'Microsoft.ContainerService/managedClusters@2020-03-01' = {
                 vmSize: agentVMSize
                 osType: 'Linux'
                 storageProfile: 'ManagedDisks'
+//@[16:30) [BCP038 (Warning)] The property "storageProfile" is not allowed on objects of type "ManagedClusterAgentPoolProfile". Permissible properties include "availabilityZones", "count", "enableAutoScaling", "enableNodePublicIP", "maxCount", "maxPods", "minCount", "mode", "nodeLabels", "nodeTaints", "orchestratorVersion", "scaleSetEvictionPolicy", "scaleSetPriority", "spotMaxPrice", "tags", "type", "vnetSubnetID". |storageProfile|
             }
         ]
         linuxProfile: {

--- a/src/Bicep.Core.Samples/Files/Dependencies_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Dependencies_LF/main.diagnostics.bicep
@@ -19,6 +19,7 @@ var resourceDependency = {
 
 output resourceAType string = resA.type
 resource resA 'My.Rp/myResourceType@2020-01-01' = {
+//@[14:47) [BCP081 (Warning)] Resource type "My.Rp/myResourceType@2020-01-01" does not have types available. |'My.Rp/myResourceType@2020-01-01'|
   name: 'resA'
   properties: {
     deployTime: dependentVar
@@ -28,6 +29,7 @@ resource resA 'My.Rp/myResourceType@2020-01-01' = {
 
 output resourceBId string = resB.id
 resource resB 'My.Rp/myResourceType@2020-01-01' = {
+//@[14:47) [BCP081 (Warning)] Resource type "My.Rp/myResourceType@2020-01-01" does not have types available. |'My.Rp/myResourceType@2020-01-01'|
   name: 'resB'
   properties: {
     dependencies: resourceDependency
@@ -40,6 +42,7 @@ var resourceIds = {
 }
 
 resource resC 'My.Rp/myResourceType@2020-01-01' = {
+//@[14:47) [BCP081 (Warning)] Resource type "My.Rp/myResourceType@2020-01-01" does not have types available. |'My.Rp/myResourceType@2020-01-01'|
   name: 'resC'
   properties: {
     resourceIds: resourceIds
@@ -47,12 +50,14 @@ resource resC 'My.Rp/myResourceType@2020-01-01' = {
 }
 
 resource resD 'My.Rp/myResourceType/childType@2020-01-01' = {
+//@[14:57) [BCP081 (Warning)] Resource type "My.Rp/myResourceType/childType@2020-01-01" does not have types available. |'My.Rp/myResourceType/childType@2020-01-01'|
   name: '${resC.name}/resD'
   properties: {
   }
 }
 
 resource resE 'My.Rp/myResourceType/childType@2020-01-01' = {
+//@[14:57) [BCP081 (Warning)] Resource type "My.Rp/myResourceType/childType@2020-01-01" does not have types available. |'My.Rp/myResourceType/childType@2020-01-01'|
   name: 'resC/resD'
   properties: {
     resDRef: resD.id

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
@@ -281,3 +281,126 @@ module childCompletionD 'ChildModules/e'
 module moduleWithNotAttachableDecorators './empty.bicep' = {
   name: 'moduleWithNotAttachableDecorators'
 }
+
+// loop parsing cases
+module expectedForKeyword 'modulea.bicep' = []
+
+module expectedForKeyword2 'modulea.bicep' = [f]
+
+module expectedLoopVar 'modulea.bicep' = [for]
+
+module expectedInKeyword 'modulea.bicep' = [for x]
+
+module expectedInKeyword2 'modulea.bicep' = [for x b]
+
+module expectedArrayExpression 'modulea.bicep' = [for x in]
+
+module expectedColon 'modulea.bicep' = [for x in y]
+
+module expectedLoopBody 'modulea.bicep' = [for x in y:]
+
+// wrong loop body type
+var emptyArray = []
+module wrongLoopBodyType 'modulea.bicep' = [for x in emptyArray:4]
+
+// missing loop body properties
+module missingLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+}]
+
+// wrong array type
+var notAnArray = true
+module wrongArrayType 'modulea.bicep' = [for x in notAnArray:{
+}]
+
+// missing fewer properties
+module missingFewerLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+  name: 'hello-${x}'
+  params: {
+
+  }
+}]
+
+// wrong parameter in the module loop
+module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
+  name: 'hello-${x}'
+  params: {
+    arrayParam: []
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    notAThing: 'test'
+  }
+}]
+
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: y]
+  }
+}]
+
+var someDuplicate = 'hello'
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+  }
+}]
+
+var otherDuplicate = 'there'
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: x]
+  }
+}]
+
+var someDuplicate = true
+var otherDuplicate = false
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+  }
+}]
+
+/*
+  valid loop - this should be moved to Modules_* test case after E2E works
+*/ 
+var myModules = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+module storageResources 'modulea.bicep' = [for module in myModules: {
+  name: module.name
+  params: {
+    arrayParam: []
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+  name: module.name
+  params: {
+    arrayParam: [for i in range(0,3): concat('test', i)]
+    objParam: module
+    stringParamB: module.location
+  }
+}]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
@@ -332,45 +332,14 @@ module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
   }
 }]
 
-module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
-  name: 'hello-${x}'
-  params: {
-    objParam: {}
-    stringParamA: 'test'
-    stringParamB: 'test'
-    arrayParam: [for x in emptyArray: y]
-  }
-}]
-
-var someDuplicate = 'hello'
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
-  name: 'hello-${someDuplicate}'
-  params: {
-    objParam: {}
-    stringParamA: 'test'
-    stringParamB: 'test'
-    arrayParam: [for x in emptyArray: x]
-  }
-}]
-
-var otherDuplicate = 'there'
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
-  name: 'hello-${someDuplicate}'
+// nonexistent arrays and loop variables
+var evenMoreDuplicates = 'there'
+module nonexistentArrays 'modulea.bicep' = [for evenMoreDuplicates in alsoDoesNotExist: {
+  name: 'hello-${whyChooseRealVariablesWhenWeCanPretend}'
   params: {
     objParam: {}
     stringParamB: 'test'
-    arrayParam: [for otherDuplicate in emptyArray: x]
-  }
-}]
-
-var someDuplicate = true
-var otherDuplicate = false
-module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
-  name: 'hello-${someDuplicate}'
-  params: {
-    objParam: {}
-    stringParamB: 'test'
-    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+    arrayParam: [for evenMoreDuplicates in totallyFake: doesNotExist]
   }
 }]
 
@@ -387,6 +356,42 @@ var myModules = [
     location: 'westus'
   }
 ]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: y]
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+  name: 'hello-${duplicateAcrossScopes}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+  }
+}]
+
+var someDuplicate = true
+var otherDuplicate = false
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+  }
+}]
+
+// simple module loop
 module storageResources 'modulea.bicep' = [for module in myModules: {
   name: module.name
   params: {
@@ -396,6 +401,7 @@ module storageResources 'modulea.bicep' = [for module in myModules: {
   }
 }]
 
+// nested module loop
 module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
   name: module.name
   params: {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
@@ -455,67 +455,20 @@ module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
   }
 }]
 
-module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
-//@[57:60) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[61:62) [BCP028 (Error)] Identifier "x" is declared multiple times. Remove or rename the duplicates. |x|
-  name: 'hello-${x}'
-  params: {
-    objParam: {}
-    stringParamA: 'test'
-    stringParamB: 'test'
-    arrayParam: [for x in emptyArray: y]
-//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[21:22) [BCP028 (Error)] Identifier "x" is declared multiple times. Remove or rename the duplicates. |x|
-//@[38:39) [BCP057 (Error)] The name "y" does not exist in the current context. |y|
-  }
-}]
-
-var someDuplicate = 'hello'
-//@[4:17) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
-//@[7:34) [BCP028 (Error)] Identifier "duplicateInGlobalAndOneLoop" is declared multiple times. Remove or rename the duplicates. |duplicateInGlobalAndOneLoop|
-//@[54:57) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[58:71) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
-  name: 'hello-${someDuplicate}'
-  params: {
-    objParam: {}
-    stringParamA: 'test'
-    stringParamB: 'test'
-    arrayParam: [for x in emptyArray: x]
-//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
-  }
-}]
-
-var otherDuplicate = 'there'
-//@[4:18) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
-//@[7:34) [BCP028 (Error)] Identifier "duplicateInGlobalAndOneLoop" is declared multiple times. Remove or rename the duplicates. |duplicateInGlobalAndOneLoop|
-//@[54:57) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[58:72) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
-  name: 'hello-${someDuplicate}'
+// nonexistent arrays and loop variables
+var evenMoreDuplicates = 'there'
+module nonexistentArrays 'modulea.bicep' = [for evenMoreDuplicates in alsoDoesNotExist: {
+//@[44:47) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[70:86) [BCP057 (Error)] The name "alsoDoesNotExist" does not exist in the current context. |alsoDoesNotExist|
+  name: 'hello-${whyChooseRealVariablesWhenWeCanPretend}'
+//@[17:55) [BCP057 (Error)] The name "whyChooseRealVariablesWhenWeCanPretend" does not exist in the current context. |whyChooseRealVariablesWhenWeCanPretend|
   params: {
     objParam: {}
     stringParamB: 'test'
-    arrayParam: [for otherDuplicate in emptyArray: x]
+    arrayParam: [for evenMoreDuplicates in totallyFake: doesNotExist]
 //@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[21:35) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
-  }
-}]
-
-var someDuplicate = true
-//@[4:17) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
-var otherDuplicate = false
-//@[4:18) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
-module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
-//@[47:50) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[51:64) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
-  name: 'hello-${someDuplicate}'
-  params: {
-    objParam: {}
-    stringParamB: 'test'
-    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
-//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[21:35) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+//@[43:54) [BCP057 (Error)] The name "totallyFake" does not exist in the current context. |totallyFake|
+//@[56:68) [BCP057 (Error)] The name "doesNotExist" does not exist in the current context. |doesNotExist|
   }
 }]
 
@@ -532,6 +485,49 @@ var myModules = [
     location: 'westus'
   }
 ]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[57:60) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: y]
+//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[38:39) [BCP057 (Error)] The name "y" does not exist in the current context. |y|
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+//@[54:57) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'hello-${duplicateAcrossScopes}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
+  }
+}]
+
+var someDuplicate = true
+var otherDuplicate = false
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@[47:50) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
+  }
+}]
+
+// simple module loop
 module storageResources 'modulea.bicep' = [for module in myModules: {
 //@[43:46) [BCP138 (Error)] Loops are not currently supported. |for|
   name: module.name
@@ -542,6 +538,7 @@ module storageResources 'modulea.bicep' = [for module in myModules: {
   }
 }]
 
+// nested module loop
 module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
 //@[43:46) [BCP138 (Error)] Loops are not currently supported. |for|
   name: module.name

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
@@ -31,7 +31,7 @@ module
 // #completionTest(24,25) -> object
 module missingValue '' = 
 //@[20:22) [BCP050 (Error)] The specified module path is empty. |''|
-//@[25:25) [BCP118 (Error)] Expected the "{" character or the "if" keyword at this location. ||
+//@[25:25) [BCP118 (Error)] Expected the "{" character, the "[" character, or the "if" keyword at this location. ||
 
 var interp = 'hello'
 module moduleWithInterpPath './${interp}.bicep' = {
@@ -277,32 +277,32 @@ module runtimeValidModule1 'empty.bicep' = {
 
 module runtimeInvalidModule1 'empty.bicep' = {
   name: runtimeValidRes1.location
-//@[8:33) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1.location|
+//@[8:33) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1.location|
 }
 
 module runtimeInvalidModule2 'empty.bicep' = {
   name: runtimeValidRes1['location']
-//@[8:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1['location']|
+//@[8:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1['location']|
 }
 
 module runtimeInvalidModule3 'empty.bicep' = {
   name: runtimeValidRes1.sku.name
-//@[8:33) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1.sku.name|
+//@[8:33) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1.sku.name|
 }
 
 module runtimeInvalidModule4 'empty.bicep' = {
   name: runtimeValidRes1.sku['name']
-//@[8:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1.sku['name']|
+//@[8:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1.sku['name']|
 }
 
 module runtimeInvalidModule5 'empty.bicep' = {
   name: runtimeValidRes1['sku']['name']
-//@[8:39) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1['sku']['name']|
+//@[8:39) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1['sku']['name']|
 }
 
 module runtimeInvalidModule6 'empty.bicep' = {
   name: runtimeValidRes1['sku'].name
-//@[8:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1['sku'].name|
+//@[8:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1['sku'].name|
 }
 
 module moduleWithDuplicateName1 './empty.bicep' = {
@@ -324,7 +324,7 @@ module completionB ''
 // #completionTest(19, 20, 21) -> cwdCompletions
 module completionC '' =
 //@[19:21) [BCP050 (Error)] The specified module path is empty. |''|
-//@[23:23) [BCP118 (Error)] Expected the "{" character or the "if" keyword at this location. ||
+//@[23:23) [BCP118 (Error)] Expected the "{" character, the "[" character, or the "if" keyword at this location. ||
 
 // #completionTest(19, 20, 21) -> cwdCompletions
 module completionD '' = {}
@@ -378,3 +378,177 @@ module moduleWithNotAttachableDecorators './empty.bicep' = {
   name: 'moduleWithNotAttachableDecorators'
 }
 
+// loop parsing cases
+module expectedForKeyword 'modulea.bicep' = []
+//@[45:46) [BCP012 (Error)] Expected the "for" keyword at this location. |]|
+
+module expectedForKeyword2 'modulea.bicep' = [f]
+//@[46:47) [BCP012 (Error)] Expected the "for" keyword at this location. |f|
+
+module expectedLoopVar 'modulea.bicep' = [for]
+//@[42:45) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[45:46) [BCP136 (Error)] Expected a loop variable identifier at this location. |]|
+
+module expectedInKeyword 'modulea.bicep' = [for x]
+//@[44:47) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[49:50) [BCP012 (Error)] Expected the "in" keyword at this location. |]|
+
+module expectedInKeyword2 'modulea.bicep' = [for x b]
+//@[45:48) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[51:52) [BCP012 (Error)] Expected the "in" keyword at this location. |b|
+//@[52:53) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. |]|
+
+module expectedArrayExpression 'modulea.bicep' = [for x in]
+//@[50:53) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[58:59) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. |]|
+
+module expectedColon 'modulea.bicep' = [for x in y]
+//@[40:43) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[49:50) [BCP057 (Error)] The name "y" does not exist in the current context. |y|
+//@[50:51) [BCP018 (Error)] Expected the ":" character at this location. |]|
+
+module expectedLoopBody 'modulea.bicep' = [for x in y:]
+//@[43:46) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[52:53) [BCP057 (Error)] The name "y" does not exist in the current context. |y|
+//@[54:55) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. |]|
+
+// wrong loop body type
+var emptyArray = []
+module wrongLoopBodyType 'modulea.bicep' = [for x in emptyArray:4]
+//@[44:47) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[64:65) [BCP033 (Error)] Expected a value of type "module" but the provided value is of type "int". |4|
+
+// missing loop body properties
+module missingLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+//@[7:32) [BCP035 (Error)] The specified "module" declaration is missing the following required properties: "name", "params". |missingLoopBodyProperties|
+//@[52:55) [BCP138 (Error)] Loops are not currently supported. |for|
+}]
+
+// wrong array type
+var notAnArray = true
+module wrongArrayType 'modulea.bicep' = [for x in notAnArray:{
+//@[41:44) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[50:60) [BCP137 (Error)] Loop expected an expression of type "array" but the provided value is of type "bool". |notAnArray|
+}]
+
+// missing fewer properties
+module missingFewerLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+//@[57:60) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'hello-${x}'
+  params: {
+//@[2:8) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "arrayParam", "objParam", "stringParamB". |params|
+
+  }
+}]
+
+// wrong parameter in the module loop
+module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[53:56) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'hello-${x}'
+  params: {
+    arrayParam: []
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    notAThing: 'test'
+//@[4:13) [BCP037 (Error)] No other properties are allowed on objects of type "params". |notAThing|
+  }
+}]
+
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[57:60) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[61:62) [BCP028 (Error)] Identifier "x" is declared multiple times. Remove or rename the duplicates. |x|
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: y]
+//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[21:22) [BCP028 (Error)] Identifier "x" is declared multiple times. Remove or rename the duplicates. |x|
+//@[38:39) [BCP057 (Error)] The name "y" does not exist in the current context. |y|
+  }
+}]
+
+var someDuplicate = 'hello'
+//@[4:17) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
+//@[7:34) [BCP028 (Error)] Identifier "duplicateInGlobalAndOneLoop" is declared multiple times. Remove or rename the duplicates. |duplicateInGlobalAndOneLoop|
+//@[54:57) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[58:71) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
+  }
+}]
+
+var otherDuplicate = 'there'
+//@[4:18) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
+//@[7:34) [BCP028 (Error)] Identifier "duplicateInGlobalAndOneLoop" is declared multiple times. Remove or rename the duplicates. |duplicateInGlobalAndOneLoop|
+//@[54:57) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[58:72) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: x]
+//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[21:35) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+  }
+}]
+
+var someDuplicate = true
+//@[4:17) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
+var otherDuplicate = false
+//@[4:18) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@[47:50) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[51:64) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[21:35) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+  }
+}]
+
+/*
+  valid loop - this should be moved to Modules_* test case after E2E works
+*/ 
+var myModules = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+module storageResources 'modulea.bicep' = [for module in myModules: {
+//@[43:46) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: module.name
+  params: {
+    arrayParam: []
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+//@[43:46) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: module.name
+  params: {
+    arrayParam: [for i in range(0,3): concat('test', i)]
+//@[17:20) [BCP138 (Error)] Loops are not currently supported. |for|
+    objParam: module
+    stringParamB: module.location
+  }
+}]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.formatted.bicep
@@ -296,45 +296,14 @@ module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray: {
   }
 }]
 
-module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray: {
-  name: 'hello-${x}'
-  params: {
-    objParam: {}
-    stringParamA: 'test'
-    stringParamB: 'test'
-    arrayParam: [for x in emptyArray: y]
-  }
-}]
-
-var someDuplicate = 'hello'
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
-  name: 'hello-${someDuplicate}'
-  params: {
-    objParam: {}
-    stringParamA: 'test'
-    stringParamB: 'test'
-    arrayParam: [for x in emptyArray: x]
-  }
-}]
-
-var otherDuplicate = 'there'
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
-  name: 'hello-${someDuplicate}'
+// nonexistent arrays and loop variables
+var evenMoreDuplicates = 'there'
+module nonexistentArrays 'modulea.bicep' = [for evenMoreDuplicates in alsoDoesNotExist: {
+  name: 'hello-${whyChooseRealVariablesWhenWeCanPretend}'
   params: {
     objParam: {}
     stringParamB: 'test'
-    arrayParam: [for otherDuplicate in emptyArray: x]
-  }
-}]
-
-var someDuplicate = true
-var otherDuplicate = false
-module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
-  name: 'hello-${someDuplicate}'
-  params: {
-    objParam: {}
-    stringParamB: 'test'
-    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+    arrayParam: [for evenMoreDuplicates in totallyFake: doesNotExist]
   }
 }]
 
@@ -351,6 +320,42 @@ var myModules = [
     location: 'westus'
   }
 ]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray: {
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: y]
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+  name: 'hello-${duplicateAcrossScopes}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+  }
+}]
+
+var someDuplicate = true
+var otherDuplicate = false
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+  }
+}]
+
+// simple module loop
 module storageResources 'modulea.bicep' = [for module in myModules: {
   name: module.name
   params: {
@@ -360,6 +365,7 @@ module storageResources 'modulea.bicep' = [for module in myModules: {
   }
 }]
 
+// nested module loop
 module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
   name: module.name
   params: {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.formatted.bicep
@@ -249,3 +249,122 @@ module childCompletionD 'ChildModules/e'
 module moduleWithNotAttachableDecorators './empty.bicep' = {
   name: 'moduleWithNotAttachableDecorators'
 }
+
+// loop parsing cases
+module expectedForKeyword 'modulea.bicep' = []
+
+module expectedForKeyword2 'modulea.bicep' = [f]
+
+module expectedLoopVar 'modulea.bicep' = [for]
+
+module expectedInKeyword 'modulea.bicep' = [for x]
+
+module expectedInKeyword2 'modulea.bicep' = [for x b]
+
+module expectedArrayExpression 'modulea.bicep' = [for x in]
+
+module expectedColon 'modulea.bicep' = [for x in y]
+
+module expectedLoopBody 'modulea.bicep' = [for x in y:]
+
+// wrong loop body type
+var emptyArray = []
+module wrongLoopBodyType 'modulea.bicep' = [for x in emptyArray: 4]
+
+// missing loop body properties
+module missingLoopBodyProperties 'modulea.bicep' = [for x in emptyArray: {}]
+
+// wrong array type
+var notAnArray = true
+module wrongArrayType 'modulea.bicep' = [for x in notAnArray: {}]
+
+// missing fewer properties
+module missingFewerLoopBodyProperties 'modulea.bicep' = [for x in emptyArray: {
+  name: 'hello-${x}'
+  params: {}
+}]
+
+// wrong parameter in the module loop
+module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray: {
+  name: 'hello-${x}'
+  params: {
+    arrayParam: []
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    notAThing: 'test'
+  }
+}]
+
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray: {
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: y]
+  }
+}]
+
+var someDuplicate = 'hello'
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+  }
+}]
+
+var otherDuplicate = 'there'
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: x]
+  }
+}]
+
+var someDuplicate = true
+var otherDuplicate = false
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+  }
+}]
+
+/*
+  valid loop - this should be moved to Modules_* test case after E2E works
+*/
+var myModules = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+module storageResources 'modulea.bicep' = [for module in myModules: {
+  name: module.name
+  params: {
+    arrayParam: []
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+  name: module.name
+  params: {
+    arrayParam: [for i in range(0, 3): concat('test', i)]
+    objParam: module
+    stringParamB: module.location
+  }
+}]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
@@ -352,3 +352,173 @@ module moduleWithNotAttachableDecorators './empty.bicep' = {
   name: 'moduleWithNotAttachableDecorators'
 }
 
+// loop parsing cases
+module expectedForKeyword 'modulea.bicep' = []
+//@[7:25) Module expectedForKeyword. Type: module. Declaration start char: 0, length: 46
+
+module expectedForKeyword2 'modulea.bicep' = [f]
+//@[7:26) Module expectedForKeyword2. Type: module. Declaration start char: 0, length: 48
+
+module expectedLoopVar 'modulea.bicep' = [for]
+//@[45:45) Local <missing>. Type: any. Declaration start char: 45, length: 0
+//@[7:22) Module expectedLoopVar. Type: module[]. Declaration start char: 0, length: 46
+
+module expectedInKeyword 'modulea.bicep' = [for x]
+//@[48:49) Local x. Type: any. Declaration start char: 48, length: 1
+//@[7:24) Module expectedInKeyword. Type: module[]. Declaration start char: 0, length: 50
+
+module expectedInKeyword2 'modulea.bicep' = [for x b]
+//@[49:50) Local x. Type: any. Declaration start char: 49, length: 1
+//@[7:25) Module expectedInKeyword2. Type: module[]. Declaration start char: 0, length: 53
+
+module expectedArrayExpression 'modulea.bicep' = [for x in]
+//@[54:55) Local x. Type: any. Declaration start char: 54, length: 1
+//@[7:30) Module expectedArrayExpression. Type: module[]. Declaration start char: 0, length: 59
+
+module expectedColon 'modulea.bicep' = [for x in y]
+//@[44:45) Local x. Type: any. Declaration start char: 44, length: 1
+//@[7:20) Module expectedColon. Type: module[]. Declaration start char: 0, length: 51
+
+module expectedLoopBody 'modulea.bicep' = [for x in y:]
+//@[47:48) Local x. Type: any. Declaration start char: 47, length: 1
+//@[7:23) Module expectedLoopBody. Type: module[]. Declaration start char: 0, length: 55
+
+// wrong loop body type
+var emptyArray = []
+//@[4:14) Variable emptyArray. Type: array. Declaration start char: 0, length: 19
+module wrongLoopBodyType 'modulea.bicep' = [for x in emptyArray:4]
+//@[48:49) Local x. Type: any. Declaration start char: 48, length: 1
+//@[7:24) Module wrongLoopBodyType. Type: module[]. Declaration start char: 0, length: 66
+
+// missing loop body properties
+module missingLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+//@[56:57) Local x. Type: any. Declaration start char: 56, length: 1
+//@[7:32) Module missingLoopBodyProperties. Type: module[]. Declaration start char: 0, length: 76
+}]
+
+// wrong array type
+var notAnArray = true
+//@[4:14) Variable notAnArray. Type: bool. Declaration start char: 0, length: 21
+module wrongArrayType 'modulea.bicep' = [for x in notAnArray:{
+//@[45:46) Local x. Type: any. Declaration start char: 45, length: 1
+//@[7:21) Module wrongArrayType. Type: module[]. Declaration start char: 0, length: 65
+}]
+
+// missing fewer properties
+module missingFewerLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+//@[61:62) Local x. Type: any. Declaration start char: 61, length: 1
+//@[7:37) Module missingFewerLoopBodyProperties. Type: module[]. Declaration start char: 0, length: 119
+  name: 'hello-${x}'
+  params: {
+
+  }
+}]
+
+// wrong parameter in the module loop
+module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[57:58) Local x. Type: any. Declaration start char: 57, length: 1
+//@[7:33) Module wrongModuleParameterInLoop. Type: module[]. Declaration start char: 0, length: 222
+  name: 'hello-${x}'
+  params: {
+    arrayParam: []
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    notAThing: 'test'
+  }
+}]
+
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[61:62) Local x. Type: any. Declaration start char: 61, length: 1
+//@[7:37) Module duplicateIdentifiersWithinLoop. Type: module[]. Declaration start char: 0, length: 226
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: y]
+//@[21:22) Local x. Type: any. Declaration start char: 21, length: 1
+  }
+}]
+
+var someDuplicate = 'hello'
+//@[4:17) Variable someDuplicate. Type: 'hello'. Declaration start char: 0, length: 27
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
+//@[58:71) Local someDuplicate. Type: any. Declaration start char: 58, length: 13
+//@[7:34) Module duplicateInGlobalAndOneLoop. Type: module[]. Declaration start char: 0, length: 240
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+//@[21:22) Local x. Type: any. Declaration start char: 21, length: 1
+  }
+}]
+
+var otherDuplicate = 'there'
+//@[4:18) Variable otherDuplicate. Type: 'there'. Declaration start char: 0, length: 28
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
+//@[58:72) Local otherDuplicate. Type: any. Declaration start char: 58, length: 14
+//@[7:34) Module duplicateInGlobalAndOneLoop. Type: error. Declaration start char: 0, length: 229
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: x]
+//@[21:35) Local otherDuplicate. Type: any. Declaration start char: 21, length: 14
+  }
+}]
+
+var someDuplicate = true
+//@[4:17) Variable someDuplicate. Type: bool. Declaration start char: 0, length: 24
+var otherDuplicate = false
+//@[4:18) Variable otherDuplicate. Type: bool. Declaration start char: 0, length: 26
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@[51:64) Local someDuplicate. Type: any. Declaration start char: 51, length: 13
+//@[7:27) Module duplicatesEverywhere. Type: module[]. Declaration start char: 0, length: 256
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@[21:35) Local otherDuplicate. Type: any. Declaration start char: 21, length: 14
+  }
+}]
+
+/*
+  valid loop - this should be moved to Modules_* test case after E2E works
+*/ 
+var myModules = [
+//@[4:13) Variable myModules. Type: array. Declaration start char: 0, length: 114
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+module storageResources 'modulea.bicep' = [for module in myModules: {
+//@[47:53) Local module. Type: any. Declaration start char: 47, length: 6
+//@[7:23) Module storageResources. Type: module[]. Declaration start char: 0, length: 182
+  name: module.name
+  params: {
+    arrayParam: []
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+//@[47:53) Local module. Type: any. Declaration start char: 47, length: 6
+//@[7:23) Module nestedModuleLoop. Type: module[]. Declaration start char: 0, length: 220
+  name: module.name
+  params: {
+    arrayParam: [for i in range(0,3): concat('test', i)]
+//@[21:22) Local i. Type: any. Declaration start char: 21, length: 1
+    objParam: module
+    stringParamB: module.location
+  }
+}]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
@@ -428,6 +428,37 @@ module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
   }
 }]
 
+// nonexistent arrays and loop variables
+var evenMoreDuplicates = 'there'
+//@[4:22) Variable evenMoreDuplicates. Type: 'there'. Declaration start char: 0, length: 32
+module nonexistentArrays 'modulea.bicep' = [for evenMoreDuplicates in alsoDoesNotExist: {
+//@[48:66) Local evenMoreDuplicates. Type: any. Declaration start char: 48, length: 18
+//@[7:24) Module nonexistentArrays. Type: module[]. Declaration start char: 0, length: 278
+  name: 'hello-${whyChooseRealVariablesWhenWeCanPretend}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for evenMoreDuplicates in totallyFake: doesNotExist]
+//@[21:39) Local evenMoreDuplicates. Type: any. Declaration start char: 21, length: 18
+  }
+}]
+
+/*
+  valid loop - this should be moved to Modules_* test case after E2E works
+*/ 
+var myModules = [
+//@[4:13) Variable myModules. Type: array. Declaration start char: 0, length: 114
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
 module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
 //@[61:62) Local x. Type: any. Declaration start char: 61, length: 1
 //@[7:37) Module duplicateIdentifiersWithinLoop. Type: module[]. Declaration start char: 0, length: 226
@@ -441,32 +472,19 @@ module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
   }
 }]
 
-var someDuplicate = 'hello'
-//@[4:17) Variable someDuplicate. Type: 'hello'. Declaration start char: 0, length: 27
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
-//@[58:71) Local someDuplicate. Type: any. Declaration start char: 58, length: 13
-//@[7:34) Module duplicateInGlobalAndOneLoop. Type: module[]. Declaration start char: 0, length: 240
-  name: 'hello-${someDuplicate}'
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+//@[4:25) Variable duplicateAcrossScopes. Type: 'hello'. Declaration start char: 0, length: 35
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+//@[58:79) Local duplicateAcrossScopes. Type: any. Declaration start char: 58, length: 21
+//@[7:34) Module duplicateInGlobalAndOneLoop. Type: module[]. Declaration start char: 0, length: 256
+  name: 'hello-${duplicateAcrossScopes}'
   params: {
     objParam: {}
     stringParamA: 'test'
     stringParamB: 'test'
     arrayParam: [for x in emptyArray: x]
 //@[21:22) Local x. Type: any. Declaration start char: 21, length: 1
-  }
-}]
-
-var otherDuplicate = 'there'
-//@[4:18) Variable otherDuplicate. Type: 'there'. Declaration start char: 0, length: 28
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
-//@[58:72) Local otherDuplicate. Type: any. Declaration start char: 58, length: 14
-//@[7:34) Module duplicateInGlobalAndOneLoop. Type: error. Declaration start char: 0, length: 229
-  name: 'hello-${someDuplicate}'
-  params: {
-    objParam: {}
-    stringParamB: 'test'
-    arrayParam: [for otherDuplicate in emptyArray: x]
-//@[21:35) Local otherDuplicate. Type: any. Declaration start char: 21, length: 14
   }
 }]
 
@@ -486,20 +504,7 @@ module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
   }
 }]
 
-/*
-  valid loop - this should be moved to Modules_* test case after E2E works
-*/ 
-var myModules = [
-//@[4:13) Variable myModules. Type: array. Declaration start char: 0, length: 114
-  {
-    name: 'one'
-    location: 'eastus2'
-  }
-  {
-    name: 'two'
-    location: 'westus'
-  }
-]
+// simple module loop
 module storageResources 'modulea.bicep' = [for module in myModules: {
 //@[47:53) Local module. Type: any. Declaration start char: 47, length: 6
 //@[7:23) Module storageResources. Type: module[]. Declaration start char: 0, length: 182
@@ -511,6 +516,7 @@ module storageResources 'modulea.bicep' = [for module in myModules: {
   }
 }]
 
+// nested module loop
 module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
 //@[47:53) Local module. Type: any. Declaration start char: 47, length: 6
 //@[7:23) Module nestedModuleLoop. Type: module[]. Declaration start char: 0, length: 220

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
@@ -1720,6 +1720,1084 @@ module moduleWithNotAttachableDecorators './empty.bicep' = {
 //@[43:44)   NewLine |\n|
 }
 //@[0:1)   RightBrace |}|
-//@[1:2) NewLine |\n|
+//@[1:3) NewLine |\n\n|
 
-//@[0:0) EndOfFile ||
+// loop parsing cases
+//@[21:22) NewLine |\n|
+module expectedForKeyword 'modulea.bicep' = []
+//@[0:46) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:25)  IdentifierSyntax
+//@[7:25)   Identifier |expectedForKeyword|
+//@[26:41)  StringSyntax
+//@[26:41)   StringComplete |'modulea.bicep'|
+//@[42:43)  Assignment |=|
+//@[44:46)  SkippedTriviaSyntax
+//@[44:45)   LeftSquare |[|
+//@[45:46)   RightSquare |]|
+//@[46:48) NewLine |\n\n|
+
+module expectedForKeyword2 'modulea.bicep' = [f]
+//@[0:48) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:26)  IdentifierSyntax
+//@[7:26)   Identifier |expectedForKeyword2|
+//@[27:42)  StringSyntax
+//@[27:42)   StringComplete |'modulea.bicep'|
+//@[43:44)  Assignment |=|
+//@[45:48)  SkippedTriviaSyntax
+//@[45:46)   LeftSquare |[|
+//@[46:47)   Identifier |f|
+//@[47:48)   RightSquare |]|
+//@[48:50) NewLine |\n\n|
+
+module expectedLoopVar 'modulea.bicep' = [for]
+//@[0:46) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:22)  IdentifierSyntax
+//@[7:22)   Identifier |expectedLoopVar|
+//@[23:38)  StringSyntax
+//@[23:38)   StringComplete |'modulea.bicep'|
+//@[39:40)  Assignment |=|
+//@[41:46)  ForSyntax
+//@[41:42)   LeftSquare |[|
+//@[42:45)   Identifier |for|
+//@[45:45)   LocalVariableSyntax
+//@[45:45)    IdentifierSyntax
+//@[45:45)     SkippedTriviaSyntax
+//@[45:45)   SkippedTriviaSyntax
+//@[45:45)   SkippedTriviaSyntax
+//@[45:45)   SkippedTriviaSyntax
+//@[45:45)   SkippedTriviaSyntax
+//@[45:46)   RightSquare |]|
+//@[46:48) NewLine |\n\n|
+
+module expectedInKeyword 'modulea.bicep' = [for x]
+//@[0:50) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:24)  IdentifierSyntax
+//@[7:24)   Identifier |expectedInKeyword|
+//@[25:40)  StringSyntax
+//@[25:40)   StringComplete |'modulea.bicep'|
+//@[41:42)  Assignment |=|
+//@[43:50)  ForSyntax
+//@[43:44)   LeftSquare |[|
+//@[44:47)   Identifier |for|
+//@[48:49)   LocalVariableSyntax
+//@[48:49)    IdentifierSyntax
+//@[48:49)     Identifier |x|
+//@[49:49)   SkippedTriviaSyntax
+//@[49:49)   SkippedTriviaSyntax
+//@[49:49)   SkippedTriviaSyntax
+//@[49:49)   SkippedTriviaSyntax
+//@[49:50)   RightSquare |]|
+//@[50:52) NewLine |\n\n|
+
+module expectedInKeyword2 'modulea.bicep' = [for x b]
+//@[0:53) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:25)  IdentifierSyntax
+//@[7:25)   Identifier |expectedInKeyword2|
+//@[26:41)  StringSyntax
+//@[26:41)   StringComplete |'modulea.bicep'|
+//@[42:43)  Assignment |=|
+//@[44:53)  ForSyntax
+//@[44:45)   LeftSquare |[|
+//@[45:48)   Identifier |for|
+//@[49:50)   LocalVariableSyntax
+//@[49:50)    IdentifierSyntax
+//@[49:50)     Identifier |x|
+//@[51:52)   SkippedTriviaSyntax
+//@[51:52)    Identifier |b|
+//@[52:52)   SkippedTriviaSyntax
+//@[52:52)   SkippedTriviaSyntax
+//@[52:52)   SkippedTriviaSyntax
+//@[52:53)   RightSquare |]|
+//@[53:55) NewLine |\n\n|
+
+module expectedArrayExpression 'modulea.bicep' = [for x in]
+//@[0:59) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:30)  IdentifierSyntax
+//@[7:30)   Identifier |expectedArrayExpression|
+//@[31:46)  StringSyntax
+//@[31:46)   StringComplete |'modulea.bicep'|
+//@[47:48)  Assignment |=|
+//@[49:59)  ForSyntax
+//@[49:50)   LeftSquare |[|
+//@[50:53)   Identifier |for|
+//@[54:55)   LocalVariableSyntax
+//@[54:55)    IdentifierSyntax
+//@[54:55)     Identifier |x|
+//@[56:58)   Identifier |in|
+//@[58:58)   SkippedTriviaSyntax
+//@[58:58)   SkippedTriviaSyntax
+//@[58:58)   SkippedTriviaSyntax
+//@[58:59)   RightSquare |]|
+//@[59:61) NewLine |\n\n|
+
+module expectedColon 'modulea.bicep' = [for x in y]
+//@[0:51) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:20)  IdentifierSyntax
+//@[7:20)   Identifier |expectedColon|
+//@[21:36)  StringSyntax
+//@[21:36)   StringComplete |'modulea.bicep'|
+//@[37:38)  Assignment |=|
+//@[39:51)  ForSyntax
+//@[39:40)   LeftSquare |[|
+//@[40:43)   Identifier |for|
+//@[44:45)   LocalVariableSyntax
+//@[44:45)    IdentifierSyntax
+//@[44:45)     Identifier |x|
+//@[46:48)   Identifier |in|
+//@[49:50)   VariableAccessSyntax
+//@[49:50)    IdentifierSyntax
+//@[49:50)     Identifier |y|
+//@[50:50)   SkippedTriviaSyntax
+//@[50:50)   SkippedTriviaSyntax
+//@[50:51)   RightSquare |]|
+//@[51:53) NewLine |\n\n|
+
+module expectedLoopBody 'modulea.bicep' = [for x in y:]
+//@[0:55) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:23)  IdentifierSyntax
+//@[7:23)   Identifier |expectedLoopBody|
+//@[24:39)  StringSyntax
+//@[24:39)   StringComplete |'modulea.bicep'|
+//@[40:41)  Assignment |=|
+//@[42:55)  ForSyntax
+//@[42:43)   LeftSquare |[|
+//@[43:46)   Identifier |for|
+//@[47:48)   LocalVariableSyntax
+//@[47:48)    IdentifierSyntax
+//@[47:48)     Identifier |x|
+//@[49:51)   Identifier |in|
+//@[52:53)   VariableAccessSyntax
+//@[52:53)    IdentifierSyntax
+//@[52:53)     Identifier |y|
+//@[53:54)   Colon |:|
+//@[54:54)   SkippedTriviaSyntax
+//@[54:55)   RightSquare |]|
+//@[55:57) NewLine |\n\n|
+
+// wrong loop body type
+//@[23:24) NewLine |\n|
+var emptyArray = []
+//@[0:19) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:14)  IdentifierSyntax
+//@[4:14)   Identifier |emptyArray|
+//@[15:16)  Assignment |=|
+//@[17:19)  ArraySyntax
+//@[17:18)   LeftSquare |[|
+//@[18:19)   RightSquare |]|
+//@[19:20) NewLine |\n|
+module wrongLoopBodyType 'modulea.bicep' = [for x in emptyArray:4]
+//@[0:66) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:24)  IdentifierSyntax
+//@[7:24)   Identifier |wrongLoopBodyType|
+//@[25:40)  StringSyntax
+//@[25:40)   StringComplete |'modulea.bicep'|
+//@[41:42)  Assignment |=|
+//@[43:66)  ForSyntax
+//@[43:44)   LeftSquare |[|
+//@[44:47)   Identifier |for|
+//@[48:49)   LocalVariableSyntax
+//@[48:49)    IdentifierSyntax
+//@[48:49)     Identifier |x|
+//@[50:52)   Identifier |in|
+//@[53:63)   VariableAccessSyntax
+//@[53:63)    IdentifierSyntax
+//@[53:63)     Identifier |emptyArray|
+//@[63:64)   Colon |:|
+//@[64:65)   IntegerLiteralSyntax
+//@[64:65)    Integer |4|
+//@[65:66)   RightSquare |]|
+//@[66:68) NewLine |\n\n|
+
+// missing loop body properties
+//@[31:32) NewLine |\n|
+module missingLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+//@[0:76) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:32)  IdentifierSyntax
+//@[7:32)   Identifier |missingLoopBodyProperties|
+//@[33:48)  StringSyntax
+//@[33:48)   StringComplete |'modulea.bicep'|
+//@[49:50)  Assignment |=|
+//@[51:76)  ForSyntax
+//@[51:52)   LeftSquare |[|
+//@[52:55)   Identifier |for|
+//@[56:57)   LocalVariableSyntax
+//@[56:57)    IdentifierSyntax
+//@[56:57)     Identifier |x|
+//@[58:60)   Identifier |in|
+//@[61:71)   VariableAccessSyntax
+//@[61:71)    IdentifierSyntax
+//@[61:71)     Identifier |emptyArray|
+//@[71:72)   Colon |:|
+//@[72:75)   ObjectSyntax
+//@[72:73)    LeftBrace |{|
+//@[73:74)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+// wrong array type
+//@[19:20) NewLine |\n|
+var notAnArray = true
+//@[0:21) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:14)  IdentifierSyntax
+//@[4:14)   Identifier |notAnArray|
+//@[15:16)  Assignment |=|
+//@[17:21)  BooleanLiteralSyntax
+//@[17:21)   TrueKeyword |true|
+//@[21:22) NewLine |\n|
+module wrongArrayType 'modulea.bicep' = [for x in notAnArray:{
+//@[0:65) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:21)  IdentifierSyntax
+//@[7:21)   Identifier |wrongArrayType|
+//@[22:37)  StringSyntax
+//@[22:37)   StringComplete |'modulea.bicep'|
+//@[38:39)  Assignment |=|
+//@[40:65)  ForSyntax
+//@[40:41)   LeftSquare |[|
+//@[41:44)   Identifier |for|
+//@[45:46)   LocalVariableSyntax
+//@[45:46)    IdentifierSyntax
+//@[45:46)     Identifier |x|
+//@[47:49)   Identifier |in|
+//@[50:60)   VariableAccessSyntax
+//@[50:60)    IdentifierSyntax
+//@[50:60)     Identifier |notAnArray|
+//@[60:61)   Colon |:|
+//@[61:64)   ObjectSyntax
+//@[61:62)    LeftBrace |{|
+//@[62:63)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+// missing fewer properties
+//@[27:28) NewLine |\n|
+module missingFewerLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+//@[0:119) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:37)  IdentifierSyntax
+//@[7:37)   Identifier |missingFewerLoopBodyProperties|
+//@[38:53)  StringSyntax
+//@[38:53)   StringComplete |'modulea.bicep'|
+//@[54:55)  Assignment |=|
+//@[56:119)  ForSyntax
+//@[56:57)   LeftSquare |[|
+//@[57:60)   Identifier |for|
+//@[61:62)   LocalVariableSyntax
+//@[61:62)    IdentifierSyntax
+//@[61:62)     Identifier |x|
+//@[63:65)   Identifier |in|
+//@[66:76)   VariableAccessSyntax
+//@[66:76)    IdentifierSyntax
+//@[66:76)     Identifier |emptyArray|
+//@[76:77)   Colon |:|
+//@[77:118)   ObjectSyntax
+//@[77:78)    LeftBrace |{|
+//@[78:79)    NewLine |\n|
+  name: 'hello-${x}'
+//@[2:20)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:20)     StringSyntax
+//@[8:17)      StringLeftPiece |'hello-${|
+//@[17:18)      VariableAccessSyntax
+//@[17:18)       IdentifierSyntax
+//@[17:18)        Identifier |x|
+//@[18:20)      StringRightPiece |}'|
+//@[20:21)    NewLine |\n|
+  params: {
+//@[2:16)    ObjectPropertySyntax
+//@[2:8)     IdentifierSyntax
+//@[2:8)      Identifier |params|
+//@[8:9)     Colon |:|
+//@[10:16)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:13)      NewLine |\n\n|
+
+  }
+//@[2:3)      RightBrace |}|
+//@[3:4)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+// wrong parameter in the module loop
+//@[37:38) NewLine |\n|
+module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[0:222) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:33)  IdentifierSyntax
+//@[7:33)   Identifier |wrongModuleParameterInLoop|
+//@[34:49)  StringSyntax
+//@[34:49)   StringComplete |'modulea.bicep'|
+//@[50:51)  Assignment |=|
+//@[52:222)  ForSyntax
+//@[52:53)   LeftSquare |[|
+//@[53:56)   Identifier |for|
+//@[57:58)   LocalVariableSyntax
+//@[57:58)    IdentifierSyntax
+//@[57:58)     Identifier |x|
+//@[59:61)   Identifier |in|
+//@[62:72)   VariableAccessSyntax
+//@[62:72)    IdentifierSyntax
+//@[62:72)     Identifier |emptyArray|
+//@[72:73)   Colon |:|
+//@[73:221)   ObjectSyntax
+//@[73:74)    LeftBrace |{|
+//@[74:75)    NewLine |\n|
+  name: 'hello-${x}'
+//@[2:20)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:20)     StringSyntax
+//@[8:17)      StringLeftPiece |'hello-${|
+//@[17:18)      VariableAccessSyntax
+//@[17:18)       IdentifierSyntax
+//@[17:18)        Identifier |x|
+//@[18:20)      StringRightPiece |}'|
+//@[20:21)    NewLine |\n|
+  params: {
+//@[2:123)    ObjectPropertySyntax
+//@[2:8)     IdentifierSyntax
+//@[2:8)      Identifier |params|
+//@[8:9)     Colon |:|
+//@[10:123)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:12)      NewLine |\n|
+    arrayParam: []
+//@[4:18)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |arrayParam|
+//@[14:15)       Colon |:|
+//@[16:18)       ArraySyntax
+//@[16:17)        LeftSquare |[|
+//@[17:18)        RightSquare |]|
+//@[18:19)      NewLine |\n|
+    objParam: {}
+//@[4:16)      ObjectPropertySyntax
+//@[4:12)       IdentifierSyntax
+//@[4:12)        Identifier |objParam|
+//@[12:13)       Colon |:|
+//@[14:16)       ObjectSyntax
+//@[14:15)        LeftBrace |{|
+//@[15:16)        RightBrace |}|
+//@[16:17)      NewLine |\n|
+    stringParamA: 'test'
+//@[4:24)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamA|
+//@[16:17)       Colon |:|
+//@[18:24)       StringSyntax
+//@[18:24)        StringComplete |'test'|
+//@[24:25)      NewLine |\n|
+    stringParamB: 'test'
+//@[4:24)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamB|
+//@[16:17)       Colon |:|
+//@[18:24)       StringSyntax
+//@[18:24)        StringComplete |'test'|
+//@[24:25)      NewLine |\n|
+    notAThing: 'test'
+//@[4:21)      ObjectPropertySyntax
+//@[4:13)       IdentifierSyntax
+//@[4:13)        Identifier |notAThing|
+//@[13:14)       Colon |:|
+//@[15:21)       StringSyntax
+//@[15:21)        StringComplete |'test'|
+//@[21:22)      NewLine |\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:4)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[0:226) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:37)  IdentifierSyntax
+//@[7:37)   Identifier |duplicateIdentifiersWithinLoop|
+//@[38:53)  StringSyntax
+//@[38:53)   StringComplete |'modulea.bicep'|
+//@[54:55)  Assignment |=|
+//@[56:226)  ForSyntax
+//@[56:57)   LeftSquare |[|
+//@[57:60)   Identifier |for|
+//@[61:62)   LocalVariableSyntax
+//@[61:62)    IdentifierSyntax
+//@[61:62)     Identifier |x|
+//@[63:65)   Identifier |in|
+//@[66:76)   VariableAccessSyntax
+//@[66:76)    IdentifierSyntax
+//@[66:76)     Identifier |emptyArray|
+//@[76:77)   Colon |:|
+//@[77:225)   ObjectSyntax
+//@[77:78)    LeftBrace |{|
+//@[78:79)    NewLine |\n|
+  name: 'hello-${x}'
+//@[2:20)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:20)     StringSyntax
+//@[8:17)      StringLeftPiece |'hello-${|
+//@[17:18)      VariableAccessSyntax
+//@[17:18)       IdentifierSyntax
+//@[17:18)        Identifier |x|
+//@[18:20)      StringRightPiece |}'|
+//@[20:21)    NewLine |\n|
+  params: {
+//@[2:123)    ObjectPropertySyntax
+//@[2:8)     IdentifierSyntax
+//@[2:8)      Identifier |params|
+//@[8:9)     Colon |:|
+//@[10:123)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:12)      NewLine |\n|
+    objParam: {}
+//@[4:16)      ObjectPropertySyntax
+//@[4:12)       IdentifierSyntax
+//@[4:12)        Identifier |objParam|
+//@[12:13)       Colon |:|
+//@[14:16)       ObjectSyntax
+//@[14:15)        LeftBrace |{|
+//@[15:16)        RightBrace |}|
+//@[16:17)      NewLine |\n|
+    stringParamA: 'test'
+//@[4:24)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamA|
+//@[16:17)       Colon |:|
+//@[18:24)       StringSyntax
+//@[18:24)        StringComplete |'test'|
+//@[24:25)      NewLine |\n|
+    stringParamB: 'test'
+//@[4:24)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamB|
+//@[16:17)       Colon |:|
+//@[18:24)       StringSyntax
+//@[18:24)        StringComplete |'test'|
+//@[24:25)      NewLine |\n|
+    arrayParam: [for x in emptyArray: y]
+//@[4:40)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |arrayParam|
+//@[14:15)       Colon |:|
+//@[16:40)       ForSyntax
+//@[16:17)        LeftSquare |[|
+//@[17:20)        Identifier |for|
+//@[21:22)        LocalVariableSyntax
+//@[21:22)         IdentifierSyntax
+//@[21:22)          Identifier |x|
+//@[23:25)        Identifier |in|
+//@[26:36)        VariableAccessSyntax
+//@[26:36)         IdentifierSyntax
+//@[26:36)          Identifier |emptyArray|
+//@[36:37)        Colon |:|
+//@[38:39)        VariableAccessSyntax
+//@[38:39)         IdentifierSyntax
+//@[38:39)          Identifier |y|
+//@[39:40)        RightSquare |]|
+//@[40:41)      NewLine |\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:4)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+var someDuplicate = 'hello'
+//@[0:27) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:17)  IdentifierSyntax
+//@[4:17)   Identifier |someDuplicate|
+//@[18:19)  Assignment |=|
+//@[20:27)  StringSyntax
+//@[20:27)   StringComplete |'hello'|
+//@[27:28) NewLine |\n|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
+//@[0:240) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:34)  IdentifierSyntax
+//@[7:34)   Identifier |duplicateInGlobalAndOneLoop|
+//@[35:50)  StringSyntax
+//@[35:50)   StringComplete |'modulea.bicep'|
+//@[51:52)  Assignment |=|
+//@[53:240)  ForSyntax
+//@[53:54)   LeftSquare |[|
+//@[54:57)   Identifier |for|
+//@[58:71)   LocalVariableSyntax
+//@[58:71)    IdentifierSyntax
+//@[58:71)     Identifier |someDuplicate|
+//@[72:74)   Identifier |in|
+//@[75:77)   ArraySyntax
+//@[75:76)    LeftSquare |[|
+//@[76:77)    RightSquare |]|
+//@[77:78)   Colon |:|
+//@[79:239)   ObjectSyntax
+//@[79:80)    LeftBrace |{|
+//@[80:81)    NewLine |\n|
+  name: 'hello-${someDuplicate}'
+//@[2:32)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:32)     StringSyntax
+//@[8:17)      StringLeftPiece |'hello-${|
+//@[17:30)      VariableAccessSyntax
+//@[17:30)       IdentifierSyntax
+//@[17:30)        Identifier |someDuplicate|
+//@[30:32)      StringRightPiece |}'|
+//@[32:33)    NewLine |\n|
+  params: {
+//@[2:123)    ObjectPropertySyntax
+//@[2:8)     IdentifierSyntax
+//@[2:8)      Identifier |params|
+//@[8:9)     Colon |:|
+//@[10:123)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:12)      NewLine |\n|
+    objParam: {}
+//@[4:16)      ObjectPropertySyntax
+//@[4:12)       IdentifierSyntax
+//@[4:12)        Identifier |objParam|
+//@[12:13)       Colon |:|
+//@[14:16)       ObjectSyntax
+//@[14:15)        LeftBrace |{|
+//@[15:16)        RightBrace |}|
+//@[16:17)      NewLine |\n|
+    stringParamA: 'test'
+//@[4:24)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamA|
+//@[16:17)       Colon |:|
+//@[18:24)       StringSyntax
+//@[18:24)        StringComplete |'test'|
+//@[24:25)      NewLine |\n|
+    stringParamB: 'test'
+//@[4:24)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamB|
+//@[16:17)       Colon |:|
+//@[18:24)       StringSyntax
+//@[18:24)        StringComplete |'test'|
+//@[24:25)      NewLine |\n|
+    arrayParam: [for x in emptyArray: x]
+//@[4:40)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |arrayParam|
+//@[14:15)       Colon |:|
+//@[16:40)       ForSyntax
+//@[16:17)        LeftSquare |[|
+//@[17:20)        Identifier |for|
+//@[21:22)        LocalVariableSyntax
+//@[21:22)         IdentifierSyntax
+//@[21:22)          Identifier |x|
+//@[23:25)        Identifier |in|
+//@[26:36)        VariableAccessSyntax
+//@[26:36)         IdentifierSyntax
+//@[26:36)          Identifier |emptyArray|
+//@[36:37)        Colon |:|
+//@[38:39)        VariableAccessSyntax
+//@[38:39)         IdentifierSyntax
+//@[38:39)          Identifier |x|
+//@[39:40)        RightSquare |]|
+//@[40:41)      NewLine |\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:4)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+var otherDuplicate = 'there'
+//@[0:28) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:18)  IdentifierSyntax
+//@[4:18)   Identifier |otherDuplicate|
+//@[19:20)  Assignment |=|
+//@[21:28)  StringSyntax
+//@[21:28)   StringComplete |'there'|
+//@[28:29) NewLine |\n|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
+//@[0:229) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:34)  IdentifierSyntax
+//@[7:34)   Identifier |duplicateInGlobalAndOneLoop|
+//@[35:50)  StringSyntax
+//@[35:50)   StringComplete |'modulea.bicep'|
+//@[51:52)  Assignment |=|
+//@[53:229)  ForSyntax
+//@[53:54)   LeftSquare |[|
+//@[54:57)   Identifier |for|
+//@[58:72)   LocalVariableSyntax
+//@[58:72)    IdentifierSyntax
+//@[58:72)     Identifier |otherDuplicate|
+//@[73:75)   Identifier |in|
+//@[76:78)   ArraySyntax
+//@[76:77)    LeftSquare |[|
+//@[77:78)    RightSquare |]|
+//@[78:79)   Colon |:|
+//@[80:228)   ObjectSyntax
+//@[80:81)    LeftBrace |{|
+//@[81:82)    NewLine |\n|
+  name: 'hello-${someDuplicate}'
+//@[2:32)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:32)     StringSyntax
+//@[8:17)      StringLeftPiece |'hello-${|
+//@[17:30)      VariableAccessSyntax
+//@[17:30)       IdentifierSyntax
+//@[17:30)        Identifier |someDuplicate|
+//@[30:32)      StringRightPiece |}'|
+//@[32:33)    NewLine |\n|
+  params: {
+//@[2:111)    ObjectPropertySyntax
+//@[2:8)     IdentifierSyntax
+//@[2:8)      Identifier |params|
+//@[8:9)     Colon |:|
+//@[10:111)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:12)      NewLine |\n|
+    objParam: {}
+//@[4:16)      ObjectPropertySyntax
+//@[4:12)       IdentifierSyntax
+//@[4:12)        Identifier |objParam|
+//@[12:13)       Colon |:|
+//@[14:16)       ObjectSyntax
+//@[14:15)        LeftBrace |{|
+//@[15:16)        RightBrace |}|
+//@[16:17)      NewLine |\n|
+    stringParamB: 'test'
+//@[4:24)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamB|
+//@[16:17)       Colon |:|
+//@[18:24)       StringSyntax
+//@[18:24)        StringComplete |'test'|
+//@[24:25)      NewLine |\n|
+    arrayParam: [for otherDuplicate in emptyArray: x]
+//@[4:53)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |arrayParam|
+//@[14:15)       Colon |:|
+//@[16:53)       ForSyntax
+//@[16:17)        LeftSquare |[|
+//@[17:20)        Identifier |for|
+//@[21:35)        LocalVariableSyntax
+//@[21:35)         IdentifierSyntax
+//@[21:35)          Identifier |otherDuplicate|
+//@[36:38)        Identifier |in|
+//@[39:49)        VariableAccessSyntax
+//@[39:49)         IdentifierSyntax
+//@[39:49)          Identifier |emptyArray|
+//@[49:50)        Colon |:|
+//@[51:52)        VariableAccessSyntax
+//@[51:52)         IdentifierSyntax
+//@[51:52)          Identifier |x|
+//@[52:53)        RightSquare |]|
+//@[53:54)      NewLine |\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:4)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+var someDuplicate = true
+//@[0:24) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:17)  IdentifierSyntax
+//@[4:17)   Identifier |someDuplicate|
+//@[18:19)  Assignment |=|
+//@[20:24)  BooleanLiteralSyntax
+//@[20:24)   TrueKeyword |true|
+//@[24:25) NewLine |\n|
+var otherDuplicate = false
+//@[0:26) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:18)  IdentifierSyntax
+//@[4:18)   Identifier |otherDuplicate|
+//@[19:20)  Assignment |=|
+//@[21:26)  BooleanLiteralSyntax
+//@[21:26)   FalseKeyword |false|
+//@[26:27) NewLine |\n|
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@[0:256) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:27)  IdentifierSyntax
+//@[7:27)   Identifier |duplicatesEverywhere|
+//@[28:43)  StringSyntax
+//@[28:43)   StringComplete |'modulea.bicep'|
+//@[44:45)  Assignment |=|
+//@[46:256)  ForSyntax
+//@[46:47)   LeftSquare |[|
+//@[47:50)   Identifier |for|
+//@[51:64)   LocalVariableSyntax
+//@[51:64)    IdentifierSyntax
+//@[51:64)     Identifier |someDuplicate|
+//@[65:67)   Identifier |in|
+//@[68:70)   ArraySyntax
+//@[68:69)    LeftSquare |[|
+//@[69:70)    RightSquare |]|
+//@[70:71)   Colon |:|
+//@[72:255)   ObjectSyntax
+//@[72:73)    LeftBrace |{|
+//@[73:74)    NewLine |\n|
+  name: 'hello-${someDuplicate}'
+//@[2:32)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:32)     StringSyntax
+//@[8:17)      StringLeftPiece |'hello-${|
+//@[17:30)      VariableAccessSyntax
+//@[17:30)       IdentifierSyntax
+//@[17:30)        Identifier |someDuplicate|
+//@[30:32)      StringRightPiece |}'|
+//@[32:33)    NewLine |\n|
+  params: {
+//@[2:146)    ObjectPropertySyntax
+//@[2:8)     IdentifierSyntax
+//@[2:8)      Identifier |params|
+//@[8:9)     Colon |:|
+//@[10:146)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:12)      NewLine |\n|
+    objParam: {}
+//@[4:16)      ObjectPropertySyntax
+//@[4:12)       IdentifierSyntax
+//@[4:12)        Identifier |objParam|
+//@[12:13)       Colon |:|
+//@[14:16)       ObjectSyntax
+//@[14:15)        LeftBrace |{|
+//@[15:16)        RightBrace |}|
+//@[16:17)      NewLine |\n|
+    stringParamB: 'test'
+//@[4:24)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamB|
+//@[16:17)       Colon |:|
+//@[18:24)       StringSyntax
+//@[18:24)        StringComplete |'test'|
+//@[24:25)      NewLine |\n|
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@[4:88)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |arrayParam|
+//@[14:15)       Colon |:|
+//@[16:88)       ForSyntax
+//@[16:17)        LeftSquare |[|
+//@[17:20)        Identifier |for|
+//@[21:35)        LocalVariableSyntax
+//@[21:35)         IdentifierSyntax
+//@[21:35)          Identifier |otherDuplicate|
+//@[36:38)        Identifier |in|
+//@[39:49)        VariableAccessSyntax
+//@[39:49)         IdentifierSyntax
+//@[39:49)          Identifier |emptyArray|
+//@[49:50)        Colon |:|
+//@[51:87)        StringSyntax
+//@[51:54)         StringLeftPiece |'${|
+//@[54:67)         VariableAccessSyntax
+//@[54:67)          IdentifierSyntax
+//@[54:67)           Identifier |someDuplicate|
+//@[67:71)         StringMiddlePiece |}-${|
+//@[71:85)         VariableAccessSyntax
+//@[71:85)          IdentifierSyntax
+//@[71:85)           Identifier |otherDuplicate|
+//@[85:87)         StringRightPiece |}'|
+//@[87:88)        RightSquare |]|
+//@[88:89)      NewLine |\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:4)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+/*
+  valid loop - this should be moved to Modules_* test case after E2E works
+*/ 
+//@[3:4) NewLine |\n|
+var myModules = [
+//@[0:114) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:13)  IdentifierSyntax
+//@[4:13)   Identifier |myModules|
+//@[14:15)  Assignment |=|
+//@[16:114)  ArraySyntax
+//@[16:17)   LeftSquare |[|
+//@[17:18)   NewLine |\n|
+  {
+//@[2:47)   ArrayItemSyntax
+//@[2:47)    ObjectSyntax
+//@[2:3)     LeftBrace |{|
+//@[3:4)     NewLine |\n|
+    name: 'one'
+//@[4:15)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:15)      StringSyntax
+//@[10:15)       StringComplete |'one'|
+//@[15:16)     NewLine |\n|
+    location: 'eastus2'
+//@[4:23)     ObjectPropertySyntax
+//@[4:12)      IdentifierSyntax
+//@[4:12)       Identifier |location|
+//@[12:13)      Colon |:|
+//@[14:23)      StringSyntax
+//@[14:23)       StringComplete |'eastus2'|
+//@[23:24)     NewLine |\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:4)   NewLine |\n|
+  {
+//@[2:46)   ArrayItemSyntax
+//@[2:46)    ObjectSyntax
+//@[2:3)     LeftBrace |{|
+//@[3:4)     NewLine |\n|
+    name: 'two'
+//@[4:15)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:15)      StringSyntax
+//@[10:15)       StringComplete |'two'|
+//@[15:16)     NewLine |\n|
+    location: 'westus'
+//@[4:22)     ObjectPropertySyntax
+//@[4:12)      IdentifierSyntax
+//@[4:12)       Identifier |location|
+//@[12:13)      Colon |:|
+//@[14:22)      StringSyntax
+//@[14:22)       StringComplete |'westus'|
+//@[22:23)     NewLine |\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:4)   NewLine |\n|
+]
+//@[0:1)   RightSquare |]|
+//@[1:2) NewLine |\n|
+module storageResources 'modulea.bicep' = [for module in myModules: {
+//@[0:182) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:23)  IdentifierSyntax
+//@[7:23)   Identifier |storageResources|
+//@[24:39)  StringSyntax
+//@[24:39)   StringComplete |'modulea.bicep'|
+//@[40:41)  Assignment |=|
+//@[42:182)  ForSyntax
+//@[42:43)   LeftSquare |[|
+//@[43:46)   Identifier |for|
+//@[47:53)   LocalVariableSyntax
+//@[47:53)    IdentifierSyntax
+//@[47:53)     Identifier |module|
+//@[54:56)   Identifier |in|
+//@[57:66)   VariableAccessSyntax
+//@[57:66)    IdentifierSyntax
+//@[57:66)     Identifier |myModules|
+//@[66:67)   Colon |:|
+//@[68:181)   ObjectSyntax
+//@[68:69)    LeftBrace |{|
+//@[69:70)    NewLine |\n|
+  name: module.name
+//@[2:19)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:19)     PropertyAccessSyntax
+//@[8:14)      VariableAccessSyntax
+//@[8:14)       IdentifierSyntax
+//@[8:14)        Identifier |module|
+//@[14:15)      Dot |.|
+//@[15:19)      IdentifierSyntax
+//@[15:19)       Identifier |name|
+//@[19:20)    NewLine |\n|
+  params: {
+//@[2:89)    ObjectPropertySyntax
+//@[2:8)     IdentifierSyntax
+//@[2:8)      Identifier |params|
+//@[8:9)     Colon |:|
+//@[10:89)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:12)      NewLine |\n|
+    arrayParam: []
+//@[4:18)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |arrayParam|
+//@[14:15)       Colon |:|
+//@[16:18)       ArraySyntax
+//@[16:17)        LeftSquare |[|
+//@[17:18)        RightSquare |]|
+//@[18:19)      NewLine |\n|
+    objParam: module
+//@[4:20)      ObjectPropertySyntax
+//@[4:12)       IdentifierSyntax
+//@[4:12)        Identifier |objParam|
+//@[12:13)       Colon |:|
+//@[14:20)       VariableAccessSyntax
+//@[14:20)        IdentifierSyntax
+//@[14:20)         Identifier |module|
+//@[20:21)      NewLine |\n|
+    stringParamB: module.location
+//@[4:33)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamB|
+//@[16:17)       Colon |:|
+//@[18:33)       PropertyAccessSyntax
+//@[18:24)        VariableAccessSyntax
+//@[18:24)         IdentifierSyntax
+//@[18:24)          Identifier |module|
+//@[24:25)        Dot |.|
+//@[25:33)        IdentifierSyntax
+//@[25:33)         Identifier |location|
+//@[33:34)      NewLine |\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:4)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+//@[0:220) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:23)  IdentifierSyntax
+//@[7:23)   Identifier |nestedModuleLoop|
+//@[24:39)  StringSyntax
+//@[24:39)   StringComplete |'modulea.bicep'|
+//@[40:41)  Assignment |=|
+//@[42:220)  ForSyntax
+//@[42:43)   LeftSquare |[|
+//@[43:46)   Identifier |for|
+//@[47:53)   LocalVariableSyntax
+//@[47:53)    IdentifierSyntax
+//@[47:53)     Identifier |module|
+//@[54:56)   Identifier |in|
+//@[57:66)   VariableAccessSyntax
+//@[57:66)    IdentifierSyntax
+//@[57:66)     Identifier |myModules|
+//@[66:67)   Colon |:|
+//@[68:219)   ObjectSyntax
+//@[68:69)    LeftBrace |{|
+//@[69:70)    NewLine |\n|
+  name: module.name
+//@[2:19)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:19)     PropertyAccessSyntax
+//@[8:14)      VariableAccessSyntax
+//@[8:14)       IdentifierSyntax
+//@[8:14)        Identifier |module|
+//@[14:15)      Dot |.|
+//@[15:19)      IdentifierSyntax
+//@[15:19)       Identifier |name|
+//@[19:20)    NewLine |\n|
+  params: {
+//@[2:127)    ObjectPropertySyntax
+//@[2:8)     IdentifierSyntax
+//@[2:8)      Identifier |params|
+//@[8:9)     Colon |:|
+//@[10:127)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:12)      NewLine |\n|
+    arrayParam: [for i in range(0,3): concat('test', i)]
+//@[4:56)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |arrayParam|
+//@[14:15)       Colon |:|
+//@[16:56)       ForSyntax
+//@[16:17)        LeftSquare |[|
+//@[17:20)        Identifier |for|
+//@[21:22)        LocalVariableSyntax
+//@[21:22)         IdentifierSyntax
+//@[21:22)          Identifier |i|
+//@[23:25)        Identifier |in|
+//@[26:36)        FunctionCallSyntax
+//@[26:31)         IdentifierSyntax
+//@[26:31)          Identifier |range|
+//@[31:32)         LeftParen |(|
+//@[32:34)         FunctionArgumentSyntax
+//@[32:33)          IntegerLiteralSyntax
+//@[32:33)           Integer |0|
+//@[33:34)          Comma |,|
+//@[34:35)         FunctionArgumentSyntax
+//@[34:35)          IntegerLiteralSyntax
+//@[34:35)           Integer |3|
+//@[35:36)         RightParen |)|
+//@[36:37)        Colon |:|
+//@[38:55)        FunctionCallSyntax
+//@[38:44)         IdentifierSyntax
+//@[38:44)          Identifier |concat|
+//@[44:45)         LeftParen |(|
+//@[45:52)         FunctionArgumentSyntax
+//@[45:51)          StringSyntax
+//@[45:51)           StringComplete |'test'|
+//@[51:52)          Comma |,|
+//@[53:54)         FunctionArgumentSyntax
+//@[53:54)          VariableAccessSyntax
+//@[53:54)           IdentifierSyntax
+//@[53:54)            Identifier |i|
+//@[54:55)         RightParen |)|
+//@[55:56)        RightSquare |]|
+//@[56:57)      NewLine |\n|
+    objParam: module
+//@[4:20)      ObjectPropertySyntax
+//@[4:12)       IdentifierSyntax
+//@[4:12)        Identifier |objParam|
+//@[12:13)       Colon |:|
+//@[14:20)       VariableAccessSyntax
+//@[14:20)        IdentifierSyntax
+//@[14:20)         Identifier |module|
+//@[20:21)      NewLine |\n|
+    stringParamB: module.location
+//@[4:33)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamB|
+//@[16:17)       Colon |:|
+//@[18:33)       PropertyAccessSyntax
+//@[18:24)        VariableAccessSyntax
+//@[18:24)         IdentifierSyntax
+//@[18:24)          Identifier |module|
+//@[24:25)        Dot |.|
+//@[25:33)        IdentifierSyntax
+//@[25:33)         Identifier |location|
+//@[33:34)      NewLine |\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:4)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:2) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
@@ -2132,6 +2132,172 @@ module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
 //@[1:2)   RightSquare |]|
 //@[2:4) NewLine |\n\n|
 
+// nonexistent arrays and loop variables
+//@[40:41) NewLine |\n|
+var evenMoreDuplicates = 'there'
+//@[0:32) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:22)  IdentifierSyntax
+//@[4:22)   Identifier |evenMoreDuplicates|
+//@[23:24)  Assignment |=|
+//@[25:32)  StringSyntax
+//@[25:32)   StringComplete |'there'|
+//@[32:33) NewLine |\n|
+module nonexistentArrays 'modulea.bicep' = [for evenMoreDuplicates in alsoDoesNotExist: {
+//@[0:278) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:24)  IdentifierSyntax
+//@[7:24)   Identifier |nonexistentArrays|
+//@[25:40)  StringSyntax
+//@[25:40)   StringComplete |'modulea.bicep'|
+//@[41:42)  Assignment |=|
+//@[43:278)  ForSyntax
+//@[43:44)   LeftSquare |[|
+//@[44:47)   Identifier |for|
+//@[48:66)   LocalVariableSyntax
+//@[48:66)    IdentifierSyntax
+//@[48:66)     Identifier |evenMoreDuplicates|
+//@[67:69)   Identifier |in|
+//@[70:86)   VariableAccessSyntax
+//@[70:86)    IdentifierSyntax
+//@[70:86)     Identifier |alsoDoesNotExist|
+//@[86:87)   Colon |:|
+//@[88:277)   ObjectSyntax
+//@[88:89)    LeftBrace |{|
+//@[89:90)    NewLine |\n|
+  name: 'hello-${whyChooseRealVariablesWhenWeCanPretend}'
+//@[2:57)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:57)     StringSyntax
+//@[8:17)      StringLeftPiece |'hello-${|
+//@[17:55)      VariableAccessSyntax
+//@[17:55)       IdentifierSyntax
+//@[17:55)        Identifier |whyChooseRealVariablesWhenWeCanPretend|
+//@[55:57)      StringRightPiece |}'|
+//@[57:58)    NewLine |\n|
+  params: {
+//@[2:127)    ObjectPropertySyntax
+//@[2:8)     IdentifierSyntax
+//@[2:8)      Identifier |params|
+//@[8:9)     Colon |:|
+//@[10:127)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:12)      NewLine |\n|
+    objParam: {}
+//@[4:16)      ObjectPropertySyntax
+//@[4:12)       IdentifierSyntax
+//@[4:12)        Identifier |objParam|
+//@[12:13)       Colon |:|
+//@[14:16)       ObjectSyntax
+//@[14:15)        LeftBrace |{|
+//@[15:16)        RightBrace |}|
+//@[16:17)      NewLine |\n|
+    stringParamB: 'test'
+//@[4:24)      ObjectPropertySyntax
+//@[4:16)       IdentifierSyntax
+//@[4:16)        Identifier |stringParamB|
+//@[16:17)       Colon |:|
+//@[18:24)       StringSyntax
+//@[18:24)        StringComplete |'test'|
+//@[24:25)      NewLine |\n|
+    arrayParam: [for evenMoreDuplicates in totallyFake: doesNotExist]
+//@[4:69)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |arrayParam|
+//@[14:15)       Colon |:|
+//@[16:69)       ForSyntax
+//@[16:17)        LeftSquare |[|
+//@[17:20)        Identifier |for|
+//@[21:39)        LocalVariableSyntax
+//@[21:39)         IdentifierSyntax
+//@[21:39)          Identifier |evenMoreDuplicates|
+//@[40:42)        Identifier |in|
+//@[43:54)        VariableAccessSyntax
+//@[43:54)         IdentifierSyntax
+//@[43:54)          Identifier |totallyFake|
+//@[54:55)        Colon |:|
+//@[56:68)        VariableAccessSyntax
+//@[56:68)         IdentifierSyntax
+//@[56:68)          Identifier |doesNotExist|
+//@[68:69)        RightSquare |]|
+//@[69:70)      NewLine |\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:4)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+/*
+  valid loop - this should be moved to Modules_* test case after E2E works
+*/ 
+//@[3:4) NewLine |\n|
+var myModules = [
+//@[0:114) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:13)  IdentifierSyntax
+//@[4:13)   Identifier |myModules|
+//@[14:15)  Assignment |=|
+//@[16:114)  ArraySyntax
+//@[16:17)   LeftSquare |[|
+//@[17:18)   NewLine |\n|
+  {
+//@[2:47)   ArrayItemSyntax
+//@[2:47)    ObjectSyntax
+//@[2:3)     LeftBrace |{|
+//@[3:4)     NewLine |\n|
+    name: 'one'
+//@[4:15)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:15)      StringSyntax
+//@[10:15)       StringComplete |'one'|
+//@[15:16)     NewLine |\n|
+    location: 'eastus2'
+//@[4:23)     ObjectPropertySyntax
+//@[4:12)      IdentifierSyntax
+//@[4:12)       Identifier |location|
+//@[12:13)      Colon |:|
+//@[14:23)      StringSyntax
+//@[14:23)       StringComplete |'eastus2'|
+//@[23:24)     NewLine |\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:4)   NewLine |\n|
+  {
+//@[2:46)   ArrayItemSyntax
+//@[2:46)    ObjectSyntax
+//@[2:3)     LeftBrace |{|
+//@[3:4)     NewLine |\n|
+    name: 'two'
+//@[4:15)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:15)      StringSyntax
+//@[10:15)       StringComplete |'two'|
+//@[15:16)     NewLine |\n|
+    location: 'westus'
+//@[4:22)     ObjectPropertySyntax
+//@[4:12)      IdentifierSyntax
+//@[4:12)       Identifier |location|
+//@[12:13)      Colon |:|
+//@[14:22)      StringSyntax
+//@[14:22)       StringComplete |'westus'|
+//@[22:23)     NewLine |\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:4)   NewLine |\n|
+]
+//@[0:1)   RightSquare |]|
+//@[1:3) NewLine |\n\n|
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+//@[74:75) NewLine |\n|
 module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
 //@[0:226) ModuleDeclarationSyntax
 //@[0:6)  Identifier |module|
@@ -2228,49 +2394,51 @@ module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
 //@[1:2)   RightSquare |]|
 //@[2:4) NewLine |\n\n|
 
-var someDuplicate = 'hello'
-//@[0:27) VariableDeclarationSyntax
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+//@[74:75) NewLine |\n|
+var duplicateAcrossScopes = 'hello'
+//@[0:35) VariableDeclarationSyntax
 //@[0:3)  Identifier |var|
-//@[4:17)  IdentifierSyntax
-//@[4:17)   Identifier |someDuplicate|
-//@[18:19)  Assignment |=|
-//@[20:27)  StringSyntax
-//@[20:27)   StringComplete |'hello'|
-//@[27:28) NewLine |\n|
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
-//@[0:240) ModuleDeclarationSyntax
+//@[4:25)  IdentifierSyntax
+//@[4:25)   Identifier |duplicateAcrossScopes|
+//@[26:27)  Assignment |=|
+//@[28:35)  StringSyntax
+//@[28:35)   StringComplete |'hello'|
+//@[35:36) NewLine |\n|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+//@[0:256) ModuleDeclarationSyntax
 //@[0:6)  Identifier |module|
 //@[7:34)  IdentifierSyntax
 //@[7:34)   Identifier |duplicateInGlobalAndOneLoop|
 //@[35:50)  StringSyntax
 //@[35:50)   StringComplete |'modulea.bicep'|
 //@[51:52)  Assignment |=|
-//@[53:240)  ForSyntax
+//@[53:256)  ForSyntax
 //@[53:54)   LeftSquare |[|
 //@[54:57)   Identifier |for|
-//@[58:71)   LocalVariableSyntax
-//@[58:71)    IdentifierSyntax
-//@[58:71)     Identifier |someDuplicate|
-//@[72:74)   Identifier |in|
-//@[75:77)   ArraySyntax
-//@[75:76)    LeftSquare |[|
-//@[76:77)    RightSquare |]|
-//@[77:78)   Colon |:|
-//@[79:239)   ObjectSyntax
-//@[79:80)    LeftBrace |{|
-//@[80:81)    NewLine |\n|
-  name: 'hello-${someDuplicate}'
-//@[2:32)    ObjectPropertySyntax
+//@[58:79)   LocalVariableSyntax
+//@[58:79)    IdentifierSyntax
+//@[58:79)     Identifier |duplicateAcrossScopes|
+//@[80:82)   Identifier |in|
+//@[83:85)   ArraySyntax
+//@[83:84)    LeftSquare |[|
+//@[84:85)    RightSquare |]|
+//@[85:86)   Colon |:|
+//@[87:255)   ObjectSyntax
+//@[87:88)    LeftBrace |{|
+//@[88:89)    NewLine |\n|
+  name: 'hello-${duplicateAcrossScopes}'
+//@[2:40)    ObjectPropertySyntax
 //@[2:6)     IdentifierSyntax
 //@[2:6)      Identifier |name|
 //@[6:7)     Colon |:|
-//@[8:32)     StringSyntax
+//@[8:40)     StringSyntax
 //@[8:17)      StringLeftPiece |'hello-${|
-//@[17:30)      VariableAccessSyntax
-//@[17:30)       IdentifierSyntax
-//@[17:30)        Identifier |someDuplicate|
-//@[30:32)      StringRightPiece |}'|
-//@[32:33)    NewLine |\n|
+//@[17:38)      VariableAccessSyntax
+//@[17:38)       IdentifierSyntax
+//@[17:38)        Identifier |duplicateAcrossScopes|
+//@[38:40)      StringRightPiece |}'|
+//@[40:41)    NewLine |\n|
   params: {
 //@[2:123)    ObjectPropertySyntax
 //@[2:8)     IdentifierSyntax
@@ -2325,103 +2493,6 @@ module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
 //@[38:39)          Identifier |x|
 //@[39:40)        RightSquare |]|
 //@[40:41)      NewLine |\n|
-  }
-//@[2:3)      RightBrace |}|
-//@[3:4)    NewLine |\n|
-}]
-//@[0:1)    RightBrace |}|
-//@[1:2)   RightSquare |]|
-//@[2:4) NewLine |\n\n|
-
-var otherDuplicate = 'there'
-//@[0:28) VariableDeclarationSyntax
-//@[0:3)  Identifier |var|
-//@[4:18)  IdentifierSyntax
-//@[4:18)   Identifier |otherDuplicate|
-//@[19:20)  Assignment |=|
-//@[21:28)  StringSyntax
-//@[21:28)   StringComplete |'there'|
-//@[28:29) NewLine |\n|
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
-//@[0:229) ModuleDeclarationSyntax
-//@[0:6)  Identifier |module|
-//@[7:34)  IdentifierSyntax
-//@[7:34)   Identifier |duplicateInGlobalAndOneLoop|
-//@[35:50)  StringSyntax
-//@[35:50)   StringComplete |'modulea.bicep'|
-//@[51:52)  Assignment |=|
-//@[53:229)  ForSyntax
-//@[53:54)   LeftSquare |[|
-//@[54:57)   Identifier |for|
-//@[58:72)   LocalVariableSyntax
-//@[58:72)    IdentifierSyntax
-//@[58:72)     Identifier |otherDuplicate|
-//@[73:75)   Identifier |in|
-//@[76:78)   ArraySyntax
-//@[76:77)    LeftSquare |[|
-//@[77:78)    RightSquare |]|
-//@[78:79)   Colon |:|
-//@[80:228)   ObjectSyntax
-//@[80:81)    LeftBrace |{|
-//@[81:82)    NewLine |\n|
-  name: 'hello-${someDuplicate}'
-//@[2:32)    ObjectPropertySyntax
-//@[2:6)     IdentifierSyntax
-//@[2:6)      Identifier |name|
-//@[6:7)     Colon |:|
-//@[8:32)     StringSyntax
-//@[8:17)      StringLeftPiece |'hello-${|
-//@[17:30)      VariableAccessSyntax
-//@[17:30)       IdentifierSyntax
-//@[17:30)        Identifier |someDuplicate|
-//@[30:32)      StringRightPiece |}'|
-//@[32:33)    NewLine |\n|
-  params: {
-//@[2:111)    ObjectPropertySyntax
-//@[2:8)     IdentifierSyntax
-//@[2:8)      Identifier |params|
-//@[8:9)     Colon |:|
-//@[10:111)     ObjectSyntax
-//@[10:11)      LeftBrace |{|
-//@[11:12)      NewLine |\n|
-    objParam: {}
-//@[4:16)      ObjectPropertySyntax
-//@[4:12)       IdentifierSyntax
-//@[4:12)        Identifier |objParam|
-//@[12:13)       Colon |:|
-//@[14:16)       ObjectSyntax
-//@[14:15)        LeftBrace |{|
-//@[15:16)        RightBrace |}|
-//@[16:17)      NewLine |\n|
-    stringParamB: 'test'
-//@[4:24)      ObjectPropertySyntax
-//@[4:16)       IdentifierSyntax
-//@[4:16)        Identifier |stringParamB|
-//@[16:17)       Colon |:|
-//@[18:24)       StringSyntax
-//@[18:24)        StringComplete |'test'|
-//@[24:25)      NewLine |\n|
-    arrayParam: [for otherDuplicate in emptyArray: x]
-//@[4:53)      ObjectPropertySyntax
-//@[4:14)       IdentifierSyntax
-//@[4:14)        Identifier |arrayParam|
-//@[14:15)       Colon |:|
-//@[16:53)       ForSyntax
-//@[16:17)        LeftSquare |[|
-//@[17:20)        Identifier |for|
-//@[21:35)        LocalVariableSyntax
-//@[21:35)         IdentifierSyntax
-//@[21:35)          Identifier |otherDuplicate|
-//@[36:38)        Identifier |in|
-//@[39:49)        VariableAccessSyntax
-//@[39:49)         IdentifierSyntax
-//@[39:49)          Identifier |emptyArray|
-//@[49:50)        Colon |:|
-//@[51:52)        VariableAccessSyntax
-//@[51:52)         IdentifierSyntax
-//@[51:52)          Identifier |x|
-//@[52:53)        RightSquare |]|
-//@[53:54)      NewLine |\n|
   }
 //@[2:3)      RightBrace |}|
 //@[3:4)    NewLine |\n|
@@ -2543,70 +2614,8 @@ module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
 //@[1:2)   RightSquare |]|
 //@[2:4) NewLine |\n\n|
 
-/*
-  valid loop - this should be moved to Modules_* test case after E2E works
-*/ 
-//@[3:4) NewLine |\n|
-var myModules = [
-//@[0:114) VariableDeclarationSyntax
-//@[0:3)  Identifier |var|
-//@[4:13)  IdentifierSyntax
-//@[4:13)   Identifier |myModules|
-//@[14:15)  Assignment |=|
-//@[16:114)  ArraySyntax
-//@[16:17)   LeftSquare |[|
-//@[17:18)   NewLine |\n|
-  {
-//@[2:47)   ArrayItemSyntax
-//@[2:47)    ObjectSyntax
-//@[2:3)     LeftBrace |{|
-//@[3:4)     NewLine |\n|
-    name: 'one'
-//@[4:15)     ObjectPropertySyntax
-//@[4:8)      IdentifierSyntax
-//@[4:8)       Identifier |name|
-//@[8:9)      Colon |:|
-//@[10:15)      StringSyntax
-//@[10:15)       StringComplete |'one'|
-//@[15:16)     NewLine |\n|
-    location: 'eastus2'
-//@[4:23)     ObjectPropertySyntax
-//@[4:12)      IdentifierSyntax
-//@[4:12)       Identifier |location|
-//@[12:13)      Colon |:|
-//@[14:23)      StringSyntax
-//@[14:23)       StringComplete |'eastus2'|
-//@[23:24)     NewLine |\n|
-  }
-//@[2:3)     RightBrace |}|
-//@[3:4)   NewLine |\n|
-  {
-//@[2:46)   ArrayItemSyntax
-//@[2:46)    ObjectSyntax
-//@[2:3)     LeftBrace |{|
-//@[3:4)     NewLine |\n|
-    name: 'two'
-//@[4:15)     ObjectPropertySyntax
-//@[4:8)      IdentifierSyntax
-//@[4:8)       Identifier |name|
-//@[8:9)      Colon |:|
-//@[10:15)      StringSyntax
-//@[10:15)       StringComplete |'two'|
-//@[15:16)     NewLine |\n|
-    location: 'westus'
-//@[4:22)     ObjectPropertySyntax
-//@[4:12)      IdentifierSyntax
-//@[4:12)       Identifier |location|
-//@[12:13)      Colon |:|
-//@[14:22)      StringSyntax
-//@[14:22)       StringComplete |'westus'|
-//@[22:23)     NewLine |\n|
-  }
-//@[2:3)     RightBrace |}|
-//@[3:4)   NewLine |\n|
-]
-//@[0:1)   RightSquare |]|
-//@[1:2) NewLine |\n|
+// simple module loop
+//@[21:22) NewLine |\n|
 module storageResources 'modulea.bicep' = [for module in myModules: {
 //@[0:182) ModuleDeclarationSyntax
 //@[0:6)  Identifier |module|
@@ -2689,6 +2698,8 @@ module storageResources 'modulea.bicep' = [for module in myModules: {
 //@[1:2)   RightSquare |]|
 //@[2:4) NewLine |\n\n|
 
+// nested module loop
+//@[21:22) NewLine |\n|
 module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
 //@[0:220) ModuleDeclarationSyntax
 //@[0:6)  Identifier |module|

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
@@ -1133,6 +1133,693 @@ module moduleWithNotAttachableDecorators './empty.bicep' = {
 //@[43:44) NewLine |\n|
 }
 //@[0:1) RightBrace |}|
-//@[1:2) NewLine |\n|
+//@[1:3) NewLine |\n\n|
 
-//@[0:0) EndOfFile ||
+// loop parsing cases
+//@[21:22) NewLine |\n|
+module expectedForKeyword 'modulea.bicep' = []
+//@[0:6) Identifier |module|
+//@[7:25) Identifier |expectedForKeyword|
+//@[26:41) StringComplete |'modulea.bicep'|
+//@[42:43) Assignment |=|
+//@[44:45) LeftSquare |[|
+//@[45:46) RightSquare |]|
+//@[46:48) NewLine |\n\n|
+
+module expectedForKeyword2 'modulea.bicep' = [f]
+//@[0:6) Identifier |module|
+//@[7:26) Identifier |expectedForKeyword2|
+//@[27:42) StringComplete |'modulea.bicep'|
+//@[43:44) Assignment |=|
+//@[45:46) LeftSquare |[|
+//@[46:47) Identifier |f|
+//@[47:48) RightSquare |]|
+//@[48:50) NewLine |\n\n|
+
+module expectedLoopVar 'modulea.bicep' = [for]
+//@[0:6) Identifier |module|
+//@[7:22) Identifier |expectedLoopVar|
+//@[23:38) StringComplete |'modulea.bicep'|
+//@[39:40) Assignment |=|
+//@[41:42) LeftSquare |[|
+//@[42:45) Identifier |for|
+//@[45:46) RightSquare |]|
+//@[46:48) NewLine |\n\n|
+
+module expectedInKeyword 'modulea.bicep' = [for x]
+//@[0:6) Identifier |module|
+//@[7:24) Identifier |expectedInKeyword|
+//@[25:40) StringComplete |'modulea.bicep'|
+//@[41:42) Assignment |=|
+//@[43:44) LeftSquare |[|
+//@[44:47) Identifier |for|
+//@[48:49) Identifier |x|
+//@[49:50) RightSquare |]|
+//@[50:52) NewLine |\n\n|
+
+module expectedInKeyword2 'modulea.bicep' = [for x b]
+//@[0:6) Identifier |module|
+//@[7:25) Identifier |expectedInKeyword2|
+//@[26:41) StringComplete |'modulea.bicep'|
+//@[42:43) Assignment |=|
+//@[44:45) LeftSquare |[|
+//@[45:48) Identifier |for|
+//@[49:50) Identifier |x|
+//@[51:52) Identifier |b|
+//@[52:53) RightSquare |]|
+//@[53:55) NewLine |\n\n|
+
+module expectedArrayExpression 'modulea.bicep' = [for x in]
+//@[0:6) Identifier |module|
+//@[7:30) Identifier |expectedArrayExpression|
+//@[31:46) StringComplete |'modulea.bicep'|
+//@[47:48) Assignment |=|
+//@[49:50) LeftSquare |[|
+//@[50:53) Identifier |for|
+//@[54:55) Identifier |x|
+//@[56:58) Identifier |in|
+//@[58:59) RightSquare |]|
+//@[59:61) NewLine |\n\n|
+
+module expectedColon 'modulea.bicep' = [for x in y]
+//@[0:6) Identifier |module|
+//@[7:20) Identifier |expectedColon|
+//@[21:36) StringComplete |'modulea.bicep'|
+//@[37:38) Assignment |=|
+//@[39:40) LeftSquare |[|
+//@[40:43) Identifier |for|
+//@[44:45) Identifier |x|
+//@[46:48) Identifier |in|
+//@[49:50) Identifier |y|
+//@[50:51) RightSquare |]|
+//@[51:53) NewLine |\n\n|
+
+module expectedLoopBody 'modulea.bicep' = [for x in y:]
+//@[0:6) Identifier |module|
+//@[7:23) Identifier |expectedLoopBody|
+//@[24:39) StringComplete |'modulea.bicep'|
+//@[40:41) Assignment |=|
+//@[42:43) LeftSquare |[|
+//@[43:46) Identifier |for|
+//@[47:48) Identifier |x|
+//@[49:51) Identifier |in|
+//@[52:53) Identifier |y|
+//@[53:54) Colon |:|
+//@[54:55) RightSquare |]|
+//@[55:57) NewLine |\n\n|
+
+// wrong loop body type
+//@[23:24) NewLine |\n|
+var emptyArray = []
+//@[0:3) Identifier |var|
+//@[4:14) Identifier |emptyArray|
+//@[15:16) Assignment |=|
+//@[17:18) LeftSquare |[|
+//@[18:19) RightSquare |]|
+//@[19:20) NewLine |\n|
+module wrongLoopBodyType 'modulea.bicep' = [for x in emptyArray:4]
+//@[0:6) Identifier |module|
+//@[7:24) Identifier |wrongLoopBodyType|
+//@[25:40) StringComplete |'modulea.bicep'|
+//@[41:42) Assignment |=|
+//@[43:44) LeftSquare |[|
+//@[44:47) Identifier |for|
+//@[48:49) Identifier |x|
+//@[50:52) Identifier |in|
+//@[53:63) Identifier |emptyArray|
+//@[63:64) Colon |:|
+//@[64:65) Integer |4|
+//@[65:66) RightSquare |]|
+//@[66:68) NewLine |\n\n|
+
+// missing loop body properties
+//@[31:32) NewLine |\n|
+module missingLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+//@[0:6) Identifier |module|
+//@[7:32) Identifier |missingLoopBodyProperties|
+//@[33:48) StringComplete |'modulea.bicep'|
+//@[49:50) Assignment |=|
+//@[51:52) LeftSquare |[|
+//@[52:55) Identifier |for|
+//@[56:57) Identifier |x|
+//@[58:60) Identifier |in|
+//@[61:71) Identifier |emptyArray|
+//@[71:72) Colon |:|
+//@[72:73) LeftBrace |{|
+//@[73:74) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+// wrong array type
+//@[19:20) NewLine |\n|
+var notAnArray = true
+//@[0:3) Identifier |var|
+//@[4:14) Identifier |notAnArray|
+//@[15:16) Assignment |=|
+//@[17:21) TrueKeyword |true|
+//@[21:22) NewLine |\n|
+module wrongArrayType 'modulea.bicep' = [for x in notAnArray:{
+//@[0:6) Identifier |module|
+//@[7:21) Identifier |wrongArrayType|
+//@[22:37) StringComplete |'modulea.bicep'|
+//@[38:39) Assignment |=|
+//@[40:41) LeftSquare |[|
+//@[41:44) Identifier |for|
+//@[45:46) Identifier |x|
+//@[47:49) Identifier |in|
+//@[50:60) Identifier |notAnArray|
+//@[60:61) Colon |:|
+//@[61:62) LeftBrace |{|
+//@[62:63) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+// missing fewer properties
+//@[27:28) NewLine |\n|
+module missingFewerLoopBodyProperties 'modulea.bicep' = [for x in emptyArray:{
+//@[0:6) Identifier |module|
+//@[7:37) Identifier |missingFewerLoopBodyProperties|
+//@[38:53) StringComplete |'modulea.bicep'|
+//@[54:55) Assignment |=|
+//@[56:57) LeftSquare |[|
+//@[57:60) Identifier |for|
+//@[61:62) Identifier |x|
+//@[63:65) Identifier |in|
+//@[66:76) Identifier |emptyArray|
+//@[76:77) Colon |:|
+//@[77:78) LeftBrace |{|
+//@[78:79) NewLine |\n|
+  name: 'hello-${x}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:17) StringLeftPiece |'hello-${|
+//@[17:18) Identifier |x|
+//@[18:20) StringRightPiece |}'|
+//@[20:21) NewLine |\n|
+  params: {
+//@[2:8) Identifier |params|
+//@[8:9) Colon |:|
+//@[10:11) LeftBrace |{|
+//@[11:13) NewLine |\n\n|
+
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+// wrong parameter in the module loop
+//@[37:38) NewLine |\n|
+module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[0:6) Identifier |module|
+//@[7:33) Identifier |wrongModuleParameterInLoop|
+//@[34:49) StringComplete |'modulea.bicep'|
+//@[50:51) Assignment |=|
+//@[52:53) LeftSquare |[|
+//@[53:56) Identifier |for|
+//@[57:58) Identifier |x|
+//@[59:61) Identifier |in|
+//@[62:72) Identifier |emptyArray|
+//@[72:73) Colon |:|
+//@[73:74) LeftBrace |{|
+//@[74:75) NewLine |\n|
+  name: 'hello-${x}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:17) StringLeftPiece |'hello-${|
+//@[17:18) Identifier |x|
+//@[18:20) StringRightPiece |}'|
+//@[20:21) NewLine |\n|
+  params: {
+//@[2:8) Identifier |params|
+//@[8:9) Colon |:|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+    arrayParam: []
+//@[4:14) Identifier |arrayParam|
+//@[14:15) Colon |:|
+//@[16:17) LeftSquare |[|
+//@[17:18) RightSquare |]|
+//@[18:19) NewLine |\n|
+    objParam: {}
+//@[4:12) Identifier |objParam|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:16) RightBrace |}|
+//@[16:17) NewLine |\n|
+    stringParamA: 'test'
+//@[4:16) Identifier |stringParamA|
+//@[16:17) Colon |:|
+//@[18:24) StringComplete |'test'|
+//@[24:25) NewLine |\n|
+    stringParamB: 'test'
+//@[4:16) Identifier |stringParamB|
+//@[16:17) Colon |:|
+//@[18:24) StringComplete |'test'|
+//@[24:25) NewLine |\n|
+    notAThing: 'test'
+//@[4:13) Identifier |notAThing|
+//@[13:14) Colon |:|
+//@[15:21) StringComplete |'test'|
+//@[21:22) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[0:6) Identifier |module|
+//@[7:37) Identifier |duplicateIdentifiersWithinLoop|
+//@[38:53) StringComplete |'modulea.bicep'|
+//@[54:55) Assignment |=|
+//@[56:57) LeftSquare |[|
+//@[57:60) Identifier |for|
+//@[61:62) Identifier |x|
+//@[63:65) Identifier |in|
+//@[66:76) Identifier |emptyArray|
+//@[76:77) Colon |:|
+//@[77:78) LeftBrace |{|
+//@[78:79) NewLine |\n|
+  name: 'hello-${x}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:17) StringLeftPiece |'hello-${|
+//@[17:18) Identifier |x|
+//@[18:20) StringRightPiece |}'|
+//@[20:21) NewLine |\n|
+  params: {
+//@[2:8) Identifier |params|
+//@[8:9) Colon |:|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+    objParam: {}
+//@[4:12) Identifier |objParam|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:16) RightBrace |}|
+//@[16:17) NewLine |\n|
+    stringParamA: 'test'
+//@[4:16) Identifier |stringParamA|
+//@[16:17) Colon |:|
+//@[18:24) StringComplete |'test'|
+//@[24:25) NewLine |\n|
+    stringParamB: 'test'
+//@[4:16) Identifier |stringParamB|
+//@[16:17) Colon |:|
+//@[18:24) StringComplete |'test'|
+//@[24:25) NewLine |\n|
+    arrayParam: [for x in emptyArray: y]
+//@[4:14) Identifier |arrayParam|
+//@[14:15) Colon |:|
+//@[16:17) LeftSquare |[|
+//@[17:20) Identifier |for|
+//@[21:22) Identifier |x|
+//@[23:25) Identifier |in|
+//@[26:36) Identifier |emptyArray|
+//@[36:37) Colon |:|
+//@[38:39) Identifier |y|
+//@[39:40) RightSquare |]|
+//@[40:41) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+var someDuplicate = 'hello'
+//@[0:3) Identifier |var|
+//@[4:17) Identifier |someDuplicate|
+//@[18:19) Assignment |=|
+//@[20:27) StringComplete |'hello'|
+//@[27:28) NewLine |\n|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
+//@[0:6) Identifier |module|
+//@[7:34) Identifier |duplicateInGlobalAndOneLoop|
+//@[35:50) StringComplete |'modulea.bicep'|
+//@[51:52) Assignment |=|
+//@[53:54) LeftSquare |[|
+//@[54:57) Identifier |for|
+//@[58:71) Identifier |someDuplicate|
+//@[72:74) Identifier |in|
+//@[75:76) LeftSquare |[|
+//@[76:77) RightSquare |]|
+//@[77:78) Colon |:|
+//@[79:80) LeftBrace |{|
+//@[80:81) NewLine |\n|
+  name: 'hello-${someDuplicate}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:17) StringLeftPiece |'hello-${|
+//@[17:30) Identifier |someDuplicate|
+//@[30:32) StringRightPiece |}'|
+//@[32:33) NewLine |\n|
+  params: {
+//@[2:8) Identifier |params|
+//@[8:9) Colon |:|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+    objParam: {}
+//@[4:12) Identifier |objParam|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:16) RightBrace |}|
+//@[16:17) NewLine |\n|
+    stringParamA: 'test'
+//@[4:16) Identifier |stringParamA|
+//@[16:17) Colon |:|
+//@[18:24) StringComplete |'test'|
+//@[24:25) NewLine |\n|
+    stringParamB: 'test'
+//@[4:16) Identifier |stringParamB|
+//@[16:17) Colon |:|
+//@[18:24) StringComplete |'test'|
+//@[24:25) NewLine |\n|
+    arrayParam: [for x in emptyArray: x]
+//@[4:14) Identifier |arrayParam|
+//@[14:15) Colon |:|
+//@[16:17) LeftSquare |[|
+//@[17:20) Identifier |for|
+//@[21:22) Identifier |x|
+//@[23:25) Identifier |in|
+//@[26:36) Identifier |emptyArray|
+//@[36:37) Colon |:|
+//@[38:39) Identifier |x|
+//@[39:40) RightSquare |]|
+//@[40:41) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+var otherDuplicate = 'there'
+//@[0:3) Identifier |var|
+//@[4:18) Identifier |otherDuplicate|
+//@[19:20) Assignment |=|
+//@[21:28) StringComplete |'there'|
+//@[28:29) NewLine |\n|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
+//@[0:6) Identifier |module|
+//@[7:34) Identifier |duplicateInGlobalAndOneLoop|
+//@[35:50) StringComplete |'modulea.bicep'|
+//@[51:52) Assignment |=|
+//@[53:54) LeftSquare |[|
+//@[54:57) Identifier |for|
+//@[58:72) Identifier |otherDuplicate|
+//@[73:75) Identifier |in|
+//@[76:77) LeftSquare |[|
+//@[77:78) RightSquare |]|
+//@[78:79) Colon |:|
+//@[80:81) LeftBrace |{|
+//@[81:82) NewLine |\n|
+  name: 'hello-${someDuplicate}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:17) StringLeftPiece |'hello-${|
+//@[17:30) Identifier |someDuplicate|
+//@[30:32) StringRightPiece |}'|
+//@[32:33) NewLine |\n|
+  params: {
+//@[2:8) Identifier |params|
+//@[8:9) Colon |:|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+    objParam: {}
+//@[4:12) Identifier |objParam|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:16) RightBrace |}|
+//@[16:17) NewLine |\n|
+    stringParamB: 'test'
+//@[4:16) Identifier |stringParamB|
+//@[16:17) Colon |:|
+//@[18:24) StringComplete |'test'|
+//@[24:25) NewLine |\n|
+    arrayParam: [for otherDuplicate in emptyArray: x]
+//@[4:14) Identifier |arrayParam|
+//@[14:15) Colon |:|
+//@[16:17) LeftSquare |[|
+//@[17:20) Identifier |for|
+//@[21:35) Identifier |otherDuplicate|
+//@[36:38) Identifier |in|
+//@[39:49) Identifier |emptyArray|
+//@[49:50) Colon |:|
+//@[51:52) Identifier |x|
+//@[52:53) RightSquare |]|
+//@[53:54) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+var someDuplicate = true
+//@[0:3) Identifier |var|
+//@[4:17) Identifier |someDuplicate|
+//@[18:19) Assignment |=|
+//@[20:24) TrueKeyword |true|
+//@[24:25) NewLine |\n|
+var otherDuplicate = false
+//@[0:3) Identifier |var|
+//@[4:18) Identifier |otherDuplicate|
+//@[19:20) Assignment |=|
+//@[21:26) FalseKeyword |false|
+//@[26:27) NewLine |\n|
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@[0:6) Identifier |module|
+//@[7:27) Identifier |duplicatesEverywhere|
+//@[28:43) StringComplete |'modulea.bicep'|
+//@[44:45) Assignment |=|
+//@[46:47) LeftSquare |[|
+//@[47:50) Identifier |for|
+//@[51:64) Identifier |someDuplicate|
+//@[65:67) Identifier |in|
+//@[68:69) LeftSquare |[|
+//@[69:70) RightSquare |]|
+//@[70:71) Colon |:|
+//@[72:73) LeftBrace |{|
+//@[73:74) NewLine |\n|
+  name: 'hello-${someDuplicate}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:17) StringLeftPiece |'hello-${|
+//@[17:30) Identifier |someDuplicate|
+//@[30:32) StringRightPiece |}'|
+//@[32:33) NewLine |\n|
+  params: {
+//@[2:8) Identifier |params|
+//@[8:9) Colon |:|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+    objParam: {}
+//@[4:12) Identifier |objParam|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:16) RightBrace |}|
+//@[16:17) NewLine |\n|
+    stringParamB: 'test'
+//@[4:16) Identifier |stringParamB|
+//@[16:17) Colon |:|
+//@[18:24) StringComplete |'test'|
+//@[24:25) NewLine |\n|
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@[4:14) Identifier |arrayParam|
+//@[14:15) Colon |:|
+//@[16:17) LeftSquare |[|
+//@[17:20) Identifier |for|
+//@[21:35) Identifier |otherDuplicate|
+//@[36:38) Identifier |in|
+//@[39:49) Identifier |emptyArray|
+//@[49:50) Colon |:|
+//@[51:54) StringLeftPiece |'${|
+//@[54:67) Identifier |someDuplicate|
+//@[67:71) StringMiddlePiece |}-${|
+//@[71:85) Identifier |otherDuplicate|
+//@[85:87) StringRightPiece |}'|
+//@[87:88) RightSquare |]|
+//@[88:89) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+/*
+  valid loop - this should be moved to Modules_* test case after E2E works
+*/ 
+//@[3:4) NewLine |\n|
+var myModules = [
+//@[0:3) Identifier |var|
+//@[4:13) Identifier |myModules|
+//@[14:15) Assignment |=|
+//@[16:17) LeftSquare |[|
+//@[17:18) NewLine |\n|
+  {
+//@[2:3) LeftBrace |{|
+//@[3:4) NewLine |\n|
+    name: 'one'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:15) StringComplete |'one'|
+//@[15:16) NewLine |\n|
+    location: 'eastus2'
+//@[4:12) Identifier |location|
+//@[12:13) Colon |:|
+//@[14:23) StringComplete |'eastus2'|
+//@[23:24) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+  {
+//@[2:3) LeftBrace |{|
+//@[3:4) NewLine |\n|
+    name: 'two'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:15) StringComplete |'two'|
+//@[15:16) NewLine |\n|
+    location: 'westus'
+//@[4:12) Identifier |location|
+//@[12:13) Colon |:|
+//@[14:22) StringComplete |'westus'|
+//@[22:23) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+]
+//@[0:1) RightSquare |]|
+//@[1:2) NewLine |\n|
+module storageResources 'modulea.bicep' = [for module in myModules: {
+//@[0:6) Identifier |module|
+//@[7:23) Identifier |storageResources|
+//@[24:39) StringComplete |'modulea.bicep'|
+//@[40:41) Assignment |=|
+//@[42:43) LeftSquare |[|
+//@[43:46) Identifier |for|
+//@[47:53) Identifier |module|
+//@[54:56) Identifier |in|
+//@[57:66) Identifier |myModules|
+//@[66:67) Colon |:|
+//@[68:69) LeftBrace |{|
+//@[69:70) NewLine |\n|
+  name: module.name
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) Identifier |module|
+//@[14:15) Dot |.|
+//@[15:19) Identifier |name|
+//@[19:20) NewLine |\n|
+  params: {
+//@[2:8) Identifier |params|
+//@[8:9) Colon |:|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+    arrayParam: []
+//@[4:14) Identifier |arrayParam|
+//@[14:15) Colon |:|
+//@[16:17) LeftSquare |[|
+//@[17:18) RightSquare |]|
+//@[18:19) NewLine |\n|
+    objParam: module
+//@[4:12) Identifier |objParam|
+//@[12:13) Colon |:|
+//@[14:20) Identifier |module|
+//@[20:21) NewLine |\n|
+    stringParamB: module.location
+//@[4:16) Identifier |stringParamB|
+//@[16:17) Colon |:|
+//@[18:24) Identifier |module|
+//@[24:25) Dot |.|
+//@[25:33) Identifier |location|
+//@[33:34) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+//@[0:6) Identifier |module|
+//@[7:23) Identifier |nestedModuleLoop|
+//@[24:39) StringComplete |'modulea.bicep'|
+//@[40:41) Assignment |=|
+//@[42:43) LeftSquare |[|
+//@[43:46) Identifier |for|
+//@[47:53) Identifier |module|
+//@[54:56) Identifier |in|
+//@[57:66) Identifier |myModules|
+//@[66:67) Colon |:|
+//@[68:69) LeftBrace |{|
+//@[69:70) NewLine |\n|
+  name: module.name
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) Identifier |module|
+//@[14:15) Dot |.|
+//@[15:19) Identifier |name|
+//@[19:20) NewLine |\n|
+  params: {
+//@[2:8) Identifier |params|
+//@[8:9) Colon |:|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+    arrayParam: [for i in range(0,3): concat('test', i)]
+//@[4:14) Identifier |arrayParam|
+//@[14:15) Colon |:|
+//@[16:17) LeftSquare |[|
+//@[17:20) Identifier |for|
+//@[21:22) Identifier |i|
+//@[23:25) Identifier |in|
+//@[26:31) Identifier |range|
+//@[31:32) LeftParen |(|
+//@[32:33) Integer |0|
+//@[33:34) Comma |,|
+//@[34:35) Integer |3|
+//@[35:36) RightParen |)|
+//@[36:37) Colon |:|
+//@[38:44) Identifier |concat|
+//@[44:45) LeftParen |(|
+//@[45:51) StringComplete |'test'|
+//@[51:52) Comma |,|
+//@[53:54) Identifier |i|
+//@[54:55) RightParen |)|
+//@[55:56) RightSquare |]|
+//@[56:57) NewLine |\n|
+    objParam: module
+//@[4:12) Identifier |objParam|
+//@[12:13) Colon |:|
+//@[14:20) Identifier |module|
+//@[20:21) NewLine |\n|
+    stringParamB: module.location
+//@[4:16) Identifier |stringParamB|
+//@[16:17) Colon |:|
+//@[18:24) Identifier |module|
+//@[24:25) Dot |.|
+//@[25:33) Identifier |location|
+//@[33:34) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:2) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
@@ -1396,6 +1396,118 @@ module wrongModuleParameterInLoop 'modulea.bicep' = [for x in emptyArray:{
 //@[1:2) RightSquare |]|
 //@[2:4) NewLine |\n\n|
 
+// nonexistent arrays and loop variables
+//@[40:41) NewLine |\n|
+var evenMoreDuplicates = 'there'
+//@[0:3) Identifier |var|
+//@[4:22) Identifier |evenMoreDuplicates|
+//@[23:24) Assignment |=|
+//@[25:32) StringComplete |'there'|
+//@[32:33) NewLine |\n|
+module nonexistentArrays 'modulea.bicep' = [for evenMoreDuplicates in alsoDoesNotExist: {
+//@[0:6) Identifier |module|
+//@[7:24) Identifier |nonexistentArrays|
+//@[25:40) StringComplete |'modulea.bicep'|
+//@[41:42) Assignment |=|
+//@[43:44) LeftSquare |[|
+//@[44:47) Identifier |for|
+//@[48:66) Identifier |evenMoreDuplicates|
+//@[67:69) Identifier |in|
+//@[70:86) Identifier |alsoDoesNotExist|
+//@[86:87) Colon |:|
+//@[88:89) LeftBrace |{|
+//@[89:90) NewLine |\n|
+  name: 'hello-${whyChooseRealVariablesWhenWeCanPretend}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:17) StringLeftPiece |'hello-${|
+//@[17:55) Identifier |whyChooseRealVariablesWhenWeCanPretend|
+//@[55:57) StringRightPiece |}'|
+//@[57:58) NewLine |\n|
+  params: {
+//@[2:8) Identifier |params|
+//@[8:9) Colon |:|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+    objParam: {}
+//@[4:12) Identifier |objParam|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:16) RightBrace |}|
+//@[16:17) NewLine |\n|
+    stringParamB: 'test'
+//@[4:16) Identifier |stringParamB|
+//@[16:17) Colon |:|
+//@[18:24) StringComplete |'test'|
+//@[24:25) NewLine |\n|
+    arrayParam: [for evenMoreDuplicates in totallyFake: doesNotExist]
+//@[4:14) Identifier |arrayParam|
+//@[14:15) Colon |:|
+//@[16:17) LeftSquare |[|
+//@[17:20) Identifier |for|
+//@[21:39) Identifier |evenMoreDuplicates|
+//@[40:42) Identifier |in|
+//@[43:54) Identifier |totallyFake|
+//@[54:55) Colon |:|
+//@[56:68) Identifier |doesNotExist|
+//@[68:69) RightSquare |]|
+//@[69:70) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+/*
+  valid loop - this should be moved to Modules_* test case after E2E works
+*/ 
+//@[3:4) NewLine |\n|
+var myModules = [
+//@[0:3) Identifier |var|
+//@[4:13) Identifier |myModules|
+//@[14:15) Assignment |=|
+//@[16:17) LeftSquare |[|
+//@[17:18) NewLine |\n|
+  {
+//@[2:3) LeftBrace |{|
+//@[3:4) NewLine |\n|
+    name: 'one'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:15) StringComplete |'one'|
+//@[15:16) NewLine |\n|
+    location: 'eastus2'
+//@[4:12) Identifier |location|
+//@[12:13) Colon |:|
+//@[14:23) StringComplete |'eastus2'|
+//@[23:24) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+  {
+//@[2:3) LeftBrace |{|
+//@[3:4) NewLine |\n|
+    name: 'two'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:15) StringComplete |'two'|
+//@[15:16) NewLine |\n|
+    location: 'westus'
+//@[4:12) Identifier |location|
+//@[12:13) Colon |:|
+//@[14:22) StringComplete |'westus'|
+//@[22:23) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+]
+//@[0:1) RightSquare |]|
+//@[1:3) NewLine |\n\n|
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+//@[74:75) NewLine |\n|
 module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
 //@[0:6) Identifier |module|
 //@[7:37) Identifier |duplicateIdentifiersWithinLoop|
@@ -1457,33 +1569,35 @@ module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
 //@[1:2) RightSquare |]|
 //@[2:4) NewLine |\n\n|
 
-var someDuplicate = 'hello'
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+//@[74:75) NewLine |\n|
+var duplicateAcrossScopes = 'hello'
 //@[0:3) Identifier |var|
-//@[4:17) Identifier |someDuplicate|
-//@[18:19) Assignment |=|
-//@[20:27) StringComplete |'hello'|
-//@[27:28) NewLine |\n|
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
+//@[4:25) Identifier |duplicateAcrossScopes|
+//@[26:27) Assignment |=|
+//@[28:35) StringComplete |'hello'|
+//@[35:36) NewLine |\n|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
 //@[0:6) Identifier |module|
 //@[7:34) Identifier |duplicateInGlobalAndOneLoop|
 //@[35:50) StringComplete |'modulea.bicep'|
 //@[51:52) Assignment |=|
 //@[53:54) LeftSquare |[|
 //@[54:57) Identifier |for|
-//@[58:71) Identifier |someDuplicate|
-//@[72:74) Identifier |in|
-//@[75:76) LeftSquare |[|
-//@[76:77) RightSquare |]|
-//@[77:78) Colon |:|
-//@[79:80) LeftBrace |{|
-//@[80:81) NewLine |\n|
-  name: 'hello-${someDuplicate}'
+//@[58:79) Identifier |duplicateAcrossScopes|
+//@[80:82) Identifier |in|
+//@[83:84) LeftSquare |[|
+//@[84:85) RightSquare |]|
+//@[85:86) Colon |:|
+//@[87:88) LeftBrace |{|
+//@[88:89) NewLine |\n|
+  name: 'hello-${duplicateAcrossScopes}'
 //@[2:6) Identifier |name|
 //@[6:7) Colon |:|
 //@[8:17) StringLeftPiece |'hello-${|
-//@[17:30) Identifier |someDuplicate|
-//@[30:32) StringRightPiece |}'|
-//@[32:33) NewLine |\n|
+//@[17:38) Identifier |duplicateAcrossScopes|
+//@[38:40) StringRightPiece |}'|
+//@[40:41) NewLine |\n|
   params: {
 //@[2:8) Identifier |params|
 //@[8:9) Colon |:|
@@ -1517,69 +1631,6 @@ module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for someDuplicate in []: {
 //@[38:39) Identifier |x|
 //@[39:40) RightSquare |]|
 //@[40:41) NewLine |\n|
-  }
-//@[2:3) RightBrace |}|
-//@[3:4) NewLine |\n|
-}]
-//@[0:1) RightBrace |}|
-//@[1:2) RightSquare |]|
-//@[2:4) NewLine |\n\n|
-
-var otherDuplicate = 'there'
-//@[0:3) Identifier |var|
-//@[4:18) Identifier |otherDuplicate|
-//@[19:20) Assignment |=|
-//@[21:28) StringComplete |'there'|
-//@[28:29) NewLine |\n|
-module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for otherDuplicate in []: {
-//@[0:6) Identifier |module|
-//@[7:34) Identifier |duplicateInGlobalAndOneLoop|
-//@[35:50) StringComplete |'modulea.bicep'|
-//@[51:52) Assignment |=|
-//@[53:54) LeftSquare |[|
-//@[54:57) Identifier |for|
-//@[58:72) Identifier |otherDuplicate|
-//@[73:75) Identifier |in|
-//@[76:77) LeftSquare |[|
-//@[77:78) RightSquare |]|
-//@[78:79) Colon |:|
-//@[80:81) LeftBrace |{|
-//@[81:82) NewLine |\n|
-  name: 'hello-${someDuplicate}'
-//@[2:6) Identifier |name|
-//@[6:7) Colon |:|
-//@[8:17) StringLeftPiece |'hello-${|
-//@[17:30) Identifier |someDuplicate|
-//@[30:32) StringRightPiece |}'|
-//@[32:33) NewLine |\n|
-  params: {
-//@[2:8) Identifier |params|
-//@[8:9) Colon |:|
-//@[10:11) LeftBrace |{|
-//@[11:12) NewLine |\n|
-    objParam: {}
-//@[4:12) Identifier |objParam|
-//@[12:13) Colon |:|
-//@[14:15) LeftBrace |{|
-//@[15:16) RightBrace |}|
-//@[16:17) NewLine |\n|
-    stringParamB: 'test'
-//@[4:16) Identifier |stringParamB|
-//@[16:17) Colon |:|
-//@[18:24) StringComplete |'test'|
-//@[24:25) NewLine |\n|
-    arrayParam: [for otherDuplicate in emptyArray: x]
-//@[4:14) Identifier |arrayParam|
-//@[14:15) Colon |:|
-//@[16:17) LeftSquare |[|
-//@[17:20) Identifier |for|
-//@[21:35) Identifier |otherDuplicate|
-//@[36:38) Identifier |in|
-//@[39:49) Identifier |emptyArray|
-//@[49:50) Colon |:|
-//@[51:52) Identifier |x|
-//@[52:53) RightSquare |]|
-//@[53:54) NewLine |\n|
   }
 //@[2:3) RightBrace |}|
 //@[3:4) NewLine |\n|
@@ -1661,51 +1712,8 @@ module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
 //@[1:2) RightSquare |]|
 //@[2:4) NewLine |\n\n|
 
-/*
-  valid loop - this should be moved to Modules_* test case after E2E works
-*/ 
-//@[3:4) NewLine |\n|
-var myModules = [
-//@[0:3) Identifier |var|
-//@[4:13) Identifier |myModules|
-//@[14:15) Assignment |=|
-//@[16:17) LeftSquare |[|
-//@[17:18) NewLine |\n|
-  {
-//@[2:3) LeftBrace |{|
-//@[3:4) NewLine |\n|
-    name: 'one'
-//@[4:8) Identifier |name|
-//@[8:9) Colon |:|
-//@[10:15) StringComplete |'one'|
-//@[15:16) NewLine |\n|
-    location: 'eastus2'
-//@[4:12) Identifier |location|
-//@[12:13) Colon |:|
-//@[14:23) StringComplete |'eastus2'|
-//@[23:24) NewLine |\n|
-  }
-//@[2:3) RightBrace |}|
-//@[3:4) NewLine |\n|
-  {
-//@[2:3) LeftBrace |{|
-//@[3:4) NewLine |\n|
-    name: 'two'
-//@[4:8) Identifier |name|
-//@[8:9) Colon |:|
-//@[10:15) StringComplete |'two'|
-//@[15:16) NewLine |\n|
-    location: 'westus'
-//@[4:12) Identifier |location|
-//@[12:13) Colon |:|
-//@[14:22) StringComplete |'westus'|
-//@[22:23) NewLine |\n|
-  }
-//@[2:3) RightBrace |}|
-//@[3:4) NewLine |\n|
-]
-//@[0:1) RightSquare |]|
-//@[1:2) NewLine |\n|
+// simple module loop
+//@[21:22) NewLine |\n|
 module storageResources 'modulea.bicep' = [for module in myModules: {
 //@[0:6) Identifier |module|
 //@[7:23) Identifier |storageResources|
@@ -1757,6 +1765,8 @@ module storageResources 'modulea.bicep' = [for module in myModules: {
 //@[1:2) RightSquare |]|
 //@[2:4) NewLine |\n\n|
 
+// nested module loop
+//@[21:22) NewLine |\n|
 module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
 //@[0:6) Identifier |module|
 //@[7:23) Identifier |nestedModuleLoop|

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
@@ -366,6 +366,7 @@ param paramMixedTwoCycle2 string {
 // wrong types of "variable"/identifier access
 var sampleVar = 'sample'
 resource sampleResource 'Microsoft.Foo/foos@2020-02-02' = {
+//@[24:55) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02" does not have types available. |'Microsoft.Foo/foos@2020-02-02'|
   name: 'foo'
 }
 output sampleOutput string = 'hello'

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -48,6 +48,20 @@
     }
   },
   {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
     "label": "az",
     "kind": "folder",
     "detail": "az",
@@ -414,6 +428,34 @@
     }
   },
   {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
@@ -456,6 +498,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
@@ -467,6 +537,90 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
     }
   },
   {
@@ -512,6 +666,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -537,6 +719,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
     }
   },
   {
@@ -582,6 +876,34 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
@@ -593,6 +915,132 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
     }
   },
   {
@@ -610,6 +1058,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
     }
   },
   {
@@ -641,6 +1103,118 @@
     "textEdit": {
       "range": {},
       "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
     }
   },
   {
@@ -1137,6 +1711,34 @@
     }
   },
   {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
@@ -1221,6 +1823,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -1249,6 +1879,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
@@ -1263,6 +1921,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
@@ -1274,6 +1960,62 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
     }
   },
   {
@@ -1319,6 +2061,62 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
@@ -1333,6 +2131,104 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -1344,6 +2240,34 @@
     "textEdit": {
       "range": {},
       "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
     }
   },
   {
@@ -1378,6 +2302,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
     }
   },
   {
@@ -1480,6 +2418,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
     }
   },
   {
@@ -1987,6 +2939,20 @@
     }
   },
   {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -2001,6 +2967,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
     }
   },
   {
@@ -2063,6 +3043,34 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
     }
   },
   {
@@ -2385,6 +3393,62 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -256,6 +256,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1041,6 +1055,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2229,6 +2257,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2254,20 +2296,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2967,20 +2995,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -284,6 +284,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1069,6 +1083,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2257,6 +2285,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2282,20 +2324,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2995,20 +3023,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -76,6 +76,20 @@
     }
   },
   {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
     "label": "az",
     "kind": "folder",
     "detail": "az",
@@ -442,6 +456,34 @@
     }
   },
   {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
@@ -484,6 +526,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
@@ -495,6 +565,90 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
     }
   },
   {
@@ -540,6 +694,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -565,6 +747,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
     }
   },
   {
@@ -610,6 +904,34 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
@@ -621,6 +943,132 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
     }
   },
   {
@@ -638,6 +1086,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
     }
   },
   {
@@ -669,6 +1131,118 @@
     "textEdit": {
       "range": {},
       "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
     }
   },
   {
@@ -1165,6 +1739,34 @@
     }
   },
   {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
@@ -1249,6 +1851,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -1277,6 +1907,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
@@ -1291,6 +1949,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
@@ -1302,6 +1988,62 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
     }
   },
   {
@@ -1347,6 +2089,62 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
@@ -1361,6 +2159,104 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -1372,6 +2268,34 @@
     "textEdit": {
       "range": {},
       "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
     }
   },
   {
@@ -1406,6 +2330,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
     }
   },
   {
@@ -1508,6 +2446,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
     }
   },
   {
@@ -2015,6 +2967,20 @@
     }
   },
   {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -2029,6 +2995,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
     }
   },
   {
@@ -2091,6 +3071,34 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
     }
   },
   {
@@ -2413,6 +3421,62 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -512,6 +512,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1283,6 +1297,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2485,6 +2513,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2510,20 +2552,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -3223,20 +3251,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -304,6 +304,20 @@
     }
   },
   {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
     "label": "az",
     "kind": "folder",
     "detail": "az",
@@ -670,6 +684,34 @@
     }
   },
   {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
@@ -709,6 +751,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
     }
   },
   {
@@ -754,6 +908,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -779,6 +961,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
     }
   },
   {
@@ -824,6 +1118,34 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
@@ -835,6 +1157,132 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
     }
   },
   {
@@ -852,6 +1300,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
     }
   },
   {
@@ -883,6 +1345,118 @@
     "textEdit": {
       "range": {},
       "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
     }
   },
   {
@@ -1393,6 +1967,34 @@
     }
   },
   {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
@@ -1477,6 +2079,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -1505,6 +2135,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
@@ -1519,6 +2177,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
@@ -1530,6 +2216,62 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
     }
   },
   {
@@ -1575,6 +2317,62 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
@@ -1589,6 +2387,104 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -1600,6 +2496,34 @@
     "textEdit": {
       "range": {},
       "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
     }
   },
   {
@@ -1634,6 +2558,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
     }
   },
   {
@@ -1736,6 +2674,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
     }
   },
   {
@@ -2243,6 +3195,20 @@
     }
   },
   {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -2257,6 +3223,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
     }
   },
   {
@@ -2319,6 +3299,34 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
     }
   },
   {
@@ -2641,6 +3649,62 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -1,0 +1,3710 @@
+[
+  {
+    "label": "'arguments'",
+    "kind": "property",
+    "detail": "arguments",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'arguments'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'arguments'"
+    }
+  },
+  {
+    "label": "'azCliVersion'",
+    "kind": "property",
+    "detail": "azCliVersion (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'azCliVersion'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'azCliVersion'"
+    }
+  },
+  {
+    "label": "'cleanupPreference'",
+    "kind": "property",
+    "detail": "cleanupPreference",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Always' | 'OnExpiration' | 'OnSuccess'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'cleanupPreference'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'cleanupPreference'"
+    }
+  },
+  {
+    "label": "'containerSettings'",
+    "kind": "property",
+    "detail": "containerSettings",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ContainerConfiguration`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'containerSettings'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'containerSettings'"
+    }
+  },
+  {
+    "label": "'environmentVariables'",
+    "kind": "property",
+    "detail": "environmentVariables",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `EnvironmentVariable[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'environmentVariables'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'environmentVariables'"
+    }
+  },
+  {
+    "label": "'forceUpdateTag'",
+    "kind": "property",
+    "detail": "forceUpdateTag",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'forceUpdateTag'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'forceUpdateTag'"
+    }
+  },
+  {
+    "label": "'outputs'",
+    "kind": "property",
+    "detail": "outputs",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Dictionary<string,Object>`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'outputs'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'outputs'"
+    }
+  },
+  {
+    "label": "'primaryScriptUri'",
+    "kind": "property",
+    "detail": "primaryScriptUri",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'primaryScriptUri'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'primaryScriptUri'"
+    }
+  },
+  {
+    "label": "'provisioningState'",
+    "kind": "property",
+    "detail": "provisioningState",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Canceled' | 'Creating' | 'Failed' | 'ProvisioningResources' | 'Running' | 'Succeeded'`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'provisioningState'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'provisioningState'"
+    }
+  },
+  {
+    "label": "'retentionInterval'",
+    "kind": "property",
+    "detail": "retentionInterval (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'retentionInterval'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'retentionInterval'"
+    }
+  },
+  {
+    "label": "'scriptContent'",
+    "kind": "property",
+    "detail": "scriptContent",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'scriptContent'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'scriptContent'"
+    }
+  },
+  {
+    "label": "'status'",
+    "kind": "property",
+    "detail": "status",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ScriptStatus`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'status'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'status'"
+    }
+  },
+  {
+    "label": "'storageAccountSettings'",
+    "kind": "property",
+    "detail": "storageAccountSettings",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `StorageAccountConfiguration`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'storageAccountSettings'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'storageAccountSettings'"
+    }
+  },
+  {
+    "label": "'supportingScriptUris'",
+    "kind": "property",
+    "detail": "supportingScriptUris",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'supportingScriptUris'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'supportingScriptUris'"
+    }
+  },
+  {
+    "label": "'timeout'",
+    "kind": "property",
+    "detail": "timeout",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'timeout'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'timeout'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -512,6 +512,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1283,6 +1297,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2485,6 +2513,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2510,20 +2552,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -3223,20 +3251,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -1,0 +1,3710 @@
+[
+  {
+    "label": "'arguments'",
+    "kind": "property",
+    "detail": "arguments",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'arguments'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'arguments'"
+    }
+  },
+  {
+    "label": "'azCliVersion'",
+    "kind": "property",
+    "detail": "azCliVersion (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'azCliVersion'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'azCliVersion'"
+    }
+  },
+  {
+    "label": "'cleanupPreference'",
+    "kind": "property",
+    "detail": "cleanupPreference",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Always' | 'OnExpiration' | 'OnSuccess'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'cleanupPreference'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'cleanupPreference'"
+    }
+  },
+  {
+    "label": "'containerSettings'",
+    "kind": "property",
+    "detail": "containerSettings",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ContainerConfiguration`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'containerSettings'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'containerSettings'"
+    }
+  },
+  {
+    "label": "'environmentVariables'",
+    "kind": "property",
+    "detail": "environmentVariables",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `EnvironmentVariable[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'environmentVariables'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'environmentVariables'"
+    }
+  },
+  {
+    "label": "'forceUpdateTag'",
+    "kind": "property",
+    "detail": "forceUpdateTag",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'forceUpdateTag'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'forceUpdateTag'"
+    }
+  },
+  {
+    "label": "'outputs'",
+    "kind": "property",
+    "detail": "outputs",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Dictionary<string,Object>`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'outputs'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'outputs'"
+    }
+  },
+  {
+    "label": "'primaryScriptUri'",
+    "kind": "property",
+    "detail": "primaryScriptUri",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'primaryScriptUri'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'primaryScriptUri'"
+    }
+  },
+  {
+    "label": "'provisioningState'",
+    "kind": "property",
+    "detail": "provisioningState",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Canceled' | 'Creating' | 'Failed' | 'ProvisioningResources' | 'Running' | 'Succeeded'`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'provisioningState'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'provisioningState'"
+    }
+  },
+  {
+    "label": "'retentionInterval'",
+    "kind": "property",
+    "detail": "retentionInterval (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'retentionInterval'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'retentionInterval'"
+    }
+  },
+  {
+    "label": "'scriptContent'",
+    "kind": "property",
+    "detail": "scriptContent",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'scriptContent'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'scriptContent'"
+    }
+  },
+  {
+    "label": "'status'",
+    "kind": "property",
+    "detail": "status",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ScriptStatus`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'status'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'status'"
+    }
+  },
+  {
+    "label": "'storageAccountSettings'",
+    "kind": "property",
+    "detail": "storageAccountSettings",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `StorageAccountConfiguration`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'storageAccountSettings'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'storageAccountSettings'"
+    }
+  },
+  {
+    "label": "'supportingScriptUris'",
+    "kind": "property",
+    "detail": "supportingScriptUris",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'supportingScriptUris'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'supportingScriptUris'"
+    }
+  },
+  {
+    "label": "'timeout'",
+    "kind": "property",
+    "detail": "timeout",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'timeout'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'timeout'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -512,6 +512,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1283,6 +1297,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2485,6 +2513,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2510,20 +2552,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -3223,20 +3251,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -260,6 +260,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1045,6 +1059,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2233,6 +2261,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2258,20 +2300,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2971,20 +2999,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -52,6 +52,20 @@
     }
   },
   {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
     "label": "az",
     "kind": "folder",
     "detail": "az",
@@ -418,6 +432,34 @@
     }
   },
   {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
@@ -460,6 +502,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
@@ -471,6 +541,90 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
     }
   },
   {
@@ -516,6 +670,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -541,6 +723,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
     }
   },
   {
@@ -586,6 +880,34 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
@@ -597,6 +919,132 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
     }
   },
   {
@@ -614,6 +1062,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
     }
   },
   {
@@ -645,6 +1107,118 @@
     "textEdit": {
       "range": {},
       "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
     }
   },
   {
@@ -1155,6 +1729,34 @@
     }
   },
   {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
@@ -1239,6 +1841,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -1267,6 +1897,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
@@ -1281,6 +1939,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
@@ -1292,6 +1978,62 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
     }
   },
   {
@@ -1337,6 +2079,160 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -1348,6 +2244,34 @@
     "textEdit": {
       "range": {},
       "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
     }
   },
   {
@@ -1382,6 +2306,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
     }
   },
   {
@@ -1484,6 +2422,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
     }
   },
   {
@@ -1991,6 +2943,20 @@
     }
   },
   {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -2005,6 +2971,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
     }
   },
   {
@@ -2067,6 +3047,34 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
     }
   },
   {
@@ -2389,6 +3397,62 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -260,6 +260,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1045,6 +1059,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2233,6 +2261,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2258,20 +2300,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2971,20 +2999,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -1,0 +1,3458 @@
+[
+  {
+    "label": "'createMode'",
+    "kind": "property",
+    "detail": "createMode (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Default' | 'Restore'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'createMode'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'createMode'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -260,6 +260,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1045,6 +1059,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2233,6 +2261,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2258,20 +2300,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2971,20 +2999,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -1,0 +1,3458 @@
+[
+  {
+    "label": "'createMode'",
+    "kind": "property",
+    "detail": "createMode (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Default' | 'Restore'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'createMode'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'createMode'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -746,6 +746,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1531,6 +1545,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2719,6 +2747,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2744,20 +2786,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -3457,20 +3485,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -538,6 +538,20 @@
     }
   },
   {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
     "label": "az",
     "kind": "folder",
     "detail": "az",
@@ -904,6 +918,34 @@
     }
   },
   {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
@@ -946,6 +988,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
@@ -957,6 +1027,90 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
     }
   },
   {
@@ -1002,6 +1156,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -1027,6 +1209,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
     }
   },
   {
@@ -1072,6 +1366,34 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
@@ -1083,6 +1405,132 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
     }
   },
   {
@@ -1100,6 +1548,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
     }
   },
   {
@@ -1131,6 +1593,118 @@
     "textEdit": {
       "range": {},
       "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
     }
   },
   {
@@ -1641,6 +2215,34 @@
     }
   },
   {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
@@ -1711,6 +2313,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -1739,6 +2369,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
@@ -1753,6 +2411,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
@@ -1764,6 +2450,62 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
     }
   },
   {
@@ -1809,6 +2551,62 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
@@ -1823,6 +2621,104 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -1834,6 +2730,34 @@
     "textEdit": {
       "range": {},
       "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
     }
   },
   {
@@ -1868,6 +2792,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
     }
   },
   {
@@ -1970,6 +2908,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
     }
   },
   {
@@ -2477,6 +3429,20 @@
     }
   },
   {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -2491,6 +3457,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
     }
   },
   {
@@ -2553,6 +3533,34 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
     }
   },
   {
@@ -2875,6 +3883,62 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -1,0 +1,3944 @@
+[
+  {
+    "label": "'apiProperties'",
+    "kind": "property",
+    "detail": "apiProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ApiProperties`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'apiProperties'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'apiProperties'"
+    }
+  },
+  {
+    "label": "'backupPolicy'",
+    "kind": "property",
+    "detail": "backupPolicy",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `BackupPolicy`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'backupPolicy'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'backupPolicy'"
+    }
+  },
+  {
+    "label": "'capabilities'",
+    "kind": "property",
+    "detail": "capabilities",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Capability[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'capabilities'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'capabilities'"
+    }
+  },
+  {
+    "label": "'connectorOffer'",
+    "kind": "property",
+    "detail": "connectorOffer",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Small'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'connectorOffer'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'connectorOffer'"
+    }
+  },
+  {
+    "label": "'consistencyPolicy'",
+    "kind": "property",
+    "detail": "consistencyPolicy",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ConsistencyPolicy`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'consistencyPolicy'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'consistencyPolicy'"
+    }
+  },
+  {
+    "label": "'cors'",
+    "kind": "property",
+    "detail": "cors",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `CorsPolicy[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'cors'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'cors'"
+    }
+  },
+  {
+    "label": "'createMode'",
+    "kind": "property",
+    "detail": "createMode (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Default'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'createMode'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'createMode'"
+    }
+  },
+  {
+    "label": "'databaseAccountOfferType'",
+    "kind": "property",
+    "detail": "databaseAccountOfferType (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'databaseAccountOfferType'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'databaseAccountOfferType'"
+    }
+  },
+  {
+    "label": "'disableKeyBasedMetadataWriteAccess'",
+    "kind": "property",
+    "detail": "disableKeyBasedMetadataWriteAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'disableKeyBasedMetadataWriteAccess'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'disableKeyBasedMetadataWriteAccess'"
+    }
+  },
+  {
+    "label": "'documentEndpoint'",
+    "kind": "property",
+    "detail": "documentEndpoint",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'documentEndpoint'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'documentEndpoint'"
+    }
+  },
+  {
+    "label": "'enableAnalyticalStorage'",
+    "kind": "property",
+    "detail": "enableAnalyticalStorage",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableAnalyticalStorage'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableAnalyticalStorage'"
+    }
+  },
+  {
+    "label": "'enableAutomaticFailover'",
+    "kind": "property",
+    "detail": "enableAutomaticFailover",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableAutomaticFailover'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableAutomaticFailover'"
+    }
+  },
+  {
+    "label": "'enableCassandraConnector'",
+    "kind": "property",
+    "detail": "enableCassandraConnector",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableCassandraConnector'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableCassandraConnector'"
+    }
+  },
+  {
+    "label": "'enableFreeTier'",
+    "kind": "property",
+    "detail": "enableFreeTier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableFreeTier'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableFreeTier'"
+    }
+  },
+  {
+    "label": "'enableMultipleWriteLocations'",
+    "kind": "property",
+    "detail": "enableMultipleWriteLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableMultipleWriteLocations'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableMultipleWriteLocations'"
+    }
+  },
+  {
+    "label": "'failoverPolicies'",
+    "kind": "property",
+    "detail": "failoverPolicies",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `FailoverPolicy[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'failoverPolicies'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'failoverPolicies'"
+    }
+  },
+  {
+    "label": "'instanceId'",
+    "kind": "property",
+    "detail": "instanceId",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'instanceId'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'instanceId'"
+    }
+  },
+  {
+    "label": "'ipRules'",
+    "kind": "property",
+    "detail": "ipRules",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `IpAddressOrRange[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'ipRules'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'ipRules'"
+    }
+  },
+  {
+    "label": "'isVirtualNetworkFilterEnabled'",
+    "kind": "property",
+    "detail": "isVirtualNetworkFilterEnabled",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'isVirtualNetworkFilterEnabled'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'isVirtualNetworkFilterEnabled'"
+    }
+  },
+  {
+    "label": "'keyVaultKeyUri'",
+    "kind": "property",
+    "detail": "keyVaultKeyUri",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'keyVaultKeyUri'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'keyVaultKeyUri'"
+    }
+  },
+  {
+    "label": "'locations'",
+    "kind": "property",
+    "detail": "locations (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'locations'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'locations'"
+    }
+  },
+  {
+    "label": "'privateEndpointConnections'",
+    "kind": "property",
+    "detail": "privateEndpointConnections",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `PrivateEndpointConnection[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'privateEndpointConnections'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'privateEndpointConnections'"
+    }
+  },
+  {
+    "label": "'provisioningState'",
+    "kind": "property",
+    "detail": "provisioningState",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'provisioningState'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'provisioningState'"
+    }
+  },
+  {
+    "label": "'publicNetworkAccess'",
+    "kind": "property",
+    "detail": "publicNetworkAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Disabled' | 'Enabled'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'publicNetworkAccess'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'publicNetworkAccess'"
+    }
+  },
+  {
+    "label": "'readLocations'",
+    "kind": "property",
+    "detail": "readLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'readLocations'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'readLocations'"
+    }
+  },
+  {
+    "label": "'restoreParameters'",
+    "kind": "property",
+    "detail": "restoreParameters",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `RestoreParameters`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'restoreParameters'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'restoreParameters'"
+    }
+  },
+  {
+    "label": "'virtualNetworkRules'",
+    "kind": "property",
+    "detail": "virtualNetworkRules",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `VirtualNetworkRule[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'virtualNetworkRules'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'virtualNetworkRules'"
+    }
+  },
+  {
+    "label": "'writeLocations'",
+    "kind": "property",
+    "detail": "writeLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'writeLocations'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'writeLocations'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -746,6 +746,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1531,6 +1545,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2719,6 +2747,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2744,20 +2786,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -3457,20 +3485,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -746,6 +746,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1531,6 +1545,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2719,6 +2747,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2744,20 +2786,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -3457,20 +3485,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -1,0 +1,3944 @@
+[
+  {
+    "label": "'apiProperties'",
+    "kind": "property",
+    "detail": "apiProperties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ApiProperties`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'apiProperties'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'apiProperties'"
+    }
+  },
+  {
+    "label": "'backupPolicy'",
+    "kind": "property",
+    "detail": "backupPolicy",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `BackupPolicy`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'backupPolicy'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'backupPolicy'"
+    }
+  },
+  {
+    "label": "'capabilities'",
+    "kind": "property",
+    "detail": "capabilities",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Capability[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'capabilities'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'capabilities'"
+    }
+  },
+  {
+    "label": "'connectorOffer'",
+    "kind": "property",
+    "detail": "connectorOffer",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Small'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'connectorOffer'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'connectorOffer'"
+    }
+  },
+  {
+    "label": "'consistencyPolicy'",
+    "kind": "property",
+    "detail": "consistencyPolicy",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `ConsistencyPolicy`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'consistencyPolicy'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'consistencyPolicy'"
+    }
+  },
+  {
+    "label": "'cors'",
+    "kind": "property",
+    "detail": "cors",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `CorsPolicy[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'cors'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'cors'"
+    }
+  },
+  {
+    "label": "'createMode'",
+    "kind": "property",
+    "detail": "createMode (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Default'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'createMode'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'createMode'"
+    }
+  },
+  {
+    "label": "'databaseAccountOfferType'",
+    "kind": "property",
+    "detail": "databaseAccountOfferType (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'databaseAccountOfferType'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'databaseAccountOfferType'"
+    }
+  },
+  {
+    "label": "'disableKeyBasedMetadataWriteAccess'",
+    "kind": "property",
+    "detail": "disableKeyBasedMetadataWriteAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'disableKeyBasedMetadataWriteAccess'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'disableKeyBasedMetadataWriteAccess'"
+    }
+  },
+  {
+    "label": "'documentEndpoint'",
+    "kind": "property",
+    "detail": "documentEndpoint",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'documentEndpoint'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'documentEndpoint'"
+    }
+  },
+  {
+    "label": "'enableAnalyticalStorage'",
+    "kind": "property",
+    "detail": "enableAnalyticalStorage",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableAnalyticalStorage'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableAnalyticalStorage'"
+    }
+  },
+  {
+    "label": "'enableAutomaticFailover'",
+    "kind": "property",
+    "detail": "enableAutomaticFailover",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableAutomaticFailover'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableAutomaticFailover'"
+    }
+  },
+  {
+    "label": "'enableCassandraConnector'",
+    "kind": "property",
+    "detail": "enableCassandraConnector",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableCassandraConnector'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableCassandraConnector'"
+    }
+  },
+  {
+    "label": "'enableFreeTier'",
+    "kind": "property",
+    "detail": "enableFreeTier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableFreeTier'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableFreeTier'"
+    }
+  },
+  {
+    "label": "'enableMultipleWriteLocations'",
+    "kind": "property",
+    "detail": "enableMultipleWriteLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'enableMultipleWriteLocations'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'enableMultipleWriteLocations'"
+    }
+  },
+  {
+    "label": "'failoverPolicies'",
+    "kind": "property",
+    "detail": "failoverPolicies",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `FailoverPolicy[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'failoverPolicies'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'failoverPolicies'"
+    }
+  },
+  {
+    "label": "'instanceId'",
+    "kind": "property",
+    "detail": "instanceId",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'instanceId'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'instanceId'"
+    }
+  },
+  {
+    "label": "'ipRules'",
+    "kind": "property",
+    "detail": "ipRules",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `IpAddressOrRange[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'ipRules'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'ipRules'"
+    }
+  },
+  {
+    "label": "'isVirtualNetworkFilterEnabled'",
+    "kind": "property",
+    "detail": "isVirtualNetworkFilterEnabled",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `bool`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'isVirtualNetworkFilterEnabled'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'isVirtualNetworkFilterEnabled'"
+    }
+  },
+  {
+    "label": "'keyVaultKeyUri'",
+    "kind": "property",
+    "detail": "keyVaultKeyUri",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'keyVaultKeyUri'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'keyVaultKeyUri'"
+    }
+  },
+  {
+    "label": "'locations'",
+    "kind": "property",
+    "detail": "locations (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'locations'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'locations'"
+    }
+  },
+  {
+    "label": "'privateEndpointConnections'",
+    "kind": "property",
+    "detail": "privateEndpointConnections",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `PrivateEndpointConnection[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'privateEndpointConnections'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'privateEndpointConnections'"
+    }
+  },
+  {
+    "label": "'provisioningState'",
+    "kind": "property",
+    "detail": "provisioningState",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'provisioningState'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'provisioningState'"
+    }
+  },
+  {
+    "label": "'publicNetworkAccess'",
+    "kind": "property",
+    "detail": "publicNetworkAccess",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Disabled' | 'Enabled'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'publicNetworkAccess'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'publicNetworkAccess'"
+    }
+  },
+  {
+    "label": "'readLocations'",
+    "kind": "property",
+    "detail": "readLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'readLocations'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'readLocations'"
+    }
+  },
+  {
+    "label": "'restoreParameters'",
+    "kind": "property",
+    "detail": "restoreParameters",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `RestoreParameters`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'restoreParameters'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'restoreParameters'"
+    }
+  },
+  {
+    "label": "'virtualNetworkRules'",
+    "kind": "property",
+    "detail": "virtualNetworkRules",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `VirtualNetworkRule[]`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'virtualNetworkRules'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'virtualNetworkRules'"
+    }
+  },
+  {
+    "label": "'writeLocations'",
+    "kind": "property",
+    "detail": "writeLocations",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Location[]`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'writeLocations'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'writeLocations'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -270,6 +270,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1041,6 +1055,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2243,6 +2271,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2268,20 +2310,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2981,20 +3009,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -62,6 +62,20 @@
     }
   },
   {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
     "label": "az",
     "kind": "folder",
     "detail": "az",
@@ -428,6 +442,34 @@
     }
   },
   {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
@@ -470,6 +512,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
@@ -481,6 +551,90 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
     }
   },
   {
@@ -526,6 +680,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -551,6 +733,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
     }
   },
   {
@@ -582,6 +876,34 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
@@ -593,6 +915,132 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
     }
   },
   {
@@ -610,6 +1058,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
     }
   },
   {
@@ -641,6 +1103,118 @@
     "textEdit": {
       "range": {},
       "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
     }
   },
   {
@@ -1151,6 +1725,34 @@
     }
   },
   {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
@@ -1235,6 +1837,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -1263,6 +1893,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
@@ -1277,6 +1935,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
@@ -1288,6 +1974,62 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
     }
   },
   {
@@ -1333,6 +2075,62 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
@@ -1347,6 +2145,104 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -1358,6 +2254,34 @@
     "textEdit": {
       "range": {},
       "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
     }
   },
   {
@@ -1392,6 +2316,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
     }
   },
   {
@@ -1494,6 +2432,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
     }
   },
   {
@@ -2001,6 +2953,20 @@
     }
   },
   {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -2015,6 +2981,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
     }
   },
   {
@@ -2077,6 +3057,34 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
     }
   },
   {
@@ -2399,6 +3407,62 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -1,0 +1,3468 @@
+[
+  {
+    "label": "'AzureCLI'",
+    "kind": "enumMember",
+    "detail": "'AzureCLI'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'AzureCLI'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'AzureCLI'"
+    }
+  },
+  {
+    "label": "'AzurePowerShell'",
+    "kind": "enumMember",
+    "detail": "'AzurePowerShell'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'AzurePowerShell'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'AzurePowerShell'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -270,6 +270,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1041,6 +1055,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2243,6 +2271,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2268,20 +2310,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2981,20 +3009,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -1,0 +1,3468 @@
+[
+  {
+    "label": "'AzureCLI'",
+    "kind": "enumMember",
+    "detail": "'AzureCLI'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'AzureCLI'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'AzureCLI'"
+    }
+  },
+  {
+    "label": "'AzurePowerShell'",
+    "kind": "enumMember",
+    "detail": "'AzurePowerShell'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'AzurePowerShell'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'AzurePowerShell'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -270,6 +270,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1041,6 +1055,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2243,6 +2271,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2268,20 +2310,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2981,20 +3009,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -52,6 +52,20 @@
     }
   },
   {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
     "label": "az",
     "kind": "folder",
     "detail": "az",
@@ -418,6 +432,34 @@
     }
   },
   {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
@@ -460,6 +502,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
@@ -471,6 +541,90 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
     }
   },
   {
@@ -516,6 +670,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -541,6 +723,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
     }
   },
   {
@@ -586,6 +880,160 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
     "label": "empty",
     "kind": "function",
     "detail": "empty()",
@@ -600,6 +1048,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
     }
   },
   {
@@ -631,6 +1093,118 @@
     "textEdit": {
       "range": {},
       "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
     }
   },
   {
@@ -1141,6 +1715,34 @@
     }
   },
   {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
@@ -1225,6 +1827,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -1253,6 +1883,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
@@ -1267,6 +1925,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
@@ -1278,6 +1964,62 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
     }
   },
   {
@@ -1323,6 +2065,62 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
@@ -1337,6 +2135,104 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -1348,6 +2244,34 @@
     "textEdit": {
       "range": {},
       "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
     }
   },
   {
@@ -1382,6 +2306,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
     }
   },
   {
@@ -1484,6 +2422,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
     }
   },
   {
@@ -1991,6 +2943,20 @@
     }
   },
   {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -2005,6 +2971,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
     }
   },
   {
@@ -2067,6 +3047,34 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
     }
   },
   {
@@ -2389,6 +3397,62 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -260,6 +260,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1031,6 +1045,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2233,6 +2261,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2258,20 +2300,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2971,20 +2999,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -260,6 +260,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1031,6 +1045,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2233,6 +2261,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2258,20 +2300,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2971,20 +2999,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -1,0 +1,3458 @@
+[
+  {
+    "label": "'kind'",
+    "kind": "property",
+    "detail": "kind (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'kind'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'kind'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -1,0 +1,3458 @@
+[
+  {
+    "label": "'kind'",
+    "kind": "property",
+    "detail": "kind (Required)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "1_'kind'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'kind'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -260,6 +260,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1031,6 +1045,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2233,6 +2261,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2258,20 +2300,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2971,20 +2999,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -34,6 +34,20 @@
     }
   },
   {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
     "label": "az",
     "kind": "folder",
     "detail": "az",
@@ -400,6 +414,34 @@
     }
   },
   {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
@@ -442,6 +484,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
@@ -453,6 +523,90 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
     }
   },
   {
@@ -498,6 +652,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -523,6 +705,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
     }
   },
   {
@@ -568,6 +862,34 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
@@ -579,6 +901,132 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
     }
   },
   {
@@ -596,6 +1044,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
     }
   },
   {
@@ -627,6 +1089,118 @@
     "textEdit": {
       "range": {},
       "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
     }
   },
   {
@@ -1123,6 +1697,34 @@
     }
   },
   {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
@@ -1207,6 +1809,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -1235,6 +1865,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
@@ -1249,6 +1907,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
@@ -1260,6 +1946,62 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
     }
   },
   {
@@ -1305,6 +2047,62 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
@@ -1319,6 +2117,104 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -1330,6 +2226,34 @@
     "textEdit": {
       "range": {},
       "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
     }
   },
   {
@@ -1364,6 +2288,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
     }
   },
   {
@@ -1466,6 +2404,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
     }
   },
   {
@@ -1973,6 +2925,20 @@
     }
   },
   {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -1987,6 +2953,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
     }
   },
   {
@@ -2049,6 +3029,34 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
     }
   },
   {
@@ -2371,6 +3379,62 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -242,6 +242,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1027,6 +1041,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2215,6 +2243,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2240,20 +2282,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2953,20 +2981,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -1,0 +1,3552 @@
+[
+  {
+    "label": "'Premium_LRS'",
+    "kind": "enumMember",
+    "detail": "'Premium_LRS'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'Premium_LRS'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'Premium_LRS'"
+    }
+  },
+  {
+    "label": "'Premium_ZRS'",
+    "kind": "enumMember",
+    "detail": "'Premium_ZRS'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'Premium_ZRS'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'Premium_ZRS'"
+    }
+  },
+  {
+    "label": "'Standard_GRS'",
+    "kind": "enumMember",
+    "detail": "'Standard_GRS'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'Standard_GRS'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'Standard_GRS'"
+    }
+  },
+  {
+    "label": "'Standard_GZRS'",
+    "kind": "enumMember",
+    "detail": "'Standard_GZRS'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'Standard_GZRS'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'Standard_GZRS'"
+    }
+  },
+  {
+    "label": "'Standard_LRS'",
+    "kind": "enumMember",
+    "detail": "'Standard_LRS'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'Standard_LRS'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'Standard_LRS'"
+    }
+  },
+  {
+    "label": "'Standard_RAGRS'",
+    "kind": "enumMember",
+    "detail": "'Standard_RAGRS'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'Standard_RAGRS'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'Standard_RAGRS'"
+    }
+  },
+  {
+    "label": "'Standard_RAGZRS'",
+    "kind": "enumMember",
+    "detail": "'Standard_RAGZRS'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'Standard_RAGZRS'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'Standard_RAGZRS'"
+    }
+  },
+  {
+    "label": "'Standard_ZRS'",
+    "kind": "enumMember",
+    "detail": "'Standard_ZRS'",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_'Standard_ZRS'",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "'Standard_ZRS'"
+    }
+  },
+  {
+    "label": "any",
+    "kind": "function",
+    "detail": "any()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_any",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "any($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "array",
+    "kind": "function",
+    "detail": "array()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_array",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "array($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
+    "label": "az",
+    "kind": "folder",
+    "detail": "az",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_az",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "az"
+    }
+  },
+  {
+    "label": "badDepends",
+    "kind": "interface",
+    "detail": "badDepends",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends"
+    }
+  },
+  {
+    "label": "badDepends2",
+    "kind": "interface",
+    "detail": "badDepends2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends2"
+    }
+  },
+  {
+    "label": "badDepends3",
+    "kind": "interface",
+    "detail": "badDepends3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends3"
+    }
+  },
+  {
+    "label": "badDepends4",
+    "kind": "interface",
+    "detail": "badDepends4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends4"
+    }
+  },
+  {
+    "label": "badDepends5",
+    "kind": "interface",
+    "detail": "badDepends5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badDepends5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badDepends5"
+    }
+  },
+  {
+    "label": "badInterp",
+    "kind": "interface",
+    "detail": "badInterp",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_badInterp",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "badInterp"
+    }
+  },
+  {
+    "label": "bar",
+    "kind": "interface",
+    "detail": "bar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_bar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bar"
+    }
+  },
+  {
+    "label": "base64",
+    "kind": "function",
+    "detail": "base64()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToJson",
+    "kind": "function",
+    "detail": "base64ToJson()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToJson",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToJson($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "base64ToString",
+    "kind": "function",
+    "detail": "base64ToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_base64ToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "base64ToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "baz",
+    "kind": "interface",
+    "detail": "baz",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_baz",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "baz"
+    }
+  },
+  {
+    "label": "bool",
+    "kind": "function",
+    "detail": "bool()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_bool",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "bool($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "coalesce",
+    "kind": "function",
+    "detail": "coalesce()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_coalesce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "coalesce($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "concat",
+    "kind": "function",
+    "detail": "concat()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_concat",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "concat($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "contains",
+    "kind": "function",
+    "detail": "contains()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_contains",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "contains($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "cyclicExistingRes",
+    "kind": "interface",
+    "detail": "cyclicExistingRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicExistingRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicExistingRes"
+    }
+  },
+  {
+    "label": "cyclicRes",
+    "kind": "interface",
+    "detail": "cyclicRes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_cyclicRes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "cyclicRes"
+    }
+  },
+  {
+    "label": "dashesInPropertyNames",
+    "kind": "interface",
+    "detail": "dashesInPropertyNames",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_dashesInPropertyNames",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dashesInPropertyNames"
+    }
+  },
+  {
+    "label": "dataUri",
+    "kind": "function",
+    "detail": "dataUri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dataUriToString",
+    "kind": "function",
+    "detail": "dataUriToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dataUriToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dataUriToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "dateTimeAdd",
+    "kind": "function",
+    "detail": "dateTimeAdd()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_dateTimeAdd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "dateTimeAdd($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "deployment",
+    "kind": "function",
+    "detail": "deployment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "deployment()$0"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "empty",
+    "kind": "function",
+    "detail": "empty()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_empty",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "empty($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
+    }
+  },
+  {
+    "label": "endsWith",
+    "kind": "function",
+    "detail": "endsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_endsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "endsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "environment",
+    "kind": "function",
+    "detail": "environment()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_environment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
+    }
+  },
+  {
+    "label": "extensionResourceId",
+    "kind": "function",
+    "detail": "extensionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_extensionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "first",
+    "kind": "function",
+    "detail": "first()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_first",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "first($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "fo",
+    "kind": "interface",
+    "detail": "fo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_fo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "fo"
+    }
+  },
+  {
+    "label": "foo",
+    "kind": "interface",
+    "detail": "foo",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_foo",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "foo"
+    }
+  },
+  {
+    "label": "format",
+    "kind": "function",
+    "detail": "format()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_format",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "format($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "guid",
+    "kind": "function",
+    "detail": "guid()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_guid",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "guid($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey"
+    }
+  },
+  {
+    "label": "incorrectPropertiesKey2",
+    "kind": "interface",
+    "detail": "incorrectPropertiesKey2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_incorrectPropertiesKey2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "incorrectPropertiesKey2"
+    }
+  },
+  {
+    "label": "indexOf",
+    "kind": "function",
+    "detail": "indexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_indexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "indexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "int",
+    "kind": "function",
+    "detail": "int()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_int",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "int($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "interpVal",
+    "kind": "variable",
+    "detail": "interpVal",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_interpVal",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "interpVal"
+    }
+  },
+  {
+    "label": "intersection",
+    "kind": "function",
+    "detail": "intersection()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_intersection",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "intersection($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "invalidDecorator",
+    "kind": "interface",
+    "detail": "invalidDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDecorator"
+    }
+  },
+  {
+    "label": "invalidDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidDuplicateName3",
+    "kind": "interface",
+    "detail": "invalidDuplicateName3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidDuplicateName3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidDuplicateName3"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName1",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName1"
+    }
+  },
+  {
+    "label": "invalidExtensionResourceDuplicateName2",
+    "kind": "interface",
+    "detail": "invalidExtensionResourceDuplicateName2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidExtensionResourceDuplicateName2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidExtensionResourceDuplicateName2"
+    }
+  },
+  {
+    "label": "invalidScope",
+    "kind": "interface",
+    "detail": "invalidScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope"
+    }
+  },
+  {
+    "label": "invalidScope2",
+    "kind": "interface",
+    "detail": "invalidScope2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope2"
+    }
+  },
+  {
+    "label": "invalidScope3",
+    "kind": "interface",
+    "detail": "invalidScope3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_invalidScope3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "invalidScope3"
+    }
+  },
+  {
+    "label": "json",
+    "kind": "function",
+    "detail": "json()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_json",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "json($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "last",
+    "kind": "function",
+    "detail": "last()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_last",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "last($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "lastIndexOf",
+    "kind": "function",
+    "detail": "lastIndexOf()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_lastIndexOf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "lastIndexOf($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "length",
+    "kind": "function",
+    "detail": "length()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_length",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "length($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes"
+    }
+  },
+  {
+    "label": "letsAccessTheDashes2",
+    "kind": "variable",
+    "detail": "letsAccessTheDashes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_letsAccessTheDashes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "letsAccessTheDashes2"
+    }
+  },
+  {
+    "label": "listKeys",
+    "kind": "function",
+    "detail": "listKeys()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_listKeys",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "listKeys($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "magicString1",
+    "kind": "variable",
+    "detail": "magicString1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString1"
+    }
+  },
+  {
+    "label": "magicString2",
+    "kind": "variable",
+    "detail": "magicString2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_magicString2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "magicString2"
+    }
+  },
+  {
+    "label": "managementGroup",
+    "kind": "function",
+    "detail": "managementGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_managementGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "managementGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "max",
+    "kind": "function",
+    "detail": "max()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_max",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "max($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "min",
+    "kind": "function",
+    "detail": "min()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_min",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "min($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelProperties",
+    "kind": "interface",
+    "detail": "missingTopLevelProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelProperties"
+    }
+  },
+  {
+    "label": "missingTopLevelPropertiesExceptName",
+    "kind": "interface",
+    "detail": "missingTopLevelPropertiesExceptName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingTopLevelPropertiesExceptName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingTopLevelPropertiesExceptName"
+    }
+  },
+  {
+    "label": "missingType",
+    "kind": "interface",
+    "detail": "missingType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingType"
+    }
+  },
+  {
+    "label": "mock",
+    "kind": "variable",
+    "detail": "mock",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_mock",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "mock"
+    }
+  },
+  {
+    "label": "nestedDiscriminator",
+    "kind": "interface",
+    "detail": "nestedDiscriminator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
+    "label": "notAResource",
+    "kind": "variable",
+    "detail": "notAResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
+    }
+  },
+  {
+    "label": "padLeft",
+    "kind": "function",
+    "detail": "padLeft()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_padLeft",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "padLeft($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "pickZones",
+    "kind": "function",
+    "detail": "pickZones()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_pickZones",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "pickZones($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "providers",
+    "kind": "function",
+    "detail": "providers()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_providers",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "providers($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "range",
+    "kind": "function",
+    "detail": "range()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_range",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "range($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "reference",
+    "kind": "function",
+    "detail": "reference()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_reference",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "reference($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "replace",
+    "kind": "function",
+    "detail": "replace()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_replace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "replace($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceGroup",
+    "kind": "function",
+    "detail": "resourceGroup()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceGroup",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceGroup($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceId",
+    "kind": "function",
+    "detail": "resourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_resourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
+    }
+  },
+  {
+    "label": "resrefpar",
+    "kind": "field",
+    "detail": "resrefpar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefpar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefpar"
+    }
+  },
+  {
+    "label": "resrefvar",
+    "kind": "variable",
+    "detail": "resrefvar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resrefvar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resrefvar"
+    }
+  },
+  {
+    "label": "runtimeInvalid",
+    "kind": "variable",
+    "detail": "runtimeInvalid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalid"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes1",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes1"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes10",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes10",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes10",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes10"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes11",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes11",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes11",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes11"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes12",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes12",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes12",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes12"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes13",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes13",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes13",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes13"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes14",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes14",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes14",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes14"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes15",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes15",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes15",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes15"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes16",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes16",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes16",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes16"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes17",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes17",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes17",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes17"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes18",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes18",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes18",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes18"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes2",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes2"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes3",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes3"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes4",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes4"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes5",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes5"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes6",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes6"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes7",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes7"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes8",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes8"
+    }
+  },
+  {
+    "label": "runtimeInvalidRes9",
+    "kind": "interface",
+    "detail": "runtimeInvalidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeInvalidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeInvalidRes9"
+    }
+  },
+  {
+    "label": "runtimeValid",
+    "kind": "variable",
+    "detail": "runtimeValid",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValid",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValid"
+    }
+  },
+  {
+    "label": "runtimeValidRes1",
+    "kind": "interface",
+    "detail": "runtimeValidRes1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "runtimeValidRes2",
+    "kind": "interface",
+    "detail": "runtimeValidRes2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes2"
+    }
+  },
+  {
+    "label": "runtimeValidRes3",
+    "kind": "interface",
+    "detail": "runtimeValidRes3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes3"
+    }
+  },
+  {
+    "label": "runtimeValidRes4",
+    "kind": "interface",
+    "detail": "runtimeValidRes4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes4"
+    }
+  },
+  {
+    "label": "runtimeValidRes5",
+    "kind": "interface",
+    "detail": "runtimeValidRes5",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes5",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes5"
+    }
+  },
+  {
+    "label": "runtimeValidRes6",
+    "kind": "interface",
+    "detail": "runtimeValidRes6",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes6",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes6"
+    }
+  },
+  {
+    "label": "runtimeValidRes7",
+    "kind": "interface",
+    "detail": "runtimeValidRes7",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes7",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes7"
+    }
+  },
+  {
+    "label": "runtimeValidRes8",
+    "kind": "interface",
+    "detail": "runtimeValidRes8",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes8",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes8"
+    }
+  },
+  {
+    "label": "runtimeValidRes9",
+    "kind": "interface",
+    "detail": "runtimeValidRes9",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeValidRes9",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeValidRes9"
+    }
+  },
+  {
+    "label": "runtimefoo1",
+    "kind": "variable",
+    "detail": "runtimefoo1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo1"
+    }
+  },
+  {
+    "label": "runtimefoo2",
+    "kind": "variable",
+    "detail": "runtimefoo2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo2"
+    }
+  },
+  {
+    "label": "runtimefoo3",
+    "kind": "variable",
+    "detail": "runtimefoo3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo3"
+    }
+  },
+  {
+    "label": "runtimefoo4",
+    "kind": "variable",
+    "detail": "runtimefoo4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimefoo4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimefoo4"
+    }
+  },
+  {
+    "label": "selfScope",
+    "kind": "interface",
+    "detail": "selfScope",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_selfScope",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "selfScope"
+    }
+  },
+  {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
+    "label": "skip",
+    "kind": "function",
+    "detail": "skip()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_skip",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "skip($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
+    }
+  },
+  {
+    "label": "split",
+    "kind": "function",
+    "detail": "split()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_split",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "split($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithQuotes"
+    }
+  },
+  {
+    "label": "startedTypingTypeWithoutQuotes",
+    "kind": "interface",
+    "detail": "startedTypingTypeWithoutQuotes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_startedTypingTypeWithoutQuotes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startedTypingTypeWithoutQuotes"
+    }
+  },
+  {
+    "label": "startsWith",
+    "kind": "function",
+    "detail": "startsWith()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_startsWith",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "startsWith($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
+    }
+  },
+  {
+    "label": "string",
+    "kind": "function",
+    "detail": "string()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_string",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "string($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscription",
+    "kind": "function",
+    "detail": "subscription()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscription",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscription($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "subscriptionResourceId",
+    "kind": "function",
+    "detail": "subscriptionResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_subscriptionResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "subscriptionResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "substring",
+    "kind": "function",
+    "detail": "substring()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_substring",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "substring($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "sys",
+    "kind": "folder",
+    "detail": "sys",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_sys",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sys"
+    }
+  },
+  {
+    "label": "take",
+    "kind": "function",
+    "detail": "take()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_take",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "take($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "tenant",
+    "kind": "function",
+    "detail": "tenant()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenant",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenant()$0"
+    }
+  },
+  {
+    "label": "tenantResourceId",
+    "kind": "function",
+    "detail": "tenantResourceId()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_tenantResourceId",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantResourceId($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toLower",
+    "kind": "function",
+    "detail": "toLower()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toLower",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toLower($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "toUpper",
+    "kind": "function",
+    "detail": "toUpper()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_toUpper",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "toUpper($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "trailingSpace",
+    "kind": "interface",
+    "detail": "trailingSpace",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_trailingSpace",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trailingSpace"
+    }
+  },
+  {
+    "label": "trim",
+    "kind": "function",
+    "detail": "trim()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_trim",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "trim($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "unfinishedVnet",
+    "kind": "interface",
+    "detail": "unfinishedVnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unfinishedVnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unfinishedVnet"
+    }
+  },
+  {
+    "label": "union",
+    "kind": "function",
+    "detail": "union()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_union",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "union($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uniqueString",
+    "kind": "function",
+    "detail": "uniqueString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uniqueString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uniqueString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uri",
+    "kind": "function",
+    "detail": "uri()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uri($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponent",
+    "kind": "function",
+    "detail": "uriComponent()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponent",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponent($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "uriComponentToString",
+    "kind": "function",
+    "detail": "uriComponentToString()",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_uriComponentToString",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "uriComponentToString($0)"
+    },
+    "command": {
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "validModule",
+    "kind": "module",
+    "detail": "validModule",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validModule",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validModule"
+    }
+  },
+  {
+    "label": "validResourceForInvalidExtensionResourceDuplicateName",
+    "kind": "interface",
+    "detail": "validResourceForInvalidExtensionResourceDuplicateName",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_validResourceForInvalidExtensionResourceDuplicateName",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
+    }
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -354,6 +354,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1139,6 +1153,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2341,6 +2369,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2366,20 +2408,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -3065,20 +3093,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/subnetIdAndProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/subnetIdAndProperties.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "id",
+    "kind": "property",
+    "detail": "id",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_id",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "id"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "properties",
+    "kind": "property",
+    "detail": "properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `SubnetPropertiesFormat`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_properties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "properties"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -242,6 +242,20 @@
     }
   },
   {
+    "label": "canHaveDuplicatesAcrossScopes",
+    "kind": "variable",
+    "detail": "canHaveDuplicatesAcrossScopes",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_canHaveDuplicatesAcrossScopes",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "canHaveDuplicatesAcrossScopes"
+    }
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",
@@ -1027,6 +1041,20 @@
     "textEdit": {
       "range": {},
       "newText": "duplicateInGlobalAndTwoLoops"
+    }
+  },
+  {
+    "label": "duplicatesEverywhere",
+    "kind": "variable",
+    "detail": "duplicatesEverywhere",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicatesEverywhere",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicatesEverywhere"
     }
   },
   {
@@ -2229,6 +2257,20 @@
     }
   },
   {
+    "label": "nonexistentArrays",
+    "kind": "interface",
+    "detail": "nonexistentArrays",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonexistentArrays",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonexistentArrays"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -2254,20 +2296,6 @@
     "textEdit": {
       "range": {},
       "newText": "notAnArray"
-    }
-  },
-  {
-    "label": "otherDuplicate",
-    "kind": "variable",
-    "detail": "otherDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_otherDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "otherDuplicate"
     }
   },
   {
@@ -2967,20 +2995,6 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
-    "label": "someDuplicate",
-    "kind": "variable",
-    "detail": "someDuplicate",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_someDuplicate",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "someDuplicate"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -34,6 +34,20 @@
     }
   },
   {
+    "label": "arrayExpressionErrors",
+    "kind": "interface",
+    "detail": "arrayExpressionErrors",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_arrayExpressionErrors",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "arrayExpressionErrors"
+    }
+  },
+  {
     "label": "az",
     "kind": "folder",
     "detail": "az",
@@ -400,6 +414,34 @@
     }
   },
   {
+    "label": "discriminatorKeyMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyMissing_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOne",
     "kind": "interface",
     "detail": "discriminatorKeySetOne",
@@ -442,6 +484,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetOneCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetOneCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeySetOneCompletions3",
@@ -453,6 +523,90 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOneCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOneCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetOneCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOneCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOneCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetOne_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetOne_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetOne_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetOne_if"
     }
   },
   {
@@ -498,6 +652,34 @@
     }
   },
   {
+    "label": "discriminatorKeySetTwoCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeySetTwoCompletionsArrayIndexer",
     "kind": "variable",
     "detail": "discriminatorKeySetTwoCompletionsArrayIndexer",
@@ -523,6 +705,118 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer2_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletionsArrayIndexer_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletionsArrayIndexer_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwoCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeySetTwoCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwoCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwoCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_for",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_for"
+    }
+  },
+  {
+    "label": "discriminatorKeySetTwo_if",
+    "kind": "interface",
+    "detail": "discriminatorKeySetTwo_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeySetTwo_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeySetTwo_if"
     }
   },
   {
@@ -568,6 +862,34 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions2_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions2_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions2_if"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions3",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3",
@@ -579,6 +901,132 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions3_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_for",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissingCompletions_if",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions_if"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_for",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_for"
+    }
+  },
+  {
+    "label": "discriminatorKeyValueMissing_if",
+    "kind": "interface",
+    "detail": "discriminatorKeyValueMissing_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissing_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissing_if"
+    }
+  },
+  {
+    "label": "duplicateIdentifiersWithinLoop",
+    "kind": "interface",
+    "detail": "duplicateIdentifiersWithinLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateIdentifiersWithinLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateIdentifiersWithinLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndOneLoop",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndOneLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndOneLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndOneLoop"
+    }
+  },
+  {
+    "label": "duplicateInGlobalAndTwoLoops",
+    "kind": "interface",
+    "detail": "duplicateInGlobalAndTwoLoops",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_duplicateInGlobalAndTwoLoops",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "duplicateInGlobalAndTwoLoops"
     }
   },
   {
@@ -596,6 +1044,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "emptyArray",
+    "kind": "variable",
+    "detail": "emptyArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_emptyArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "emptyArray"
     }
   },
   {
@@ -627,6 +1089,118 @@
     "textEdit": {
       "range": {},
       "newText": "environment()$0"
+    }
+  },
+  {
+    "label": "expectedArrayExpression",
+    "kind": "interface",
+    "detail": "expectedArrayExpression",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedArrayExpression",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedArrayExpression"
+    }
+  },
+  {
+    "label": "expectedColon",
+    "kind": "interface",
+    "detail": "expectedColon",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedColon",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedColon"
+    }
+  },
+  {
+    "label": "expectedForKeyword",
+    "kind": "interface",
+    "detail": "expectedForKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword"
+    }
+  },
+  {
+    "label": "expectedForKeyword2",
+    "kind": "interface",
+    "detail": "expectedForKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedForKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedForKeyword2"
+    }
+  },
+  {
+    "label": "expectedInKeyword",
+    "kind": "interface",
+    "detail": "expectedInKeyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword"
+    }
+  },
+  {
+    "label": "expectedInKeyword2",
+    "kind": "interface",
+    "detail": "expectedInKeyword2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedInKeyword2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedInKeyword2"
+    }
+  },
+  {
+    "label": "expectedLoopBody",
+    "kind": "interface",
+    "detail": "expectedLoopBody",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopBody",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopBody"
+    }
+  },
+  {
+    "label": "expectedLoopVar",
+    "kind": "interface",
+    "detail": "expectedLoopVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_expectedLoopVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "expectedLoopVar"
     }
   },
   {
@@ -1137,6 +1711,34 @@
     }
   },
   {
+    "label": "missingFewerRequiredProperties",
+    "kind": "interface",
+    "detail": "missingFewerRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingFewerRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingFewerRequiredProperties"
+    }
+  },
+  {
+    "label": "missingRequiredProperties",
+    "kind": "interface",
+    "detail": "missingRequiredProperties",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_missingRequiredProperties",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "missingRequiredProperties"
+    }
+  },
+  {
     "label": "missingTopLevelProperties",
     "kind": "interface",
     "detail": "missingTopLevelProperties",
@@ -1221,6 +1823,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorArrayIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorArrayIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorArrayIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorArrayIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorArrayIndexCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions",
@@ -1249,6 +1879,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions2_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions3",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions3",
@@ -1263,6 +1921,34 @@
     }
   },
   {
+    "label": "nestedDiscriminatorCompletions3_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions3_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions3_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions3_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions3_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorCompletions4",
     "kind": "variable",
     "detail": "nestedDiscriminatorCompletions4",
@@ -1274,6 +1960,62 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorCompletions4"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions4_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions4_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions4_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions4_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorCompletions_if"
     }
   },
   {
@@ -1319,6 +2061,62 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions2_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions2_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions2_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyCompletions_if"
+    }
+  },
+  {
     "label": "nestedDiscriminatorMissingKeyIndexCompletions",
     "kind": "variable",
     "detail": "nestedDiscriminatorMissingKeyIndexCompletions",
@@ -1333,6 +2131,104 @@
     }
   },
   {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "kind": "variable",
+    "detail": "nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKeyIndexCompletions_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKeyIndexCompletions_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminatorMissingKey_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminatorMissingKey_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminatorMissingKey_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminatorMissingKey_if"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_for",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_for",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_for",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_for"
+    }
+  },
+  {
+    "label": "nestedDiscriminator_if",
+    "kind": "interface",
+    "detail": "nestedDiscriminator_if",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedDiscriminator_if",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedDiscriminator_if"
+    }
+  },
+  {
+    "label": "nestedPropertyAccessOnConditional",
+    "kind": "interface",
+    "detail": "nestedPropertyAccessOnConditional",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nestedPropertyAccessOnConditional",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nestedPropertyAccessOnConditional"
+    }
+  },
+  {
     "label": "notAResource",
     "kind": "variable",
     "detail": "notAResource",
@@ -1344,6 +2240,34 @@
     "textEdit": {
       "range": {},
       "newText": "notAResource"
+    }
+  },
+  {
+    "label": "notAnArray",
+    "kind": "variable",
+    "detail": "notAnArray",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_notAnArray",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "notAnArray"
+    }
+  },
+  {
+    "label": "otherDuplicate",
+    "kind": "variable",
+    "detail": "otherDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_otherDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "otherDuplicate"
     }
   },
   {
@@ -1378,6 +2302,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "premiumStorages",
+    "kind": "interface",
+    "detail": "premiumStorages",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_premiumStorages",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "premiumStorages"
     }
   },
   {
@@ -1480,6 +2418,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "resourceListIsNotSingleResource",
+    "kind": "variable",
+    "detail": "resourceListIsNotSingleResource",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resourceListIsNotSingleResource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resourceListIsNotSingleResource"
     }
   },
   {
@@ -1987,6 +2939,20 @@
     }
   },
   {
+    "label": "sigh",
+    "kind": "variable",
+    "detail": "sigh",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sigh",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "sigh"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -2001,6 +2967,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "someDuplicate",
+    "kind": "variable",
+    "detail": "someDuplicate",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_someDuplicate",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "someDuplicate"
     }
   },
   {
@@ -2063,6 +3043,34 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "storageAccounts",
+    "kind": "variable",
+    "detail": "storageAccounts",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageAccounts",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageAccounts"
+    }
+  },
+  {
+    "label": "storageResources",
+    "kind": "interface",
+    "detail": "storageResources",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageResources",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageResources"
     }
   },
   {
@@ -2385,6 +3393,62 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "vnet",
+    "kind": "interface",
+    "detail": "vnet",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vnet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vnet"
+    }
+  },
+  {
+    "label": "wrongArrayType",
+    "kind": "interface",
+    "detail": "wrongArrayType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongArrayType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongArrayType"
+    }
+  },
+  {
+    "label": "wrongLoopBodyType",
+    "kind": "interface",
+    "detail": "wrongLoopBodyType",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongLoopBodyType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongLoopBodyType"
+    }
+  },
+  {
+    "label": "wrongPropertyInNestedLoop",
+    "kind": "interface",
+    "detail": "wrongPropertyInNestedLoop",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_wrongPropertyInNestedLoop",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "wrongPropertyInNestedLoop"
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/vmProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/vmProperties.json
@@ -1,0 +1,422 @@
+[
+  {
+    "label": "additionalCapabilities",
+    "kind": "property",
+    "detail": "additionalCapabilities",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `AdditionalCapabilities`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_additionalCapabilities",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "additionalCapabilities"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "availabilitySet",
+    "kind": "property",
+    "detail": "availabilitySet",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `SubResource`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_availabilitySet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "availabilitySet"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "billingProfile",
+    "kind": "property",
+    "detail": "billingProfile",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `BillingProfile`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_billingProfile",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "billingProfile"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "diagnosticsProfile",
+    "kind": "property",
+    "detail": "diagnosticsProfile",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `DiagnosticsProfile`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_diagnosticsProfile",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "diagnosticsProfile"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "evictionPolicy",
+    "kind": "property",
+    "detail": "evictionPolicy",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Deallocate' | 'Delete'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_evictionPolicy",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "evictionPolicy"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "extensionsTimeBudget",
+    "kind": "property",
+    "detail": "extensionsTimeBudget",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_extensionsTimeBudget",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "extensionsTimeBudget"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "hardwareProfile",
+    "kind": "property",
+    "detail": "hardwareProfile",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `HardwareProfile`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_hardwareProfile",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "hardwareProfile"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "host",
+    "kind": "property",
+    "detail": "host",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `SubResource`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_host",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "host"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "hostGroup",
+    "kind": "property",
+    "detail": "hostGroup",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `SubResource`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_hostGroup",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "hostGroup"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "instanceView",
+    "kind": "property",
+    "detail": "instanceView",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `VirtualMachineInstanceView`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_instanceView",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "instanceView"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "licenseType",
+    "kind": "property",
+    "detail": "licenseType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_licenseType",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "licenseType"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "networkProfile",
+    "kind": "property",
+    "detail": "networkProfile",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `NetworkProfile`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_networkProfile",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "networkProfile"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "osProfile",
+    "kind": "property",
+    "detail": "osProfile",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `OSProfile`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_osProfile",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "osProfile"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "priority",
+    "kind": "property",
+    "detail": "priority",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `'Low' | 'Regular' | 'Spot'`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_priority",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "priority"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "provisioningState",
+    "kind": "property",
+    "detail": "provisioningState",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_provisioningState",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "provisioningState"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "proximityPlacementGroup",
+    "kind": "property",
+    "detail": "proximityPlacementGroup",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `SubResource`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_proximityPlacementGroup",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "proximityPlacementGroup"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "securityProfile",
+    "kind": "property",
+    "detail": "securityProfile",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `SecurityProfile`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_securityProfile",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "securityProfile"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "storageProfile",
+    "kind": "property",
+    "detail": "storageProfile",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `StorageProfile`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storageProfile",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "storageProfile"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "virtualMachineScaleSet",
+    "kind": "property",
+    "detail": "virtualMachineScaleSet",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `SubResource`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_virtualMachineScaleSet",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "virtualMachineScaleSet"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  },
+  {
+    "label": "vmId",
+    "kind": "property",
+    "detail": "vmId",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `string`  \nRead-only property  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_vmId",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "vmId"
+    },
+    "commitCharacters": [
+      "."
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -889,47 +889,13 @@ resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01
   }
 }]
 
-// duplicate identifiers within the loop
-// (these duplicates are self-contained - usage of i above is allowed)
-resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-  name: 'vnet-${i}'
+// nonexistent arrays and loop variables
+resource nonexistentArrays 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in notAThing: {
+  name: 'vnet-${justPlainWrong}'
   properties: {
-    subnets: [for i in range(0, 4): {
-      name: 'subnet-${i}-${i}'
-    }]
-  }
-}]
-
-// duplicate identifers in global and single loop scope
-var someDuplicate = 'hello'
-resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-  name: 'vnet-${someDuplicate}'
-  properties: {
-    subnets: [for i in range(0, 4): {
-      name: 'subnet-${i}-${i}'
-    }]
-  }
-}]
-
-// duplicate in global and multiple loop scopes
-var otherDuplicate = 'hello'
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
-  name: 'vnet-${otherDuplicate}'
-  properties: {
-    subnets: [for otherDuplicate in range(0, 4): {
-      name: 'subnet-${otherDuplicate}'
-    }]
-  }
-}]
-
-// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
-var someDuplicate = true
-var otherDuplicate = []
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-  name: 'vnet-${someDuplicate}'
-  properties: {
-    subnets: [for otherDuplicate in range(0, 4): {
-      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+    subnets: [for j in alsoNotAThing: {
+      doesNotExist: 'test'
+      name: 'subnet-${fake}-${totallyFake}'
     }]
   }
 }]
@@ -947,6 +913,35 @@ var storageAccounts = [
     location: 'westus'
   }
 ]
+// duplicate identifiers within the loop are allowed
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+// duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
+var canHaveDuplicatesAcrossScopes = 'hello'
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
+  name: 'vnet-${canHaveDuplicatesAcrossScopes}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+// duplicate in global and multiple loop scopes are allowed (inner hides the outer)
+var duplicatesEverywhere = 'hello'
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
+  name: 'vnet-${duplicatesEverywhere}'
+  properties: {
+    subnets: [for duplicatesEverywhere in range(0, 4): {
+      name: 'subnet-${duplicatesEverywhere}'
+    }]
+  }
+}]
 // just a storage account loop
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
   name: account.name

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -372,11 +372,33 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
   }
 }
 
+/*
+Discriminator key missing
+*/
 resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   // #completionTest(0,1,2) -> discriminatorProperty
   
 }
 
+/*
+Discriminator key missing (conditional)
+*/
+resource discriminatorKeyMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(true) {
+  // #completionTest(0,1,2) -> discriminatorProperty
+  
+}
+
+/*
+Discriminator key missing (loop)
+*/
+resource discriminatorKeyMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+  // #completionTest(0,1,2) -> discriminatorProperty
+  
+}]
+
+/*
+Discriminator key value missing with property access
+*/
 resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols
   kind:   
@@ -389,6 +411,44 @@ var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 // #completionTest(76) -> missingDiscriminatorPropertyIndexPlusSymbols
 var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
 
+/*
+Discriminator key value missing with property access (conditional)
+*/
+
+resource discriminatorKeyValueMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(false) {
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_if
+  kind:   
+}
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions_if = discriminatorKeyValueMissing_if.p
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2_if = discriminatorKeyValueMissing_if.
+
+// #completionTest(82) -> missingDiscriminatorPropertyIndexPlusSymbols_if
+var discriminatorKeyValueMissingCompletions3_if = discriminatorKeyValueMissing_if[]
+
+/*
+Discriminator key value missing with property access (loops)
+*/
+resource discriminatorKeyValueMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_for
+  kind:   
+}]
+
+// cannot . access properties of a resource loop
+var resourceListIsNotSingleResource = discriminatorKeyValueMissing_for.kind
+
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions_for = discriminatorKeyValueMissing_for[0].p
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2_for = discriminatorKeyValueMissing_for[0].
+
+// #completionTest(87) -> missingDiscriminatorPropertyIndexPlusSymbols_for
+var discriminatorKeyValueMissingCompletions3_for = discriminatorKeyValueMissing_for[0][]
+
+/*
+Discriminator value set 1
+*/
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -406,6 +466,49 @@ var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 // #completionTest(75) -> cliPropertyAccessIndexesPlusSymbols
 var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 
+/*
+Discriminator value set 1 (conditional)
+*/
+resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
+  kind: 'AzureCLI'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+    
+  }
+}
+// #completionTest(81) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions_if = discriminatorKeySetOne_if.properties.a
+// #completionTest(81) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2_if = discriminatorKeySetOne_if.properties.
+
+// #completionTest(81) -> cliPropertyAccessIndexesPlusSymbols_if
+var discriminatorKeySetOneCompletions3_if = discriminatorKeySetOne_if.properties[]
+
+/*
+Discriminator value set 1 (loop)
+*/
+resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
+  kind: 'AzureCLI'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+    
+  }
+}]
+// #completionTest(86) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions_for = discriminatorKeySetOne_for[0].properties.a
+// #completionTest(94) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2_for = discriminatorKeySetOne_for[any(true)].properties.
+
+// #completionTest(86) -> cliPropertyAccessIndexesPlusSymbols_for
+var discriminatorKeySetOneCompletions3_for = discriminatorKeySetOne_for[1].properties[]
+
+/*
+Discriminator value set 2
+*/
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -424,6 +527,52 @@ var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
 var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['properties'].a
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
+
+/*
+Discriminator value set 2 (conditional)
+*/
+resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  kind: 'AzurePowerShell'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+    
+  }
+}
+// #completionTest(81) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions_if = discriminatorKeySetTwo_if.properties.a
+// #completionTest(81) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2_if = discriminatorKeySetTwo_if.properties.
+
+// #completionTest(96) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer_if = discriminatorKeySetTwo_if['properties'].a
+// #completionTest(96) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2_if = discriminatorKeySetTwo_if['properties'].
+
+/*
+Discriminator value set 2 (loops)
+*/
+resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+  kind: 'AzurePowerShell'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+    
+  }
+}]
+// #completionTest(86) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions_for = discriminatorKeySetTwo_for[0].properties.a
+// #completionTest(86) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2_for = discriminatorKeySetTwo_for[0].properties.
+
+// #completionTest(101) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer_for = discriminatorKeySetTwo_for[0]['properties'].a
+// #completionTest(101) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2_for = discriminatorKeySetTwo_for[0]['properties'].
+
+
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
@@ -480,6 +629,9 @@ var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
 
+/* 
+Nested discriminator missing key
+*/
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
   location: 'l'
@@ -496,6 +648,48 @@ var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['p
 // #completionTest(94) -> createModeIndexPlusSymbols
 var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKey.properties['']
 
+/* 
+Nested discriminator missing key (conditional)
+*/
+resource nestedDiscriminatorMissingKey_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(bool(1)) {
+  name: 'test'
+  location: 'l'
+  properties: {
+    //createMode: 'Default'
+
+  }
+}
+// #completionTest(96) -> createMode
+var nestedDiscriminatorMissingKeyCompletions_if = nestedDiscriminatorMissingKey_if.properties.cr
+// #completionTest(98) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2_if = nestedDiscriminatorMissingKey_if['properties'].
+
+// #completionTest(100) -> createModeIndexPlusSymbols_if
+var nestedDiscriminatorMissingKeyIndexCompletions_if = nestedDiscriminatorMissingKey_if.properties['']
+
+/* 
+Nested discriminator missing key (loop)
+*/
+resource nestedDiscriminatorMissingKey_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+  name: 'test'
+  location: 'l'
+  properties: {
+    //createMode: 'Default'
+
+  }
+}]
+// #completionTest(101) -> createMode
+var nestedDiscriminatorMissingKeyCompletions_for = nestedDiscriminatorMissingKey_for[0].properties.cr
+// #completionTest(103) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2_for = nestedDiscriminatorMissingKey_for[0]['properties'].
+
+// #completionTest(105) -> createModeIndexPlusSymbols_for
+var nestedDiscriminatorMissingKeyIndexCompletions_for = nestedDiscriminatorMissingKey_for[0].properties['']
+
+
+/*
+Nested discriminator
+*/
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
   location: 'l'
@@ -515,6 +709,67 @@ var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
 
 // #completionTest(79) -> defaultCreateModeIndexes
 var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
+
+/*
+Nested discriminator (conditional)
+*/
+resource nestedDiscriminator_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(true) {
+  name: 'test'
+  location: 'l'
+  properties: {
+    createMode: 'Default'
+
+  }
+}
+// #completionTest(75) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions_if = nestedDiscriminator_if.properties.a
+// #completionTest(79) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2_if = nestedDiscriminator_if['properties'].a
+// #completionTest(75) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3_if = nestedDiscriminator_if.properties.
+// #completionTest(78) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4_if = nestedDiscriminator_if['properties'].
+
+// #completionTest(85) -> defaultCreateModeIndexes_if
+var nestedDiscriminatorArrayIndexCompletions_if = nestedDiscriminator_if.properties[a]
+
+
+/*
+Nested discriminator (loop)
+*/
+resource nestedDiscriminator_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+  name: 'test'
+  location: 'l'
+  properties: {
+    createMode: 'Default'
+
+  }
+}]
+// #completionTest(80) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions_for = nestedDiscriminator_for[0].properties.a
+// #completionTest(84) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2_for = nestedDiscriminator_for[0]['properties'].a
+// #completionTest(80) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3_for = nestedDiscriminator_for[0].properties.
+// #completionTest(83) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4_for = nestedDiscriminator_for[0]['properties'].
+
+// #completionTest(90) -> defaultCreateModeIndexes_for
+var nestedDiscriminatorArrayIndexCompletions_for = nestedDiscriminator_for[0].properties[a]
+
+// sample resource to validate completions on the next declarations
+resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@2020-06-01' = if(true) {
+  location: 'test'
+  name: 'test'
+  properties: {
+    additionalCapabilities: {
+      
+    }
+  }
+}
+// this validates that we can get nested property access completions on a conditional resource
+//#completionTest(56) -> vmProperties
+var sigh = nestedPropertyAccessOnConditional.properties.
 
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
   name: 'selfScope'
@@ -579,3 +834,145 @@ resource cyclicExistingRes 'Mock.Rp/mockExistingResource@2020-01-01' existing = 
   name: 'cyclicExistingRes'
   scope: cyclicExistingRes
 }
+
+// loop parsing cases
+resource expectedForKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = []
+
+resource expectedForKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [f]
+
+resource expectedLoopVar 'Microsoft.Storage/storageAccounts@2019-06-01' = [for]
+
+resource expectedInKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x]
+
+resource expectedInKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x b]
+
+resource expectedArrayExpression 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in]
+
+resource expectedColon 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y]
+
+resource expectedLoopBody 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y:]
+
+// loop semantic analysis cases
+var emptyArray = []
+resource wrongLoopBodyType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in emptyArray:4]
+
+// errors in the array expression
+resource arrayExpressionErrors 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in union([], 2): {
+}]
+
+// wrong array type
+var notAnArray = true
+resource wrongArrayType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in notAnArray: {
+}]
+
+// missing required properties
+resource missingRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+}]
+
+// fewer missing required properties and a wrong property
+resource missingFewerRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+  name: account
+  location: 'eastus42'
+  properties: {
+    wrong: 'test'
+  }
+}]
+
+// wrong property inside the nested property loop
+resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for j in range(0, 4): {
+      doesNotExist: 'test'
+      name: 'subnet-${i}-${j}'
+    }]
+  }
+}]
+
+// duplicate identifiers within the loop
+// (these duplicates are self-contained - usage of i above is allowed)
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+
+// duplicate identifers in global and single loop scope
+var someDuplicate = 'hello'
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+  name: 'vnet-${someDuplicate}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+
+// duplicate in global and multiple loop scopes
+var otherDuplicate = 'hello'
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
+  name: 'vnet-${otherDuplicate}'
+  properties: {
+    subnets: [for otherDuplicate in range(0, 4): {
+      name: 'subnet-${otherDuplicate}'
+    }]
+  }
+}]
+
+// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
+var someDuplicate = true
+var otherDuplicate = []
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+  name: 'vnet-${someDuplicate}'
+  properties: {
+    subnets: [for otherDuplicate in range(0, 4): {
+      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+    }]
+  }
+}]
+
+/*
+  valid loop cases - this should be moved to Resources_* test case after codegen works
+*/ 
+var storageAccounts = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+// just a storage account loop
+resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+  name: account.name
+  location: account.location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}]
+// using the same loop variable in a new language scope should be allowed
+resource premiumStorages 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+  name: account.name
+  location: account.location
+  sku: {
+    // #completionTest(9,10) -> storageSkuNamePlusSymbols
+    name: 
+  }
+  kind: 'StorageV2'
+}]
+// basic nested loop
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for j in range(0, 4): {
+      // #completionTest(0,1,2,3,4,5,6) -> subnetIdAndProperties
+      name: 'subnet-${i}-${j}'
+    }]
+  }
+}]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -1201,68 +1201,20 @@ resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01
   }
 }]
 
-// duplicate identifiers within the loop
-// (these duplicates are self-contained - usage of i above is allowed)
-resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[90:93) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[94:95) [BCP028 (Error)] Identifier "i" is declared multiple times. Remove or rename the duplicates. |i|
-  name: 'vnet-${i}'
+// nonexistent arrays and loop variables
+resource nonexistentArrays 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in notAThing: {
+//@[77:80) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[86:95) [BCP057 (Error)] The name "notAThing" does not exist in the current context. |notAThing|
+  name: 'vnet-${justPlainWrong}'
+//@[16:30) [BCP057 (Error)] The name "justPlainWrong" does not exist in the current context. |justPlainWrong|
   properties: {
-    subnets: [for i in range(0, 4): {
+    subnets: [for j in alsoNotAThing: {
 //@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[18:19) [BCP028 (Error)] Identifier "i" is declared multiple times. Remove or rename the duplicates. |i|
-      name: 'subnet-${i}-${i}'
-    }]
-  }
-}]
-
-// duplicate identifers in global and single loop scope
-var someDuplicate = 'hello'
-//@[4:17) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
-resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-//@[87:90) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[91:104) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
-  name: 'vnet-${someDuplicate}'
-  properties: {
-    subnets: [for i in range(0, 4): {
-//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
-      name: 'subnet-${i}-${i}'
-    }]
-  }
-}]
-
-// duplicate in global and multiple loop scopes
-var otherDuplicate = 'hello'
-//@[4:18) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
-//@[9:37) [BCP028 (Error)] Identifier "duplicateInGlobalAndTwoLoops" is declared multiple times. Remove or rename the duplicates. |duplicateInGlobalAndTwoLoops|
-//@[88:91) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[92:106) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
-  name: 'vnet-${otherDuplicate}'
-  properties: {
-    subnets: [for otherDuplicate in range(0, 4): {
-//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[18:32) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
-      name: 'subnet-${otherDuplicate}'
-    }]
-  }
-}]
-
-// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
-var someDuplicate = true
-//@[4:17) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
-var otherDuplicate = []
-//@[4:18) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-//@[9:37) [BCP028 (Error)] Identifier "duplicateInGlobalAndTwoLoops" is declared multiple times. Remove or rename the duplicates. |duplicateInGlobalAndTwoLoops|
-//@[88:91) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[92:105) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
-  name: 'vnet-${someDuplicate}'
-  properties: {
-    subnets: [for otherDuplicate in range(0, 4): {
-//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
-//@[18:32) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
-      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+//@[23:36) [BCP057 (Error)] The name "alsoNotAThing" does not exist in the current context. |alsoNotAThing|
+      doesNotExist: 'test'
+      name: 'subnet-${fake}-${totallyFake}'
+//@[22:26) [BCP057 (Error)] The name "fake" does not exist in the current context. |fake|
+//@[30:41) [BCP057 (Error)] The name "totallyFake" does not exist in the current context. |totallyFake|
     }]
   }
 }]
@@ -1280,6 +1232,41 @@ var storageAccounts = [
     location: 'westus'
   }
 ]
+// duplicate identifiers within the loop are allowed
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[90:93) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+// duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
+var canHaveDuplicatesAcrossScopes = 'hello'
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
+//@[87:90) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'vnet-${canHaveDuplicatesAcrossScopes}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+// duplicate in global and multiple loop scopes are allowed (inner hides the outer)
+var duplicatesEverywhere = 'hello'
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
+//@[88:91) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'vnet-${duplicatesEverywhere}'
+  properties: {
+    subnets: [for duplicatesEverywhere in range(0, 4): {
+//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
+      name: 'subnet-${duplicatesEverywhere}'
+    }]
+  }
+}]
 // just a storage account loop
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
 //@[76:79) [BCP138 (Error)] Loops are not currently supported. |for|

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -29,7 +29,7 @@ resource trailingSpace
 resource foo 'ddd'= 
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
 //@[13:18) [BCP029 (Error)] The resource type is not valid. Specify a valid resource type of format "<provider>/<types>@<apiVersion>". |'ddd'|
-//@[20:20) [BCP118 (Error)] Expected the "{" character or the "if" keyword at this location. ||
+//@[20:20) [BCP118 (Error)] Expected the "{" character, the "[" character, or the "if" keyword at this location. ||
 
 // wrong resource type
 resource foo 'ddd'={
@@ -57,16 +57,19 @@ resource foo 'Microsoft.${provider}/foos@2020-02-02-alpha'= if (true) {
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'={
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
 //@[9:12) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 }
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (name == 'value') {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
 //@[9:12) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[56:60) [BCP057 (Error)] The name "name" does not exist in the current context. |name|
 }
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if ({ 'a': b }.a == 'foo') {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[63:64) [BCP057 (Error)] The name "b" does not exist in the current context. |b|
 //@[65:66) [BCP019 (Error)] Expected a new line character at this location. |}|
 }
@@ -75,23 +78,28 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if ({ 'a': b }.a == 'foo') {
 // simulate typing if condition
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[54:54) [BCP018 (Error)] Expected the "(" character at this location. ||
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[56:56) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. ||
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (true
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[60:60) [BCP018 (Error)] Expected the ")" character at this location. ||
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (true)
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[61:61) [BCP018 (Error)] Expected the "{" character at this location. ||
 
 // missing condition
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[55:56) [BCP018 (Error)] Expected the "(" character at this location. |{|
   name: 'foo'
 //@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. |'foo'|
@@ -101,6 +109,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if {
 // #completionTest(56) -> symbols
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if () {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[56:57) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. |)|
   name: 'foo'
 //@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. |'foo'|
@@ -109,6 +118,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if () {
 // #completionTest(57, 59) -> symbols
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (     ) {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[61:62) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. |)|
   name: 'foo'
 //@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. |'foo'|
@@ -117,6 +127,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (     ) {
 // invalid condition type
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (123) {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[55:60) [BCP046 (Error)] Expected a value of type "bool". |(123)|
   name: 'foo'
 //@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. |'foo'|
@@ -125,6 +136,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (123) {
 // runtime functions are no allowed in resource conditions
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (reference('Micorosft.Management/managementGroups/MG', '2020-05-01').name == 'something') {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[57:66) [BCP066 (Error)] Function "reference" is not valid at this location. It can only be used in resource declarations. |reference|
   name: 'foo'
 //@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. |'foo'|
@@ -132,6 +144,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (reference('Micorosft.Ma
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (listKeys('foo', '2020-05-01').bar == true) {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[57:65) [BCP066 (Error)] Function "listKeys" is not valid at this location. It can only be used in resource declarations. |listKeys|
   name: 'foo'
 //@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. |'foo'|
@@ -140,6 +153,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (listKeys('foo', '2020-0
 // duplicate property at the top level
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
 //@[2:6) [BCP025 (Error)] The property "name" is declared multiple times in this object. Remove or rename the duplicate properties. |name|
   name: true
@@ -149,6 +163,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 // duplicate property at the top level with string literal syntax
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
 //@[2:6) [BCP025 (Error)] The property "name" is declared multiple times in this object. Remove or rename the duplicate properties. |name|
   'name': true
@@ -158,6 +173,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 // duplicate property inside
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
 //@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. |'foo'|
   properties: {
@@ -171,6 +187,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 // duplicate property inside with string literal syntax
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
 //@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. |'foo'|
   properties: {
@@ -184,6 +201,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 // wrong property types
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. |foo|
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
 //@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. |'foo'|
   location: [
@@ -194,6 +212,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 }
 
 resource bar 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: true ? 's' : 'a' + 1
 //@[21:28) [BCP045 (Error)] Cannot apply operator "+" to operands of type "'a'" and "int". |'a' + 1|
   properties: {
@@ -224,6 +243,7 @@ output resrefout bool = bar.id
 
 // attempting to set read-only properties
 resource baz 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'test'
 //@[8:14) [BCP121 (Error)] Resources: "baz", "badDepends", "badDepends2", "badDepends3", "badDepends4", "badDepends5", "badInterp" are defined with this same name in a file. Rename them or split into different modules. |'test'|
   id: 2
@@ -235,6 +255,7 @@ resource baz 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 }
 
 resource badDepends 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[20:57) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'test'
 //@[8:14) [BCP121 (Error)] Resources: "baz", "badDepends", "badDepends2", "badDepends3", "badDepends4", "badDepends5", "badInterp" are defined with this same name in a file. Rename them or split into different modules. |'test'|
   dependsOn: [
@@ -244,6 +265,7 @@ resource badDepends 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 }
 
 resource badDepends2 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[21:58) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'test'
 //@[8:14) [BCP121 (Error)] Resources: "baz", "badDepends", "badDepends2", "badDepends3", "badDepends4", "badDepends5", "badInterp" are defined with this same name in a file. Rename them or split into different modules. |'test'|
   dependsOn: [
@@ -255,11 +277,13 @@ resource badDepends2 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 }
 
 resource badDepends3 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[21:58) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'test'
 //@[8:14) [BCP121 (Error)] Resources: "baz", "badDepends", "badDepends2", "badDepends3", "badDepends4", "badDepends5", "badInterp" are defined with this same name in a file. Rename them or split into different modules. |'test'|
 }
 
 resource badDepends4 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[21:58) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'test'
 //@[8:14) [BCP121 (Error)] Resources: "baz", "badDepends", "badDepends2", "badDepends3", "badDepends4", "badDepends5", "badInterp" are defined with this same name in a file. Rename them or split into different modules. |'test'|
   dependsOn: [
@@ -268,6 +292,7 @@ resource badDepends4 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 }
 
 resource badDepends5 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[21:58) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'test'
 //@[8:14) [BCP121 (Error)] Resources: "baz", "badDepends", "badDepends2", "badDepends3", "badDepends4", "badDepends5", "badInterp" are defined with this same name in a file. Rename them or split into different modules. |'test'|
   dependsOn: badDepends3.dependsOn
@@ -276,6 +301,7 @@ resource badDepends5 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 
 var interpVal = 'abc'
 resource badInterp 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[19:56) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'test'
 //@[8:14) [BCP121 (Error)] Resources: "baz", "badDepends", "badDepends2", "badDepends3", "badDepends4", "badDepends5", "badInterp" are defined with this same name in a file. Rename them or split into different modules. |'test'|
   '${interpVal}': 'unsupported' // resource definition does not allow for additionalProperties
@@ -322,17 +348,17 @@ resource runtimeValidRes5 'Microsoft.Advisor/recommendations/suppressions@2020-0
 
 resource runtimeInvalidRes1 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeValidRes1.location
-//@[8:33) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1.location|
+//@[8:33) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1.location|
 }
 
 resource runtimeInvalidRes2 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeValidRes1['location']
-//@[8:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1['location']|
+//@[8:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1['location']|
 }
 
 resource runtimeInvalidRes3 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   name: runtimeValidRes1.properties.evictionPolicy
-//@[8:50) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1.properties.evictionPolicy|
+//@[8:50) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1.properties.evictionPolicy|
   kind:'AzureCLI'
   location: 'eastus'
   properties: {
@@ -343,40 +369,40 @@ resource runtimeInvalidRes3 'Microsoft.Resources/deploymentScripts@2020-10-01' =
 
 resource runtimeInvalidRes4 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeValidRes1['properties'].evictionPolicy
-//@[8:53) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1['properties'].evictionPolicy|
+//@[8:53) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1['properties'].evictionPolicy|
 }
 
 resource runtimeInvalidRes5 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeValidRes1['properties']['evictionPolicy']
-//@[8:56) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1['properties']['evictionPolicy']|
+//@[8:56) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1['properties']['evictionPolicy']|
 }
 
 resource runtimeInvalidRes6 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeValidRes1.properties['evictionPolicy']
-//@[8:53) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1.properties['evictionPolicy']|
+//@[8:53) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1.properties['evictionPolicy']|
 }
 
 resource runtimeInvalidRes7 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeValidRes2.properties.azCliVersion
-//@[8:48) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes2.properties.azCliVersion|
+//@[8:48) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "type". |runtimeValidRes2.properties.azCliVersion|
 }
 
 var magicString1 = 'location'
 resource runtimeInvalidRes8 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeValidRes2['${magicString1}']
-//@[8:43) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes2['${magicString1}']|
+//@[8:43) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "type". |runtimeValidRes2['${magicString1}']|
 }
 
 // note: this should be fine, but we block string interpolation all together if there's a potential runtime property usage for name.
 var magicString2 = 'name'
 resource runtimeInvalidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeValidRes2['${magicString2}']
-//@[8:43) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes2['${magicString2}']|
+//@[8:43) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "type". |runtimeValidRes2['${magicString2}']|
 }
 
 resource runtimeInvalidRes10 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: '${runtimeValidRes3.location}'
-//@[11:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes3 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes3.location|
+//@[28:36) [BCP053 (Error)] The type "Microsoft.Advisor/recommendations/suppressions" does not contain property "location". Available properties include "apiVersion", "id", "name", "properties", "type". |location|
 }
 
 resource runtimeInvalidRes11 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
@@ -387,18 +413,18 @@ resource runtimeInvalidRes11 'Microsoft.Advisor/recommendations/suppressions@202
 
 resource runtimeInvalidRes12 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: concat(runtimeValidRes1.location, runtimeValidRes2['location'], runtimeInvalidRes3['properties'].azCliVersion, validModule.params.name)
-//@[15:40) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1.location|
-//@[42:70) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes2['location']|
-//@[72:117) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeInvalidRes3 are "apiVersion", "id", "name", "scope", "type". |runtimeInvalidRes3['properties'].azCliVersion|
+//@[15:40) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1.location|
+//@[42:70) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "type". |runtimeValidRes2['location']|
+//@[72:117) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeInvalidRes3 are "apiVersion", "id", "name", "type". |runtimeInvalidRes3['properties'].azCliVersion|
 //@[119:142) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of validModule are "name", "scope". |validModule.params.name|
 //@[131:137) [BCP077 (Error)] The property "params" on type "module" is write-only. Write-only properties cannot be accessed. |params|
 }
 
 resource runtimeInvalidRes13 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: '${runtimeValidRes1.location}${runtimeValidRes2['location']}${runtimeInvalidRes3.properties['azCliVersion']}${validModule['params'].name}'
-//@[11:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1.location|
-//@[39:67) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes2['location']|
-//@[70:115) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeInvalidRes3 are "apiVersion", "id", "name", "scope", "type". |runtimeInvalidRes3.properties['azCliVersion']|
+//@[11:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1.location|
+//@[39:67) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "type". |runtimeValidRes2['location']|
+//@[70:115) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeInvalidRes3 are "apiVersion", "id", "name", "type". |runtimeInvalidRes3.properties['azCliVersion']|
 //@[118:144) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of validModule are "name", "scope". |validModule['params'].name|
 //@[130:138) [BCP077 (Error)] The property "params" on type "module" is write-only. Write-only properties cannot be accessed. |'params'|
 }
@@ -427,31 +453,31 @@ var runtimeValid = {
 
 resource runtimeInvalidRes14 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeInvalid.foo1
-//@[8:27) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeInvalid.foo1|
+//@[8:27) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeInvalid.foo1|
 }
 
 resource runtimeInvalidRes15 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeInvalid.foo2
-//@[8:27) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeInvalid.foo2|
+//@[8:27) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeInvalid.foo2|
 }
 
 resource runtimeInvalidRes16 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeInvalid.foo3.properties.azCliVersion
-//@[8:51) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeInvalid.foo3.properties.azCliVersion|
+//@[8:51) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeInvalid.foo3.properties.azCliVersion|
 }
 
 // Note: This is actually a runtime valid value. However, other properties of the variable cannot be resolved, so we block this.
 resource runtimeInvalidRes17 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: runtimeInvalid.foo4
-//@[8:27) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeInvalid.foo4|
+//@[8:27) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeInvalid.foo4|
 }
 
 resource runtimeInvalidRes18 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: concat(runtimeInvalid.foo1, runtimeValidRes2['properties'].azCliVersion, '${runtimeValidRes1.location}', runtimefoo4.hop)
-//@[15:34) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeInvalid.foo1|
-//@[36:79) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes2['properties'].azCliVersion|
-//@[84:109) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "scope", "type". |runtimeValidRes1.location|
-//@[113:128) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimefoo4" -> "runtimefoo2" -> "runtimeValidRes2"). Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "scope", "type". |runtimefoo4.hop|
+//@[15:34) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeInvalid" -> "runtimefoo1" -> "runtimeValidRes1"). Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeInvalid.foo1|
+//@[36:79) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "type". |runtimeValidRes2['properties'].azCliVersion|
+//@[84:109) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1.location|
+//@[113:128) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimefoo4" -> "runtimefoo2" -> "runtimeValidRes2"). Accessible properties of runtimeValidRes2 are "apiVersion", "id", "name", "type". |runtimefoo4.hop|
 }
 
 resource runtimeValidRes6 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
@@ -471,12 +497,13 @@ resource runtimeValidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-0
 }
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-//@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |missingTopLevelProperties|
+//@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "kind", "location", "name", "sku". |missingTopLevelProperties|
   // #completionTest(0, 1, 2) -> topLevelProperties
 
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
+//@[9:44) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "kind", "location", "sku". |missingTopLevelPropertiesExceptName|
   // #completionTest(0, 1, 2) -> topLevelPropertiesMinusName
   name: 'me'
   // do not remove whitespace before the closing curly
@@ -505,12 +532,37 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
   }
 }
 
+/*
+Discriminator key missing
+*/
 resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:32) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |discriminatorKeyMissing|
+//@[86:148) [BCP078 (Error)] The property "kind" requires a value of type "'AzureCLI' | 'AzurePowerShell'", but none was supplied. |{\r\n  // #completionTest(0,1,2) -> discriminatorProperty\r\n  \r\n}|
   // #completionTest(0,1,2) -> discriminatorProperty
   
 }
 
+/*
+Discriminator key missing (conditional)
+*/
+resource discriminatorKeyMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(true) {
+//@[98:160) [BCP078 (Error)] The property "kind" requires a value of type "'AzureCLI' | 'AzurePowerShell'", but none was supplied. |{\r\n  // #completionTest(0,1,2) -> discriminatorProperty\r\n  \r\n}|
+  // #completionTest(0,1,2) -> discriminatorProperty
+  
+}
+
+/*
+Discriminator key missing (loop)
+*/
+resource discriminatorKeyMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[91:94) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[108:170) [BCP078 (Error)] The property "kind" requires a value of type "'AzureCLI' | 'AzurePowerShell'", but none was supplied. |{\r\n  // #completionTest(0,1,2) -> discriminatorProperty\r\n  \r\n}|
+  // #completionTest(0,1,2) -> discriminatorProperty
+  
+}]
+
+/*
+Discriminator key value missing with property access
+*/
 resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols
   kind:   
@@ -518,7 +570,6 @@ resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@202
 }
 // #completionTest(76) -> missingDiscriminatorPropertyAccess
 var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
-//@[75:76) [BCP053 (Error)] The type "Microsoft.Resources/deploymentScripts@2020-10-01" does not contain property "p". Available properties include "apiVersion", "eTag", "extendedLocation", "id", "identity", "kind", "location", "managedBy", "managedByExtended", "name", "plan", "properties", "scale", "sku", "tags", "type", "zones". |p|
 // #completionTest(76) -> missingDiscriminatorPropertyAccess
 var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 //@[76:76) [BCP020 (Error)] Expected a function or property name at this location. ||
@@ -527,18 +578,66 @@ var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
 //@[76:76) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
 
+/*
+Discriminator key value missing with property access (conditional)
+*/
+
+resource discriminatorKeyValueMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(false) {
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_if
+  kind:   
+//@[10:10) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. ||
+}
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions_if = discriminatorKeyValueMissing_if.p
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2_if = discriminatorKeyValueMissing_if.
+//@[82:82) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(82) -> missingDiscriminatorPropertyIndexPlusSymbols_if
+var discriminatorKeyValueMissingCompletions3_if = discriminatorKeyValueMissing_if[]
+//@[82:82) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+
+/*
+Discriminator key value missing with property access (loops)
+*/
+resource discriminatorKeyValueMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[96:99) [BCP138 (Error)] Loops are not currently supported. |for|
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_for
+  kind:   
+//@[10:10) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. ||
+}]
+
+// cannot . access properties of a resource loop
+var resourceListIsNotSingleResource = discriminatorKeyValueMissing_for.kind
+//@[71:75) [BCP055 (Error)] Cannot access properties of type "Microsoft.Resources/deploymentScripts@2020-10-01[]". An "object" type is required. |kind|
+
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions_for = discriminatorKeyValueMissing_for[0].p
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2_for = discriminatorKeyValueMissing_for[0].
+//@[87:87) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(87) -> missingDiscriminatorPropertyIndexPlusSymbols_for
+var discriminatorKeyValueMissingCompletions3_for = discriminatorKeyValueMissing_for[0][]
+//@[87:87) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+
+/*
+Discriminator value set 1
+*/
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |discriminatorKeySetOne|
+//@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne|
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
 
   properties: {
+//@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
   }
 }
 // #completionTest(75) -> cliPropertyAccess
 var discriminatorKeySetOneCompletions = discriminatorKeySetOne.properties.a
+//@[74:75) [BCP053 (Warning)] The type "AzureCliScriptProperties" does not contain property "a". Available properties include "arguments", "azCliVersion", "cleanupPreference", "containerSettings", "environmentVariables", "forceUpdateTag", "outputs", "primaryScriptUri", "provisioningState", "retentionInterval", "scriptContent", "status", "storageAccountSettings", "supportingScriptUris", "timeout". |a|
 // #completionTest(75) -> cliPropertyAccess
 var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 //@[75:75) [BCP020 (Error)] Expected a function or property name at this location. ||
@@ -547,39 +646,155 @@ var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 //@[75:75) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
 
+/*
+Discriminator value set 1 (conditional)
+*/
+resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
+//@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne_if|
+  kind: 'AzureCLI'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+//@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+    
+  }
+}
+// #completionTest(81) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions_if = discriminatorKeySetOne_if.properties.a
+//@[80:81) [BCP053 (Warning)] The type "AzureCliScriptProperties" does not contain property "a". Available properties include "arguments", "azCliVersion", "cleanupPreference", "containerSettings", "environmentVariables", "forceUpdateTag", "outputs", "primaryScriptUri", "provisioningState", "retentionInterval", "scriptContent", "status", "storageAccountSettings", "supportingScriptUris", "timeout". |a|
+// #completionTest(81) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2_if = discriminatorKeySetOne_if.properties.
+//@[81:81) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(81) -> cliPropertyAccessIndexesPlusSymbols_if
+var discriminatorKeySetOneCompletions3_if = discriminatorKeySetOne_if.properties[]
+//@[81:81) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+
+/*
+Discriminator value set 1 (loop)
+*/
+resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
+//@[9:35) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne_for|
+//@[91:94) [BCP138 (Error)] Loops are not currently supported. |for|
+  kind: 'AzureCLI'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+//@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+    
+  }
+}]
+// #completionTest(86) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions_for = discriminatorKeySetOne_for[0].properties.a
+//@[85:86) [BCP053 (Warning)] The type "AzureCliScriptProperties" does not contain property "a". Available properties include "arguments", "azCliVersion", "cleanupPreference", "containerSettings", "environmentVariables", "forceUpdateTag", "outputs", "primaryScriptUri", "provisioningState", "retentionInterval", "scriptContent", "status", "storageAccountSettings", "supportingScriptUris", "timeout". |a|
+// #completionTest(94) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2_for = discriminatorKeySetOne_for[any(true)].properties.
+//@[94:94) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(86) -> cliPropertyAccessIndexesPlusSymbols_for
+var discriminatorKeySetOneCompletions3_for = discriminatorKeySetOne_for[1].properties[]
+//@[86:86) [BCP117 (Error)] An empty indexer is not allowed. Specify a valid expression. ||
+
+/*
+Discriminator value set 2
+*/
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |discriminatorKeySetTwo|
+//@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo|
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
 
   properties: {
+//@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
   }
 }
 // #completionTest(75) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletions = discriminatorKeySetTwo.properties.a
+//@[74:75) [BCP053 (Warning)] The type "AzurePowerShellScriptProperties" does not contain property "a". Available properties include "arguments", "azPowerShellVersion", "cleanupPreference", "containerSettings", "environmentVariables", "forceUpdateTag", "outputs", "primaryScriptUri", "provisioningState", "retentionInterval", "scriptContent", "status", "storageAccountSettings", "supportingScriptUris", "timeout". |a|
 // #completionTest(75) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
 //@[75:75) [BCP020 (Error)] Expected a function or property name at this location. ||
 
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['properties'].a
+//@[89:90) [BCP053 (Warning)] The type "AzurePowerShellScriptProperties" does not contain property "a". Available properties include "arguments", "azPowerShellVersion", "cleanupPreference", "containerSettings", "environmentVariables", "forceUpdateTag", "outputs", "primaryScriptUri", "provisioningState", "retentionInterval", "scriptContent", "status", "storageAccountSettings", "supportingScriptUris", "timeout". |a|
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
 //@[90:90) [BCP020 (Error)] Expected a function or property name at this location. ||
 
+/*
+Discriminator value set 2 (conditional)
+*/
+resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo_if|
+  kind: 'AzurePowerShell'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+//@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+    
+  }
+}
+// #completionTest(81) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions_if = discriminatorKeySetTwo_if.properties.a
+//@[80:81) [BCP053 (Warning)] The type "AzurePowerShellScriptProperties" does not contain property "a". Available properties include "arguments", "azPowerShellVersion", "cleanupPreference", "containerSettings", "environmentVariables", "forceUpdateTag", "outputs", "primaryScriptUri", "provisioningState", "retentionInterval", "scriptContent", "status", "storageAccountSettings", "supportingScriptUris", "timeout". |a|
+// #completionTest(81) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2_if = discriminatorKeySetTwo_if.properties.
+//@[81:81) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(96) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer_if = discriminatorKeySetTwo_if['properties'].a
+//@[95:96) [BCP053 (Warning)] The type "AzurePowerShellScriptProperties" does not contain property "a". Available properties include "arguments", "azPowerShellVersion", "cleanupPreference", "containerSettings", "environmentVariables", "forceUpdateTag", "outputs", "primaryScriptUri", "provisioningState", "retentionInterval", "scriptContent", "status", "storageAccountSettings", "supportingScriptUris", "timeout". |a|
+// #completionTest(96) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2_if = discriminatorKeySetTwo_if['properties'].
+//@[96:96) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+/*
+Discriminator value set 2 (loops)
+*/
+resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[9:35) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo_for|
+//@[90:93) [BCP138 (Error)] Loops are not currently supported. |for|
+  kind: 'AzurePowerShell'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+//@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+    
+  }
+}]
+// #completionTest(86) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions_for = discriminatorKeySetTwo_for[0].properties.a
+//@[85:86) [BCP053 (Warning)] The type "AzurePowerShellScriptProperties" does not contain property "a". Available properties include "arguments", "azPowerShellVersion", "cleanupPreference", "containerSettings", "environmentVariables", "forceUpdateTag", "outputs", "primaryScriptUri", "provisioningState", "retentionInterval", "scriptContent", "status", "storageAccountSettings", "supportingScriptUris", "timeout". |a|
+// #completionTest(86) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2_for = discriminatorKeySetTwo_for[0].properties.
+//@[86:86) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(101) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer_for = discriminatorKeySetTwo_for[0]['properties'].a
+//@[100:101) [BCP053 (Warning)] The type "AzurePowerShellScriptProperties" does not contain property "a". Available properties include "arguments", "azPowerShellVersion", "cleanupPreference", "containerSettings", "environmentVariables", "forceUpdateTag", "outputs", "primaryScriptUri", "provisioningState", "retentionInterval", "scriptContent", "status", "storageAccountSettings", "supportingScriptUris", "timeout". |a|
+// #completionTest(101) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2_for = discriminatorKeySetTwo_for[0]['properties'].
+//@[101:101) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+
+
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |incorrectPropertiesKey|
+//@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name", "properties". |incorrectPropertiesKey|
   kind: 'AzureCLI'
 
   propertes: {
-//@[2:11) [BCP089 (Error)] The property "propertes" is not allowed on objects of type "Microsoft.Resources/deploymentScripts@2020-10-01". Did you mean "properties"? |propertes|
+//@[2:11) [BCP089 (Error)] The property "propertes" is not allowed on objects of type "AzureCLI". Did you mean "properties"? |propertes|
   }
 }
 
 var mock = incorrectPropertiesKey.p
-//@[34:35) [BCP053 (Error)] The type "Microsoft.Resources/deploymentScripts@2020-10-01" does not contain property "p". Available properties include "apiVersion", "eTag", "extendedLocation", "id", "identity", "kind", "location", "managedBy", "managedByExtended", "name", "plan", "properties", "scale", "sku", "tags", "type", "zones". |p|
+//@[34:35) [BCP053 (Error)] The type "AzureCLI" does not contain property "p". Available properties include "apiVersion", "id", "identity", "kind", "location", "name", "properties", "systemData", "tags", "type". |p|
 
 resource incorrectPropertiesKey2 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
@@ -631,19 +846,24 @@ resource startedTypingTypeWithoutQuotes virma
 //@[45:45) [BCP018 (Error)] Expected the "=" character at this location. ||
 
 resource dashesInPropertyNames 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
-//@[9:30) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "name". |dashesInPropertyNames|
+//@[9:30) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |dashesInPropertyNames|
 }
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
+//@[77:78) [BCP053 (Warning)] The type "schemas:30_autoScalerProfile" does not contain property "s". Available properties include "balance-similar-node-groups", "expander", "max-empty-bulk-delete", "max-graceful-termination-sec", "max-total-unready-percentage", "new-pod-scale-up-delay", "ok-total-unready-count", "scale-down-delay-after-add", "scale-down-delay-after-delete", "scale-down-delay-after-failure", "scale-down-unneeded-time", "scale-down-unready-time", "scale-down-utilization-threshold", "scan-interval", "skip-nodes-with-local-storage", "skip-nodes-with-system-pods". |s|
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
 //@[78:78) [BCP020 (Error)] Expected a function or property name at this location. ||
 
+/* 
+Nested discriminator missing key
+*/
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
-//@[8:14) [BCP121 (Error)] Resources: "nestedDiscriminatorMissingKey", "nestedDiscriminator" are defined with this same name in a file. Rename them or split into different modules. |'test'|
+//@[8:14) [BCP121 (Error)] Resources: "nestedDiscriminatorMissingKey", "nestedDiscriminatorMissingKey_if", "nestedDiscriminator", "nestedDiscriminator_if" are defined with this same name in a file. Rename them or split into different modules. |'test'|
   location: 'l'
   properties: {
+//@[14:51) [BCP078 (Warning)] The property "createMode" requires a value of type "'Default' | 'Restore'", but none was supplied. |{\r\n    //createMode: 'Default'\r\n\r\n  }|
     //createMode: 'Default'
 
   }
@@ -657,19 +877,70 @@ var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['p
 // #completionTest(94) -> createModeIndexPlusSymbols
 var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKey.properties['']
 
-resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+/* 
+Nested discriminator missing key (conditional)
+*/
+resource nestedDiscriminatorMissingKey_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(bool(1)) {
   name: 'test'
-//@[8:14) [BCP121 (Error)] Resources: "nestedDiscriminatorMissingKey", "nestedDiscriminator" are defined with this same name in a file. Rename them or split into different modules. |'test'|
+//@[8:14) [BCP121 (Error)] Resources: "nestedDiscriminatorMissingKey", "nestedDiscriminatorMissingKey_if", "nestedDiscriminator", "nestedDiscriminator_if" are defined with this same name in a file. Rename them or split into different modules. |'test'|
   location: 'l'
   properties: {
+//@[14:51) [BCP078 (Warning)] The property "createMode" requires a value of type "'Default' | 'Restore'", but none was supplied. |{\r\n    //createMode: 'Default'\r\n\r\n  }|
+    //createMode: 'Default'
+
+  }
+}
+// #completionTest(96) -> createMode
+var nestedDiscriminatorMissingKeyCompletions_if = nestedDiscriminatorMissingKey_if.properties.cr
+// #completionTest(98) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2_if = nestedDiscriminatorMissingKey_if['properties'].
+//@[98:98) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(100) -> createModeIndexPlusSymbols_if
+var nestedDiscriminatorMissingKeyIndexCompletions_if = nestedDiscriminatorMissingKey_if.properties['']
+
+/* 
+Nested discriminator missing key (loop)
+*/
+resource nestedDiscriminatorMissingKey_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+//@[105:108) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'test'
+  location: 'l'
+  properties: {
+//@[14:51) [BCP078 (Warning)] The property "createMode" requires a value of type "'Default' | 'Restore'", but none was supplied. |{\r\n    //createMode: 'Default'\r\n\r\n  }|
+    //createMode: 'Default'
+
+  }
+}]
+// #completionTest(101) -> createMode
+var nestedDiscriminatorMissingKeyCompletions_for = nestedDiscriminatorMissingKey_for[0].properties.cr
+// #completionTest(103) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2_for = nestedDiscriminatorMissingKey_for[0]['properties'].
+//@[103:103) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(105) -> createModeIndexPlusSymbols_for
+var nestedDiscriminatorMissingKeyIndexCompletions_for = nestedDiscriminatorMissingKey_for[0].properties['']
+
+
+/*
+Nested discriminator
+*/
+resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+  name: 'test'
+//@[8:14) [BCP121 (Error)] Resources: "nestedDiscriminatorMissingKey", "nestedDiscriminatorMissingKey_if", "nestedDiscriminator", "nestedDiscriminator_if" are defined with this same name in a file. Rename them or split into different modules. |'test'|
+  location: 'l'
+  properties: {
+//@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "databaseAccountOfferType", "locations". |properties|
     createMode: 'Default'
 
   }
 }
 // #completionTest(69) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions = nestedDiscriminator.properties.a
+//@[68:69) [BCP053 (Warning)] The type "Default" does not contain property "a". Available properties include "apiProperties", "backupPolicy", "capabilities", "connectorOffer", "consistencyPolicy", "cors", "createMode", "databaseAccountOfferType", "disableKeyBasedMetadataWriteAccess", "documentEndpoint", "enableAnalyticalStorage", "enableAutomaticFailover", "enableCassandraConnector", "enableFreeTier", "enableMultipleWriteLocations", "failoverPolicies", "instanceId", "ipRules", "isVirtualNetworkFilterEnabled", "keyVaultKeyUri", "locations", "privateEndpointConnections", "provisioningState", "publicNetworkAccess", "readLocations", "restoreParameters", "virtualNetworkRules", "writeLocations". |a|
 // #completionTest(73) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions2 = nestedDiscriminator['properties'].a
+//@[72:73) [BCP053 (Warning)] The type "Default" does not contain property "a". Available properties include "apiProperties", "backupPolicy", "capabilities", "connectorOffer", "consistencyPolicy", "cors", "createMode", "databaseAccountOfferType", "disableKeyBasedMetadataWriteAccess", "documentEndpoint", "enableAnalyticalStorage", "enableAutomaticFailover", "enableCassandraConnector", "enableFreeTier", "enableMultipleWriteLocations", "failoverPolicies", "instanceId", "ipRules", "isVirtualNetworkFilterEnabled", "keyVaultKeyUri", "locations", "privateEndpointConnections", "provisioningState", "publicNetworkAccess", "readLocations", "restoreParameters", "virtualNetworkRules", "writeLocations". |a|
 // #completionTest(69) -> defaultCreateModeProperties
 var nestedDiscriminatorCompletions3 = nestedDiscriminator.properties.
 //@[69:69) [BCP020 (Error)] Expected a function or property name at this location. ||
@@ -681,7 +952,84 @@ var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
 var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
 //@[78:79) [BCP057 (Error)] The name "a" does not exist in the current context. |a|
 
+/*
+Nested discriminator (conditional)
+*/
+resource nestedDiscriminator_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(true) {
+  name: 'test'
+//@[8:14) [BCP121 (Error)] Resources: "nestedDiscriminatorMissingKey", "nestedDiscriminatorMissingKey_if", "nestedDiscriminator", "nestedDiscriminator_if" are defined with this same name in a file. Rename them or split into different modules. |'test'|
+  location: 'l'
+  properties: {
+//@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "databaseAccountOfferType", "locations". |properties|
+    createMode: 'Default'
+
+  }
+}
+// #completionTest(75) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions_if = nestedDiscriminator_if.properties.a
+//@[74:75) [BCP053 (Warning)] The type "Default" does not contain property "a". Available properties include "apiProperties", "backupPolicy", "capabilities", "connectorOffer", "consistencyPolicy", "cors", "createMode", "databaseAccountOfferType", "disableKeyBasedMetadataWriteAccess", "documentEndpoint", "enableAnalyticalStorage", "enableAutomaticFailover", "enableCassandraConnector", "enableFreeTier", "enableMultipleWriteLocations", "failoverPolicies", "instanceId", "ipRules", "isVirtualNetworkFilterEnabled", "keyVaultKeyUri", "locations", "privateEndpointConnections", "provisioningState", "publicNetworkAccess", "readLocations", "restoreParameters", "virtualNetworkRules", "writeLocations". |a|
+// #completionTest(79) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2_if = nestedDiscriminator_if['properties'].a
+//@[78:79) [BCP053 (Warning)] The type "Default" does not contain property "a". Available properties include "apiProperties", "backupPolicy", "capabilities", "connectorOffer", "consistencyPolicy", "cors", "createMode", "databaseAccountOfferType", "disableKeyBasedMetadataWriteAccess", "documentEndpoint", "enableAnalyticalStorage", "enableAutomaticFailover", "enableCassandraConnector", "enableFreeTier", "enableMultipleWriteLocations", "failoverPolicies", "instanceId", "ipRules", "isVirtualNetworkFilterEnabled", "keyVaultKeyUri", "locations", "privateEndpointConnections", "provisioningState", "publicNetworkAccess", "readLocations", "restoreParameters", "virtualNetworkRules", "writeLocations". |a|
+// #completionTest(75) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3_if = nestedDiscriminator_if.properties.
+//@[75:75) [BCP020 (Error)] Expected a function or property name at this location. ||
+// #completionTest(78) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4_if = nestedDiscriminator_if['properties'].
+//@[78:78) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(85) -> defaultCreateModeIndexes_if
+var nestedDiscriminatorArrayIndexCompletions_if = nestedDiscriminator_if.properties[a]
+//@[84:85) [BCP057 (Error)] The name "a" does not exist in the current context. |a|
+
+
+/*
+Nested discriminator (loop)
+*/
+resource nestedDiscriminator_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+//@[95:98) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'test'
+  location: 'l'
+  properties: {
+//@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "databaseAccountOfferType", "locations". |properties|
+    createMode: 'Default'
+
+  }
+}]
+// #completionTest(80) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions_for = nestedDiscriminator_for[0].properties.a
+//@[79:80) [BCP053 (Warning)] The type "Default" does not contain property "a". Available properties include "apiProperties", "backupPolicy", "capabilities", "connectorOffer", "consistencyPolicy", "cors", "createMode", "databaseAccountOfferType", "disableKeyBasedMetadataWriteAccess", "documentEndpoint", "enableAnalyticalStorage", "enableAutomaticFailover", "enableCassandraConnector", "enableFreeTier", "enableMultipleWriteLocations", "failoverPolicies", "instanceId", "ipRules", "isVirtualNetworkFilterEnabled", "keyVaultKeyUri", "locations", "privateEndpointConnections", "provisioningState", "publicNetworkAccess", "readLocations", "restoreParameters", "virtualNetworkRules", "writeLocations". |a|
+// #completionTest(84) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2_for = nestedDiscriminator_for[0]['properties'].a
+//@[83:84) [BCP053 (Warning)] The type "Default" does not contain property "a". Available properties include "apiProperties", "backupPolicy", "capabilities", "connectorOffer", "consistencyPolicy", "cors", "createMode", "databaseAccountOfferType", "disableKeyBasedMetadataWriteAccess", "documentEndpoint", "enableAnalyticalStorage", "enableAutomaticFailover", "enableCassandraConnector", "enableFreeTier", "enableMultipleWriteLocations", "failoverPolicies", "instanceId", "ipRules", "isVirtualNetworkFilterEnabled", "keyVaultKeyUri", "locations", "privateEndpointConnections", "provisioningState", "publicNetworkAccess", "readLocations", "restoreParameters", "virtualNetworkRules", "writeLocations". |a|
+// #completionTest(80) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3_for = nestedDiscriminator_for[0].properties.
+//@[80:80) [BCP020 (Error)] Expected a function or property name at this location. ||
+// #completionTest(83) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4_for = nestedDiscriminator_for[0]['properties'].
+//@[83:83) [BCP020 (Error)] Expected a function or property name at this location. ||
+
+// #completionTest(90) -> defaultCreateModeIndexes_for
+var nestedDiscriminatorArrayIndexCompletions_for = nestedDiscriminator_for[0].properties[a]
+//@[89:90) [BCP057 (Error)] The name "a" does not exist in the current context. |a|
+
+// sample resource to validate completions on the next declarations
+resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@2020-06-01' = if(true) {
+  location: 'test'
+  name: 'test'
+  properties: {
+    additionalCapabilities: {
+      
+    }
+  }
+}
+// this validates that we can get nested property access completions on a conditional resource
+//#completionTest(56) -> vmProperties
+var sigh = nestedPropertyAccessOnConditional.properties.
+//@[56:56) [BCP020 (Error)] Expected a function or property name at this location. ||
+
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
+//@[19:50) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-12-01" does not have types available. |'My.Rp/mockResource@2020-12-01'|
   name: 'selfScope'
   scope: selfScope
 //@[9:18) [BCP079 (Error)] This expression is referencing its own declaration, which is not allowed. |selfScope|
@@ -692,45 +1040,54 @@ var notAResource = {
   a: 'resource!'
 }
 resource invalidScope 'My.Rp/mockResource@2020-12-01' = {
+//@[22:53) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-12-01" does not have types available. |'My.Rp/mockResource@2020-12-01'|
   name: 'invalidScope'
   scope: notAResource
 //@[9:21) [BCP036 (Error)] The property "scope" expected a value of type "resource" but the provided value is of type "object". |notAResource|
 }
 
 resource invalidScope2 'My.Rp/mockResource@2020-12-01' = {
+//@[23:54) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-12-01" does not have types available. |'My.Rp/mockResource@2020-12-01'|
   name: 'invalidScope2'
   scope: resourceGroup()
 }
 
 resource invalidScope3 'My.Rp/mockResource@2020-12-01' = {
+//@[23:54) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-12-01" does not have types available. |'My.Rp/mockResource@2020-12-01'|
   name: 'invalidScope3'
   scope: subscription()
 }
 
 resource invalidDuplicateName1 'Mock.Rp/mockResource@2020-01-01' = {
+//@[31:64) [BCP081 (Warning)] Resource type "Mock.Rp/mockResource@2020-01-01" does not have types available. |'Mock.Rp/mockResource@2020-01-01'|
   name: 'invalidDuplicateName'
 //@[8:30) [BCP121 (Error)] Resources: "invalidDuplicateName1", "invalidDuplicateName2", "invalidDuplicateName3" are defined with this same name in a file. Rename them or split into different modules. |'invalidDuplicateName'|
 }
 resource invalidDuplicateName2 'Mock.Rp/mockResource@2020-01-01' = {
+//@[31:64) [BCP081 (Warning)] Resource type "Mock.Rp/mockResource@2020-01-01" does not have types available. |'Mock.Rp/mockResource@2020-01-01'|
   name: 'invalidDuplicateName'
 //@[8:30) [BCP121 (Error)] Resources: "invalidDuplicateName1", "invalidDuplicateName2", "invalidDuplicateName3" are defined with this same name in a file. Rename them or split into different modules. |'invalidDuplicateName'|
 }
 resource invalidDuplicateName3 'Mock.Rp/mockResource@2019-01-01' = {
+//@[31:64) [BCP081 (Warning)] Resource type "Mock.Rp/mockResource@2019-01-01" does not have types available. |'Mock.Rp/mockResource@2019-01-01'|
   name: 'invalidDuplicateName'
 //@[8:30) [BCP121 (Error)] Resources: "invalidDuplicateName1", "invalidDuplicateName2", "invalidDuplicateName3" are defined with this same name in a file. Rename them or split into different modules. |'invalidDuplicateName'|
 }
 
 resource validResourceForInvalidExtensionResourceDuplicateName 'Mock.Rp/mockResource@2020-01-01' = {
+//@[63:96) [BCP081 (Warning)] Resource type "Mock.Rp/mockResource@2020-01-01" does not have types available. |'Mock.Rp/mockResource@2020-01-01'|
   name: 'validResourceForInvalidExtensionResourceDuplicateName'
 }
 
 resource invalidExtensionResourceDuplicateName1 'Mock.Rp/mockExtResource@2020-01-01' = {
+//@[48:84) [BCP081 (Warning)] Resource type "Mock.Rp/mockExtResource@2020-01-01" does not have types available. |'Mock.Rp/mockExtResource@2020-01-01'|
   name: 'invalidExtensionResourceDuplicateName'
 //@[8:47) [BCP121 (Error)] Resources: "invalidExtensionResourceDuplicateName1", "invalidExtensionResourceDuplicateName2" are defined with this same name in a file. Rename them or split into different modules. |'invalidExtensionResourceDuplicateName'|
   scope: validResourceForInvalidExtensionResourceDuplicateName
 }
 
 resource invalidExtensionResourceDuplicateName2 'Mock.Rp/mockExtResource@2019-01-01' = {
+//@[48:84) [BCP081 (Warning)] Resource type "Mock.Rp/mockExtResource@2019-01-01" does not have types available. |'Mock.Rp/mockExtResource@2019-01-01'|
   name: 'invalidExtensionResourceDuplicateName'
 //@[8:47) [BCP121 (Error)] Resources: "invalidExtensionResourceDuplicateName1", "invalidExtensionResourceDuplicateName2" are defined with this same name in a file. Rename them or split into different modules. |'invalidExtensionResourceDuplicateName'|
   scope: validResourceForInvalidExtensionResourceDuplicateName
@@ -741,17 +1098,219 @@ resource invalidExtensionResourceDuplicateName2 'Mock.Rp/mockExtResource@2019-01
 @secure()
 //@[1:7) [BCP127 (Error)] Function "secure" cannot be used as a resource decorator. |secure|
 resource invalidDecorator 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+//@[26:63) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'invalidDecorator'
 }
 
 resource cyclicRes 'Mock.Rp/mockExistingResource@2020-01-01' = {
+//@[19:60) [BCP081 (Warning)] Resource type "Mock.Rp/mockExistingResource@2020-01-01" does not have types available. |'Mock.Rp/mockExistingResource@2020-01-01'|
   name: 'cyclicRes'
   scope: cyclicRes
 //@[9:18) [BCP079 (Error)] This expression is referencing its own declaration, which is not allowed. |cyclicRes|
 }
 
 resource cyclicExistingRes 'Mock.Rp/mockExistingResource@2020-01-01' existing = {
+//@[27:68) [BCP081 (Warning)] Resource type "Mock.Rp/mockExistingResource@2020-01-01" does not have types available. |'Mock.Rp/mockExistingResource@2020-01-01'|
   name: 'cyclicExistingRes'
   scope: cyclicExistingRes
 //@[9:26) [BCP079 (Error)] This expression is referencing its own declaration, which is not allowed. |cyclicExistingRes|
 }
+
+// loop parsing cases
+resource expectedForKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = []
+//@[78:79) [BCP012 (Error)] Expected the "for" keyword at this location. |]|
+
+resource expectedForKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [f]
+//@[79:80) [BCP012 (Error)] Expected the "for" keyword at this location. |f|
+
+resource expectedLoopVar 'Microsoft.Storage/storageAccounts@2019-06-01' = [for]
+//@[75:78) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[78:79) [BCP136 (Error)] Expected a loop variable identifier at this location. |]|
+
+resource expectedInKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x]
+//@[77:80) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[82:83) [BCP012 (Error)] Expected the "in" keyword at this location. |]|
+
+resource expectedInKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x b]
+//@[78:81) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[84:85) [BCP012 (Error)] Expected the "in" keyword at this location. |b|
+//@[85:86) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. |]|
+
+resource expectedArrayExpression 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in]
+//@[83:86) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[91:92) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. |]|
+
+resource expectedColon 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y]
+//@[73:76) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[82:83) [BCP057 (Error)] The name "y" does not exist in the current context. |y|
+//@[83:84) [BCP018 (Error)] Expected the ":" character at this location. |]|
+
+resource expectedLoopBody 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y:]
+//@[76:79) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[85:86) [BCP057 (Error)] The name "y" does not exist in the current context. |y|
+//@[87:88) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. |]|
+
+// loop semantic analysis cases
+var emptyArray = []
+resource wrongLoopBodyType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in emptyArray:4]
+//@[77:80) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[97:98) [BCP033 (Error)] Expected a value of type "Microsoft.Storage/storageAccounts" but the provided value is of type "int". |4|
+
+// errors in the array expression
+resource arrayExpressionErrors 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in union([], 2): {
+//@[81:84) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[106:107) [BCP070 (Error)] Argument of type "int" is not assignable to parameter of type "array". |2|
+}]
+
+// wrong array type
+var notAnArray = true
+resource wrongArrayType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in notAnArray: {
+//@[74:77) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[89:99) [BCP137 (Error)] Loop expected an expression of type "array" but the provided value is of type "bool". |notAnArray|
+}]
+
+// missing required properties
+resource missingRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+//@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "kind", "location", "name", "sku". |missingRequiredProperties|
+//@[85:88) [BCP138 (Error)] Loops are not currently supported. |for|
+}]
+
+// fewer missing required properties and a wrong property
+resource missingFewerRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+//@[9:39) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "kind", "sku". |missingFewerRequiredProperties|
+//@[90:93) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: account
+  location: 'eastus42'
+  properties: {
+    wrong: 'test'
+//@[4:9) [BCP038 (Warning)] The property "wrong" is not allowed on objects of type "StorageAccountPropertiesCreateParameters". Permissible properties include "accessTier", "allowBlobPublicAccess", "azureFilesIdentityBasedAuthentication", "customDomain", "encryption", "isHnsEnabled", "largeFileSharesState", "minimumTlsVersion", "networkAcls", "routingPreference", "supportsHttpsTrafficOnly". |wrong|
+  }
+}]
+
+// wrong property inside the nested property loop
+resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[85:88) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for j in range(0, 4): {
+//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
+      doesNotExist: 'test'
+//@[6:18) [BCP038 (Warning)] The property "doesNotExist" is not allowed on objects of type "Subnet". Permissible properties include "id", "properties". |doesNotExist|
+      name: 'subnet-${i}-${j}'
+    }]
+  }
+}]
+
+// duplicate identifiers within the loop
+// (these duplicates are self-contained - usage of i above is allowed)
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[90:93) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[94:95) [BCP028 (Error)] Identifier "i" is declared multiple times. Remove or rename the duplicates. |i|
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[18:19) [BCP028 (Error)] Identifier "i" is declared multiple times. Remove or rename the duplicates. |i|
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+
+// duplicate identifers in global and single loop scope
+var someDuplicate = 'hello'
+//@[4:17) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+//@[87:90) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[91:104) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
+  name: 'vnet-${someDuplicate}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+
+// duplicate in global and multiple loop scopes
+var otherDuplicate = 'hello'
+//@[4:18) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
+//@[9:37) [BCP028 (Error)] Identifier "duplicateInGlobalAndTwoLoops" is declared multiple times. Remove or rename the duplicates. |duplicateInGlobalAndTwoLoops|
+//@[88:91) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[92:106) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+  name: 'vnet-${otherDuplicate}'
+  properties: {
+    subnets: [for otherDuplicate in range(0, 4): {
+//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[18:32) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+      name: 'subnet-${otherDuplicate}'
+    }]
+  }
+}]
+
+// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
+var someDuplicate = true
+//@[4:17) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
+var otherDuplicate = []
+//@[4:18) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+//@[9:37) [BCP028 (Error)] Identifier "duplicateInGlobalAndTwoLoops" is declared multiple times. Remove or rename the duplicates. |duplicateInGlobalAndTwoLoops|
+//@[88:91) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[92:105) [BCP028 (Error)] Identifier "someDuplicate" is declared multiple times. Remove or rename the duplicates. |someDuplicate|
+  name: 'vnet-${someDuplicate}'
+  properties: {
+    subnets: [for otherDuplicate in range(0, 4): {
+//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
+//@[18:32) [BCP028 (Error)] Identifier "otherDuplicate" is declared multiple times. Remove or rename the duplicates. |otherDuplicate|
+      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+    }]
+  }
+}]
+
+/*
+  valid loop cases - this should be moved to Resources_* test case after codegen works
+*/ 
+var storageAccounts = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+// just a storage account loop
+resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+//@[76:79) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: account.name
+  location: account.location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}]
+// using the same loop variable in a new language scope should be allowed
+resource premiumStorages 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+//@[75:78) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: account.name
+  location: account.location
+  sku: {
+    // #completionTest(9,10) -> storageSkuNamePlusSymbols
+    name: 
+//@[10:10) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. ||
+  }
+  kind: 'StorageV2'
+}]
+// basic nested loop
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[64:67) [BCP138 (Error)] Loops are not currently supported. |for|
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for j in range(0, 4): {
+//@[14:17) [BCP138 (Error)] Loops are not currently supported. |for|
+      // #completionTest(0,1,2,3,4,5,6) -> subnetIdAndProperties
+      name: 'subnet-${i}-${j}'
+    }]
+  }
+}]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -1183,7 +1183,7 @@ resource missingFewerRequiredProperties 'Microsoft.Storage/storageAccounts@2019-
   location: 'eastus42'
   properties: {
     wrong: 'test'
-//@[4:9) [BCP038 (Warning)] The property "wrong" is not allowed on objects of type "StorageAccountPropertiesCreateParameters". Permissible properties include "accessTier", "allowBlobPublicAccess", "azureFilesIdentityBasedAuthentication", "customDomain", "encryption", "isHnsEnabled", "largeFileSharesState", "minimumTlsVersion", "networkAcls", "routingPreference", "supportsHttpsTrafficOnly". |wrong|
+//@[4:9) [BCP038 (Warning)] The property "wrong" is not allowed on objects of type "StorageAccountPropertiesCreateParameters". Permissible properties include "accessTier", "allowBlobPublicAccess", "allowSharedKeyAccess", "azureFilesIdentityBasedAuthentication", "customDomain", "encryption", "isHnsEnabled", "largeFileSharesState", "minimumTlsVersion", "networkAcls", "routingPreference", "supportsHttpsTrafficOnly". |wrong|
   }
 }]
 

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
@@ -852,47 +852,13 @@ resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01
   }
 }]
 
-// duplicate identifiers within the loop
-// (these duplicates are self-contained - usage of i above is allowed)
-resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-  name: 'vnet-${i}'
+// nonexistent arrays and loop variables
+resource nonexistentArrays 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in notAThing: {
+  name: 'vnet-${justPlainWrong}'
   properties: {
-    subnets: [for i in range(0, 4): {
-      name: 'subnet-${i}-${i}'
-    }]
-  }
-}]
-
-// duplicate identifers in global and single loop scope
-var someDuplicate = 'hello'
-resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-  name: 'vnet-${someDuplicate}'
-  properties: {
-    subnets: [for i in range(0, 4): {
-      name: 'subnet-${i}-${i}'
-    }]
-  }
-}]
-
-// duplicate in global and multiple loop scopes
-var otherDuplicate = 'hello'
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
-  name: 'vnet-${otherDuplicate}'
-  properties: {
-    subnets: [for otherDuplicate in range(0, 4): {
-      name: 'subnet-${otherDuplicate}'
-    }]
-  }
-}]
-
-// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
-var someDuplicate = true
-var otherDuplicate = []
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-  name: 'vnet-${someDuplicate}'
-  properties: {
-    subnets: [for otherDuplicate in range(0, 4): {
-      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+    subnets: [for j in alsoNotAThing: {
+      doesNotExist: 'test'
+      name: 'subnet-${fake}-${totallyFake}'
     }]
   }
 }]
@@ -910,6 +876,35 @@ var storageAccounts = [
     location: 'westus'
   }
 ]
+// duplicate identifiers within the loop are allowed
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+// duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
+var canHaveDuplicatesAcrossScopes = 'hello'
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
+  name: 'vnet-${canHaveDuplicatesAcrossScopes}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+// duplicate in global and multiple loop scopes are allowed (inner hides the outer)
+var duplicatesEverywhere = 'hello'
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
+  name: 'vnet-${duplicatesEverywhere}'
+  properties: {
+    subnets: [for duplicatesEverywhere in range(0, 4): {
+      name: 'subnet-${duplicatesEverywhere}'
+    }]
+  }
+}]
 // just a storage account loop
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
   name: account.name

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
@@ -361,10 +361,30 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
   }
 }
 
+/*
+Discriminator key missing
+*/
 resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   // #completionTest(0,1,2) -> discriminatorProperty
 }
 
+/*
+Discriminator key missing (conditional)
+*/
+resource discriminatorKeyMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if (true) {
+  // #completionTest(0,1,2) -> discriminatorProperty
+}
+
+/*
+Discriminator key missing (loop)
+*/
+resource discriminatorKeyMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+  // #completionTest(0,1,2) -> discriminatorProperty
+}]
+
+/*
+Discriminator key value missing with property access
+*/
 resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols
   kind:   
@@ -377,6 +397,44 @@ var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
 // #completionTest(76) -> missingDiscriminatorPropertyIndexPlusSymbols
 var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
 
+/*
+Discriminator key value missing with property access (conditional)
+*/
+
+resource discriminatorKeyValueMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(false) {
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_if
+  kind:   
+}
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions_if = discriminatorKeyValueMissing_if.p
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2_if = discriminatorKeyValueMissing_if.
+
+// #completionTest(82) -> missingDiscriminatorPropertyIndexPlusSymbols_if
+var discriminatorKeyValueMissingCompletions3_if = discriminatorKeyValueMissing_if[]
+
+/*
+Discriminator key value missing with property access (loops)
+*/
+resource discriminatorKeyValueMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_for
+  kind:   
+}]
+
+// cannot . access properties of a resource loop
+var resourceListIsNotSingleResource = discriminatorKeyValueMissing_for.kind
+
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions_for = discriminatorKeyValueMissing_for[0].p
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2_for = discriminatorKeyValueMissing_for[0].
+
+// #completionTest(87) -> missingDiscriminatorPropertyIndexPlusSymbols_for
+var discriminatorKeyValueMissingCompletions3_for = discriminatorKeyValueMissing_for[0][]
+
+/*
+Discriminator value set 1
+*/
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -393,6 +451,47 @@ var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 // #completionTest(75) -> cliPropertyAccessIndexesPlusSymbols
 var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 
+/*
+Discriminator value set 1 (conditional)
+*/
+resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if (2 == 3) {
+  kind: 'AzureCLI'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+  }
+}
+// #completionTest(81) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions_if = discriminatorKeySetOne_if.properties.a
+// #completionTest(81) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2_if = discriminatorKeySetOne_if.properties.
+
+// #completionTest(81) -> cliPropertyAccessIndexesPlusSymbols_if
+var discriminatorKeySetOneCompletions3_if = discriminatorKeySetOne_if.properties[]
+
+/*
+Discriminator value set 1 (loop)
+*/
+resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+  kind: 'AzureCLI'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+  }
+}]
+// #completionTest(86) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions_for = discriminatorKeySetOne_for[0].properties.a
+// #completionTest(94) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2_for = discriminatorKeySetOne_for[any(true)].properties.
+
+// #completionTest(86) -> cliPropertyAccessIndexesPlusSymbols_for
+var discriminatorKeySetOneCompletions3_for = discriminatorKeySetOne_for[1].properties[]
+
+/*
+Discriminator value set 2
+*/
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -410,6 +509,48 @@ var discriminatorKeySetTwoCompletions2 = discriminatorKeySetTwo.properties.
 var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['properties'].a
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
+
+/*
+Discriminator value set 2 (conditional)
+*/
+resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  kind: 'AzurePowerShell'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+  }
+}
+// #completionTest(81) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions_if = discriminatorKeySetTwo_if.properties.a
+// #completionTest(81) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2_if = discriminatorKeySetTwo_if.properties.
+
+// #completionTest(96) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer_if = discriminatorKeySetTwo_if['properties'].a
+// #completionTest(96) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2_if = discriminatorKeySetTwo_if['properties'].
+
+/*
+Discriminator value set 2 (loops)
+*/
+resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+  kind: 'AzurePowerShell'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+  }
+}]
+// #completionTest(86) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions_for = discriminatorKeySetTwo_for[0].properties.a
+// #completionTest(86) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2_for = discriminatorKeySetTwo_for[0].properties.
+
+// #completionTest(101) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer_for = discriminatorKeySetTwo_for[0]['properties'].a
+// #completionTest(101) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2_for = discriminatorKeySetTwo_for[0]['properties'].
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
@@ -464,6 +605,9 @@ var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
 
+/* 
+Nested discriminator missing key
+*/
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
   location: 'l'
@@ -479,6 +623,45 @@ var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['p
 // #completionTest(94) -> createModeIndexPlusSymbols
 var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKey.properties['']
 
+/* 
+Nested discriminator missing key (conditional)
+*/
+resource nestedDiscriminatorMissingKey_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if (bool(1)) {
+  name: 'test'
+  location: 'l'
+  properties: {
+    //createMode: 'Default'
+  }
+}
+// #completionTest(96) -> createMode
+var nestedDiscriminatorMissingKeyCompletions_if = nestedDiscriminatorMissingKey_if.properties.cr
+// #completionTest(98) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2_if = nestedDiscriminatorMissingKey_if['properties'].
+
+// #completionTest(100) -> createModeIndexPlusSymbols_if
+var nestedDiscriminatorMissingKeyIndexCompletions_if = nestedDiscriminatorMissingKey_if.properties['']
+
+/* 
+Nested discriminator missing key (loop)
+*/
+resource nestedDiscriminatorMissingKey_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+  name: 'test'
+  location: 'l'
+  properties: {
+    //createMode: 'Default'
+  }
+}]
+// #completionTest(101) -> createMode
+var nestedDiscriminatorMissingKeyCompletions_for = nestedDiscriminatorMissingKey_for[0].properties.cr
+// #completionTest(103) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2_for = nestedDiscriminatorMissingKey_for[0]['properties'].
+
+// #completionTest(105) -> createModeIndexPlusSymbols_for
+var nestedDiscriminatorMissingKeyIndexCompletions_for = nestedDiscriminatorMissingKey_for[0].properties['']
+
+/*
+Nested discriminator
+*/
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
   name: 'test'
   location: 'l'
@@ -497,6 +680,62 @@ var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
 
 // #completionTest(79) -> defaultCreateModeIndexes
 var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
+
+/*
+Nested discriminator (conditional)
+*/
+resource nestedDiscriminator_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if (true) {
+  name: 'test'
+  location: 'l'
+  properties: {
+    createMode: 'Default'
+  }
+}
+// #completionTest(75) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions_if = nestedDiscriminator_if.properties.a
+// #completionTest(79) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2_if = nestedDiscriminator_if['properties'].a
+// #completionTest(75) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3_if = nestedDiscriminator_if.properties.
+// #completionTest(78) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4_if = nestedDiscriminator_if['properties'].
+
+// #completionTest(85) -> defaultCreateModeIndexes_if
+var nestedDiscriminatorArrayIndexCompletions_if = nestedDiscriminator_if.properties[a]
+
+/*
+Nested discriminator (loop)
+*/
+resource nestedDiscriminator_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+  name: 'test'
+  location: 'l'
+  properties: {
+    createMode: 'Default'
+  }
+}]
+// #completionTest(80) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions_for = nestedDiscriminator_for[0].properties.a
+// #completionTest(84) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2_for = nestedDiscriminator_for[0]['properties'].a
+// #completionTest(80) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3_for = nestedDiscriminator_for[0].properties.
+// #completionTest(83) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4_for = nestedDiscriminator_for[0]['properties'].
+
+// #completionTest(90) -> defaultCreateModeIndexes_for
+var nestedDiscriminatorArrayIndexCompletions_for = nestedDiscriminator_for[0].properties[a]
+
+// sample resource to validate completions on the next declarations
+resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@2020-06-01' = if (true) {
+  location: 'test'
+  name: 'test'
+  properties: {
+    additionalCapabilities: {}
+  }
+}
+// this validates that we can get nested property access completions on a conditional resource
+//#completionTest(56) -> vmProperties
+var sigh = nestedPropertyAccessOnConditional.properties.
 
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
   name: 'selfScope'
@@ -561,3 +800,142 @@ resource cyclicExistingRes 'Mock.Rp/mockExistingResource@2020-01-01' existing = 
   name: 'cyclicExistingRes'
   scope: cyclicExistingRes
 }
+
+// loop parsing cases
+resource expectedForKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = []
+
+resource expectedForKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [f]
+
+resource expectedLoopVar 'Microsoft.Storage/storageAccounts@2019-06-01' = [for]
+
+resource expectedInKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x]
+
+resource expectedInKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x b]
+
+resource expectedArrayExpression 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in]
+
+resource expectedColon 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y]
+
+resource expectedLoopBody 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y:]
+
+// loop semantic analysis cases
+var emptyArray = []
+resource wrongLoopBodyType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in emptyArray: 4]
+
+// errors in the array expression
+resource arrayExpressionErrors 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in union([], 2): {}]
+
+// wrong array type
+var notAnArray = true
+resource wrongArrayType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in notAnArray: {}]
+
+// missing required properties
+resource missingRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {}]
+
+// fewer missing required properties and a wrong property
+resource missingFewerRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+  name: account
+  location: 'eastus42'
+  properties: {
+    wrong: 'test'
+  }
+}]
+
+// wrong property inside the nested property loop
+resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for j in range(0, 4): {
+      doesNotExist: 'test'
+      name: 'subnet-${i}-${j}'
+    }]
+  }
+}]
+
+// duplicate identifiers within the loop
+// (these duplicates are self-contained - usage of i above is allowed)
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+
+// duplicate identifers in global and single loop scope
+var someDuplicate = 'hello'
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+  name: 'vnet-${someDuplicate}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+
+// duplicate in global and multiple loop scopes
+var otherDuplicate = 'hello'
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
+  name: 'vnet-${otherDuplicate}'
+  properties: {
+    subnets: [for otherDuplicate in range(0, 4): {
+      name: 'subnet-${otherDuplicate}'
+    }]
+  }
+}]
+
+// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
+var someDuplicate = true
+var otherDuplicate = []
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+  name: 'vnet-${someDuplicate}'
+  properties: {
+    subnets: [for otherDuplicate in range(0, 4): {
+      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+    }]
+  }
+}]
+
+/*
+  valid loop cases - this should be moved to Resources_* test case after codegen works
+*/
+var storageAccounts = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+// just a storage account loop
+resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+  name: account.name
+  location: account.location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}]
+// using the same loop variable in a new language scope should be allowed
+resource premiumStorages 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+  name: account.name
+  location: account.location
+  sku: {
+    // #completionTest(9,10) -> storageSkuNamePlusSymbols
+    name: 
+  }
+  kind: 'StorageV2'
+}]
+// basic nested loop
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for j in range(0, 4): {
+      // #completionTest(0,1,2,3,4,5,6) -> subnetIdAndProperties
+      name: 'subnet-${i}-${j}'
+    }]
+  }
+}]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -344,7 +344,7 @@ resource runtimeInvalidRes13 'Microsoft.Advisor/recommendations/suppressions@202
 var runtimefoo1 = runtimeValidRes1['location']
 //@[4:15) Variable runtimefoo1. Type: string. Declaration start char: 0, length: 46
 var runtimefoo2 = runtimeValidRes2['properties'].azCliVersion
-//@[4:15) Variable runtimefoo2. Type: any. Declaration start char: 0, length: 61
+//@[4:15) Variable runtimefoo2. Type: string. Declaration start char: 0, length: 61
 var runtimefoo3 = runtimeValidRes2
 //@[4:15) Variable runtimefoo3. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 34
 var runtimefoo4 = {
@@ -451,12 +451,37 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
   }
 }
 
+/*
+Discriminator key missing
+*/
 resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:32) Resource discriminatorKeyMissing. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 148
   // #completionTest(0,1,2) -> discriminatorProperty
   
 }
 
+/*
+Discriminator key missing (conditional)
+*/
+resource discriminatorKeyMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(true) {
+//@[9:35) Resource discriminatorKeyMissing_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 160
+  // #completionTest(0,1,2) -> discriminatorProperty
+  
+}
+
+/*
+Discriminator key missing (loop)
+*/
+resource discriminatorKeyMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[95:100) Local thing. Type: any. Declaration start char: 95, length: 5
+//@[9:36) Resource discriminatorKeyMissing_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 171
+  // #completionTest(0,1,2) -> discriminatorProperty
+  
+}]
+
+/*
+Discriminator key value missing with property access
+*/
 resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:37) Resource discriminatorKeyValueMissing. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 175
   // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols
@@ -464,15 +489,63 @@ resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@202
 }
 // #completionTest(76) -> missingDiscriminatorPropertyAccess
 var discriminatorKeyValueMissingCompletions = discriminatorKeyValueMissing.p
-//@[4:43) Variable discriminatorKeyValueMissingCompletions. Type: error. Declaration start char: 0, length: 76
+//@[4:43) Variable discriminatorKeyValueMissingCompletions. Type: any. Declaration start char: 0, length: 76
 // #completionTest(76) -> missingDiscriminatorPropertyAccess
 var discriminatorKeyValueMissingCompletions2 = discriminatorKeyValueMissing.
-//@[4:44) Variable discriminatorKeyValueMissingCompletions2. Type: error. Declaration start char: 0, length: 76
+//@[4:44) Variable discriminatorKeyValueMissingCompletions2. Type: any. Declaration start char: 0, length: 76
 
 // #completionTest(76) -> missingDiscriminatorPropertyIndexPlusSymbols
 var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
 //@[4:44) Variable discriminatorKeyValueMissingCompletions3. Type: error. Declaration start char: 0, length: 77
 
+/*
+Discriminator key value missing with property access (conditional)
+*/
+
+resource discriminatorKeyValueMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(false) {
+//@[9:40) Resource discriminatorKeyValueMissing_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 191
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_if
+  kind:   
+}
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions_if = discriminatorKeyValueMissing_if.p
+//@[4:46) Variable discriminatorKeyValueMissingCompletions_if. Type: any. Declaration start char: 0, length: 82
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2_if = discriminatorKeyValueMissing_if.
+//@[4:47) Variable discriminatorKeyValueMissingCompletions2_if. Type: any. Declaration start char: 0, length: 82
+
+// #completionTest(82) -> missingDiscriminatorPropertyIndexPlusSymbols_if
+var discriminatorKeyValueMissingCompletions3_if = discriminatorKeyValueMissing_if[]
+//@[4:47) Variable discriminatorKeyValueMissingCompletions3_if. Type: error. Declaration start char: 0, length: 83
+
+/*
+Discriminator key value missing with property access (loops)
+*/
+resource discriminatorKeyValueMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[100:105) Local thing. Type: any. Declaration start char: 100, length: 5
+//@[9:41) Resource discriminatorKeyValueMissing_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 202
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_for
+  kind:   
+}]
+
+// cannot . access properties of a resource loop
+var resourceListIsNotSingleResource = discriminatorKeyValueMissing_for.kind
+//@[4:35) Variable resourceListIsNotSingleResource. Type: error. Declaration start char: 0, length: 75
+
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions_for = discriminatorKeyValueMissing_for[0].p
+//@[4:47) Variable discriminatorKeyValueMissingCompletions_for. Type: any. Declaration start char: 0, length: 87
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+var discriminatorKeyValueMissingCompletions2_for = discriminatorKeyValueMissing_for[0].
+//@[4:48) Variable discriminatorKeyValueMissingCompletions2_for. Type: any. Declaration start char: 0, length: 87
+
+// #completionTest(87) -> missingDiscriminatorPropertyIndexPlusSymbols_for
+var discriminatorKeyValueMissingCompletions3_for = discriminatorKeyValueMissing_for[0][]
+//@[4:48) Variable discriminatorKeyValueMissingCompletions3_for. Type: error. Declaration start char: 0, length: 88
+
+/*
+Discriminator value set 1
+*/
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) Resource discriminatorKeySetOne. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 264
   kind: 'AzureCLI'
@@ -494,6 +567,58 @@ var discriminatorKeySetOneCompletions2 = discriminatorKeySetOne.properties.
 var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 //@[4:38) Variable discriminatorKeySetOneCompletions3. Type: error. Declaration start char: 0, length: 76
 
+/*
+Discriminator value set 1 (conditional)
+*/
+resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
+//@[9:34) Resource discriminatorKeySetOne_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 276
+  kind: 'AzureCLI'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+    
+  }
+}
+// #completionTest(81) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions_if = discriminatorKeySetOne_if.properties.a
+//@[4:40) Variable discriminatorKeySetOneCompletions_if. Type: any. Declaration start char: 0, length: 81
+// #completionTest(81) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2_if = discriminatorKeySetOne_if.properties.
+//@[4:41) Variable discriminatorKeySetOneCompletions2_if. Type: error. Declaration start char: 0, length: 81
+
+// #completionTest(81) -> cliPropertyAccessIndexesPlusSymbols_if
+var discriminatorKeySetOneCompletions3_if = discriminatorKeySetOne_if.properties[]
+//@[4:41) Variable discriminatorKeySetOneCompletions3_if. Type: error. Declaration start char: 0, length: 82
+
+/*
+Discriminator value set 1 (loop)
+*/
+resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
+//@[95:100) Local thing. Type: any. Declaration start char: 95, length: 5
+//@[9:35) Resource discriminatorKeySetOne_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 288
+  kind: 'AzureCLI'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+    
+  }
+}]
+// #completionTest(86) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions_for = discriminatorKeySetOne_for[0].properties.a
+//@[4:41) Variable discriminatorKeySetOneCompletions_for. Type: any. Declaration start char: 0, length: 86
+// #completionTest(94) -> cliPropertyAccess
+var discriminatorKeySetOneCompletions2_for = discriminatorKeySetOne_for[any(true)].properties.
+//@[4:42) Variable discriminatorKeySetOneCompletions2_for. Type: error. Declaration start char: 0, length: 94
+
+// #completionTest(86) -> cliPropertyAccessIndexesPlusSymbols_for
+var discriminatorKeySetOneCompletions3_for = discriminatorKeySetOne_for[1].properties[]
+//@[4:42) Variable discriminatorKeySetOneCompletions3_for. Type: error. Declaration start char: 0, length: 87
+
+/*
+Discriminator value set 2
+*/
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) Resource discriminatorKeySetTwo. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 270
   kind: 'AzurePowerShell'
@@ -517,6 +642,63 @@ var discriminatorKeySetTwoCompletionsArrayIndexer = discriminatorKeySetTwo['prop
 // #completionTest(90) -> powershellPropertyAccess
 var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['properties'].
 //@[4:50) Variable discriminatorKeySetTwoCompletionsArrayIndexer2. Type: error. Declaration start char: 0, length: 90
+
+/*
+Discriminator value set 2 (conditional)
+*/
+resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[9:34) Resource discriminatorKeySetTwo_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 273
+  kind: 'AzurePowerShell'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+    
+  }
+}
+// #completionTest(81) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions_if = discriminatorKeySetTwo_if.properties.a
+//@[4:40) Variable discriminatorKeySetTwoCompletions_if. Type: any. Declaration start char: 0, length: 81
+// #completionTest(81) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2_if = discriminatorKeySetTwo_if.properties.
+//@[4:41) Variable discriminatorKeySetTwoCompletions2_if. Type: error. Declaration start char: 0, length: 81
+
+// #completionTest(96) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer_if = discriminatorKeySetTwo_if['properties'].a
+//@[4:52) Variable discriminatorKeySetTwoCompletionsArrayIndexer_if. Type: any. Declaration start char: 0, length: 96
+// #completionTest(96) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2_if = discriminatorKeySetTwo_if['properties'].
+//@[4:53) Variable discriminatorKeySetTwoCompletionsArrayIndexer2_if. Type: error. Declaration start char: 0, length: 96
+
+/*
+Discriminator value set 2 (loops)
+*/
+resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[94:99) Local thing. Type: any. Declaration start char: 94, length: 5
+//@[9:35) Resource discriminatorKeySetTwo_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 293
+  kind: 'AzurePowerShell'
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+
+  properties: {
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+    
+  }
+}]
+// #completionTest(86) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions_for = discriminatorKeySetTwo_for[0].properties.a
+//@[4:41) Variable discriminatorKeySetTwoCompletions_for. Type: any. Declaration start char: 0, length: 86
+// #completionTest(86) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletions2_for = discriminatorKeySetTwo_for[0].properties.
+//@[4:42) Variable discriminatorKeySetTwoCompletions2_for. Type: error. Declaration start char: 0, length: 86
+
+// #completionTest(101) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer_for = discriminatorKeySetTwo_for[0]['properties'].a
+//@[4:53) Variable discriminatorKeySetTwoCompletionsArrayIndexer_for. Type: any. Declaration start char: 0, length: 101
+// #completionTest(101) -> powershellPropertyAccess
+var discriminatorKeySetTwoCompletionsArrayIndexer2_for = discriminatorKeySetTwo_for[0]['properties'].
+//@[4:54) Variable discriminatorKeySetTwoCompletionsArrayIndexer2_for. Type: error. Declaration start char: 0, length: 101
+
+
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[9:31) Resource incorrectPropertiesKey. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 132
@@ -580,8 +762,11 @@ var letsAccessTheDashes = dashesInPropertyNames.properties.autoScalerProfile.s
 //@[4:23) Variable letsAccessTheDashes. Type: any. Declaration start char: 0, length: 78
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
 var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
-//@[4:24) Variable letsAccessTheDashes2. Type: any. Declaration start char: 0, length: 78
+//@[4:24) Variable letsAccessTheDashes2. Type: error. Declaration start char: 0, length: 78
 
+/* 
+Nested discriminator missing key
+*/
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[9:38) Resource nestedDiscriminatorMissingKey. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 190
   name: 'test'
@@ -596,12 +781,63 @@ var nestedDiscriminatorMissingKeyCompletions = nestedDiscriminatorMissingKey.pro
 //@[4:44) Variable nestedDiscriminatorMissingKeyCompletions. Type: any. Declaration start char: 0, length: 90
 // #completionTest(92) -> createMode
 var nestedDiscriminatorMissingKeyCompletions2 = nestedDiscriminatorMissingKey['properties'].
-//@[4:45) Variable nestedDiscriminatorMissingKeyCompletions2. Type: error. Declaration start char: 0, length: 92
+//@[4:45) Variable nestedDiscriminatorMissingKeyCompletions2. Type: any. Declaration start char: 0, length: 92
 
 // #completionTest(94) -> createModeIndexPlusSymbols
 var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKey.properties['']
 //@[4:49) Variable nestedDiscriminatorMissingKeyIndexCompletions. Type: any. Declaration start char: 0, length: 96
 
+/* 
+Nested discriminator missing key (conditional)
+*/
+resource nestedDiscriminatorMissingKey_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(bool(1)) {
+//@[9:41) Resource nestedDiscriminatorMissingKey_if. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 205
+  name: 'test'
+  location: 'l'
+  properties: {
+    //createMode: 'Default'
+
+  }
+}
+// #completionTest(96) -> createMode
+var nestedDiscriminatorMissingKeyCompletions_if = nestedDiscriminatorMissingKey_if.properties.cr
+//@[4:47) Variable nestedDiscriminatorMissingKeyCompletions_if. Type: any. Declaration start char: 0, length: 96
+// #completionTest(98) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2_if = nestedDiscriminatorMissingKey_if['properties'].
+//@[4:48) Variable nestedDiscriminatorMissingKeyCompletions2_if. Type: any. Declaration start char: 0, length: 98
+
+// #completionTest(100) -> createModeIndexPlusSymbols_if
+var nestedDiscriminatorMissingKeyIndexCompletions_if = nestedDiscriminatorMissingKey_if.properties['']
+//@[4:52) Variable nestedDiscriminatorMissingKeyIndexCompletions_if. Type: any. Declaration start char: 0, length: 102
+
+/* 
+Nested discriminator missing key (loop)
+*/
+resource nestedDiscriminatorMissingKey_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+//@[109:114) Local thing. Type: any. Declaration start char: 109, length: 5
+//@[9:42) Resource nestedDiscriminatorMissingKey_for. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview[]. Declaration start char: 0, length: 213
+  name: 'test'
+  location: 'l'
+  properties: {
+    //createMode: 'Default'
+
+  }
+}]
+// #completionTest(101) -> createMode
+var nestedDiscriminatorMissingKeyCompletions_for = nestedDiscriminatorMissingKey_for[0].properties.cr
+//@[4:48) Variable nestedDiscriminatorMissingKeyCompletions_for. Type: any. Declaration start char: 0, length: 101
+// #completionTest(103) -> createMode
+var nestedDiscriminatorMissingKeyCompletions2_for = nestedDiscriminatorMissingKey_for[0]['properties'].
+//@[4:49) Variable nestedDiscriminatorMissingKeyCompletions2_for. Type: any. Declaration start char: 0, length: 103
+
+// #completionTest(105) -> createModeIndexPlusSymbols_for
+var nestedDiscriminatorMissingKeyIndexCompletions_for = nestedDiscriminatorMissingKey_for[0].properties['']
+//@[4:53) Variable nestedDiscriminatorMissingKeyIndexCompletions_for. Type: any. Declaration start char: 0, length: 107
+
+
+/*
+Nested discriminator
+*/
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[9:28) Resource nestedDiscriminator. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 178
   name: 'test'
@@ -627,6 +863,82 @@ var nestedDiscriminatorCompletions4 = nestedDiscriminator['properties'].
 // #completionTest(79) -> defaultCreateModeIndexes
 var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
 //@[4:44) Variable nestedDiscriminatorArrayIndexCompletions. Type: error. Declaration start char: 0, length: 80
+
+/*
+Nested discriminator (conditional)
+*/
+resource nestedDiscriminator_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(true) {
+//@[9:31) Resource nestedDiscriminator_if. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 190
+  name: 'test'
+  location: 'l'
+  properties: {
+    createMode: 'Default'
+
+  }
+}
+// #completionTest(75) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions_if = nestedDiscriminator_if.properties.a
+//@[4:37) Variable nestedDiscriminatorCompletions_if. Type: any. Declaration start char: 0, length: 75
+// #completionTest(79) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2_if = nestedDiscriminator_if['properties'].a
+//@[4:38) Variable nestedDiscriminatorCompletions2_if. Type: any. Declaration start char: 0, length: 79
+// #completionTest(75) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3_if = nestedDiscriminator_if.properties.
+//@[4:38) Variable nestedDiscriminatorCompletions3_if. Type: error. Declaration start char: 0, length: 75
+// #completionTest(78) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4_if = nestedDiscriminator_if['properties'].
+//@[4:38) Variable nestedDiscriminatorCompletions4_if. Type: error. Declaration start char: 0, length: 78
+
+// #completionTest(85) -> defaultCreateModeIndexes_if
+var nestedDiscriminatorArrayIndexCompletions_if = nestedDiscriminator_if.properties[a]
+//@[4:47) Variable nestedDiscriminatorArrayIndexCompletions_if. Type: error. Declaration start char: 0, length: 86
+
+
+/*
+Nested discriminator (loop)
+*/
+resource nestedDiscriminator_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+//@[99:104) Local thing. Type: any. Declaration start char: 99, length: 5
+//@[9:32) Resource nestedDiscriminator_for. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview[]. Declaration start char: 0, length: 201
+  name: 'test'
+  location: 'l'
+  properties: {
+    createMode: 'Default'
+
+  }
+}]
+// #completionTest(80) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions_for = nestedDiscriminator_for[0].properties.a
+//@[4:38) Variable nestedDiscriminatorCompletions_for. Type: any. Declaration start char: 0, length: 80
+// #completionTest(84) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions2_for = nestedDiscriminator_for[0]['properties'].a
+//@[4:39) Variable nestedDiscriminatorCompletions2_for. Type: any. Declaration start char: 0, length: 84
+// #completionTest(80) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions3_for = nestedDiscriminator_for[0].properties.
+//@[4:39) Variable nestedDiscriminatorCompletions3_for. Type: error. Declaration start char: 0, length: 80
+// #completionTest(83) -> defaultCreateModeProperties
+var nestedDiscriminatorCompletions4_for = nestedDiscriminator_for[0]['properties'].
+//@[4:39) Variable nestedDiscriminatorCompletions4_for. Type: error. Declaration start char: 0, length: 83
+
+// #completionTest(90) -> defaultCreateModeIndexes_for
+var nestedDiscriminatorArrayIndexCompletions_for = nestedDiscriminator_for[0].properties[a]
+//@[4:48) Variable nestedDiscriminatorArrayIndexCompletions_for. Type: error. Declaration start char: 0, length: 91
+
+// sample resource to validate completions on the next declarations
+resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@2020-06-01' = if(true) {
+//@[9:42) Resource nestedPropertyAccessOnConditional. Type: Microsoft.Compute/virtualMachines@2020-06-01. Declaration start char: 0, length: 209
+  location: 'test'
+  name: 'test'
+  properties: {
+    additionalCapabilities: {
+      
+    }
+  }
+}
+// this validates that we can get nested property access completions on a conditional resource
+//#completionTest(56) -> vmProperties
+var sigh = nestedPropertyAccessOnConditional.properties.
+//@[4:8) Variable sigh. Type: error. Declaration start char: 0, length: 56
 
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
 //@[9:18) Resource selfScope. Type: My.Rp/mockResource@2020-12-01. Declaration start char: 0, length: 98
@@ -705,3 +1017,198 @@ resource cyclicExistingRes 'Mock.Rp/mockExistingResource@2020-01-01' existing = 
   name: 'cyclicExistingRes'
   scope: cyclicExistingRes
 }
+
+// loop parsing cases
+resource expectedForKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = []
+//@[9:27) Resource expectedForKeyword. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 79
+
+resource expectedForKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [f]
+//@[9:28) Resource expectedForKeyword2. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 81
+
+resource expectedLoopVar 'Microsoft.Storage/storageAccounts@2019-06-01' = [for]
+//@[78:78) Local <missing>. Type: any. Declaration start char: 78, length: 0
+//@[9:24) Resource expectedLoopVar. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 79
+
+resource expectedInKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x]
+//@[81:82) Local x. Type: any. Declaration start char: 81, length: 1
+//@[9:26) Resource expectedInKeyword. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 83
+
+resource expectedInKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x b]
+//@[82:83) Local x. Type: any. Declaration start char: 82, length: 1
+//@[9:27) Resource expectedInKeyword2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 86
+
+resource expectedArrayExpression 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in]
+//@[87:88) Local x. Type: any. Declaration start char: 87, length: 1
+//@[9:32) Resource expectedArrayExpression. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 92
+
+resource expectedColon 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y]
+//@[77:78) Local x. Type: any. Declaration start char: 77, length: 1
+//@[9:22) Resource expectedColon. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 84
+
+resource expectedLoopBody 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y:]
+//@[80:81) Local x. Type: any. Declaration start char: 80, length: 1
+//@[9:25) Resource expectedLoopBody. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 88
+
+// loop semantic analysis cases
+var emptyArray = []
+//@[4:14) Variable emptyArray. Type: array. Declaration start char: 0, length: 19
+resource wrongLoopBodyType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in emptyArray:4]
+//@[81:82) Local x. Type: any. Declaration start char: 81, length: 1
+//@[9:26) Resource wrongLoopBodyType. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 99
+
+// errors in the array expression
+resource arrayExpressionErrors 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in union([], 2): {
+//@[85:92) Local account. Type: any. Declaration start char: 85, length: 7
+//@[9:30) Resource arrayExpressionErrors. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 115
+}]
+
+// wrong array type
+var notAnArray = true
+//@[4:14) Variable notAnArray. Type: bool. Declaration start char: 0, length: 21
+resource wrongArrayType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in notAnArray: {
+//@[78:85) Local account. Type: any. Declaration start char: 78, length: 7
+//@[9:23) Resource wrongArrayType. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 106
+}]
+
+// missing required properties
+resource missingRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+//@[89:96) Local account. Type: any. Declaration start char: 89, length: 7
+//@[9:34) Resource missingRequiredProperties. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 109
+}]
+
+// fewer missing required properties and a wrong property
+resource missingFewerRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+//@[94:101) Local account. Type: any. Declaration start char: 94, length: 7
+//@[9:39) Resource missingFewerRequiredProperties. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 196
+  name: account
+  location: 'eastus42'
+  properties: {
+    wrong: 'test'
+  }
+}]
+
+// wrong property inside the nested property loop
+resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[89:90) Local i. Type: any. Declaration start char: 89, length: 1
+//@[9:34) Resource wrongPropertyInNestedLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 262
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for j in range(0, 4): {
+//@[18:19) Local j. Type: any. Declaration start char: 18, length: 1
+      doesNotExist: 'test'
+      name: 'subnet-${i}-${j}'
+    }]
+  }
+}]
+
+// duplicate identifiers within the loop
+// (these duplicates are self-contained - usage of i above is allowed)
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[94:95) Local i. Type: any. Declaration start char: 94, length: 1
+//@[9:39) Resource duplicateIdentifiersWithinLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 239
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+//@[18:19) Local i. Type: any. Declaration start char: 18, length: 1
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+
+// duplicate identifers in global and single loop scope
+var someDuplicate = 'hello'
+//@[4:17) Variable someDuplicate. Type: 'hello'. Declaration start char: 0, length: 27
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+//@[91:104) Local someDuplicate. Type: any. Declaration start char: 91, length: 13
+//@[9:36) Resource duplicateInGlobalAndOneLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 260
+  name: 'vnet-${someDuplicate}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+//@[18:19) Local i. Type: any. Declaration start char: 18, length: 1
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+
+// duplicate in global and multiple loop scopes
+var otherDuplicate = 'hello'
+//@[4:18) Variable otherDuplicate. Type: 'hello'. Declaration start char: 0, length: 28
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
+//@[92:106) Local otherDuplicate. Type: any. Declaration start char: 92, length: 14
+//@[9:37) Resource duplicateInGlobalAndTwoLoops. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 284
+  name: 'vnet-${otherDuplicate}'
+  properties: {
+    subnets: [for otherDuplicate in range(0, 4): {
+//@[18:32) Local otherDuplicate. Type: any. Declaration start char: 18, length: 14
+      name: 'subnet-${otherDuplicate}'
+    }]
+  }
+}]
+
+// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
+var someDuplicate = true
+//@[4:17) Variable someDuplicate. Type: bool. Declaration start char: 0, length: 24
+var otherDuplicate = []
+//@[4:18) Variable otherDuplicate. Type: array. Declaration start char: 0, length: 23
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+//@[92:105) Local someDuplicate. Type: any. Declaration start char: 92, length: 13
+//@[9:37) Resource duplicateInGlobalAndTwoLoops. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 299
+  name: 'vnet-${someDuplicate}'
+  properties: {
+    subnets: [for otherDuplicate in range(0, 4): {
+//@[18:32) Local otherDuplicate. Type: any. Declaration start char: 18, length: 14
+      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+    }]
+  }
+}]
+
+/*
+  valid loop cases - this should be moved to Resources_* test case after codegen works
+*/ 
+var storageAccounts = [
+//@[4:19) Variable storageAccounts. Type: array. Declaration start char: 0, length: 129
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+// just a storage account loop
+resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+//@[80:87) Local account. Type: any. Declaration start char: 80, length: 7
+//@[9:25) Resource storageResources. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 227
+  name: account.name
+  location: account.location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}]
+// using the same loop variable in a new language scope should be allowed
+resource premiumStorages 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+//@[79:86) Local account. Type: any. Declaration start char: 79, length: 7
+//@[9:24) Resource premiumStorages. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 271
+  name: account.name
+  location: account.location
+  sku: {
+    // #completionTest(9,10) -> storageSkuNamePlusSymbols
+    name: 
+  }
+  kind: 'StorageV2'
+}]
+// basic nested loop
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[68:69) Local i. Type: any. Declaration start char: 68, length: 1
+//@[9:13) Resource vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 279
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for j in range(0, 4): {
+//@[18:19) Local j. Type: any. Declaration start char: 18, length: 1
+      // #completionTest(0,1,2,3,4,5,6) -> subnetIdAndProperties
+      name: 'subnet-${i}-${j}'
+    }]
+  }
+}]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -1101,63 +1101,16 @@ resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01
   }
 }]
 
-// duplicate identifiers within the loop
-// (these duplicates are self-contained - usage of i above is allowed)
-resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[94:95) Local i. Type: any. Declaration start char: 94, length: 1
-//@[9:39) Resource duplicateIdentifiersWithinLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 239
-  name: 'vnet-${i}'
+// nonexistent arrays and loop variables
+resource nonexistentArrays 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in notAThing: {
+//@[81:82) Local i. Type: any. Declaration start char: 81, length: 1
+//@[9:26) Resource nonexistentArrays. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 280
+  name: 'vnet-${justPlainWrong}'
   properties: {
-    subnets: [for i in range(0, 4): {
-//@[18:19) Local i. Type: any. Declaration start char: 18, length: 1
-      name: 'subnet-${i}-${i}'
-    }]
-  }
-}]
-
-// duplicate identifers in global and single loop scope
-var someDuplicate = 'hello'
-//@[4:17) Variable someDuplicate. Type: 'hello'. Declaration start char: 0, length: 27
-resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-//@[91:104) Local someDuplicate. Type: any. Declaration start char: 91, length: 13
-//@[9:36) Resource duplicateInGlobalAndOneLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 260
-  name: 'vnet-${someDuplicate}'
-  properties: {
-    subnets: [for i in range(0, 4): {
-//@[18:19) Local i. Type: any. Declaration start char: 18, length: 1
-      name: 'subnet-${i}-${i}'
-    }]
-  }
-}]
-
-// duplicate in global and multiple loop scopes
-var otherDuplicate = 'hello'
-//@[4:18) Variable otherDuplicate. Type: 'hello'. Declaration start char: 0, length: 28
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
-//@[92:106) Local otherDuplicate. Type: any. Declaration start char: 92, length: 14
-//@[9:37) Resource duplicateInGlobalAndTwoLoops. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 284
-  name: 'vnet-${otherDuplicate}'
-  properties: {
-    subnets: [for otherDuplicate in range(0, 4): {
-//@[18:32) Local otherDuplicate. Type: any. Declaration start char: 18, length: 14
-      name: 'subnet-${otherDuplicate}'
-    }]
-  }
-}]
-
-// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
-var someDuplicate = true
-//@[4:17) Variable someDuplicate. Type: bool. Declaration start char: 0, length: 24
-var otherDuplicate = []
-//@[4:18) Variable otherDuplicate. Type: array. Declaration start char: 0, length: 23
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-//@[92:105) Local someDuplicate. Type: any. Declaration start char: 92, length: 13
-//@[9:37) Resource duplicateInGlobalAndTwoLoops. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 299
-  name: 'vnet-${someDuplicate}'
-  properties: {
-    subnets: [for otherDuplicate in range(0, 4): {
-//@[18:32) Local otherDuplicate. Type: any. Declaration start char: 18, length: 14
-      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+    subnets: [for j in alsoNotAThing: {
+//@[18:19) Local j. Type: any. Declaration start char: 18, length: 1
+      doesNotExist: 'test'
+      name: 'subnet-${fake}-${totallyFake}'
     }]
   }
 }]
@@ -1176,6 +1129,46 @@ var storageAccounts = [
     location: 'westus'
   }
 ]
+// duplicate identifiers within the loop are allowed
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[94:95) Local i. Type: any. Declaration start char: 94, length: 1
+//@[9:39) Resource duplicateIdentifiersWithinLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 239
+  name: 'vnet-${i}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+//@[18:19) Local i. Type: any. Declaration start char: 18, length: 1
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+// duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
+var canHaveDuplicatesAcrossScopes = 'hello'
+//@[4:33) Variable canHaveDuplicatesAcrossScopes. Type: 'hello'. Declaration start char: 0, length: 43
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
+//@[91:120) Local canHaveDuplicatesAcrossScopes. Type: any. Declaration start char: 91, length: 29
+//@[9:36) Resource duplicateInGlobalAndOneLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 292
+  name: 'vnet-${canHaveDuplicatesAcrossScopes}'
+  properties: {
+    subnets: [for i in range(0, 4): {
+//@[18:19) Local i. Type: any. Declaration start char: 18, length: 1
+      name: 'subnet-${i}-${i}'
+    }]
+  }
+}]
+// duplicate in global and multiple loop scopes are allowed (inner hides the outer)
+var duplicatesEverywhere = 'hello'
+//@[4:24) Variable duplicatesEverywhere. Type: 'hello'. Declaration start char: 0, length: 34
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
+//@[92:112) Local duplicatesEverywhere. Type: any. Declaration start char: 92, length: 20
+//@[9:37) Resource duplicateInGlobalAndTwoLoops. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 308
+  name: 'vnet-${duplicatesEverywhere}'
+  properties: {
+    subnets: [for duplicatesEverywhere in range(0, 4): {
+//@[18:38) Local duplicatesEverywhere. Type: any. Declaration start char: 18, length: 20
+      name: 'subnet-${duplicatesEverywhere}'
+    }]
+  }
+}]
 // just a storage account loop
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
 //@[80:87) Local account. Type: any. Declaration start char: 80, length: 7

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -6052,10 +6052,171 @@ resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01
 //@[1:2)   RightSquare |]|
 //@[2:6) NewLine |\r\n\r\n|
 
-// duplicate identifiers within the loop
+// nonexistent arrays and loop variables
 //@[40:42) NewLine |\r\n|
-// (these duplicates are self-contained - usage of i above is allowed)
-//@[70:72) NewLine |\r\n|
+resource nonexistentArrays 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in notAThing: {
+//@[0:280) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:26)  IdentifierSyntax
+//@[9:26)   Identifier |nonexistentArrays|
+//@[27:73)  StringSyntax
+//@[27:73)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[74:75)  Assignment |=|
+//@[76:280)  ForSyntax
+//@[76:77)   LeftSquare |[|
+//@[77:80)   Identifier |for|
+//@[81:82)   LocalVariableSyntax
+//@[81:82)    IdentifierSyntax
+//@[81:82)     Identifier |i|
+//@[83:85)   Identifier |in|
+//@[86:95)   VariableAccessSyntax
+//@[86:95)    IdentifierSyntax
+//@[86:95)     Identifier |notAThing|
+//@[95:96)   Colon |:|
+//@[97:279)   ObjectSyntax
+//@[97:98)    LeftBrace |{|
+//@[98:100)    NewLine |\r\n|
+  name: 'vnet-${justPlainWrong}'
+//@[2:32)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:32)     StringSyntax
+//@[8:16)      StringLeftPiece |'vnet-${|
+//@[16:30)      VariableAccessSyntax
+//@[16:30)       IdentifierSyntax
+//@[16:30)        Identifier |justPlainWrong|
+//@[30:32)      StringRightPiece |}'|
+//@[32:34)    NewLine |\r\n|
+  properties: {
+//@[2:142)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:142)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    subnets: [for j in alsoNotAThing: {
+//@[4:120)      ObjectPropertySyntax
+//@[4:11)       IdentifierSyntax
+//@[4:11)        Identifier |subnets|
+//@[11:12)       Colon |:|
+//@[13:120)       ForSyntax
+//@[13:14)        LeftSquare |[|
+//@[14:17)        Identifier |for|
+//@[18:19)        LocalVariableSyntax
+//@[18:19)         IdentifierSyntax
+//@[18:19)          Identifier |j|
+//@[20:22)        Identifier |in|
+//@[23:36)        VariableAccessSyntax
+//@[23:36)         IdentifierSyntax
+//@[23:36)          Identifier |alsoNotAThing|
+//@[36:37)        Colon |:|
+//@[38:119)        ObjectSyntax
+//@[38:39)         LeftBrace |{|
+//@[39:41)         NewLine |\r\n|
+      doesNotExist: 'test'
+//@[6:26)         ObjectPropertySyntax
+//@[6:18)          IdentifierSyntax
+//@[6:18)           Identifier |doesNotExist|
+//@[18:19)          Colon |:|
+//@[20:26)          StringSyntax
+//@[20:26)           StringComplete |'test'|
+//@[26:28)         NewLine |\r\n|
+      name: 'subnet-${fake}-${totallyFake}'
+//@[6:43)         ObjectPropertySyntax
+//@[6:10)          IdentifierSyntax
+//@[6:10)           Identifier |name|
+//@[10:11)          Colon |:|
+//@[12:43)          StringSyntax
+//@[12:22)           StringLeftPiece |'subnet-${|
+//@[22:26)           VariableAccessSyntax
+//@[22:26)            IdentifierSyntax
+//@[22:26)             Identifier |fake|
+//@[26:30)           StringMiddlePiece |}-${|
+//@[30:41)           VariableAccessSyntax
+//@[30:41)            IdentifierSyntax
+//@[30:41)             Identifier |totallyFake|
+//@[41:43)           StringRightPiece |}'|
+//@[43:45)         NewLine |\r\n|
+    }]
+//@[4:5)         RightBrace |}|
+//@[5:6)        RightSquare |]|
+//@[6:8)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+/*
+  valid loop cases - this should be moved to Resources_* test case after codegen works
+*/ 
+//@[3:5) NewLine |\r\n|
+var storageAccounts = [
+//@[0:129) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:19)  IdentifierSyntax
+//@[4:19)   Identifier |storageAccounts|
+//@[20:21)  Assignment |=|
+//@[22:129)  ArraySyntax
+//@[22:23)   LeftSquare |[|
+//@[23:25)   NewLine |\r\n|
+  {
+//@[2:50)   ArrayItemSyntax
+//@[2:50)    ObjectSyntax
+//@[2:3)     LeftBrace |{|
+//@[3:5)     NewLine |\r\n|
+    name: 'one'
+//@[4:15)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:15)      StringSyntax
+//@[10:15)       StringComplete |'one'|
+//@[15:17)     NewLine |\r\n|
+    location: 'eastus2'
+//@[4:23)     ObjectPropertySyntax
+//@[4:12)      IdentifierSyntax
+//@[4:12)       Identifier |location|
+//@[12:13)      Colon |:|
+//@[14:23)      StringSyntax
+//@[14:23)       StringComplete |'eastus2'|
+//@[23:25)     NewLine |\r\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\r\n|
+  {
+//@[2:49)   ArrayItemSyntax
+//@[2:49)    ObjectSyntax
+//@[2:3)     LeftBrace |{|
+//@[3:5)     NewLine |\r\n|
+    name: 'two'
+//@[4:15)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:15)      StringSyntax
+//@[10:15)       StringComplete |'two'|
+//@[15:17)     NewLine |\r\n|
+    location: 'westus'
+//@[4:22)     ObjectPropertySyntax
+//@[4:12)      IdentifierSyntax
+//@[4:12)       Identifier |location|
+//@[12:13)      Colon |:|
+//@[14:22)      StringSyntax
+//@[14:22)       StringComplete |'westus'|
+//@[22:24)     NewLine |\r\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\r\n|
+]
+//@[0:1)   RightSquare |]|
+//@[1:3) NewLine |\r\n|
+// duplicate identifiers within the loop are allowed
+//@[52:54) NewLine |\r\n|
 resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
 //@[0:239) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
@@ -6161,62 +6322,61 @@ resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-
 }]
 //@[0:1)    RightBrace |}|
 //@[1:2)   RightSquare |]|
-//@[2:6) NewLine |\r\n\r\n|
-
-// duplicate identifers in global and single loop scope
-//@[55:57) NewLine |\r\n|
-var someDuplicate = 'hello'
-//@[0:27) VariableDeclarationSyntax
+//@[2:4) NewLine |\r\n|
+// duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
+//@[100:102) NewLine |\r\n|
+var canHaveDuplicatesAcrossScopes = 'hello'
+//@[0:43) VariableDeclarationSyntax
 //@[0:3)  Identifier |var|
-//@[4:17)  IdentifierSyntax
-//@[4:17)   Identifier |someDuplicate|
-//@[18:19)  Assignment |=|
-//@[20:27)  StringSyntax
-//@[20:27)   StringComplete |'hello'|
-//@[27:29) NewLine |\r\n|
-resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-//@[0:260) ResourceDeclarationSyntax
+//@[4:33)  IdentifierSyntax
+//@[4:33)   Identifier |canHaveDuplicatesAcrossScopes|
+//@[34:35)  Assignment |=|
+//@[36:43)  StringSyntax
+//@[36:43)   StringComplete |'hello'|
+//@[43:45) NewLine |\r\n|
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
+//@[0:292) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:36)  IdentifierSyntax
 //@[9:36)   Identifier |duplicateInGlobalAndOneLoop|
 //@[37:83)  StringSyntax
 //@[37:83)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
 //@[84:85)  Assignment |=|
-//@[86:260)  ForSyntax
+//@[86:292)  ForSyntax
 //@[86:87)   LeftSquare |[|
 //@[87:90)   Identifier |for|
-//@[91:104)   LocalVariableSyntax
-//@[91:104)    IdentifierSyntax
-//@[91:104)     Identifier |someDuplicate|
-//@[105:107)   Identifier |in|
-//@[108:119)   FunctionCallSyntax
-//@[108:113)    IdentifierSyntax
-//@[108:113)     Identifier |range|
-//@[113:114)    LeftParen |(|
-//@[114:116)    FunctionArgumentSyntax
-//@[114:115)     IntegerLiteralSyntax
-//@[114:115)      Integer |0|
-//@[115:116)     Comma |,|
-//@[117:118)    FunctionArgumentSyntax
-//@[117:118)     IntegerLiteralSyntax
-//@[117:118)      Integer |3|
-//@[118:119)    RightParen |)|
-//@[119:120)   Colon |:|
-//@[121:259)   ObjectSyntax
-//@[121:122)    LeftBrace |{|
-//@[122:124)    NewLine |\r\n|
-  name: 'vnet-${someDuplicate}'
-//@[2:31)    ObjectPropertySyntax
+//@[91:120)   LocalVariableSyntax
+//@[91:120)    IdentifierSyntax
+//@[91:120)     Identifier |canHaveDuplicatesAcrossScopes|
+//@[121:123)   Identifier |in|
+//@[124:135)   FunctionCallSyntax
+//@[124:129)    IdentifierSyntax
+//@[124:129)     Identifier |range|
+//@[129:130)    LeftParen |(|
+//@[130:132)    FunctionArgumentSyntax
+//@[130:131)     IntegerLiteralSyntax
+//@[130:131)      Integer |0|
+//@[131:132)     Comma |,|
+//@[133:134)    FunctionArgumentSyntax
+//@[133:134)     IntegerLiteralSyntax
+//@[133:134)      Integer |3|
+//@[134:135)    RightParen |)|
+//@[135:136)   Colon |:|
+//@[137:291)   ObjectSyntax
+//@[137:138)    LeftBrace |{|
+//@[138:140)    NewLine |\r\n|
+  name: 'vnet-${canHaveDuplicatesAcrossScopes}'
+//@[2:47)    ObjectPropertySyntax
 //@[2:6)     IdentifierSyntax
 //@[2:6)      Identifier |name|
 //@[6:7)     Colon |:|
-//@[8:31)     StringSyntax
+//@[8:47)     StringSyntax
 //@[8:16)      StringLeftPiece |'vnet-${|
-//@[16:29)      VariableAccessSyntax
-//@[16:29)       IdentifierSyntax
-//@[16:29)        Identifier |someDuplicate|
-//@[29:31)      StringRightPiece |}'|
-//@[31:33)    NewLine |\r\n|
+//@[16:45)      VariableAccessSyntax
+//@[16:45)       IdentifierSyntax
+//@[16:45)        Identifier |canHaveDuplicatesAcrossScopes|
+//@[45:47)      StringRightPiece |}'|
+//@[47:49)    NewLine |\r\n|
   properties: {
 //@[2:99)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
@@ -6279,110 +6439,109 @@ resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-
 }]
 //@[0:1)    RightBrace |}|
 //@[1:2)   RightSquare |]|
-//@[2:6) NewLine |\r\n\r\n|
-
-// duplicate in global and multiple loop scopes
-//@[47:49) NewLine |\r\n|
-var otherDuplicate = 'hello'
-//@[0:28) VariableDeclarationSyntax
+//@[2:4) NewLine |\r\n|
+// duplicate in global and multiple loop scopes are allowed (inner hides the outer)
+//@[83:85) NewLine |\r\n|
+var duplicatesEverywhere = 'hello'
+//@[0:34) VariableDeclarationSyntax
 //@[0:3)  Identifier |var|
-//@[4:18)  IdentifierSyntax
-//@[4:18)   Identifier |otherDuplicate|
-//@[19:20)  Assignment |=|
-//@[21:28)  StringSyntax
-//@[21:28)   StringComplete |'hello'|
-//@[28:30) NewLine |\r\n|
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
-//@[0:284) ResourceDeclarationSyntax
+//@[4:24)  IdentifierSyntax
+//@[4:24)   Identifier |duplicatesEverywhere|
+//@[25:26)  Assignment |=|
+//@[27:34)  StringSyntax
+//@[27:34)   StringComplete |'hello'|
+//@[34:36) NewLine |\r\n|
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
+//@[0:308) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:37)  IdentifierSyntax
 //@[9:37)   Identifier |duplicateInGlobalAndTwoLoops|
 //@[38:84)  StringSyntax
 //@[38:84)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
 //@[85:86)  Assignment |=|
-//@[87:284)  ForSyntax
+//@[87:308)  ForSyntax
 //@[87:88)   LeftSquare |[|
 //@[88:91)   Identifier |for|
-//@[92:106)   LocalVariableSyntax
-//@[92:106)    IdentifierSyntax
-//@[92:106)     Identifier |otherDuplicate|
-//@[107:109)   Identifier |in|
-//@[110:121)   FunctionCallSyntax
-//@[110:115)    IdentifierSyntax
-//@[110:115)     Identifier |range|
-//@[115:116)    LeftParen |(|
-//@[116:118)    FunctionArgumentSyntax
-//@[116:117)     IntegerLiteralSyntax
-//@[116:117)      Integer |0|
-//@[117:118)     Comma |,|
-//@[119:120)    FunctionArgumentSyntax
-//@[119:120)     IntegerLiteralSyntax
-//@[119:120)      Integer |3|
-//@[120:121)    RightParen |)|
-//@[121:122)   Colon |:|
-//@[123:283)   ObjectSyntax
-//@[123:124)    LeftBrace |{|
-//@[124:126)    NewLine |\r\n|
-  name: 'vnet-${otherDuplicate}'
-//@[2:32)    ObjectPropertySyntax
+//@[92:112)   LocalVariableSyntax
+//@[92:112)    IdentifierSyntax
+//@[92:112)     Identifier |duplicatesEverywhere|
+//@[113:115)   Identifier |in|
+//@[116:127)   FunctionCallSyntax
+//@[116:121)    IdentifierSyntax
+//@[116:121)     Identifier |range|
+//@[121:122)    LeftParen |(|
+//@[122:124)    FunctionArgumentSyntax
+//@[122:123)     IntegerLiteralSyntax
+//@[122:123)      Integer |0|
+//@[123:124)     Comma |,|
+//@[125:126)    FunctionArgumentSyntax
+//@[125:126)     IntegerLiteralSyntax
+//@[125:126)      Integer |3|
+//@[126:127)    RightParen |)|
+//@[127:128)   Colon |:|
+//@[129:307)   ObjectSyntax
+//@[129:130)    LeftBrace |{|
+//@[130:132)    NewLine |\r\n|
+  name: 'vnet-${duplicatesEverywhere}'
+//@[2:38)    ObjectPropertySyntax
 //@[2:6)     IdentifierSyntax
 //@[2:6)      Identifier |name|
 //@[6:7)     Colon |:|
-//@[8:32)     StringSyntax
+//@[8:38)     StringSyntax
 //@[8:16)      StringLeftPiece |'vnet-${|
-//@[16:30)      VariableAccessSyntax
-//@[16:30)       IdentifierSyntax
-//@[16:30)        Identifier |otherDuplicate|
-//@[30:32)      StringRightPiece |}'|
-//@[32:34)    NewLine |\r\n|
+//@[16:36)      VariableAccessSyntax
+//@[16:36)       IdentifierSyntax
+//@[16:36)        Identifier |duplicatesEverywhere|
+//@[36:38)      StringRightPiece |}'|
+//@[38:40)    NewLine |\r\n|
   properties: {
-//@[2:120)    ObjectPropertySyntax
+//@[2:132)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
 //@[2:12)      Identifier |properties|
 //@[12:13)     Colon |:|
-//@[14:120)     ObjectSyntax
+//@[14:132)     ObjectSyntax
 //@[14:15)      LeftBrace |{|
 //@[15:17)      NewLine |\r\n|
-    subnets: [for otherDuplicate in range(0, 4): {
-//@[4:98)      ObjectPropertySyntax
+    subnets: [for duplicatesEverywhere in range(0, 4): {
+//@[4:110)      ObjectPropertySyntax
 //@[4:11)       IdentifierSyntax
 //@[4:11)        Identifier |subnets|
 //@[11:12)       Colon |:|
-//@[13:98)       ForSyntax
+//@[13:110)       ForSyntax
 //@[13:14)        LeftSquare |[|
 //@[14:17)        Identifier |for|
-//@[18:32)        LocalVariableSyntax
-//@[18:32)         IdentifierSyntax
-//@[18:32)          Identifier |otherDuplicate|
-//@[33:35)        Identifier |in|
-//@[36:47)        FunctionCallSyntax
-//@[36:41)         IdentifierSyntax
-//@[36:41)          Identifier |range|
-//@[41:42)         LeftParen |(|
-//@[42:44)         FunctionArgumentSyntax
-//@[42:43)          IntegerLiteralSyntax
-//@[42:43)           Integer |0|
-//@[43:44)          Comma |,|
-//@[45:46)         FunctionArgumentSyntax
-//@[45:46)          IntegerLiteralSyntax
-//@[45:46)           Integer |4|
-//@[46:47)         RightParen |)|
-//@[47:48)        Colon |:|
-//@[49:97)        ObjectSyntax
-//@[49:50)         LeftBrace |{|
-//@[50:52)         NewLine |\r\n|
-      name: 'subnet-${otherDuplicate}'
-//@[6:38)         ObjectPropertySyntax
+//@[18:38)        LocalVariableSyntax
+//@[18:38)         IdentifierSyntax
+//@[18:38)          Identifier |duplicatesEverywhere|
+//@[39:41)        Identifier |in|
+//@[42:53)        FunctionCallSyntax
+//@[42:47)         IdentifierSyntax
+//@[42:47)          Identifier |range|
+//@[47:48)         LeftParen |(|
+//@[48:50)         FunctionArgumentSyntax
+//@[48:49)          IntegerLiteralSyntax
+//@[48:49)           Integer |0|
+//@[49:50)          Comma |,|
+//@[51:52)         FunctionArgumentSyntax
+//@[51:52)          IntegerLiteralSyntax
+//@[51:52)           Integer |4|
+//@[52:53)         RightParen |)|
+//@[53:54)        Colon |:|
+//@[55:109)        ObjectSyntax
+//@[55:56)         LeftBrace |{|
+//@[56:58)         NewLine |\r\n|
+      name: 'subnet-${duplicatesEverywhere}'
+//@[6:44)         ObjectPropertySyntax
 //@[6:10)          IdentifierSyntax
 //@[6:10)           Identifier |name|
 //@[10:11)          Colon |:|
-//@[12:38)          StringSyntax
+//@[12:44)          StringSyntax
 //@[12:22)           StringLeftPiece |'subnet-${|
-//@[22:36)           VariableAccessSyntax
-//@[22:36)            IdentifierSyntax
-//@[22:36)             Identifier |otherDuplicate|
-//@[36:38)           StringRightPiece |}'|
-//@[38:40)         NewLine |\r\n|
+//@[22:42)           VariableAccessSyntax
+//@[22:42)            IdentifierSyntax
+//@[22:42)             Identifier |duplicatesEverywhere|
+//@[42:44)           StringRightPiece |}'|
+//@[44:46)         NewLine |\r\n|
     }]
 //@[4:5)         RightBrace |}|
 //@[5:6)        RightSquare |]|
@@ -6393,200 +6552,7 @@ resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06
 }]
 //@[0:1)    RightBrace |}|
 //@[1:2)   RightSquare |]|
-//@[2:6) NewLine |\r\n\r\n|
-
-// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
-//@[119:121) NewLine |\r\n|
-var someDuplicate = true
-//@[0:24) VariableDeclarationSyntax
-//@[0:3)  Identifier |var|
-//@[4:17)  IdentifierSyntax
-//@[4:17)   Identifier |someDuplicate|
-//@[18:19)  Assignment |=|
-//@[20:24)  BooleanLiteralSyntax
-//@[20:24)   TrueKeyword |true|
-//@[24:26) NewLine |\r\n|
-var otherDuplicate = []
-//@[0:23) VariableDeclarationSyntax
-//@[0:3)  Identifier |var|
-//@[4:18)  IdentifierSyntax
-//@[4:18)   Identifier |otherDuplicate|
-//@[19:20)  Assignment |=|
-//@[21:23)  ArraySyntax
-//@[21:22)   LeftSquare |[|
-//@[22:23)   RightSquare |]|
-//@[23:25) NewLine |\r\n|
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-//@[0:299) ResourceDeclarationSyntax
-//@[0:8)  Identifier |resource|
-//@[9:37)  IdentifierSyntax
-//@[9:37)   Identifier |duplicateInGlobalAndTwoLoops|
-//@[38:84)  StringSyntax
-//@[38:84)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[85:86)  Assignment |=|
-//@[87:299)  ForSyntax
-//@[87:88)   LeftSquare |[|
-//@[88:91)   Identifier |for|
-//@[92:105)   LocalVariableSyntax
-//@[92:105)    IdentifierSyntax
-//@[92:105)     Identifier |someDuplicate|
-//@[106:108)   Identifier |in|
-//@[109:120)   FunctionCallSyntax
-//@[109:114)    IdentifierSyntax
-//@[109:114)     Identifier |range|
-//@[114:115)    LeftParen |(|
-//@[115:117)    FunctionArgumentSyntax
-//@[115:116)     IntegerLiteralSyntax
-//@[115:116)      Integer |0|
-//@[116:117)     Comma |,|
-//@[118:119)    FunctionArgumentSyntax
-//@[118:119)     IntegerLiteralSyntax
-//@[118:119)      Integer |3|
-//@[119:120)    RightParen |)|
-//@[120:121)   Colon |:|
-//@[122:298)   ObjectSyntax
-//@[122:123)    LeftBrace |{|
-//@[123:125)    NewLine |\r\n|
-  name: 'vnet-${someDuplicate}'
-//@[2:31)    ObjectPropertySyntax
-//@[2:6)     IdentifierSyntax
-//@[2:6)      Identifier |name|
-//@[6:7)     Colon |:|
-//@[8:31)     StringSyntax
-//@[8:16)      StringLeftPiece |'vnet-${|
-//@[16:29)      VariableAccessSyntax
-//@[16:29)       IdentifierSyntax
-//@[16:29)        Identifier |someDuplicate|
-//@[29:31)      StringRightPiece |}'|
-//@[31:33)    NewLine |\r\n|
-  properties: {
-//@[2:137)    ObjectPropertySyntax
-//@[2:12)     IdentifierSyntax
-//@[2:12)      Identifier |properties|
-//@[12:13)     Colon |:|
-//@[14:137)     ObjectSyntax
-//@[14:15)      LeftBrace |{|
-//@[15:17)      NewLine |\r\n|
-    subnets: [for otherDuplicate in range(0, 4): {
-//@[4:115)      ObjectPropertySyntax
-//@[4:11)       IdentifierSyntax
-//@[4:11)        Identifier |subnets|
-//@[11:12)       Colon |:|
-//@[13:115)       ForSyntax
-//@[13:14)        LeftSquare |[|
-//@[14:17)        Identifier |for|
-//@[18:32)        LocalVariableSyntax
-//@[18:32)         IdentifierSyntax
-//@[18:32)          Identifier |otherDuplicate|
-//@[33:35)        Identifier |in|
-//@[36:47)        FunctionCallSyntax
-//@[36:41)         IdentifierSyntax
-//@[36:41)          Identifier |range|
-//@[41:42)         LeftParen |(|
-//@[42:44)         FunctionArgumentSyntax
-//@[42:43)          IntegerLiteralSyntax
-//@[42:43)           Integer |0|
-//@[43:44)          Comma |,|
-//@[45:46)         FunctionArgumentSyntax
-//@[45:46)          IntegerLiteralSyntax
-//@[45:46)           Integer |4|
-//@[46:47)         RightParen |)|
-//@[47:48)        Colon |:|
-//@[49:114)        ObjectSyntax
-//@[49:50)         LeftBrace |{|
-//@[50:52)         NewLine |\r\n|
-      name: 'subnet-${otherDuplicate}-${someDuplicate}'
-//@[6:55)         ObjectPropertySyntax
-//@[6:10)          IdentifierSyntax
-//@[6:10)           Identifier |name|
-//@[10:11)          Colon |:|
-//@[12:55)          StringSyntax
-//@[12:22)           StringLeftPiece |'subnet-${|
-//@[22:36)           VariableAccessSyntax
-//@[22:36)            IdentifierSyntax
-//@[22:36)             Identifier |otherDuplicate|
-//@[36:40)           StringMiddlePiece |}-${|
-//@[40:53)           VariableAccessSyntax
-//@[40:53)            IdentifierSyntax
-//@[40:53)             Identifier |someDuplicate|
-//@[53:55)           StringRightPiece |}'|
-//@[55:57)         NewLine |\r\n|
-    }]
-//@[4:5)         RightBrace |}|
-//@[5:6)        RightSquare |]|
-//@[6:8)      NewLine |\r\n|
-  }
-//@[2:3)      RightBrace |}|
-//@[3:5)    NewLine |\r\n|
-}]
-//@[0:1)    RightBrace |}|
-//@[1:2)   RightSquare |]|
-//@[2:6) NewLine |\r\n\r\n|
-
-/*
-  valid loop cases - this should be moved to Resources_* test case after codegen works
-*/ 
-//@[3:5) NewLine |\r\n|
-var storageAccounts = [
-//@[0:129) VariableDeclarationSyntax
-//@[0:3)  Identifier |var|
-//@[4:19)  IdentifierSyntax
-//@[4:19)   Identifier |storageAccounts|
-//@[20:21)  Assignment |=|
-//@[22:129)  ArraySyntax
-//@[22:23)   LeftSquare |[|
-//@[23:25)   NewLine |\r\n|
-  {
-//@[2:50)   ArrayItemSyntax
-//@[2:50)    ObjectSyntax
-//@[2:3)     LeftBrace |{|
-//@[3:5)     NewLine |\r\n|
-    name: 'one'
-//@[4:15)     ObjectPropertySyntax
-//@[4:8)      IdentifierSyntax
-//@[4:8)       Identifier |name|
-//@[8:9)      Colon |:|
-//@[10:15)      StringSyntax
-//@[10:15)       StringComplete |'one'|
-//@[15:17)     NewLine |\r\n|
-    location: 'eastus2'
-//@[4:23)     ObjectPropertySyntax
-//@[4:12)      IdentifierSyntax
-//@[4:12)       Identifier |location|
-//@[12:13)      Colon |:|
-//@[14:23)      StringSyntax
-//@[14:23)       StringComplete |'eastus2'|
-//@[23:25)     NewLine |\r\n|
-  }
-//@[2:3)     RightBrace |}|
-//@[3:5)   NewLine |\r\n|
-  {
-//@[2:49)   ArrayItemSyntax
-//@[2:49)    ObjectSyntax
-//@[2:3)     LeftBrace |{|
-//@[3:5)     NewLine |\r\n|
-    name: 'two'
-//@[4:15)     ObjectPropertySyntax
-//@[4:8)      IdentifierSyntax
-//@[4:8)       Identifier |name|
-//@[8:9)      Colon |:|
-//@[10:15)      StringSyntax
-//@[10:15)       StringComplete |'two'|
-//@[15:17)     NewLine |\r\n|
-    location: 'westus'
-//@[4:22)     ObjectPropertySyntax
-//@[4:12)      IdentifierSyntax
-//@[4:12)       Identifier |location|
-//@[12:13)      Colon |:|
-//@[14:22)      StringSyntax
-//@[14:22)       StringComplete |'westus'|
-//@[22:24)     NewLine |\r\n|
-  }
-//@[2:3)     RightBrace |}|
-//@[3:5)   NewLine |\r\n|
-]
-//@[0:1)   RightSquare |]|
-//@[1:3) NewLine |\r\n|
+//@[2:4) NewLine |\r\n|
 // just a storage account loop
 //@[30:32) NewLine |\r\n|
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -2721,6 +2721,10 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 //@[0:1)   RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
 
+/*
+Discriminator key missing
+*/
+//@[2:4) NewLine |\r\n|
 resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:148) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
@@ -2740,6 +2744,75 @@ resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-
 //@[0:1)   RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
 
+/*
+Discriminator key missing (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeyMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(true) {
+//@[0:160) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:35)  IdentifierSyntax
+//@[9:35)   Identifier |discriminatorKeyMissing_if|
+//@[36:86)  StringSyntax
+//@[36:86)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[87:88)  Assignment |=|
+//@[89:160)  IfConditionSyntax
+//@[89:91)   Identifier |if|
+//@[91:97)   ParenthesizedExpressionSyntax
+//@[91:92)    LeftParen |(|
+//@[92:96)    BooleanLiteralSyntax
+//@[92:96)     TrueKeyword |true|
+//@[96:97)    RightParen |)|
+//@[98:160)   ObjectSyntax
+//@[98:99)    LeftBrace |{|
+//@[99:101)    NewLine |\r\n|
+  // #completionTest(0,1,2) -> discriminatorProperty
+//@[52:54)    NewLine |\r\n|
+  
+//@[2:4)    NewLine |\r\n|
+}
+//@[0:1)    RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
+/*
+Discriminator key missing (loop)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeyMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[0:171) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:36)  IdentifierSyntax
+//@[9:36)   Identifier |discriminatorKeyMissing_for|
+//@[37:87)  StringSyntax
+//@[37:87)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[88:89)  Assignment |=|
+//@[90:171)  ForSyntax
+//@[90:91)   LeftSquare |[|
+//@[91:94)   Identifier |for|
+//@[95:100)   LocalVariableSyntax
+//@[95:100)    IdentifierSyntax
+//@[95:100)     Identifier |thing|
+//@[101:103)   Identifier |in|
+//@[104:106)   ArraySyntax
+//@[104:105)    LeftSquare |[|
+//@[105:106)    RightSquare |]|
+//@[106:107)   Colon |:|
+//@[108:170)   ObjectSyntax
+//@[108:109)    LeftBrace |{|
+//@[109:111)    NewLine |\r\n|
+  // #completionTest(0,1,2) -> discriminatorProperty
+//@[52:54)    NewLine |\r\n|
+  
+//@[2:4)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+/*
+Discriminator key value missing with property access
+*/
+//@[2:4) NewLine |\r\n|
 resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:175) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
@@ -2813,6 +2886,217 @@ var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
 //@[76:77)   RightSquare |]|
 //@[77:81) NewLine |\r\n\r\n|
 
+/*
+Discriminator key value missing with property access (conditional)
+*/
+//@[2:6) NewLine |\r\n\r\n|
+
+resource discriminatorKeyValueMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(false) {
+//@[0:191) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:40)  IdentifierSyntax
+//@[9:40)   Identifier |discriminatorKeyValueMissing_if|
+//@[41:91)  StringSyntax
+//@[41:91)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[92:93)  Assignment |=|
+//@[94:191)  IfConditionSyntax
+//@[94:96)   Identifier |if|
+//@[96:103)   ParenthesizedExpressionSyntax
+//@[96:97)    LeftParen |(|
+//@[97:102)    BooleanLiteralSyntax
+//@[97:102)     FalseKeyword |false|
+//@[102:103)    RightParen |)|
+//@[104:191)   ObjectSyntax
+//@[104:105)    LeftBrace |{|
+//@[105:107)    NewLine |\r\n|
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_if
+//@[69:71)    NewLine |\r\n|
+  kind:   
+//@[2:10)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |kind|
+//@[6:7)     Colon |:|
+//@[10:10)     SkippedTriviaSyntax
+//@[10:12)    NewLine |\r\n|
+}
+//@[0:1)    RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions_if = discriminatorKeyValueMissing_if.p
+//@[0:82) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:46)  IdentifierSyntax
+//@[4:46)   Identifier |discriminatorKeyValueMissingCompletions_if|
+//@[47:48)  Assignment |=|
+//@[49:82)  PropertyAccessSyntax
+//@[49:80)   VariableAccessSyntax
+//@[49:80)    IdentifierSyntax
+//@[49:80)     Identifier |discriminatorKeyValueMissing_if|
+//@[80:81)   Dot |.|
+//@[81:82)   IdentifierSyntax
+//@[81:82)    Identifier |p|
+//@[82:84) NewLine |\r\n|
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions2_if = discriminatorKeyValueMissing_if.
+//@[0:82) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:47)  IdentifierSyntax
+//@[4:47)   Identifier |discriminatorKeyValueMissingCompletions2_if|
+//@[48:49)  Assignment |=|
+//@[50:82)  PropertyAccessSyntax
+//@[50:81)   VariableAccessSyntax
+//@[50:81)    IdentifierSyntax
+//@[50:81)     Identifier |discriminatorKeyValueMissing_if|
+//@[81:82)   Dot |.|
+//@[82:82)   IdentifierSyntax
+//@[82:82)    SkippedTriviaSyntax
+//@[82:86) NewLine |\r\n\r\n|
+
+// #completionTest(82) -> missingDiscriminatorPropertyIndexPlusSymbols_if
+//@[73:75) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions3_if = discriminatorKeyValueMissing_if[]
+//@[0:83) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:47)  IdentifierSyntax
+//@[4:47)   Identifier |discriminatorKeyValueMissingCompletions3_if|
+//@[48:49)  Assignment |=|
+//@[50:83)  ArrayAccessSyntax
+//@[50:81)   VariableAccessSyntax
+//@[50:81)    IdentifierSyntax
+//@[50:81)     Identifier |discriminatorKeyValueMissing_if|
+//@[81:82)   LeftSquare |[|
+//@[82:82)   SkippedTriviaSyntax
+//@[82:83)   RightSquare |]|
+//@[83:87) NewLine |\r\n\r\n|
+
+/*
+Discriminator key value missing with property access (loops)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeyValueMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[0:202) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:41)  IdentifierSyntax
+//@[9:41)   Identifier |discriminatorKeyValueMissing_for|
+//@[42:92)  StringSyntax
+//@[42:92)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[93:94)  Assignment |=|
+//@[95:202)  ForSyntax
+//@[95:96)   LeftSquare |[|
+//@[96:99)   Identifier |for|
+//@[100:105)   LocalVariableSyntax
+//@[100:105)    IdentifierSyntax
+//@[100:105)     Identifier |thing|
+//@[106:108)   Identifier |in|
+//@[109:111)   ArraySyntax
+//@[109:110)    LeftSquare |[|
+//@[110:111)    RightSquare |]|
+//@[111:112)   Colon |:|
+//@[113:201)   ObjectSyntax
+//@[113:114)    LeftBrace |{|
+//@[114:116)    NewLine |\r\n|
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_for
+//@[70:72)    NewLine |\r\n|
+  kind:   
+//@[2:10)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |kind|
+//@[6:7)     Colon |:|
+//@[10:10)     SkippedTriviaSyntax
+//@[10:12)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// cannot . access properties of a resource loop
+//@[48:50) NewLine |\r\n|
+var resourceListIsNotSingleResource = discriminatorKeyValueMissing_for.kind
+//@[0:75) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:35)  IdentifierSyntax
+//@[4:35)   Identifier |resourceListIsNotSingleResource|
+//@[36:37)  Assignment |=|
+//@[38:75)  PropertyAccessSyntax
+//@[38:70)   VariableAccessSyntax
+//@[38:70)    IdentifierSyntax
+//@[38:70)     Identifier |discriminatorKeyValueMissing_for|
+//@[70:71)   Dot |.|
+//@[71:75)   IdentifierSyntax
+//@[71:75)    Identifier |kind|
+//@[75:79) NewLine |\r\n\r\n|
+
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions_for = discriminatorKeyValueMissing_for[0].p
+//@[0:87) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:47)  IdentifierSyntax
+//@[4:47)   Identifier |discriminatorKeyValueMissingCompletions_for|
+//@[48:49)  Assignment |=|
+//@[50:87)  PropertyAccessSyntax
+//@[50:85)   ArrayAccessSyntax
+//@[50:82)    VariableAccessSyntax
+//@[50:82)     IdentifierSyntax
+//@[50:82)      Identifier |discriminatorKeyValueMissing_for|
+//@[82:83)    LeftSquare |[|
+//@[83:84)    IntegerLiteralSyntax
+//@[83:84)     Integer |0|
+//@[84:85)    RightSquare |]|
+//@[85:86)   Dot |.|
+//@[86:87)   IdentifierSyntax
+//@[86:87)    Identifier |p|
+//@[87:89) NewLine |\r\n|
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions2_for = discriminatorKeyValueMissing_for[0].
+//@[0:87) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:48)  IdentifierSyntax
+//@[4:48)   Identifier |discriminatorKeyValueMissingCompletions2_for|
+//@[49:50)  Assignment |=|
+//@[51:87)  PropertyAccessSyntax
+//@[51:86)   ArrayAccessSyntax
+//@[51:83)    VariableAccessSyntax
+//@[51:83)     IdentifierSyntax
+//@[51:83)      Identifier |discriminatorKeyValueMissing_for|
+//@[83:84)    LeftSquare |[|
+//@[84:85)    IntegerLiteralSyntax
+//@[84:85)     Integer |0|
+//@[85:86)    RightSquare |]|
+//@[86:87)   Dot |.|
+//@[87:87)   IdentifierSyntax
+//@[87:87)    SkippedTriviaSyntax
+//@[87:91) NewLine |\r\n\r\n|
+
+// #completionTest(87) -> missingDiscriminatorPropertyIndexPlusSymbols_for
+//@[74:76) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions3_for = discriminatorKeyValueMissing_for[0][]
+//@[0:88) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:48)  IdentifierSyntax
+//@[4:48)   Identifier |discriminatorKeyValueMissingCompletions3_for|
+//@[49:50)  Assignment |=|
+//@[51:88)  ArrayAccessSyntax
+//@[51:86)   ArrayAccessSyntax
+//@[51:83)    VariableAccessSyntax
+//@[51:83)     IdentifierSyntax
+//@[51:83)      Identifier |discriminatorKeyValueMissing_for|
+//@[83:84)    LeftSquare |[|
+//@[84:85)    IntegerLiteralSyntax
+//@[84:85)     Integer |0|
+//@[85:86)    RightSquare |]|
+//@[86:87)   LeftSquare |[|
+//@[87:87)   SkippedTriviaSyntax
+//@[87:88)   RightSquare |]|
+//@[88:92) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 1
+*/
+//@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:264) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
@@ -2915,6 +3199,266 @@ var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 //@[75:76)   RightSquare |]|
 //@[76:80) NewLine |\r\n\r\n|
 
+/*
+Discriminator value set 1 (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
+//@[0:276) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:34)  IdentifierSyntax
+//@[9:34)   Identifier |discriminatorKeySetOne_if|
+//@[35:85)  StringSyntax
+//@[35:85)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[86:87)  Assignment |=|
+//@[88:276)  IfConditionSyntax
+//@[88:90)   Identifier |if|
+//@[90:96)   ParenthesizedExpressionSyntax
+//@[90:91)    LeftParen |(|
+//@[91:95)    BinaryOperationSyntax
+//@[91:92)     IntegerLiteralSyntax
+//@[91:92)      Integer |2|
+//@[92:94)     Equals |==|
+//@[94:95)     IntegerLiteralSyntax
+//@[94:95)      Integer |3|
+//@[95:96)    RightParen |)|
+//@[97:276)   ObjectSyntax
+//@[97:98)    LeftBrace |{|
+//@[98:100)    NewLine |\r\n|
+  kind: 'AzureCLI'
+//@[2:18)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |kind|
+//@[6:7)     Colon |:|
+//@[8:18)     StringSyntax
+//@[8:18)      StringComplete |'AzureCLI'|
+//@[18:20)    NewLine |\r\n|
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+//@[55:59)    NewLine |\r\n\r\n|
+
+  properties: {
+//@[2:94)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:94)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+//@[66:68)      NewLine |\r\n|
+    
+//@[4:6)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}
+//@[0:1)    RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(81) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions_if = discriminatorKeySetOne_if.properties.a
+//@[0:81) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:40)  IdentifierSyntax
+//@[4:40)   Identifier |discriminatorKeySetOneCompletions_if|
+//@[41:42)  Assignment |=|
+//@[43:81)  PropertyAccessSyntax
+//@[43:79)   PropertyAccessSyntax
+//@[43:68)    VariableAccessSyntax
+//@[43:68)     IdentifierSyntax
+//@[43:68)      Identifier |discriminatorKeySetOne_if|
+//@[68:69)    Dot |.|
+//@[69:79)    IdentifierSyntax
+//@[69:79)     Identifier |properties|
+//@[79:80)   Dot |.|
+//@[80:81)   IdentifierSyntax
+//@[80:81)    Identifier |a|
+//@[81:83) NewLine |\r\n|
+// #completionTest(81) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions2_if = discriminatorKeySetOne_if.properties.
+//@[0:81) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:41)  IdentifierSyntax
+//@[4:41)   Identifier |discriminatorKeySetOneCompletions2_if|
+//@[42:43)  Assignment |=|
+//@[44:81)  PropertyAccessSyntax
+//@[44:80)   PropertyAccessSyntax
+//@[44:69)    VariableAccessSyntax
+//@[44:69)     IdentifierSyntax
+//@[44:69)      Identifier |discriminatorKeySetOne_if|
+//@[69:70)    Dot |.|
+//@[70:80)    IdentifierSyntax
+//@[70:80)     Identifier |properties|
+//@[80:81)   Dot |.|
+//@[81:81)   IdentifierSyntax
+//@[81:81)    SkippedTriviaSyntax
+//@[81:85) NewLine |\r\n\r\n|
+
+// #completionTest(81) -> cliPropertyAccessIndexesPlusSymbols_if
+//@[64:66) NewLine |\r\n|
+var discriminatorKeySetOneCompletions3_if = discriminatorKeySetOne_if.properties[]
+//@[0:82) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:41)  IdentifierSyntax
+//@[4:41)   Identifier |discriminatorKeySetOneCompletions3_if|
+//@[42:43)  Assignment |=|
+//@[44:82)  ArrayAccessSyntax
+//@[44:80)   PropertyAccessSyntax
+//@[44:69)    VariableAccessSyntax
+//@[44:69)     IdentifierSyntax
+//@[44:69)      Identifier |discriminatorKeySetOne_if|
+//@[69:70)    Dot |.|
+//@[70:80)    IdentifierSyntax
+//@[70:80)     Identifier |properties|
+//@[80:81)   LeftSquare |[|
+//@[81:81)   SkippedTriviaSyntax
+//@[81:82)   RightSquare |]|
+//@[82:86) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 1 (loop)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
+//@[0:288) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:35)  IdentifierSyntax
+//@[9:35)   Identifier |discriminatorKeySetOne_for|
+//@[36:86)  StringSyntax
+//@[36:86)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[87:88)  Assignment |=|
+//@[89:288)  ForSyntax
+//@[89:90)   LeftSquare |[|
+//@[91:94)   Identifier |for|
+//@[95:100)   LocalVariableSyntax
+//@[95:100)    IdentifierSyntax
+//@[95:100)     Identifier |thing|
+//@[101:103)   Identifier |in|
+//@[104:106)   ArraySyntax
+//@[104:105)    LeftSquare |[|
+//@[105:106)    RightSquare |]|
+//@[106:107)   Colon |:|
+//@[108:287)   ObjectSyntax
+//@[108:109)    LeftBrace |{|
+//@[109:111)    NewLine |\r\n|
+  kind: 'AzureCLI'
+//@[2:18)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |kind|
+//@[6:7)     Colon |:|
+//@[8:18)     StringSyntax
+//@[8:18)      StringComplete |'AzureCLI'|
+//@[18:20)    NewLine |\r\n|
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+//@[55:59)    NewLine |\r\n\r\n|
+
+  properties: {
+//@[2:94)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:94)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+//@[66:68)      NewLine |\r\n|
+    
+//@[4:6)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// #completionTest(86) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions_for = discriminatorKeySetOne_for[0].properties.a
+//@[0:86) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:41)  IdentifierSyntax
+//@[4:41)   Identifier |discriminatorKeySetOneCompletions_for|
+//@[42:43)  Assignment |=|
+//@[44:86)  PropertyAccessSyntax
+//@[44:84)   PropertyAccessSyntax
+//@[44:73)    ArrayAccessSyntax
+//@[44:70)     VariableAccessSyntax
+//@[44:70)      IdentifierSyntax
+//@[44:70)       Identifier |discriminatorKeySetOne_for|
+//@[70:71)     LeftSquare |[|
+//@[71:72)     IntegerLiteralSyntax
+//@[71:72)      Integer |0|
+//@[72:73)     RightSquare |]|
+//@[73:74)    Dot |.|
+//@[74:84)    IdentifierSyntax
+//@[74:84)     Identifier |properties|
+//@[84:85)   Dot |.|
+//@[85:86)   IdentifierSyntax
+//@[85:86)    Identifier |a|
+//@[86:88) NewLine |\r\n|
+// #completionTest(94) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions2_for = discriminatorKeySetOne_for[any(true)].properties.
+//@[0:94) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:42)  IdentifierSyntax
+//@[4:42)   Identifier |discriminatorKeySetOneCompletions2_for|
+//@[43:44)  Assignment |=|
+//@[45:94)  PropertyAccessSyntax
+//@[45:93)   PropertyAccessSyntax
+//@[45:82)    ArrayAccessSyntax
+//@[45:71)     VariableAccessSyntax
+//@[45:71)      IdentifierSyntax
+//@[45:71)       Identifier |discriminatorKeySetOne_for|
+//@[71:72)     LeftSquare |[|
+//@[72:81)     FunctionCallSyntax
+//@[72:75)      IdentifierSyntax
+//@[72:75)       Identifier |any|
+//@[75:76)      LeftParen |(|
+//@[76:80)      FunctionArgumentSyntax
+//@[76:80)       BooleanLiteralSyntax
+//@[76:80)        TrueKeyword |true|
+//@[80:81)      RightParen |)|
+//@[81:82)     RightSquare |]|
+//@[82:83)    Dot |.|
+//@[83:93)    IdentifierSyntax
+//@[83:93)     Identifier |properties|
+//@[93:94)   Dot |.|
+//@[94:94)   IdentifierSyntax
+//@[94:94)    SkippedTriviaSyntax
+//@[94:98) NewLine |\r\n\r\n|
+
+// #completionTest(86) -> cliPropertyAccessIndexesPlusSymbols_for
+//@[65:67) NewLine |\r\n|
+var discriminatorKeySetOneCompletions3_for = discriminatorKeySetOne_for[1].properties[]
+//@[0:87) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:42)  IdentifierSyntax
+//@[4:42)   Identifier |discriminatorKeySetOneCompletions3_for|
+//@[43:44)  Assignment |=|
+//@[45:87)  ArrayAccessSyntax
+//@[45:85)   PropertyAccessSyntax
+//@[45:74)    ArrayAccessSyntax
+//@[45:71)     VariableAccessSyntax
+//@[45:71)      IdentifierSyntax
+//@[45:71)       Identifier |discriminatorKeySetOne_for|
+//@[71:72)     LeftSquare |[|
+//@[72:73)     IntegerLiteralSyntax
+//@[72:73)      Integer |1|
+//@[73:74)     RightSquare |]|
+//@[74:75)    Dot |.|
+//@[75:85)    IdentifierSyntax
+//@[75:85)     Identifier |properties|
+//@[85:86)   LeftSquare |[|
+//@[86:86)   SkippedTriviaSyntax
+//@[86:87)   RightSquare |]|
+//@[87:91) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 2
+*/
+//@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:270) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
@@ -3038,6 +3582,296 @@ var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['pro
 //@[90:90)   IdentifierSyntax
 //@[90:90)    SkippedTriviaSyntax
 //@[90:94) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 2 (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[0:273) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:34)  IdentifierSyntax
+//@[9:34)   Identifier |discriminatorKeySetTwo_if|
+//@[35:85)  StringSyntax
+//@[35:85)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[86:87)  Assignment |=|
+//@[88:273)  ObjectSyntax
+//@[88:89)   LeftBrace |{|
+//@[89:91)   NewLine |\r\n|
+  kind: 'AzurePowerShell'
+//@[2:25)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |kind|
+//@[6:7)    Colon |:|
+//@[8:25)    StringSyntax
+//@[8:25)     StringComplete |'AzurePowerShell'|
+//@[25:27)   NewLine |\r\n|
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+//@[55:59)   NewLine |\r\n\r\n|
+
+  properties: {
+//@[2:93)   ObjectPropertySyntax
+//@[2:12)    IdentifierSyntax
+//@[2:12)     Identifier |properties|
+//@[12:13)    Colon |:|
+//@[14:93)    ObjectSyntax
+//@[14:15)     LeftBrace |{|
+//@[15:17)     NewLine |\r\n|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+//@[65:67)     NewLine |\r\n|
+    
+//@[4:6)     NewLine |\r\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(81) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions_if = discriminatorKeySetTwo_if.properties.a
+//@[0:81) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:40)  IdentifierSyntax
+//@[4:40)   Identifier |discriminatorKeySetTwoCompletions_if|
+//@[41:42)  Assignment |=|
+//@[43:81)  PropertyAccessSyntax
+//@[43:79)   PropertyAccessSyntax
+//@[43:68)    VariableAccessSyntax
+//@[43:68)     IdentifierSyntax
+//@[43:68)      Identifier |discriminatorKeySetTwo_if|
+//@[68:69)    Dot |.|
+//@[69:79)    IdentifierSyntax
+//@[69:79)     Identifier |properties|
+//@[79:80)   Dot |.|
+//@[80:81)   IdentifierSyntax
+//@[80:81)    Identifier |a|
+//@[81:83) NewLine |\r\n|
+// #completionTest(81) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions2_if = discriminatorKeySetTwo_if.properties.
+//@[0:81) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:41)  IdentifierSyntax
+//@[4:41)   Identifier |discriminatorKeySetTwoCompletions2_if|
+//@[42:43)  Assignment |=|
+//@[44:81)  PropertyAccessSyntax
+//@[44:80)   PropertyAccessSyntax
+//@[44:69)    VariableAccessSyntax
+//@[44:69)     IdentifierSyntax
+//@[44:69)      Identifier |discriminatorKeySetTwo_if|
+//@[69:70)    Dot |.|
+//@[70:80)    IdentifierSyntax
+//@[70:80)     Identifier |properties|
+//@[80:81)   Dot |.|
+//@[81:81)   IdentifierSyntax
+//@[81:81)    SkippedTriviaSyntax
+//@[81:85) NewLine |\r\n\r\n|
+
+// #completionTest(96) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer_if = discriminatorKeySetTwo_if['properties'].a
+//@[0:96) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:52)  IdentifierSyntax
+//@[4:52)   Identifier |discriminatorKeySetTwoCompletionsArrayIndexer_if|
+//@[53:54)  Assignment |=|
+//@[55:96)  PropertyAccessSyntax
+//@[55:94)   ArrayAccessSyntax
+//@[55:80)    VariableAccessSyntax
+//@[55:80)     IdentifierSyntax
+//@[55:80)      Identifier |discriminatorKeySetTwo_if|
+//@[80:81)    LeftSquare |[|
+//@[81:93)    StringSyntax
+//@[81:93)     StringComplete |'properties'|
+//@[93:94)    RightSquare |]|
+//@[94:95)   Dot |.|
+//@[95:96)   IdentifierSyntax
+//@[95:96)    Identifier |a|
+//@[96:98) NewLine |\r\n|
+// #completionTest(96) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer2_if = discriminatorKeySetTwo_if['properties'].
+//@[0:96) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:53)  IdentifierSyntax
+//@[4:53)   Identifier |discriminatorKeySetTwoCompletionsArrayIndexer2_if|
+//@[54:55)  Assignment |=|
+//@[56:96)  PropertyAccessSyntax
+//@[56:95)   ArrayAccessSyntax
+//@[56:81)    VariableAccessSyntax
+//@[56:81)     IdentifierSyntax
+//@[56:81)      Identifier |discriminatorKeySetTwo_if|
+//@[81:82)    LeftSquare |[|
+//@[82:94)    StringSyntax
+//@[82:94)     StringComplete |'properties'|
+//@[94:95)    RightSquare |]|
+//@[95:96)   Dot |.|
+//@[96:96)   IdentifierSyntax
+//@[96:96)    SkippedTriviaSyntax
+//@[96:100) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 2 (loops)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[0:293) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:35)  IdentifierSyntax
+//@[9:35)   Identifier |discriminatorKeySetTwo_for|
+//@[36:86)  StringSyntax
+//@[36:86)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[87:88)  Assignment |=|
+//@[89:293)  ForSyntax
+//@[89:90)   LeftSquare |[|
+//@[90:93)   Identifier |for|
+//@[94:99)   LocalVariableSyntax
+//@[94:99)    IdentifierSyntax
+//@[94:99)     Identifier |thing|
+//@[100:102)   Identifier |in|
+//@[103:105)   ArraySyntax
+//@[103:104)    LeftSquare |[|
+//@[104:105)    RightSquare |]|
+//@[105:106)   Colon |:|
+//@[107:292)   ObjectSyntax
+//@[107:108)    LeftBrace |{|
+//@[108:110)    NewLine |\r\n|
+  kind: 'AzurePowerShell'
+//@[2:25)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |kind|
+//@[6:7)     Colon |:|
+//@[8:25)     StringSyntax
+//@[8:25)      StringComplete |'AzurePowerShell'|
+//@[25:27)    NewLine |\r\n|
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+//@[55:59)    NewLine |\r\n\r\n|
+
+  properties: {
+//@[2:93)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:93)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+//@[65:67)      NewLine |\r\n|
+    
+//@[4:6)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// #completionTest(86) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions_for = discriminatorKeySetTwo_for[0].properties.a
+//@[0:86) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:41)  IdentifierSyntax
+//@[4:41)   Identifier |discriminatorKeySetTwoCompletions_for|
+//@[42:43)  Assignment |=|
+//@[44:86)  PropertyAccessSyntax
+//@[44:84)   PropertyAccessSyntax
+//@[44:73)    ArrayAccessSyntax
+//@[44:70)     VariableAccessSyntax
+//@[44:70)      IdentifierSyntax
+//@[44:70)       Identifier |discriminatorKeySetTwo_for|
+//@[70:71)     LeftSquare |[|
+//@[71:72)     IntegerLiteralSyntax
+//@[71:72)      Integer |0|
+//@[72:73)     RightSquare |]|
+//@[73:74)    Dot |.|
+//@[74:84)    IdentifierSyntax
+//@[74:84)     Identifier |properties|
+//@[84:85)   Dot |.|
+//@[85:86)   IdentifierSyntax
+//@[85:86)    Identifier |a|
+//@[86:88) NewLine |\r\n|
+// #completionTest(86) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions2_for = discriminatorKeySetTwo_for[0].properties.
+//@[0:86) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:42)  IdentifierSyntax
+//@[4:42)   Identifier |discriminatorKeySetTwoCompletions2_for|
+//@[43:44)  Assignment |=|
+//@[45:86)  PropertyAccessSyntax
+//@[45:85)   PropertyAccessSyntax
+//@[45:74)    ArrayAccessSyntax
+//@[45:71)     VariableAccessSyntax
+//@[45:71)      IdentifierSyntax
+//@[45:71)       Identifier |discriminatorKeySetTwo_for|
+//@[71:72)     LeftSquare |[|
+//@[72:73)     IntegerLiteralSyntax
+//@[72:73)      Integer |0|
+//@[73:74)     RightSquare |]|
+//@[74:75)    Dot |.|
+//@[75:85)    IdentifierSyntax
+//@[75:85)     Identifier |properties|
+//@[85:86)   Dot |.|
+//@[86:86)   IdentifierSyntax
+//@[86:86)    SkippedTriviaSyntax
+//@[86:90) NewLine |\r\n\r\n|
+
+// #completionTest(101) -> powershellPropertyAccess
+//@[51:53) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer_for = discriminatorKeySetTwo_for[0]['properties'].a
+//@[0:101) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:53)  IdentifierSyntax
+//@[4:53)   Identifier |discriminatorKeySetTwoCompletionsArrayIndexer_for|
+//@[54:55)  Assignment |=|
+//@[56:101)  PropertyAccessSyntax
+//@[56:99)   ArrayAccessSyntax
+//@[56:85)    ArrayAccessSyntax
+//@[56:82)     VariableAccessSyntax
+//@[56:82)      IdentifierSyntax
+//@[56:82)       Identifier |discriminatorKeySetTwo_for|
+//@[82:83)     LeftSquare |[|
+//@[83:84)     IntegerLiteralSyntax
+//@[83:84)      Integer |0|
+//@[84:85)     RightSquare |]|
+//@[85:86)    LeftSquare |[|
+//@[86:98)    StringSyntax
+//@[86:98)     StringComplete |'properties'|
+//@[98:99)    RightSquare |]|
+//@[99:100)   Dot |.|
+//@[100:101)   IdentifierSyntax
+//@[100:101)    Identifier |a|
+//@[101:103) NewLine |\r\n|
+// #completionTest(101) -> powershellPropertyAccess
+//@[51:53) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer2_for = discriminatorKeySetTwo_for[0]['properties'].
+//@[0:101) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:54)  IdentifierSyntax
+//@[4:54)   Identifier |discriminatorKeySetTwoCompletionsArrayIndexer2_for|
+//@[55:56)  Assignment |=|
+//@[57:101)  PropertyAccessSyntax
+//@[57:100)   ArrayAccessSyntax
+//@[57:86)    ArrayAccessSyntax
+//@[57:83)     VariableAccessSyntax
+//@[57:83)      IdentifierSyntax
+//@[57:83)       Identifier |discriminatorKeySetTwo_for|
+//@[83:84)     LeftSquare |[|
+//@[84:85)     IntegerLiteralSyntax
+//@[84:85)      Integer |0|
+//@[85:86)     RightSquare |]|
+//@[86:87)    LeftSquare |[|
+//@[87:99)    StringSyntax
+//@[87:99)     StringComplete |'properties'|
+//@[99:100)    RightSquare |]|
+//@[100:101)   Dot |.|
+//@[101:101)   IdentifierSyntax
+//@[101:101)    SkippedTriviaSyntax
+//@[101:109) NewLine |\r\n\r\n\r\n\r\n|
+
+
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:132) ResourceDeclarationSyntax
@@ -3319,6 +4153,10 @@ var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
 //@[78:78)    SkippedTriviaSyntax
 //@[78:82) NewLine |\r\n\r\n|
 
+/* 
+Nested discriminator missing key
+*/
+//@[2:4) NewLine |\r\n|
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[0:190) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
@@ -3427,6 +4265,275 @@ var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKe
 //@[95:96)   RightSquare |]|
 //@[96:100) NewLine |\r\n\r\n|
 
+/* 
+Nested discriminator missing key (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource nestedDiscriminatorMissingKey_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(bool(1)) {
+//@[0:205) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:41)  IdentifierSyntax
+//@[9:41)   Identifier |nestedDiscriminatorMissingKey_if|
+//@[42:100)  StringSyntax
+//@[42:100)   StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[101:102)  Assignment |=|
+//@[103:205)  IfConditionSyntax
+//@[103:105)   Identifier |if|
+//@[105:114)   ParenthesizedExpressionSyntax
+//@[105:106)    LeftParen |(|
+//@[106:113)    FunctionCallSyntax
+//@[106:110)     IdentifierSyntax
+//@[106:110)      Identifier |bool|
+//@[110:111)     LeftParen |(|
+//@[111:112)     FunctionArgumentSyntax
+//@[111:112)      IntegerLiteralSyntax
+//@[111:112)       Integer |1|
+//@[112:113)     RightParen |)|
+//@[113:114)    RightParen |)|
+//@[115:205)   ObjectSyntax
+//@[115:116)    LeftBrace |{|
+//@[116:118)    NewLine |\r\n|
+  name: 'test'
+//@[2:14)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:14)     StringSyntax
+//@[8:14)      StringComplete |'test'|
+//@[14:16)    NewLine |\r\n|
+  location: 'l'
+//@[2:15)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:15)     StringSyntax
+//@[12:15)      StringComplete |'l'|
+//@[15:17)    NewLine |\r\n|
+  properties: {
+//@[2:51)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:51)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    //createMode: 'Default'
+//@[27:31)      NewLine |\r\n\r\n|
+
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}
+//@[0:1)    RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(96) -> createMode
+//@[36:38) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions_if = nestedDiscriminatorMissingKey_if.properties.cr
+//@[0:96) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:47)  IdentifierSyntax
+//@[4:47)   Identifier |nestedDiscriminatorMissingKeyCompletions_if|
+//@[48:49)  Assignment |=|
+//@[50:96)  PropertyAccessSyntax
+//@[50:93)   PropertyAccessSyntax
+//@[50:82)    VariableAccessSyntax
+//@[50:82)     IdentifierSyntax
+//@[50:82)      Identifier |nestedDiscriminatorMissingKey_if|
+//@[82:83)    Dot |.|
+//@[83:93)    IdentifierSyntax
+//@[83:93)     Identifier |properties|
+//@[93:94)   Dot |.|
+//@[94:96)   IdentifierSyntax
+//@[94:96)    Identifier |cr|
+//@[96:98) NewLine |\r\n|
+// #completionTest(98) -> createMode
+//@[36:38) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions2_if = nestedDiscriminatorMissingKey_if['properties'].
+//@[0:98) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:48)  IdentifierSyntax
+//@[4:48)   Identifier |nestedDiscriminatorMissingKeyCompletions2_if|
+//@[49:50)  Assignment |=|
+//@[51:98)  PropertyAccessSyntax
+//@[51:97)   ArrayAccessSyntax
+//@[51:83)    VariableAccessSyntax
+//@[51:83)     IdentifierSyntax
+//@[51:83)      Identifier |nestedDiscriminatorMissingKey_if|
+//@[83:84)    LeftSquare |[|
+//@[84:96)    StringSyntax
+//@[84:96)     StringComplete |'properties'|
+//@[96:97)    RightSquare |]|
+//@[97:98)   Dot |.|
+//@[98:98)   IdentifierSyntax
+//@[98:98)    SkippedTriviaSyntax
+//@[98:102) NewLine |\r\n\r\n|
+
+// #completionTest(100) -> createModeIndexPlusSymbols_if
+//@[56:58) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyIndexCompletions_if = nestedDiscriminatorMissingKey_if.properties['']
+//@[0:102) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:52)  IdentifierSyntax
+//@[4:52)   Identifier |nestedDiscriminatorMissingKeyIndexCompletions_if|
+//@[53:54)  Assignment |=|
+//@[55:102)  ArrayAccessSyntax
+//@[55:98)   PropertyAccessSyntax
+//@[55:87)    VariableAccessSyntax
+//@[55:87)     IdentifierSyntax
+//@[55:87)      Identifier |nestedDiscriminatorMissingKey_if|
+//@[87:88)    Dot |.|
+//@[88:98)    IdentifierSyntax
+//@[88:98)     Identifier |properties|
+//@[98:99)   LeftSquare |[|
+//@[99:101)   StringSyntax
+//@[99:101)    StringComplete |''|
+//@[101:102)   RightSquare |]|
+//@[102:106) NewLine |\r\n\r\n|
+
+/* 
+Nested discriminator missing key (loop)
+*/
+//@[2:4) NewLine |\r\n|
+resource nestedDiscriminatorMissingKey_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+//@[0:213) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:42)  IdentifierSyntax
+//@[9:42)   Identifier |nestedDiscriminatorMissingKey_for|
+//@[43:101)  StringSyntax
+//@[43:101)   StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[102:103)  Assignment |=|
+//@[104:213)  ForSyntax
+//@[104:105)   LeftSquare |[|
+//@[105:108)   Identifier |for|
+//@[109:114)   LocalVariableSyntax
+//@[109:114)    IdentifierSyntax
+//@[109:114)     Identifier |thing|
+//@[115:117)   Identifier |in|
+//@[118:120)   ArraySyntax
+//@[118:119)    LeftSquare |[|
+//@[119:120)    RightSquare |]|
+//@[120:121)   Colon |:|
+//@[122:212)   ObjectSyntax
+//@[122:123)    LeftBrace |{|
+//@[123:125)    NewLine |\r\n|
+  name: 'test'
+//@[2:14)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:14)     StringSyntax
+//@[8:14)      StringComplete |'test'|
+//@[14:16)    NewLine |\r\n|
+  location: 'l'
+//@[2:15)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:15)     StringSyntax
+//@[12:15)      StringComplete |'l'|
+//@[15:17)    NewLine |\r\n|
+  properties: {
+//@[2:51)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:51)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    //createMode: 'Default'
+//@[27:31)      NewLine |\r\n\r\n|
+
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// #completionTest(101) -> createMode
+//@[37:39) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions_for = nestedDiscriminatorMissingKey_for[0].properties.cr
+//@[0:101) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:48)  IdentifierSyntax
+//@[4:48)   Identifier |nestedDiscriminatorMissingKeyCompletions_for|
+//@[49:50)  Assignment |=|
+//@[51:101)  PropertyAccessSyntax
+//@[51:98)   PropertyAccessSyntax
+//@[51:87)    ArrayAccessSyntax
+//@[51:84)     VariableAccessSyntax
+//@[51:84)      IdentifierSyntax
+//@[51:84)       Identifier |nestedDiscriminatorMissingKey_for|
+//@[84:85)     LeftSquare |[|
+//@[85:86)     IntegerLiteralSyntax
+//@[85:86)      Integer |0|
+//@[86:87)     RightSquare |]|
+//@[87:88)    Dot |.|
+//@[88:98)    IdentifierSyntax
+//@[88:98)     Identifier |properties|
+//@[98:99)   Dot |.|
+//@[99:101)   IdentifierSyntax
+//@[99:101)    Identifier |cr|
+//@[101:103) NewLine |\r\n|
+// #completionTest(103) -> createMode
+//@[37:39) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions2_for = nestedDiscriminatorMissingKey_for[0]['properties'].
+//@[0:103) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:49)  IdentifierSyntax
+//@[4:49)   Identifier |nestedDiscriminatorMissingKeyCompletions2_for|
+//@[50:51)  Assignment |=|
+//@[52:103)  PropertyAccessSyntax
+//@[52:102)   ArrayAccessSyntax
+//@[52:88)    ArrayAccessSyntax
+//@[52:85)     VariableAccessSyntax
+//@[52:85)      IdentifierSyntax
+//@[52:85)       Identifier |nestedDiscriminatorMissingKey_for|
+//@[85:86)     LeftSquare |[|
+//@[86:87)     IntegerLiteralSyntax
+//@[86:87)      Integer |0|
+//@[87:88)     RightSquare |]|
+//@[88:89)    LeftSquare |[|
+//@[89:101)    StringSyntax
+//@[89:101)     StringComplete |'properties'|
+//@[101:102)    RightSquare |]|
+//@[102:103)   Dot |.|
+//@[103:103)   IdentifierSyntax
+//@[103:103)    SkippedTriviaSyntax
+//@[103:107) NewLine |\r\n\r\n|
+
+// #completionTest(105) -> createModeIndexPlusSymbols_for
+//@[57:59) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyIndexCompletions_for = nestedDiscriminatorMissingKey_for[0].properties['']
+//@[0:107) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:53)  IdentifierSyntax
+//@[4:53)   Identifier |nestedDiscriminatorMissingKeyIndexCompletions_for|
+//@[54:55)  Assignment |=|
+//@[56:107)  ArrayAccessSyntax
+//@[56:103)   PropertyAccessSyntax
+//@[56:92)    ArrayAccessSyntax
+//@[56:89)     VariableAccessSyntax
+//@[56:89)      IdentifierSyntax
+//@[56:89)       Identifier |nestedDiscriminatorMissingKey_for|
+//@[89:90)     LeftSquare |[|
+//@[90:91)     IntegerLiteralSyntax
+//@[90:91)      Integer |0|
+//@[91:92)     RightSquare |]|
+//@[92:93)    Dot |.|
+//@[93:103)    IdentifierSyntax
+//@[93:103)     Identifier |properties|
+//@[103:104)   LeftSquare |[|
+//@[104:106)   StringSyntax
+//@[104:106)    StringComplete |''|
+//@[106:107)   RightSquare |]|
+//@[107:113) NewLine |\r\n\r\n\r\n|
+
+
+/*
+Nested discriminator
+*/
+//@[2:4) NewLine |\r\n|
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[0:178) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
@@ -3582,6 +4689,457 @@ var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
 //@[78:79)     Identifier |a|
 //@[79:80)   RightSquare |]|
 //@[80:84) NewLine |\r\n\r\n|
+
+/*
+Nested discriminator (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource nestedDiscriminator_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(true) {
+//@[0:190) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:31)  IdentifierSyntax
+//@[9:31)   Identifier |nestedDiscriminator_if|
+//@[32:90)  StringSyntax
+//@[32:90)   StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[91:92)  Assignment |=|
+//@[93:190)  IfConditionSyntax
+//@[93:95)   Identifier |if|
+//@[95:101)   ParenthesizedExpressionSyntax
+//@[95:96)    LeftParen |(|
+//@[96:100)    BooleanLiteralSyntax
+//@[96:100)     TrueKeyword |true|
+//@[100:101)    RightParen |)|
+//@[102:190)   ObjectSyntax
+//@[102:103)    LeftBrace |{|
+//@[103:105)    NewLine |\r\n|
+  name: 'test'
+//@[2:14)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:14)     StringSyntax
+//@[8:14)      StringComplete |'test'|
+//@[14:16)    NewLine |\r\n|
+  location: 'l'
+//@[2:15)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:15)     StringSyntax
+//@[12:15)      StringComplete |'l'|
+//@[15:17)    NewLine |\r\n|
+  properties: {
+//@[2:49)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:49)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    createMode: 'Default'
+//@[4:25)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |createMode|
+//@[14:15)       Colon |:|
+//@[16:25)       StringSyntax
+//@[16:25)        StringComplete |'Default'|
+//@[25:29)      NewLine |\r\n\r\n|
+
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}
+//@[0:1)    RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(75) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions_if = nestedDiscriminator_if.properties.a
+//@[0:75) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:37)  IdentifierSyntax
+//@[4:37)   Identifier |nestedDiscriminatorCompletions_if|
+//@[38:39)  Assignment |=|
+//@[40:75)  PropertyAccessSyntax
+//@[40:73)   PropertyAccessSyntax
+//@[40:62)    VariableAccessSyntax
+//@[40:62)     IdentifierSyntax
+//@[40:62)      Identifier |nestedDiscriminator_if|
+//@[62:63)    Dot |.|
+//@[63:73)    IdentifierSyntax
+//@[63:73)     Identifier |properties|
+//@[73:74)   Dot |.|
+//@[74:75)   IdentifierSyntax
+//@[74:75)    Identifier |a|
+//@[75:77) NewLine |\r\n|
+// #completionTest(79) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions2_if = nestedDiscriminator_if['properties'].a
+//@[0:79) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:38)  IdentifierSyntax
+//@[4:38)   Identifier |nestedDiscriminatorCompletions2_if|
+//@[39:40)  Assignment |=|
+//@[41:79)  PropertyAccessSyntax
+//@[41:77)   ArrayAccessSyntax
+//@[41:63)    VariableAccessSyntax
+//@[41:63)     IdentifierSyntax
+//@[41:63)      Identifier |nestedDiscriminator_if|
+//@[63:64)    LeftSquare |[|
+//@[64:76)    StringSyntax
+//@[64:76)     StringComplete |'properties'|
+//@[76:77)    RightSquare |]|
+//@[77:78)   Dot |.|
+//@[78:79)   IdentifierSyntax
+//@[78:79)    Identifier |a|
+//@[79:81) NewLine |\r\n|
+// #completionTest(75) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions3_if = nestedDiscriminator_if.properties.
+//@[0:75) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:38)  IdentifierSyntax
+//@[4:38)   Identifier |nestedDiscriminatorCompletions3_if|
+//@[39:40)  Assignment |=|
+//@[41:75)  PropertyAccessSyntax
+//@[41:74)   PropertyAccessSyntax
+//@[41:63)    VariableAccessSyntax
+//@[41:63)     IdentifierSyntax
+//@[41:63)      Identifier |nestedDiscriminator_if|
+//@[63:64)    Dot |.|
+//@[64:74)    IdentifierSyntax
+//@[64:74)     Identifier |properties|
+//@[74:75)   Dot |.|
+//@[75:75)   IdentifierSyntax
+//@[75:75)    SkippedTriviaSyntax
+//@[75:77) NewLine |\r\n|
+// #completionTest(78) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions4_if = nestedDiscriminator_if['properties'].
+//@[0:78) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:38)  IdentifierSyntax
+//@[4:38)   Identifier |nestedDiscriminatorCompletions4_if|
+//@[39:40)  Assignment |=|
+//@[41:78)  PropertyAccessSyntax
+//@[41:77)   ArrayAccessSyntax
+//@[41:63)    VariableAccessSyntax
+//@[41:63)     IdentifierSyntax
+//@[41:63)      Identifier |nestedDiscriminator_if|
+//@[63:64)    LeftSquare |[|
+//@[64:76)    StringSyntax
+//@[64:76)     StringComplete |'properties'|
+//@[76:77)    RightSquare |]|
+//@[77:78)   Dot |.|
+//@[78:78)   IdentifierSyntax
+//@[78:78)    SkippedTriviaSyntax
+//@[78:82) NewLine |\r\n\r\n|
+
+// #completionTest(85) -> defaultCreateModeIndexes_if
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorArrayIndexCompletions_if = nestedDiscriminator_if.properties[a]
+//@[0:86) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:47)  IdentifierSyntax
+//@[4:47)   Identifier |nestedDiscriminatorArrayIndexCompletions_if|
+//@[48:49)  Assignment |=|
+//@[50:86)  ArrayAccessSyntax
+//@[50:83)   PropertyAccessSyntax
+//@[50:72)    VariableAccessSyntax
+//@[50:72)     IdentifierSyntax
+//@[50:72)      Identifier |nestedDiscriminator_if|
+//@[72:73)    Dot |.|
+//@[73:83)    IdentifierSyntax
+//@[73:83)     Identifier |properties|
+//@[83:84)   LeftSquare |[|
+//@[84:85)   VariableAccessSyntax
+//@[84:85)    IdentifierSyntax
+//@[84:85)     Identifier |a|
+//@[85:86)   RightSquare |]|
+//@[86:92) NewLine |\r\n\r\n\r\n|
+
+
+/*
+Nested discriminator (loop)
+*/
+//@[2:4) NewLine |\r\n|
+resource nestedDiscriminator_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+//@[0:201) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:32)  IdentifierSyntax
+//@[9:32)   Identifier |nestedDiscriminator_for|
+//@[33:91)  StringSyntax
+//@[33:91)   StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[92:93)  Assignment |=|
+//@[94:201)  ForSyntax
+//@[94:95)   LeftSquare |[|
+//@[95:98)   Identifier |for|
+//@[99:104)   LocalVariableSyntax
+//@[99:104)    IdentifierSyntax
+//@[99:104)     Identifier |thing|
+//@[105:107)   Identifier |in|
+//@[108:110)   ArraySyntax
+//@[108:109)    LeftSquare |[|
+//@[109:110)    RightSquare |]|
+//@[110:111)   Colon |:|
+//@[112:200)   ObjectSyntax
+//@[112:113)    LeftBrace |{|
+//@[113:115)    NewLine |\r\n|
+  name: 'test'
+//@[2:14)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:14)     StringSyntax
+//@[8:14)      StringComplete |'test'|
+//@[14:16)    NewLine |\r\n|
+  location: 'l'
+//@[2:15)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:15)     StringSyntax
+//@[12:15)      StringComplete |'l'|
+//@[15:17)    NewLine |\r\n|
+  properties: {
+//@[2:49)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:49)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    createMode: 'Default'
+//@[4:25)      ObjectPropertySyntax
+//@[4:14)       IdentifierSyntax
+//@[4:14)        Identifier |createMode|
+//@[14:15)       Colon |:|
+//@[16:25)       StringSyntax
+//@[16:25)        StringComplete |'Default'|
+//@[25:29)      NewLine |\r\n\r\n|
+
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// #completionTest(80) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions_for = nestedDiscriminator_for[0].properties.a
+//@[0:80) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:38)  IdentifierSyntax
+//@[4:38)   Identifier |nestedDiscriminatorCompletions_for|
+//@[39:40)  Assignment |=|
+//@[41:80)  PropertyAccessSyntax
+//@[41:78)   PropertyAccessSyntax
+//@[41:67)    ArrayAccessSyntax
+//@[41:64)     VariableAccessSyntax
+//@[41:64)      IdentifierSyntax
+//@[41:64)       Identifier |nestedDiscriminator_for|
+//@[64:65)     LeftSquare |[|
+//@[65:66)     IntegerLiteralSyntax
+//@[65:66)      Integer |0|
+//@[66:67)     RightSquare |]|
+//@[67:68)    Dot |.|
+//@[68:78)    IdentifierSyntax
+//@[68:78)     Identifier |properties|
+//@[78:79)   Dot |.|
+//@[79:80)   IdentifierSyntax
+//@[79:80)    Identifier |a|
+//@[80:82) NewLine |\r\n|
+// #completionTest(84) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions2_for = nestedDiscriminator_for[0]['properties'].a
+//@[0:84) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:39)  IdentifierSyntax
+//@[4:39)   Identifier |nestedDiscriminatorCompletions2_for|
+//@[40:41)  Assignment |=|
+//@[42:84)  PropertyAccessSyntax
+//@[42:82)   ArrayAccessSyntax
+//@[42:68)    ArrayAccessSyntax
+//@[42:65)     VariableAccessSyntax
+//@[42:65)      IdentifierSyntax
+//@[42:65)       Identifier |nestedDiscriminator_for|
+//@[65:66)     LeftSquare |[|
+//@[66:67)     IntegerLiteralSyntax
+//@[66:67)      Integer |0|
+//@[67:68)     RightSquare |]|
+//@[68:69)    LeftSquare |[|
+//@[69:81)    StringSyntax
+//@[69:81)     StringComplete |'properties'|
+//@[81:82)    RightSquare |]|
+//@[82:83)   Dot |.|
+//@[83:84)   IdentifierSyntax
+//@[83:84)    Identifier |a|
+//@[84:86) NewLine |\r\n|
+// #completionTest(80) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions3_for = nestedDiscriminator_for[0].properties.
+//@[0:80) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:39)  IdentifierSyntax
+//@[4:39)   Identifier |nestedDiscriminatorCompletions3_for|
+//@[40:41)  Assignment |=|
+//@[42:80)  PropertyAccessSyntax
+//@[42:79)   PropertyAccessSyntax
+//@[42:68)    ArrayAccessSyntax
+//@[42:65)     VariableAccessSyntax
+//@[42:65)      IdentifierSyntax
+//@[42:65)       Identifier |nestedDiscriminator_for|
+//@[65:66)     LeftSquare |[|
+//@[66:67)     IntegerLiteralSyntax
+//@[66:67)      Integer |0|
+//@[67:68)     RightSquare |]|
+//@[68:69)    Dot |.|
+//@[69:79)    IdentifierSyntax
+//@[69:79)     Identifier |properties|
+//@[79:80)   Dot |.|
+//@[80:80)   IdentifierSyntax
+//@[80:80)    SkippedTriviaSyntax
+//@[80:82) NewLine |\r\n|
+// #completionTest(83) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions4_for = nestedDiscriminator_for[0]['properties'].
+//@[0:83) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:39)  IdentifierSyntax
+//@[4:39)   Identifier |nestedDiscriminatorCompletions4_for|
+//@[40:41)  Assignment |=|
+//@[42:83)  PropertyAccessSyntax
+//@[42:82)   ArrayAccessSyntax
+//@[42:68)    ArrayAccessSyntax
+//@[42:65)     VariableAccessSyntax
+//@[42:65)      IdentifierSyntax
+//@[42:65)       Identifier |nestedDiscriminator_for|
+//@[65:66)     LeftSquare |[|
+//@[66:67)     IntegerLiteralSyntax
+//@[66:67)      Integer |0|
+//@[67:68)     RightSquare |]|
+//@[68:69)    LeftSquare |[|
+//@[69:81)    StringSyntax
+//@[69:81)     StringComplete |'properties'|
+//@[81:82)    RightSquare |]|
+//@[82:83)   Dot |.|
+//@[83:83)   IdentifierSyntax
+//@[83:83)    SkippedTriviaSyntax
+//@[83:87) NewLine |\r\n\r\n|
+
+// #completionTest(90) -> defaultCreateModeIndexes_for
+//@[54:56) NewLine |\r\n|
+var nestedDiscriminatorArrayIndexCompletions_for = nestedDiscriminator_for[0].properties[a]
+//@[0:91) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:48)  IdentifierSyntax
+//@[4:48)   Identifier |nestedDiscriminatorArrayIndexCompletions_for|
+//@[49:50)  Assignment |=|
+//@[51:91)  ArrayAccessSyntax
+//@[51:88)   PropertyAccessSyntax
+//@[51:77)    ArrayAccessSyntax
+//@[51:74)     VariableAccessSyntax
+//@[51:74)      IdentifierSyntax
+//@[51:74)       Identifier |nestedDiscriminator_for|
+//@[74:75)     LeftSquare |[|
+//@[75:76)     IntegerLiteralSyntax
+//@[75:76)      Integer |0|
+//@[76:77)     RightSquare |]|
+//@[77:78)    Dot |.|
+//@[78:88)    IdentifierSyntax
+//@[78:88)     Identifier |properties|
+//@[88:89)   LeftSquare |[|
+//@[89:90)   VariableAccessSyntax
+//@[89:90)    IdentifierSyntax
+//@[89:90)     Identifier |a|
+//@[90:91)   RightSquare |]|
+//@[91:95) NewLine |\r\n\r\n|
+
+// sample resource to validate completions on the next declarations
+//@[67:69) NewLine |\r\n|
+resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@2020-06-01' = if(true) {
+//@[0:209) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:42)  IdentifierSyntax
+//@[9:42)   Identifier |nestedPropertyAccessOnConditional|
+//@[43:89)  StringSyntax
+//@[43:89)   StringComplete |'Microsoft.Compute/virtualMachines@2020-06-01'|
+//@[90:91)  Assignment |=|
+//@[92:209)  IfConditionSyntax
+//@[92:94)   Identifier |if|
+//@[94:100)   ParenthesizedExpressionSyntax
+//@[94:95)    LeftParen |(|
+//@[95:99)    BooleanLiteralSyntax
+//@[95:99)     TrueKeyword |true|
+//@[99:100)    RightParen |)|
+//@[101:209)   ObjectSyntax
+//@[101:102)    LeftBrace |{|
+//@[102:104)    NewLine |\r\n|
+  location: 'test'
+//@[2:18)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:18)     StringSyntax
+//@[12:18)      StringComplete |'test'|
+//@[18:20)    NewLine |\r\n|
+  name: 'test'
+//@[2:14)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:14)     StringSyntax
+//@[8:14)      StringComplete |'test'|
+//@[14:16)    NewLine |\r\n|
+  properties: {
+//@[2:66)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:66)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    additionalCapabilities: {
+//@[4:44)      ObjectPropertySyntax
+//@[4:26)       IdentifierSyntax
+//@[4:26)        Identifier |additionalCapabilities|
+//@[26:27)       Colon |:|
+//@[28:44)       ObjectSyntax
+//@[28:29)        LeftBrace |{|
+//@[29:31)        NewLine |\r\n|
+      
+//@[6:8)        NewLine |\r\n|
+    }
+//@[4:5)        RightBrace |}|
+//@[5:7)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}
+//@[0:1)    RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// this validates that we can get nested property access completions on a conditional resource
+//@[94:96) NewLine |\r\n|
+//#completionTest(56) -> vmProperties
+//@[37:39) NewLine |\r\n|
+var sigh = nestedPropertyAccessOnConditional.properties.
+//@[0:56) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:8)  IdentifierSyntax
+//@[4:8)   Identifier |sigh|
+//@[9:10)  Assignment |=|
+//@[11:56)  PropertyAccessSyntax
+//@[11:55)   PropertyAccessSyntax
+//@[11:44)    VariableAccessSyntax
+//@[11:44)     IdentifierSyntax
+//@[11:44)      Identifier |nestedPropertyAccessOnConditional|
+//@[44:45)    Dot |.|
+//@[45:55)    IdentifierSyntax
+//@[45:55)     Identifier |properties|
+//@[55:56)   Dot |.|
+//@[56:56)   IdentifierSyntax
+//@[56:56)    SkippedTriviaSyntax
+//@[56:60) NewLine |\r\n\r\n|
 
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
 //@[0:98) ResourceDeclarationSyntax
@@ -4008,4 +5566,1297 @@ resource cyclicExistingRes 'Mock.Rp/mockExistingResource@2020-01-01' existing = 
 //@[26:28)   NewLine |\r\n|
 }
 //@[0:1)   RightBrace |}|
-//@[1:1) EndOfFile ||
+//@[1:5) NewLine |\r\n\r\n|
+
+// loop parsing cases
+//@[21:23) NewLine |\r\n|
+resource expectedForKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = []
+//@[0:79) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:27)  IdentifierSyntax
+//@[9:27)   Identifier |expectedForKeyword|
+//@[28:74)  StringSyntax
+//@[28:74)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[75:76)  Assignment |=|
+//@[77:79)  SkippedTriviaSyntax
+//@[77:78)   LeftSquare |[|
+//@[78:79)   RightSquare |]|
+//@[79:83) NewLine |\r\n\r\n|
+
+resource expectedForKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [f]
+//@[0:81) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:28)  IdentifierSyntax
+//@[9:28)   Identifier |expectedForKeyword2|
+//@[29:75)  StringSyntax
+//@[29:75)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[76:77)  Assignment |=|
+//@[78:81)  SkippedTriviaSyntax
+//@[78:79)   LeftSquare |[|
+//@[79:80)   Identifier |f|
+//@[80:81)   RightSquare |]|
+//@[81:85) NewLine |\r\n\r\n|
+
+resource expectedLoopVar 'Microsoft.Storage/storageAccounts@2019-06-01' = [for]
+//@[0:79) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:24)  IdentifierSyntax
+//@[9:24)   Identifier |expectedLoopVar|
+//@[25:71)  StringSyntax
+//@[25:71)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[72:73)  Assignment |=|
+//@[74:79)  ForSyntax
+//@[74:75)   LeftSquare |[|
+//@[75:78)   Identifier |for|
+//@[78:78)   LocalVariableSyntax
+//@[78:78)    IdentifierSyntax
+//@[78:78)     SkippedTriviaSyntax
+//@[78:78)   SkippedTriviaSyntax
+//@[78:78)   SkippedTriviaSyntax
+//@[78:78)   SkippedTriviaSyntax
+//@[78:78)   SkippedTriviaSyntax
+//@[78:79)   RightSquare |]|
+//@[79:83) NewLine |\r\n\r\n|
+
+resource expectedInKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x]
+//@[0:83) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:26)  IdentifierSyntax
+//@[9:26)   Identifier |expectedInKeyword|
+//@[27:73)  StringSyntax
+//@[27:73)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[74:75)  Assignment |=|
+//@[76:83)  ForSyntax
+//@[76:77)   LeftSquare |[|
+//@[77:80)   Identifier |for|
+//@[81:82)   LocalVariableSyntax
+//@[81:82)    IdentifierSyntax
+//@[81:82)     Identifier |x|
+//@[82:82)   SkippedTriviaSyntax
+//@[82:82)   SkippedTriviaSyntax
+//@[82:82)   SkippedTriviaSyntax
+//@[82:82)   SkippedTriviaSyntax
+//@[82:83)   RightSquare |]|
+//@[83:87) NewLine |\r\n\r\n|
+
+resource expectedInKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x b]
+//@[0:86) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:27)  IdentifierSyntax
+//@[9:27)   Identifier |expectedInKeyword2|
+//@[28:74)  StringSyntax
+//@[28:74)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[75:76)  Assignment |=|
+//@[77:86)  ForSyntax
+//@[77:78)   LeftSquare |[|
+//@[78:81)   Identifier |for|
+//@[82:83)   LocalVariableSyntax
+//@[82:83)    IdentifierSyntax
+//@[82:83)     Identifier |x|
+//@[84:85)   SkippedTriviaSyntax
+//@[84:85)    Identifier |b|
+//@[85:85)   SkippedTriviaSyntax
+//@[85:85)   SkippedTriviaSyntax
+//@[85:85)   SkippedTriviaSyntax
+//@[85:86)   RightSquare |]|
+//@[86:90) NewLine |\r\n\r\n|
+
+resource expectedArrayExpression 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in]
+//@[0:92) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:32)  IdentifierSyntax
+//@[9:32)   Identifier |expectedArrayExpression|
+//@[33:79)  StringSyntax
+//@[33:79)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[80:81)  Assignment |=|
+//@[82:92)  ForSyntax
+//@[82:83)   LeftSquare |[|
+//@[83:86)   Identifier |for|
+//@[87:88)   LocalVariableSyntax
+//@[87:88)    IdentifierSyntax
+//@[87:88)     Identifier |x|
+//@[89:91)   Identifier |in|
+//@[91:91)   SkippedTriviaSyntax
+//@[91:91)   SkippedTriviaSyntax
+//@[91:91)   SkippedTriviaSyntax
+//@[91:92)   RightSquare |]|
+//@[92:96) NewLine |\r\n\r\n|
+
+resource expectedColon 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y]
+//@[0:84) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:22)  IdentifierSyntax
+//@[9:22)   Identifier |expectedColon|
+//@[23:69)  StringSyntax
+//@[23:69)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[70:71)  Assignment |=|
+//@[72:84)  ForSyntax
+//@[72:73)   LeftSquare |[|
+//@[73:76)   Identifier |for|
+//@[77:78)   LocalVariableSyntax
+//@[77:78)    IdentifierSyntax
+//@[77:78)     Identifier |x|
+//@[79:81)   Identifier |in|
+//@[82:83)   VariableAccessSyntax
+//@[82:83)    IdentifierSyntax
+//@[82:83)     Identifier |y|
+//@[83:83)   SkippedTriviaSyntax
+//@[83:83)   SkippedTriviaSyntax
+//@[83:84)   RightSquare |]|
+//@[84:88) NewLine |\r\n\r\n|
+
+resource expectedLoopBody 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y:]
+//@[0:88) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:25)  IdentifierSyntax
+//@[9:25)   Identifier |expectedLoopBody|
+//@[26:72)  StringSyntax
+//@[26:72)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[73:74)  Assignment |=|
+//@[75:88)  ForSyntax
+//@[75:76)   LeftSquare |[|
+//@[76:79)   Identifier |for|
+//@[80:81)   LocalVariableSyntax
+//@[80:81)    IdentifierSyntax
+//@[80:81)     Identifier |x|
+//@[82:84)   Identifier |in|
+//@[85:86)   VariableAccessSyntax
+//@[85:86)    IdentifierSyntax
+//@[85:86)     Identifier |y|
+//@[86:87)   Colon |:|
+//@[87:87)   SkippedTriviaSyntax
+//@[87:88)   RightSquare |]|
+//@[88:92) NewLine |\r\n\r\n|
+
+// loop semantic analysis cases
+//@[31:33) NewLine |\r\n|
+var emptyArray = []
+//@[0:19) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:14)  IdentifierSyntax
+//@[4:14)   Identifier |emptyArray|
+//@[15:16)  Assignment |=|
+//@[17:19)  ArraySyntax
+//@[17:18)   LeftSquare |[|
+//@[18:19)   RightSquare |]|
+//@[19:21) NewLine |\r\n|
+resource wrongLoopBodyType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in emptyArray:4]
+//@[0:99) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:26)  IdentifierSyntax
+//@[9:26)   Identifier |wrongLoopBodyType|
+//@[27:73)  StringSyntax
+//@[27:73)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[74:75)  Assignment |=|
+//@[76:99)  ForSyntax
+//@[76:77)   LeftSquare |[|
+//@[77:80)   Identifier |for|
+//@[81:82)   LocalVariableSyntax
+//@[81:82)    IdentifierSyntax
+//@[81:82)     Identifier |x|
+//@[83:85)   Identifier |in|
+//@[86:96)   VariableAccessSyntax
+//@[86:96)    IdentifierSyntax
+//@[86:96)     Identifier |emptyArray|
+//@[96:97)   Colon |:|
+//@[97:98)   IntegerLiteralSyntax
+//@[97:98)    Integer |4|
+//@[98:99)   RightSquare |]|
+//@[99:103) NewLine |\r\n\r\n|
+
+// errors in the array expression
+//@[33:35) NewLine |\r\n|
+resource arrayExpressionErrors 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in union([], 2): {
+//@[0:115) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:30)  IdentifierSyntax
+//@[9:30)   Identifier |arrayExpressionErrors|
+//@[31:77)  StringSyntax
+//@[31:77)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[78:79)  Assignment |=|
+//@[80:115)  ForSyntax
+//@[80:81)   LeftSquare |[|
+//@[81:84)   Identifier |for|
+//@[85:92)   LocalVariableSyntax
+//@[85:92)    IdentifierSyntax
+//@[85:92)     Identifier |account|
+//@[93:95)   Identifier |in|
+//@[96:108)   FunctionCallSyntax
+//@[96:101)    IdentifierSyntax
+//@[96:101)     Identifier |union|
+//@[101:102)    LeftParen |(|
+//@[102:105)    FunctionArgumentSyntax
+//@[102:104)     ArraySyntax
+//@[102:103)      LeftSquare |[|
+//@[103:104)      RightSquare |]|
+//@[104:105)     Comma |,|
+//@[106:107)    FunctionArgumentSyntax
+//@[106:107)     IntegerLiteralSyntax
+//@[106:107)      Integer |2|
+//@[107:108)    RightParen |)|
+//@[108:109)   Colon |:|
+//@[110:114)   ObjectSyntax
+//@[110:111)    LeftBrace |{|
+//@[111:113)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// wrong array type
+//@[19:21) NewLine |\r\n|
+var notAnArray = true
+//@[0:21) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:14)  IdentifierSyntax
+//@[4:14)   Identifier |notAnArray|
+//@[15:16)  Assignment |=|
+//@[17:21)  BooleanLiteralSyntax
+//@[17:21)   TrueKeyword |true|
+//@[21:23) NewLine |\r\n|
+resource wrongArrayType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in notAnArray: {
+//@[0:106) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:23)  IdentifierSyntax
+//@[9:23)   Identifier |wrongArrayType|
+//@[24:70)  StringSyntax
+//@[24:70)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[71:72)  Assignment |=|
+//@[73:106)  ForSyntax
+//@[73:74)   LeftSquare |[|
+//@[74:77)   Identifier |for|
+//@[78:85)   LocalVariableSyntax
+//@[78:85)    IdentifierSyntax
+//@[78:85)     Identifier |account|
+//@[86:88)   Identifier |in|
+//@[89:99)   VariableAccessSyntax
+//@[89:99)    IdentifierSyntax
+//@[89:99)     Identifier |notAnArray|
+//@[99:100)   Colon |:|
+//@[101:105)   ObjectSyntax
+//@[101:102)    LeftBrace |{|
+//@[102:104)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// missing required properties
+//@[30:32) NewLine |\r\n|
+resource missingRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+//@[0:109) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:34)  IdentifierSyntax
+//@[9:34)   Identifier |missingRequiredProperties|
+//@[35:81)  StringSyntax
+//@[35:81)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[82:83)  Assignment |=|
+//@[84:109)  ForSyntax
+//@[84:85)   LeftSquare |[|
+//@[85:88)   Identifier |for|
+//@[89:96)   LocalVariableSyntax
+//@[89:96)    IdentifierSyntax
+//@[89:96)     Identifier |account|
+//@[97:99)   Identifier |in|
+//@[100:102)   ArraySyntax
+//@[100:101)    LeftSquare |[|
+//@[101:102)    RightSquare |]|
+//@[102:103)   Colon |:|
+//@[104:108)   ObjectSyntax
+//@[104:105)    LeftBrace |{|
+//@[105:107)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// fewer missing required properties and a wrong property
+//@[57:59) NewLine |\r\n|
+resource missingFewerRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+//@[0:196) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:39)  IdentifierSyntax
+//@[9:39)   Identifier |missingFewerRequiredProperties|
+//@[40:86)  StringSyntax
+//@[40:86)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[87:88)  Assignment |=|
+//@[89:196)  ForSyntax
+//@[89:90)   LeftSquare |[|
+//@[90:93)   Identifier |for|
+//@[94:101)   LocalVariableSyntax
+//@[94:101)    IdentifierSyntax
+//@[94:101)     Identifier |account|
+//@[102:104)   Identifier |in|
+//@[105:107)   ArraySyntax
+//@[105:106)    LeftSquare |[|
+//@[106:107)    RightSquare |]|
+//@[107:108)   Colon |:|
+//@[109:195)   ObjectSyntax
+//@[109:110)    LeftBrace |{|
+//@[110:112)    NewLine |\r\n|
+  name: account
+//@[2:15)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:15)     VariableAccessSyntax
+//@[8:15)      IdentifierSyntax
+//@[8:15)       Identifier |account|
+//@[15:17)    NewLine |\r\n|
+  location: 'eastus42'
+//@[2:22)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:22)     StringSyntax
+//@[12:22)      StringComplete |'eastus42'|
+//@[22:24)    NewLine |\r\n|
+  properties: {
+//@[2:39)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:39)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    wrong: 'test'
+//@[4:17)      ObjectPropertySyntax
+//@[4:9)       IdentifierSyntax
+//@[4:9)        Identifier |wrong|
+//@[9:10)       Colon |:|
+//@[11:17)       StringSyntax
+//@[11:17)        StringComplete |'test'|
+//@[17:19)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// wrong property inside the nested property loop
+//@[49:51) NewLine |\r\n|
+resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[0:262) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:34)  IdentifierSyntax
+//@[9:34)   Identifier |wrongPropertyInNestedLoop|
+//@[35:81)  StringSyntax
+//@[35:81)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[82:83)  Assignment |=|
+//@[84:262)  ForSyntax
+//@[84:85)   LeftSquare |[|
+//@[85:88)   Identifier |for|
+//@[89:90)   LocalVariableSyntax
+//@[89:90)    IdentifierSyntax
+//@[89:90)     Identifier |i|
+//@[91:93)   Identifier |in|
+//@[94:105)   FunctionCallSyntax
+//@[94:99)    IdentifierSyntax
+//@[94:99)     Identifier |range|
+//@[99:100)    LeftParen |(|
+//@[100:102)    FunctionArgumentSyntax
+//@[100:101)     IntegerLiteralSyntax
+//@[100:101)      Integer |0|
+//@[101:102)     Comma |,|
+//@[103:104)    FunctionArgumentSyntax
+//@[103:104)     IntegerLiteralSyntax
+//@[103:104)      Integer |3|
+//@[104:105)    RightParen |)|
+//@[105:106)   Colon |:|
+//@[107:261)   ObjectSyntax
+//@[107:108)    LeftBrace |{|
+//@[108:110)    NewLine |\r\n|
+  name: 'vnet-${i}'
+//@[2:19)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:19)     StringSyntax
+//@[8:16)      StringLeftPiece |'vnet-${|
+//@[16:17)      VariableAccessSyntax
+//@[16:17)       IdentifierSyntax
+//@[16:17)        Identifier |i|
+//@[17:19)      StringRightPiece |}'|
+//@[19:21)    NewLine |\r\n|
+  properties: {
+//@[2:127)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:127)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    subnets: [for j in range(0, 4): {
+//@[4:105)      ObjectPropertySyntax
+//@[4:11)       IdentifierSyntax
+//@[4:11)        Identifier |subnets|
+//@[11:12)       Colon |:|
+//@[13:105)       ForSyntax
+//@[13:14)        LeftSquare |[|
+//@[14:17)        Identifier |for|
+//@[18:19)        LocalVariableSyntax
+//@[18:19)         IdentifierSyntax
+//@[18:19)          Identifier |j|
+//@[20:22)        Identifier |in|
+//@[23:34)        FunctionCallSyntax
+//@[23:28)         IdentifierSyntax
+//@[23:28)          Identifier |range|
+//@[28:29)         LeftParen |(|
+//@[29:31)         FunctionArgumentSyntax
+//@[29:30)          IntegerLiteralSyntax
+//@[29:30)           Integer |0|
+//@[30:31)          Comma |,|
+//@[32:33)         FunctionArgumentSyntax
+//@[32:33)          IntegerLiteralSyntax
+//@[32:33)           Integer |4|
+//@[33:34)         RightParen |)|
+//@[34:35)        Colon |:|
+//@[36:104)        ObjectSyntax
+//@[36:37)         LeftBrace |{|
+//@[37:39)         NewLine |\r\n|
+      doesNotExist: 'test'
+//@[6:26)         ObjectPropertySyntax
+//@[6:18)          IdentifierSyntax
+//@[6:18)           Identifier |doesNotExist|
+//@[18:19)          Colon |:|
+//@[20:26)          StringSyntax
+//@[20:26)           StringComplete |'test'|
+//@[26:28)         NewLine |\r\n|
+      name: 'subnet-${i}-${j}'
+//@[6:30)         ObjectPropertySyntax
+//@[6:10)          IdentifierSyntax
+//@[6:10)           Identifier |name|
+//@[10:11)          Colon |:|
+//@[12:30)          StringSyntax
+//@[12:22)           StringLeftPiece |'subnet-${|
+//@[22:23)           VariableAccessSyntax
+//@[22:23)            IdentifierSyntax
+//@[22:23)             Identifier |i|
+//@[23:27)           StringMiddlePiece |}-${|
+//@[27:28)           VariableAccessSyntax
+//@[27:28)            IdentifierSyntax
+//@[27:28)             Identifier |j|
+//@[28:30)           StringRightPiece |}'|
+//@[30:32)         NewLine |\r\n|
+    }]
+//@[4:5)         RightBrace |}|
+//@[5:6)        RightSquare |]|
+//@[6:8)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// duplicate identifiers within the loop
+//@[40:42) NewLine |\r\n|
+// (these duplicates are self-contained - usage of i above is allowed)
+//@[70:72) NewLine |\r\n|
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[0:239) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:39)  IdentifierSyntax
+//@[9:39)   Identifier |duplicateIdentifiersWithinLoop|
+//@[40:86)  StringSyntax
+//@[40:86)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[87:88)  Assignment |=|
+//@[89:239)  ForSyntax
+//@[89:90)   LeftSquare |[|
+//@[90:93)   Identifier |for|
+//@[94:95)   LocalVariableSyntax
+//@[94:95)    IdentifierSyntax
+//@[94:95)     Identifier |i|
+//@[96:98)   Identifier |in|
+//@[99:110)   FunctionCallSyntax
+//@[99:104)    IdentifierSyntax
+//@[99:104)     Identifier |range|
+//@[104:105)    LeftParen |(|
+//@[105:107)    FunctionArgumentSyntax
+//@[105:106)     IntegerLiteralSyntax
+//@[105:106)      Integer |0|
+//@[106:107)     Comma |,|
+//@[108:109)    FunctionArgumentSyntax
+//@[108:109)     IntegerLiteralSyntax
+//@[108:109)      Integer |3|
+//@[109:110)    RightParen |)|
+//@[110:111)   Colon |:|
+//@[112:238)   ObjectSyntax
+//@[112:113)    LeftBrace |{|
+//@[113:115)    NewLine |\r\n|
+  name: 'vnet-${i}'
+//@[2:19)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:19)     StringSyntax
+//@[8:16)      StringLeftPiece |'vnet-${|
+//@[16:17)      VariableAccessSyntax
+//@[16:17)       IdentifierSyntax
+//@[16:17)        Identifier |i|
+//@[17:19)      StringRightPiece |}'|
+//@[19:21)    NewLine |\r\n|
+  properties: {
+//@[2:99)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:99)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    subnets: [for i in range(0, 4): {
+//@[4:77)      ObjectPropertySyntax
+//@[4:11)       IdentifierSyntax
+//@[4:11)        Identifier |subnets|
+//@[11:12)       Colon |:|
+//@[13:77)       ForSyntax
+//@[13:14)        LeftSquare |[|
+//@[14:17)        Identifier |for|
+//@[18:19)        LocalVariableSyntax
+//@[18:19)         IdentifierSyntax
+//@[18:19)          Identifier |i|
+//@[20:22)        Identifier |in|
+//@[23:34)        FunctionCallSyntax
+//@[23:28)         IdentifierSyntax
+//@[23:28)          Identifier |range|
+//@[28:29)         LeftParen |(|
+//@[29:31)         FunctionArgumentSyntax
+//@[29:30)          IntegerLiteralSyntax
+//@[29:30)           Integer |0|
+//@[30:31)          Comma |,|
+//@[32:33)         FunctionArgumentSyntax
+//@[32:33)          IntegerLiteralSyntax
+//@[32:33)           Integer |4|
+//@[33:34)         RightParen |)|
+//@[34:35)        Colon |:|
+//@[36:76)        ObjectSyntax
+//@[36:37)         LeftBrace |{|
+//@[37:39)         NewLine |\r\n|
+      name: 'subnet-${i}-${i}'
+//@[6:30)         ObjectPropertySyntax
+//@[6:10)          IdentifierSyntax
+//@[6:10)           Identifier |name|
+//@[10:11)          Colon |:|
+//@[12:30)          StringSyntax
+//@[12:22)           StringLeftPiece |'subnet-${|
+//@[22:23)           VariableAccessSyntax
+//@[22:23)            IdentifierSyntax
+//@[22:23)             Identifier |i|
+//@[23:27)           StringMiddlePiece |}-${|
+//@[27:28)           VariableAccessSyntax
+//@[27:28)            IdentifierSyntax
+//@[27:28)             Identifier |i|
+//@[28:30)           StringRightPiece |}'|
+//@[30:32)         NewLine |\r\n|
+    }]
+//@[4:5)         RightBrace |}|
+//@[5:6)        RightSquare |]|
+//@[6:8)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// duplicate identifers in global and single loop scope
+//@[55:57) NewLine |\r\n|
+var someDuplicate = 'hello'
+//@[0:27) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:17)  IdentifierSyntax
+//@[4:17)   Identifier |someDuplicate|
+//@[18:19)  Assignment |=|
+//@[20:27)  StringSyntax
+//@[20:27)   StringComplete |'hello'|
+//@[27:29) NewLine |\r\n|
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+//@[0:260) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:36)  IdentifierSyntax
+//@[9:36)   Identifier |duplicateInGlobalAndOneLoop|
+//@[37:83)  StringSyntax
+//@[37:83)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[84:85)  Assignment |=|
+//@[86:260)  ForSyntax
+//@[86:87)   LeftSquare |[|
+//@[87:90)   Identifier |for|
+//@[91:104)   LocalVariableSyntax
+//@[91:104)    IdentifierSyntax
+//@[91:104)     Identifier |someDuplicate|
+//@[105:107)   Identifier |in|
+//@[108:119)   FunctionCallSyntax
+//@[108:113)    IdentifierSyntax
+//@[108:113)     Identifier |range|
+//@[113:114)    LeftParen |(|
+//@[114:116)    FunctionArgumentSyntax
+//@[114:115)     IntegerLiteralSyntax
+//@[114:115)      Integer |0|
+//@[115:116)     Comma |,|
+//@[117:118)    FunctionArgumentSyntax
+//@[117:118)     IntegerLiteralSyntax
+//@[117:118)      Integer |3|
+//@[118:119)    RightParen |)|
+//@[119:120)   Colon |:|
+//@[121:259)   ObjectSyntax
+//@[121:122)    LeftBrace |{|
+//@[122:124)    NewLine |\r\n|
+  name: 'vnet-${someDuplicate}'
+//@[2:31)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:31)     StringSyntax
+//@[8:16)      StringLeftPiece |'vnet-${|
+//@[16:29)      VariableAccessSyntax
+//@[16:29)       IdentifierSyntax
+//@[16:29)        Identifier |someDuplicate|
+//@[29:31)      StringRightPiece |}'|
+//@[31:33)    NewLine |\r\n|
+  properties: {
+//@[2:99)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:99)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    subnets: [for i in range(0, 4): {
+//@[4:77)      ObjectPropertySyntax
+//@[4:11)       IdentifierSyntax
+//@[4:11)        Identifier |subnets|
+//@[11:12)       Colon |:|
+//@[13:77)       ForSyntax
+//@[13:14)        LeftSquare |[|
+//@[14:17)        Identifier |for|
+//@[18:19)        LocalVariableSyntax
+//@[18:19)         IdentifierSyntax
+//@[18:19)          Identifier |i|
+//@[20:22)        Identifier |in|
+//@[23:34)        FunctionCallSyntax
+//@[23:28)         IdentifierSyntax
+//@[23:28)          Identifier |range|
+//@[28:29)         LeftParen |(|
+//@[29:31)         FunctionArgumentSyntax
+//@[29:30)          IntegerLiteralSyntax
+//@[29:30)           Integer |0|
+//@[30:31)          Comma |,|
+//@[32:33)         FunctionArgumentSyntax
+//@[32:33)          IntegerLiteralSyntax
+//@[32:33)           Integer |4|
+//@[33:34)         RightParen |)|
+//@[34:35)        Colon |:|
+//@[36:76)        ObjectSyntax
+//@[36:37)         LeftBrace |{|
+//@[37:39)         NewLine |\r\n|
+      name: 'subnet-${i}-${i}'
+//@[6:30)         ObjectPropertySyntax
+//@[6:10)          IdentifierSyntax
+//@[6:10)           Identifier |name|
+//@[10:11)          Colon |:|
+//@[12:30)          StringSyntax
+//@[12:22)           StringLeftPiece |'subnet-${|
+//@[22:23)           VariableAccessSyntax
+//@[22:23)            IdentifierSyntax
+//@[22:23)             Identifier |i|
+//@[23:27)           StringMiddlePiece |}-${|
+//@[27:28)           VariableAccessSyntax
+//@[27:28)            IdentifierSyntax
+//@[27:28)             Identifier |i|
+//@[28:30)           StringRightPiece |}'|
+//@[30:32)         NewLine |\r\n|
+    }]
+//@[4:5)         RightBrace |}|
+//@[5:6)        RightSquare |]|
+//@[6:8)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// duplicate in global and multiple loop scopes
+//@[47:49) NewLine |\r\n|
+var otherDuplicate = 'hello'
+//@[0:28) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:18)  IdentifierSyntax
+//@[4:18)   Identifier |otherDuplicate|
+//@[19:20)  Assignment |=|
+//@[21:28)  StringSyntax
+//@[21:28)   StringComplete |'hello'|
+//@[28:30) NewLine |\r\n|
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
+//@[0:284) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:37)  IdentifierSyntax
+//@[9:37)   Identifier |duplicateInGlobalAndTwoLoops|
+//@[38:84)  StringSyntax
+//@[38:84)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[85:86)  Assignment |=|
+//@[87:284)  ForSyntax
+//@[87:88)   LeftSquare |[|
+//@[88:91)   Identifier |for|
+//@[92:106)   LocalVariableSyntax
+//@[92:106)    IdentifierSyntax
+//@[92:106)     Identifier |otherDuplicate|
+//@[107:109)   Identifier |in|
+//@[110:121)   FunctionCallSyntax
+//@[110:115)    IdentifierSyntax
+//@[110:115)     Identifier |range|
+//@[115:116)    LeftParen |(|
+//@[116:118)    FunctionArgumentSyntax
+//@[116:117)     IntegerLiteralSyntax
+//@[116:117)      Integer |0|
+//@[117:118)     Comma |,|
+//@[119:120)    FunctionArgumentSyntax
+//@[119:120)     IntegerLiteralSyntax
+//@[119:120)      Integer |3|
+//@[120:121)    RightParen |)|
+//@[121:122)   Colon |:|
+//@[123:283)   ObjectSyntax
+//@[123:124)    LeftBrace |{|
+//@[124:126)    NewLine |\r\n|
+  name: 'vnet-${otherDuplicate}'
+//@[2:32)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:32)     StringSyntax
+//@[8:16)      StringLeftPiece |'vnet-${|
+//@[16:30)      VariableAccessSyntax
+//@[16:30)       IdentifierSyntax
+//@[16:30)        Identifier |otherDuplicate|
+//@[30:32)      StringRightPiece |}'|
+//@[32:34)    NewLine |\r\n|
+  properties: {
+//@[2:120)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:120)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    subnets: [for otherDuplicate in range(0, 4): {
+//@[4:98)      ObjectPropertySyntax
+//@[4:11)       IdentifierSyntax
+//@[4:11)        Identifier |subnets|
+//@[11:12)       Colon |:|
+//@[13:98)       ForSyntax
+//@[13:14)        LeftSquare |[|
+//@[14:17)        Identifier |for|
+//@[18:32)        LocalVariableSyntax
+//@[18:32)         IdentifierSyntax
+//@[18:32)          Identifier |otherDuplicate|
+//@[33:35)        Identifier |in|
+//@[36:47)        FunctionCallSyntax
+//@[36:41)         IdentifierSyntax
+//@[36:41)          Identifier |range|
+//@[41:42)         LeftParen |(|
+//@[42:44)         FunctionArgumentSyntax
+//@[42:43)          IntegerLiteralSyntax
+//@[42:43)           Integer |0|
+//@[43:44)          Comma |,|
+//@[45:46)         FunctionArgumentSyntax
+//@[45:46)          IntegerLiteralSyntax
+//@[45:46)           Integer |4|
+//@[46:47)         RightParen |)|
+//@[47:48)        Colon |:|
+//@[49:97)        ObjectSyntax
+//@[49:50)         LeftBrace |{|
+//@[50:52)         NewLine |\r\n|
+      name: 'subnet-${otherDuplicate}'
+//@[6:38)         ObjectPropertySyntax
+//@[6:10)          IdentifierSyntax
+//@[6:10)           Identifier |name|
+//@[10:11)          Colon |:|
+//@[12:38)          StringSyntax
+//@[12:22)           StringLeftPiece |'subnet-${|
+//@[22:36)           VariableAccessSyntax
+//@[22:36)            IdentifierSyntax
+//@[22:36)             Identifier |otherDuplicate|
+//@[36:38)           StringRightPiece |}'|
+//@[38:40)         NewLine |\r\n|
+    }]
+//@[4:5)         RightBrace |}|
+//@[5:6)        RightSquare |]|
+//@[6:8)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
+//@[119:121) NewLine |\r\n|
+var someDuplicate = true
+//@[0:24) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:17)  IdentifierSyntax
+//@[4:17)   Identifier |someDuplicate|
+//@[18:19)  Assignment |=|
+//@[20:24)  BooleanLiteralSyntax
+//@[20:24)   TrueKeyword |true|
+//@[24:26) NewLine |\r\n|
+var otherDuplicate = []
+//@[0:23) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:18)  IdentifierSyntax
+//@[4:18)   Identifier |otherDuplicate|
+//@[19:20)  Assignment |=|
+//@[21:23)  ArraySyntax
+//@[21:22)   LeftSquare |[|
+//@[22:23)   RightSquare |]|
+//@[23:25) NewLine |\r\n|
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+//@[0:299) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:37)  IdentifierSyntax
+//@[9:37)   Identifier |duplicateInGlobalAndTwoLoops|
+//@[38:84)  StringSyntax
+//@[38:84)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[85:86)  Assignment |=|
+//@[87:299)  ForSyntax
+//@[87:88)   LeftSquare |[|
+//@[88:91)   Identifier |for|
+//@[92:105)   LocalVariableSyntax
+//@[92:105)    IdentifierSyntax
+//@[92:105)     Identifier |someDuplicate|
+//@[106:108)   Identifier |in|
+//@[109:120)   FunctionCallSyntax
+//@[109:114)    IdentifierSyntax
+//@[109:114)     Identifier |range|
+//@[114:115)    LeftParen |(|
+//@[115:117)    FunctionArgumentSyntax
+//@[115:116)     IntegerLiteralSyntax
+//@[115:116)      Integer |0|
+//@[116:117)     Comma |,|
+//@[118:119)    FunctionArgumentSyntax
+//@[118:119)     IntegerLiteralSyntax
+//@[118:119)      Integer |3|
+//@[119:120)    RightParen |)|
+//@[120:121)   Colon |:|
+//@[122:298)   ObjectSyntax
+//@[122:123)    LeftBrace |{|
+//@[123:125)    NewLine |\r\n|
+  name: 'vnet-${someDuplicate}'
+//@[2:31)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:31)     StringSyntax
+//@[8:16)      StringLeftPiece |'vnet-${|
+//@[16:29)      VariableAccessSyntax
+//@[16:29)       IdentifierSyntax
+//@[16:29)        Identifier |someDuplicate|
+//@[29:31)      StringRightPiece |}'|
+//@[31:33)    NewLine |\r\n|
+  properties: {
+//@[2:137)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:137)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    subnets: [for otherDuplicate in range(0, 4): {
+//@[4:115)      ObjectPropertySyntax
+//@[4:11)       IdentifierSyntax
+//@[4:11)        Identifier |subnets|
+//@[11:12)       Colon |:|
+//@[13:115)       ForSyntax
+//@[13:14)        LeftSquare |[|
+//@[14:17)        Identifier |for|
+//@[18:32)        LocalVariableSyntax
+//@[18:32)         IdentifierSyntax
+//@[18:32)          Identifier |otherDuplicate|
+//@[33:35)        Identifier |in|
+//@[36:47)        FunctionCallSyntax
+//@[36:41)         IdentifierSyntax
+//@[36:41)          Identifier |range|
+//@[41:42)         LeftParen |(|
+//@[42:44)         FunctionArgumentSyntax
+//@[42:43)          IntegerLiteralSyntax
+//@[42:43)           Integer |0|
+//@[43:44)          Comma |,|
+//@[45:46)         FunctionArgumentSyntax
+//@[45:46)          IntegerLiteralSyntax
+//@[45:46)           Integer |4|
+//@[46:47)         RightParen |)|
+//@[47:48)        Colon |:|
+//@[49:114)        ObjectSyntax
+//@[49:50)         LeftBrace |{|
+//@[50:52)         NewLine |\r\n|
+      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+//@[6:55)         ObjectPropertySyntax
+//@[6:10)          IdentifierSyntax
+//@[6:10)           Identifier |name|
+//@[10:11)          Colon |:|
+//@[12:55)          StringSyntax
+//@[12:22)           StringLeftPiece |'subnet-${|
+//@[22:36)           VariableAccessSyntax
+//@[22:36)            IdentifierSyntax
+//@[22:36)             Identifier |otherDuplicate|
+//@[36:40)           StringMiddlePiece |}-${|
+//@[40:53)           VariableAccessSyntax
+//@[40:53)            IdentifierSyntax
+//@[40:53)             Identifier |someDuplicate|
+//@[53:55)           StringRightPiece |}'|
+//@[55:57)         NewLine |\r\n|
+    }]
+//@[4:5)         RightBrace |}|
+//@[5:6)        RightSquare |]|
+//@[6:8)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+/*
+  valid loop cases - this should be moved to Resources_* test case after codegen works
+*/ 
+//@[3:5) NewLine |\r\n|
+var storageAccounts = [
+//@[0:129) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:19)  IdentifierSyntax
+//@[4:19)   Identifier |storageAccounts|
+//@[20:21)  Assignment |=|
+//@[22:129)  ArraySyntax
+//@[22:23)   LeftSquare |[|
+//@[23:25)   NewLine |\r\n|
+  {
+//@[2:50)   ArrayItemSyntax
+//@[2:50)    ObjectSyntax
+//@[2:3)     LeftBrace |{|
+//@[3:5)     NewLine |\r\n|
+    name: 'one'
+//@[4:15)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:15)      StringSyntax
+//@[10:15)       StringComplete |'one'|
+//@[15:17)     NewLine |\r\n|
+    location: 'eastus2'
+//@[4:23)     ObjectPropertySyntax
+//@[4:12)      IdentifierSyntax
+//@[4:12)       Identifier |location|
+//@[12:13)      Colon |:|
+//@[14:23)      StringSyntax
+//@[14:23)       StringComplete |'eastus2'|
+//@[23:25)     NewLine |\r\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\r\n|
+  {
+//@[2:49)   ArrayItemSyntax
+//@[2:49)    ObjectSyntax
+//@[2:3)     LeftBrace |{|
+//@[3:5)     NewLine |\r\n|
+    name: 'two'
+//@[4:15)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:15)      StringSyntax
+//@[10:15)       StringComplete |'two'|
+//@[15:17)     NewLine |\r\n|
+    location: 'westus'
+//@[4:22)     ObjectPropertySyntax
+//@[4:12)      IdentifierSyntax
+//@[4:12)       Identifier |location|
+//@[12:13)      Colon |:|
+//@[14:22)      StringSyntax
+//@[14:22)       StringComplete |'westus'|
+//@[22:24)     NewLine |\r\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\r\n|
+]
+//@[0:1)   RightSquare |]|
+//@[1:3) NewLine |\r\n|
+// just a storage account loop
+//@[30:32) NewLine |\r\n|
+resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+//@[0:227) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:25)  IdentifierSyntax
+//@[9:25)   Identifier |storageResources|
+//@[26:72)  StringSyntax
+//@[26:72)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[73:74)  Assignment |=|
+//@[75:227)  ForSyntax
+//@[75:76)   LeftSquare |[|
+//@[76:79)   Identifier |for|
+//@[80:87)   LocalVariableSyntax
+//@[80:87)    IdentifierSyntax
+//@[80:87)     Identifier |account|
+//@[88:90)   Identifier |in|
+//@[91:106)   VariableAccessSyntax
+//@[91:106)    IdentifierSyntax
+//@[91:106)     Identifier |storageAccounts|
+//@[106:107)   Colon |:|
+//@[108:226)   ObjectSyntax
+//@[108:109)    LeftBrace |{|
+//@[109:111)    NewLine |\r\n|
+  name: account.name
+//@[2:20)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:20)     PropertyAccessSyntax
+//@[8:15)      VariableAccessSyntax
+//@[8:15)       IdentifierSyntax
+//@[8:15)        Identifier |account|
+//@[15:16)      Dot |.|
+//@[16:20)      IdentifierSyntax
+//@[16:20)       Identifier |name|
+//@[20:22)    NewLine |\r\n|
+  location: account.location
+//@[2:28)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:28)     PropertyAccessSyntax
+//@[12:19)      VariableAccessSyntax
+//@[12:19)       IdentifierSyntax
+//@[12:19)        Identifier |account|
+//@[19:20)      Dot |.|
+//@[20:28)      IdentifierSyntax
+//@[20:28)       Identifier |location|
+//@[28:30)    NewLine |\r\n|
+  sku: {
+//@[2:39)    ObjectPropertySyntax
+//@[2:5)     IdentifierSyntax
+//@[2:5)      Identifier |sku|
+//@[5:6)     Colon |:|
+//@[7:39)     ObjectSyntax
+//@[7:8)      LeftBrace |{|
+//@[8:10)      NewLine |\r\n|
+    name: 'Standard_LRS'
+//@[4:24)      ObjectPropertySyntax
+//@[4:8)       IdentifierSyntax
+//@[4:8)        Identifier |name|
+//@[8:9)       Colon |:|
+//@[10:24)       StringSyntax
+//@[10:24)        StringComplete |'Standard_LRS'|
+//@[24:26)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+  kind: 'StorageV2'
+//@[2:19)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |kind|
+//@[6:7)     Colon |:|
+//@[8:19)     StringSyntax
+//@[8:19)      StringComplete |'StorageV2'|
+//@[19:21)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// using the same loop variable in a new language scope should be allowed
+//@[73:75) NewLine |\r\n|
+resource premiumStorages 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+//@[0:271) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:24)  IdentifierSyntax
+//@[9:24)   Identifier |premiumStorages|
+//@[25:71)  StringSyntax
+//@[25:71)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[72:73)  Assignment |=|
+//@[74:271)  ForSyntax
+//@[74:75)   LeftSquare |[|
+//@[75:78)   Identifier |for|
+//@[79:86)   LocalVariableSyntax
+//@[79:86)    IdentifierSyntax
+//@[79:86)     Identifier |account|
+//@[87:89)   Identifier |in|
+//@[90:105)   VariableAccessSyntax
+//@[90:105)    IdentifierSyntax
+//@[90:105)     Identifier |storageAccounts|
+//@[105:106)   Colon |:|
+//@[107:270)   ObjectSyntax
+//@[107:108)    LeftBrace |{|
+//@[108:110)    NewLine |\r\n|
+  name: account.name
+//@[2:20)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:20)     PropertyAccessSyntax
+//@[8:15)      VariableAccessSyntax
+//@[8:15)       IdentifierSyntax
+//@[8:15)        Identifier |account|
+//@[15:16)      Dot |.|
+//@[16:20)      IdentifierSyntax
+//@[16:20)       Identifier |name|
+//@[20:22)    NewLine |\r\n|
+  location: account.location
+//@[2:28)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:28)     PropertyAccessSyntax
+//@[12:19)      VariableAccessSyntax
+//@[12:19)       IdentifierSyntax
+//@[12:19)        Identifier |account|
+//@[19:20)      Dot |.|
+//@[20:28)      IdentifierSyntax
+//@[20:28)       Identifier |location|
+//@[28:30)    NewLine |\r\n|
+  sku: {
+//@[2:84)    ObjectPropertySyntax
+//@[2:5)     IdentifierSyntax
+//@[2:5)      Identifier |sku|
+//@[5:6)     Colon |:|
+//@[7:84)     ObjectSyntax
+//@[7:8)      LeftBrace |{|
+//@[8:10)      NewLine |\r\n|
+    // #completionTest(9,10) -> storageSkuNamePlusSymbols
+//@[57:59)      NewLine |\r\n|
+    name: 
+//@[4:10)      ObjectPropertySyntax
+//@[4:8)       IdentifierSyntax
+//@[4:8)        Identifier |name|
+//@[8:9)       Colon |:|
+//@[10:10)       SkippedTriviaSyntax
+//@[10:12)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+  kind: 'StorageV2'
+//@[2:19)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |kind|
+//@[6:7)     Colon |:|
+//@[8:19)     StringSyntax
+//@[8:19)      StringComplete |'StorageV2'|
+//@[19:21)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// basic nested loop
+//@[20:22) NewLine |\r\n|
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[0:279) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:13)  IdentifierSyntax
+//@[9:13)   Identifier |vnet|
+//@[14:60)  StringSyntax
+//@[14:60)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[61:62)  Assignment |=|
+//@[63:279)  ForSyntax
+//@[63:64)   LeftSquare |[|
+//@[64:67)   Identifier |for|
+//@[68:69)   LocalVariableSyntax
+//@[68:69)    IdentifierSyntax
+//@[68:69)     Identifier |i|
+//@[70:72)   Identifier |in|
+//@[73:84)   FunctionCallSyntax
+//@[73:78)    IdentifierSyntax
+//@[73:78)     Identifier |range|
+//@[78:79)    LeftParen |(|
+//@[79:81)    FunctionArgumentSyntax
+//@[79:80)     IntegerLiteralSyntax
+//@[79:80)      Integer |0|
+//@[80:81)     Comma |,|
+//@[82:83)    FunctionArgumentSyntax
+//@[82:83)     IntegerLiteralSyntax
+//@[82:83)      Integer |3|
+//@[83:84)    RightParen |)|
+//@[84:85)   Colon |:|
+//@[86:278)   ObjectSyntax
+//@[86:87)    LeftBrace |{|
+//@[87:89)    NewLine |\r\n|
+  name: 'vnet-${i}'
+//@[2:19)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:19)     StringSyntax
+//@[8:16)      StringLeftPiece |'vnet-${|
+//@[16:17)      VariableAccessSyntax
+//@[16:17)       IdentifierSyntax
+//@[16:17)        Identifier |i|
+//@[17:19)      StringRightPiece |}'|
+//@[19:21)    NewLine |\r\n|
+  properties: {
+//@[2:165)    ObjectPropertySyntax
+//@[2:12)     IdentifierSyntax
+//@[2:12)      Identifier |properties|
+//@[12:13)     Colon |:|
+//@[14:165)     ObjectSyntax
+//@[14:15)      LeftBrace |{|
+//@[15:17)      NewLine |\r\n|
+    subnets: [for j in range(0, 4): {
+//@[4:143)      ObjectPropertySyntax
+//@[4:11)       IdentifierSyntax
+//@[4:11)        Identifier |subnets|
+//@[11:12)       Colon |:|
+//@[13:143)       ForSyntax
+//@[13:14)        LeftSquare |[|
+//@[14:17)        Identifier |for|
+//@[18:19)        LocalVariableSyntax
+//@[18:19)         IdentifierSyntax
+//@[18:19)          Identifier |j|
+//@[20:22)        Identifier |in|
+//@[23:34)        FunctionCallSyntax
+//@[23:28)         IdentifierSyntax
+//@[23:28)          Identifier |range|
+//@[28:29)         LeftParen |(|
+//@[29:31)         FunctionArgumentSyntax
+//@[29:30)          IntegerLiteralSyntax
+//@[29:30)           Integer |0|
+//@[30:31)          Comma |,|
+//@[32:33)         FunctionArgumentSyntax
+//@[32:33)          IntegerLiteralSyntax
+//@[32:33)           Integer |4|
+//@[33:34)         RightParen |)|
+//@[34:35)        Colon |:|
+//@[36:142)        ObjectSyntax
+//@[36:37)         LeftBrace |{|
+//@[37:39)         NewLine |\r\n|
+      // #completionTest(0,1,2,3,4,5,6) -> subnetIdAndProperties
+//@[64:66)         NewLine |\r\n|
+      name: 'subnet-${i}-${j}'
+//@[6:30)         ObjectPropertySyntax
+//@[6:10)          IdentifierSyntax
+//@[6:10)           Identifier |name|
+//@[10:11)          Colon |:|
+//@[12:30)          StringSyntax
+//@[12:22)           StringLeftPiece |'subnet-${|
+//@[22:23)           VariableAccessSyntax
+//@[22:23)            IdentifierSyntax
+//@[22:23)             Identifier |i|
+//@[23:27)           StringMiddlePiece |}-${|
+//@[27:28)           VariableAccessSyntax
+//@[27:28)            IdentifierSyntax
+//@[27:28)             Identifier |j|
+//@[28:30)           StringRightPiece |}'|
+//@[30:32)         NewLine |\r\n|
+    }]
+//@[4:5)         RightBrace |}|
+//@[5:6)        RightSquare |]|
+//@[6:8)      NewLine |\r\n|
+  }
+//@[2:3)      RightBrace |}|
+//@[3:5)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:2) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -3932,10 +3932,117 @@ resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01
 //@[1:2) RightSquare |]|
 //@[2:6) NewLine |\r\n\r\n|
 
-// duplicate identifiers within the loop
+// nonexistent arrays and loop variables
 //@[40:42) NewLine |\r\n|
-// (these duplicates are self-contained - usage of i above is allowed)
-//@[70:72) NewLine |\r\n|
+resource nonexistentArrays 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in notAThing: {
+//@[0:8) Identifier |resource|
+//@[9:26) Identifier |nonexistentArrays|
+//@[27:73) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[74:75) Assignment |=|
+//@[76:77) LeftSquare |[|
+//@[77:80) Identifier |for|
+//@[81:82) Identifier |i|
+//@[83:85) Identifier |in|
+//@[86:95) Identifier |notAThing|
+//@[95:96) Colon |:|
+//@[97:98) LeftBrace |{|
+//@[98:100) NewLine |\r\n|
+  name: 'vnet-${justPlainWrong}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:16) StringLeftPiece |'vnet-${|
+//@[16:30) Identifier |justPlainWrong|
+//@[30:32) StringRightPiece |}'|
+//@[32:34) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    subnets: [for j in alsoNotAThing: {
+//@[4:11) Identifier |subnets|
+//@[11:12) Colon |:|
+//@[13:14) LeftSquare |[|
+//@[14:17) Identifier |for|
+//@[18:19) Identifier |j|
+//@[20:22) Identifier |in|
+//@[23:36) Identifier |alsoNotAThing|
+//@[36:37) Colon |:|
+//@[38:39) LeftBrace |{|
+//@[39:41) NewLine |\r\n|
+      doesNotExist: 'test'
+//@[6:18) Identifier |doesNotExist|
+//@[18:19) Colon |:|
+//@[20:26) StringComplete |'test'|
+//@[26:28) NewLine |\r\n|
+      name: 'subnet-${fake}-${totallyFake}'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:22) StringLeftPiece |'subnet-${|
+//@[22:26) Identifier |fake|
+//@[26:30) StringMiddlePiece |}-${|
+//@[30:41) Identifier |totallyFake|
+//@[41:43) StringRightPiece |}'|
+//@[43:45) NewLine |\r\n|
+    }]
+//@[4:5) RightBrace |}|
+//@[5:6) RightSquare |]|
+//@[6:8) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+/*
+  valid loop cases - this should be moved to Resources_* test case after codegen works
+*/ 
+//@[3:5) NewLine |\r\n|
+var storageAccounts = [
+//@[0:3) Identifier |var|
+//@[4:19) Identifier |storageAccounts|
+//@[20:21) Assignment |=|
+//@[22:23) LeftSquare |[|
+//@[23:25) NewLine |\r\n|
+  {
+//@[2:3) LeftBrace |{|
+//@[3:5) NewLine |\r\n|
+    name: 'one'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:15) StringComplete |'one'|
+//@[15:17) NewLine |\r\n|
+    location: 'eastus2'
+//@[4:12) Identifier |location|
+//@[12:13) Colon |:|
+//@[14:23) StringComplete |'eastus2'|
+//@[23:25) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+  {
+//@[2:3) LeftBrace |{|
+//@[3:5) NewLine |\r\n|
+    name: 'two'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:15) StringComplete |'two'|
+//@[15:17) NewLine |\r\n|
+    location: 'westus'
+//@[4:12) Identifier |location|
+//@[12:13) Colon |:|
+//@[14:22) StringComplete |'westus'|
+//@[22:24) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+]
+//@[0:1) RightSquare |]|
+//@[1:3) NewLine |\r\n|
+// duplicate identifiers within the loop are allowed
+//@[52:54) NewLine |\r\n|
 resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
 //@[0:8) Identifier |resource|
 //@[9:39) Identifier |duplicateIdentifiersWithinLoop|
@@ -4001,41 +4108,40 @@ resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-
 }]
 //@[0:1) RightBrace |}|
 //@[1:2) RightSquare |]|
-//@[2:6) NewLine |\r\n\r\n|
-
-// duplicate identifers in global and single loop scope
-//@[55:57) NewLine |\r\n|
-var someDuplicate = 'hello'
+//@[2:4) NewLine |\r\n|
+// duplicate identifers in global and single loop scope are allowed (inner variable hides the outer)
+//@[100:102) NewLine |\r\n|
+var canHaveDuplicatesAcrossScopes = 'hello'
 //@[0:3) Identifier |var|
-//@[4:17) Identifier |someDuplicate|
-//@[18:19) Assignment |=|
-//@[20:27) StringComplete |'hello'|
-//@[27:29) NewLine |\r\n|
-resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+//@[4:33) Identifier |canHaveDuplicatesAcrossScopes|
+//@[34:35) Assignment |=|
+//@[36:43) StringComplete |'hello'|
+//@[43:45) NewLine |\r\n|
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
 //@[0:8) Identifier |resource|
 //@[9:36) Identifier |duplicateInGlobalAndOneLoop|
 //@[37:83) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
 //@[84:85) Assignment |=|
 //@[86:87) LeftSquare |[|
 //@[87:90) Identifier |for|
-//@[91:104) Identifier |someDuplicate|
-//@[105:107) Identifier |in|
-//@[108:113) Identifier |range|
-//@[113:114) LeftParen |(|
-//@[114:115) Integer |0|
-//@[115:116) Comma |,|
-//@[117:118) Integer |3|
-//@[118:119) RightParen |)|
-//@[119:120) Colon |:|
-//@[121:122) LeftBrace |{|
-//@[122:124) NewLine |\r\n|
-  name: 'vnet-${someDuplicate}'
+//@[91:120) Identifier |canHaveDuplicatesAcrossScopes|
+//@[121:123) Identifier |in|
+//@[124:129) Identifier |range|
+//@[129:130) LeftParen |(|
+//@[130:131) Integer |0|
+//@[131:132) Comma |,|
+//@[133:134) Integer |3|
+//@[134:135) RightParen |)|
+//@[135:136) Colon |:|
+//@[137:138) LeftBrace |{|
+//@[138:140) NewLine |\r\n|
+  name: 'vnet-${canHaveDuplicatesAcrossScopes}'
 //@[2:6) Identifier |name|
 //@[6:7) Colon |:|
 //@[8:16) StringLeftPiece |'vnet-${|
-//@[16:29) Identifier |someDuplicate|
-//@[29:31) StringRightPiece |}'|
-//@[31:33) NewLine |\r\n|
+//@[16:45) Identifier |canHaveDuplicatesAcrossScopes|
+//@[45:47) StringRightPiece |}'|
+//@[47:49) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -4076,151 +4182,68 @@ resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-
 }]
 //@[0:1) RightBrace |}|
 //@[1:2) RightSquare |]|
-//@[2:6) NewLine |\r\n\r\n|
-
-// duplicate in global and multiple loop scopes
-//@[47:49) NewLine |\r\n|
-var otherDuplicate = 'hello'
+//@[2:4) NewLine |\r\n|
+// duplicate in global and multiple loop scopes are allowed (inner hides the outer)
+//@[83:85) NewLine |\r\n|
+var duplicatesEverywhere = 'hello'
 //@[0:3) Identifier |var|
-//@[4:18) Identifier |otherDuplicate|
-//@[19:20) Assignment |=|
-//@[21:28) StringComplete |'hello'|
-//@[28:30) NewLine |\r\n|
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
+//@[4:24) Identifier |duplicatesEverywhere|
+//@[25:26) Assignment |=|
+//@[27:34) StringComplete |'hello'|
+//@[34:36) NewLine |\r\n|
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
 //@[0:8) Identifier |resource|
 //@[9:37) Identifier |duplicateInGlobalAndTwoLoops|
 //@[38:84) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
 //@[85:86) Assignment |=|
 //@[87:88) LeftSquare |[|
 //@[88:91) Identifier |for|
-//@[92:106) Identifier |otherDuplicate|
-//@[107:109) Identifier |in|
-//@[110:115) Identifier |range|
-//@[115:116) LeftParen |(|
-//@[116:117) Integer |0|
-//@[117:118) Comma |,|
-//@[119:120) Integer |3|
-//@[120:121) RightParen |)|
-//@[121:122) Colon |:|
-//@[123:124) LeftBrace |{|
-//@[124:126) NewLine |\r\n|
-  name: 'vnet-${otherDuplicate}'
+//@[92:112) Identifier |duplicatesEverywhere|
+//@[113:115) Identifier |in|
+//@[116:121) Identifier |range|
+//@[121:122) LeftParen |(|
+//@[122:123) Integer |0|
+//@[123:124) Comma |,|
+//@[125:126) Integer |3|
+//@[126:127) RightParen |)|
+//@[127:128) Colon |:|
+//@[129:130) LeftBrace |{|
+//@[130:132) NewLine |\r\n|
+  name: 'vnet-${duplicatesEverywhere}'
 //@[2:6) Identifier |name|
 //@[6:7) Colon |:|
 //@[8:16) StringLeftPiece |'vnet-${|
-//@[16:30) Identifier |otherDuplicate|
-//@[30:32) StringRightPiece |}'|
-//@[32:34) NewLine |\r\n|
-  properties: {
-//@[2:12) Identifier |properties|
-//@[12:13) Colon |:|
-//@[14:15) LeftBrace |{|
-//@[15:17) NewLine |\r\n|
-    subnets: [for otherDuplicate in range(0, 4): {
-//@[4:11) Identifier |subnets|
-//@[11:12) Colon |:|
-//@[13:14) LeftSquare |[|
-//@[14:17) Identifier |for|
-//@[18:32) Identifier |otherDuplicate|
-//@[33:35) Identifier |in|
-//@[36:41) Identifier |range|
-//@[41:42) LeftParen |(|
-//@[42:43) Integer |0|
-//@[43:44) Comma |,|
-//@[45:46) Integer |4|
-//@[46:47) RightParen |)|
-//@[47:48) Colon |:|
-//@[49:50) LeftBrace |{|
-//@[50:52) NewLine |\r\n|
-      name: 'subnet-${otherDuplicate}'
-//@[6:10) Identifier |name|
-//@[10:11) Colon |:|
-//@[12:22) StringLeftPiece |'subnet-${|
-//@[22:36) Identifier |otherDuplicate|
+//@[16:36) Identifier |duplicatesEverywhere|
 //@[36:38) StringRightPiece |}'|
 //@[38:40) NewLine |\r\n|
-    }]
-//@[4:5) RightBrace |}|
-//@[5:6) RightSquare |]|
-//@[6:8) NewLine |\r\n|
-  }
-//@[2:3) RightBrace |}|
-//@[3:5) NewLine |\r\n|
-}]
-//@[0:1) RightBrace |}|
-//@[1:2) RightSquare |]|
-//@[2:6) NewLine |\r\n\r\n|
-
-// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
-//@[119:121) NewLine |\r\n|
-var someDuplicate = true
-//@[0:3) Identifier |var|
-//@[4:17) Identifier |someDuplicate|
-//@[18:19) Assignment |=|
-//@[20:24) TrueKeyword |true|
-//@[24:26) NewLine |\r\n|
-var otherDuplicate = []
-//@[0:3) Identifier |var|
-//@[4:18) Identifier |otherDuplicate|
-//@[19:20) Assignment |=|
-//@[21:22) LeftSquare |[|
-//@[22:23) RightSquare |]|
-//@[23:25) NewLine |\r\n|
-resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
-//@[0:8) Identifier |resource|
-//@[9:37) Identifier |duplicateInGlobalAndTwoLoops|
-//@[38:84) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
-//@[85:86) Assignment |=|
-//@[87:88) LeftSquare |[|
-//@[88:91) Identifier |for|
-//@[92:105) Identifier |someDuplicate|
-//@[106:108) Identifier |in|
-//@[109:114) Identifier |range|
-//@[114:115) LeftParen |(|
-//@[115:116) Integer |0|
-//@[116:117) Comma |,|
-//@[118:119) Integer |3|
-//@[119:120) RightParen |)|
-//@[120:121) Colon |:|
-//@[122:123) LeftBrace |{|
-//@[123:125) NewLine |\r\n|
-  name: 'vnet-${someDuplicate}'
-//@[2:6) Identifier |name|
-//@[6:7) Colon |:|
-//@[8:16) StringLeftPiece |'vnet-${|
-//@[16:29) Identifier |someDuplicate|
-//@[29:31) StringRightPiece |}'|
-//@[31:33) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
 //@[14:15) LeftBrace |{|
 //@[15:17) NewLine |\r\n|
-    subnets: [for otherDuplicate in range(0, 4): {
+    subnets: [for duplicatesEverywhere in range(0, 4): {
 //@[4:11) Identifier |subnets|
 //@[11:12) Colon |:|
 //@[13:14) LeftSquare |[|
 //@[14:17) Identifier |for|
-//@[18:32) Identifier |otherDuplicate|
-//@[33:35) Identifier |in|
-//@[36:41) Identifier |range|
-//@[41:42) LeftParen |(|
-//@[42:43) Integer |0|
-//@[43:44) Comma |,|
-//@[45:46) Integer |4|
-//@[46:47) RightParen |)|
-//@[47:48) Colon |:|
-//@[49:50) LeftBrace |{|
-//@[50:52) NewLine |\r\n|
-      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+//@[18:38) Identifier |duplicatesEverywhere|
+//@[39:41) Identifier |in|
+//@[42:47) Identifier |range|
+//@[47:48) LeftParen |(|
+//@[48:49) Integer |0|
+//@[49:50) Comma |,|
+//@[51:52) Integer |4|
+//@[52:53) RightParen |)|
+//@[53:54) Colon |:|
+//@[55:56) LeftBrace |{|
+//@[56:58) NewLine |\r\n|
+      name: 'subnet-${duplicatesEverywhere}'
 //@[6:10) Identifier |name|
 //@[10:11) Colon |:|
 //@[12:22) StringLeftPiece |'subnet-${|
-//@[22:36) Identifier |otherDuplicate|
-//@[36:40) StringMiddlePiece |}-${|
-//@[40:53) Identifier |someDuplicate|
-//@[53:55) StringRightPiece |}'|
-//@[55:57) NewLine |\r\n|
+//@[22:42) Identifier |duplicatesEverywhere|
+//@[42:44) StringRightPiece |}'|
+//@[44:46) NewLine |\r\n|
     }]
 //@[4:5) RightBrace |}|
 //@[5:6) RightSquare |]|
@@ -4231,53 +4254,7 @@ resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06
 }]
 //@[0:1) RightBrace |}|
 //@[1:2) RightSquare |]|
-//@[2:6) NewLine |\r\n\r\n|
-
-/*
-  valid loop cases - this should be moved to Resources_* test case after codegen works
-*/ 
-//@[3:5) NewLine |\r\n|
-var storageAccounts = [
-//@[0:3) Identifier |var|
-//@[4:19) Identifier |storageAccounts|
-//@[20:21) Assignment |=|
-//@[22:23) LeftSquare |[|
-//@[23:25) NewLine |\r\n|
-  {
-//@[2:3) LeftBrace |{|
-//@[3:5) NewLine |\r\n|
-    name: 'one'
-//@[4:8) Identifier |name|
-//@[8:9) Colon |:|
-//@[10:15) StringComplete |'one'|
-//@[15:17) NewLine |\r\n|
-    location: 'eastus2'
-//@[4:12) Identifier |location|
-//@[12:13) Colon |:|
-//@[14:23) StringComplete |'eastus2'|
-//@[23:25) NewLine |\r\n|
-  }
-//@[2:3) RightBrace |}|
-//@[3:5) NewLine |\r\n|
-  {
-//@[2:3) LeftBrace |{|
-//@[3:5) NewLine |\r\n|
-    name: 'two'
-//@[4:8) Identifier |name|
-//@[8:9) Colon |:|
-//@[10:15) StringComplete |'two'|
-//@[15:17) NewLine |\r\n|
-    location: 'westus'
-//@[4:12) Identifier |location|
-//@[12:13) Colon |:|
-//@[14:22) StringComplete |'westus'|
-//@[22:24) NewLine |\r\n|
-  }
-//@[2:3) RightBrace |}|
-//@[3:5) NewLine |\r\n|
-]
-//@[0:1) RightSquare |]|
-//@[1:3) NewLine |\r\n|
+//@[2:4) NewLine |\r\n|
 // just a storage account loop
 //@[30:32) NewLine |\r\n|
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -1746,6 +1746,10 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 //@[0:1) RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
 
+/*
+Discriminator key missing
+*/
+//@[2:4) NewLine |\r\n|
 resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:8) Identifier |resource|
 //@[9:32) Identifier |discriminatorKeyMissing|
@@ -1761,6 +1765,60 @@ resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-
 //@[0:1) RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
 
+/*
+Discriminator key missing (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeyMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(true) {
+//@[0:8) Identifier |resource|
+//@[9:35) Identifier |discriminatorKeyMissing_if|
+//@[36:86) StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[87:88) Assignment |=|
+//@[89:91) Identifier |if|
+//@[91:92) LeftParen |(|
+//@[92:96) TrueKeyword |true|
+//@[96:97) RightParen |)|
+//@[98:99) LeftBrace |{|
+//@[99:101) NewLine |\r\n|
+  // #completionTest(0,1,2) -> discriminatorProperty
+//@[52:54) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
+/*
+Discriminator key missing (loop)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeyMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[0:8) Identifier |resource|
+//@[9:36) Identifier |discriminatorKeyMissing_for|
+//@[37:87) StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[88:89) Assignment |=|
+//@[90:91) LeftSquare |[|
+//@[91:94) Identifier |for|
+//@[95:100) Identifier |thing|
+//@[101:103) Identifier |in|
+//@[104:105) LeftSquare |[|
+//@[105:106) RightSquare |]|
+//@[106:107) Colon |:|
+//@[108:109) LeftBrace |{|
+//@[109:111) NewLine |\r\n|
+  // #completionTest(0,1,2) -> discriminatorProperty
+//@[52:54) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+/*
+Discriminator key value missing with property access
+*/
+//@[2:4) NewLine |\r\n|
 resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:8) Identifier |resource|
 //@[9:37) Identifier |discriminatorKeyValueMissing|
@@ -1808,6 +1866,146 @@ var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
 //@[76:77) RightSquare |]|
 //@[77:81) NewLine |\r\n\r\n|
 
+/*
+Discriminator key value missing with property access (conditional)
+*/
+//@[2:6) NewLine |\r\n\r\n|
+
+resource discriminatorKeyValueMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(false) {
+//@[0:8) Identifier |resource|
+//@[9:40) Identifier |discriminatorKeyValueMissing_if|
+//@[41:91) StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[92:93) Assignment |=|
+//@[94:96) Identifier |if|
+//@[96:97) LeftParen |(|
+//@[97:102) FalseKeyword |false|
+//@[102:103) RightParen |)|
+//@[104:105) LeftBrace |{|
+//@[105:107) NewLine |\r\n|
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_if
+//@[69:71) NewLine |\r\n|
+  kind:   
+//@[2:6) Identifier |kind|
+//@[6:7) Colon |:|
+//@[10:12) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions_if = discriminatorKeyValueMissing_if.p
+//@[0:3) Identifier |var|
+//@[4:46) Identifier |discriminatorKeyValueMissingCompletions_if|
+//@[47:48) Assignment |=|
+//@[49:80) Identifier |discriminatorKeyValueMissing_if|
+//@[80:81) Dot |.|
+//@[81:82) Identifier |p|
+//@[82:84) NewLine |\r\n|
+// #completionTest(82) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions2_if = discriminatorKeyValueMissing_if.
+//@[0:3) Identifier |var|
+//@[4:47) Identifier |discriminatorKeyValueMissingCompletions2_if|
+//@[48:49) Assignment |=|
+//@[50:81) Identifier |discriminatorKeyValueMissing_if|
+//@[81:82) Dot |.|
+//@[82:86) NewLine |\r\n\r\n|
+
+// #completionTest(82) -> missingDiscriminatorPropertyIndexPlusSymbols_if
+//@[73:75) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions3_if = discriminatorKeyValueMissing_if[]
+//@[0:3) Identifier |var|
+//@[4:47) Identifier |discriminatorKeyValueMissingCompletions3_if|
+//@[48:49) Assignment |=|
+//@[50:81) Identifier |discriminatorKeyValueMissing_if|
+//@[81:82) LeftSquare |[|
+//@[82:83) RightSquare |]|
+//@[83:87) NewLine |\r\n\r\n|
+
+/*
+Discriminator key value missing with property access (loops)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeyValueMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[0:8) Identifier |resource|
+//@[9:41) Identifier |discriminatorKeyValueMissing_for|
+//@[42:92) StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[93:94) Assignment |=|
+//@[95:96) LeftSquare |[|
+//@[96:99) Identifier |for|
+//@[100:105) Identifier |thing|
+//@[106:108) Identifier |in|
+//@[109:110) LeftSquare |[|
+//@[110:111) RightSquare |]|
+//@[111:112) Colon |:|
+//@[113:114) LeftBrace |{|
+//@[114:116) NewLine |\r\n|
+  // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_for
+//@[70:72) NewLine |\r\n|
+  kind:   
+//@[2:6) Identifier |kind|
+//@[6:7) Colon |:|
+//@[10:12) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// cannot . access properties of a resource loop
+//@[48:50) NewLine |\r\n|
+var resourceListIsNotSingleResource = discriminatorKeyValueMissing_for.kind
+//@[0:3) Identifier |var|
+//@[4:35) Identifier |resourceListIsNotSingleResource|
+//@[36:37) Assignment |=|
+//@[38:70) Identifier |discriminatorKeyValueMissing_for|
+//@[70:71) Dot |.|
+//@[71:75) Identifier |kind|
+//@[75:79) NewLine |\r\n\r\n|
+
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions_for = discriminatorKeyValueMissing_for[0].p
+//@[0:3) Identifier |var|
+//@[4:47) Identifier |discriminatorKeyValueMissingCompletions_for|
+//@[48:49) Assignment |=|
+//@[50:82) Identifier |discriminatorKeyValueMissing_for|
+//@[82:83) LeftSquare |[|
+//@[83:84) Integer |0|
+//@[84:85) RightSquare |]|
+//@[85:86) Dot |.|
+//@[86:87) Identifier |p|
+//@[87:89) NewLine |\r\n|
+// #completionTest(87) -> missingDiscriminatorPropertyAccess
+//@[60:62) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions2_for = discriminatorKeyValueMissing_for[0].
+//@[0:3) Identifier |var|
+//@[4:48) Identifier |discriminatorKeyValueMissingCompletions2_for|
+//@[49:50) Assignment |=|
+//@[51:83) Identifier |discriminatorKeyValueMissing_for|
+//@[83:84) LeftSquare |[|
+//@[84:85) Integer |0|
+//@[85:86) RightSquare |]|
+//@[86:87) Dot |.|
+//@[87:91) NewLine |\r\n\r\n|
+
+// #completionTest(87) -> missingDiscriminatorPropertyIndexPlusSymbols_for
+//@[74:76) NewLine |\r\n|
+var discriminatorKeyValueMissingCompletions3_for = discriminatorKeyValueMissing_for[0][]
+//@[0:3) Identifier |var|
+//@[4:48) Identifier |discriminatorKeyValueMissingCompletions3_for|
+//@[49:50) Assignment |=|
+//@[51:83) Identifier |discriminatorKeyValueMissing_for|
+//@[83:84) LeftSquare |[|
+//@[84:85) Integer |0|
+//@[85:86) RightSquare |]|
+//@[86:87) LeftSquare |[|
+//@[87:88) RightSquare |]|
+//@[88:92) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 1
+*/
+//@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:8) Identifier |resource|
 //@[9:31) Identifier |discriminatorKeySetOne|
@@ -1875,6 +2073,178 @@ var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 //@[75:76) RightSquare |]|
 //@[76:80) NewLine |\r\n\r\n|
 
+/*
+Discriminator value set 1 (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
+//@[0:8) Identifier |resource|
+//@[9:34) Identifier |discriminatorKeySetOne_if|
+//@[35:85) StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[86:87) Assignment |=|
+//@[88:90) Identifier |if|
+//@[90:91) LeftParen |(|
+//@[91:92) Integer |2|
+//@[92:94) Equals |==|
+//@[94:95) Integer |3|
+//@[95:96) RightParen |)|
+//@[97:98) LeftBrace |{|
+//@[98:100) NewLine |\r\n|
+  kind: 'AzureCLI'
+//@[2:6) Identifier |kind|
+//@[6:7) Colon |:|
+//@[8:18) StringComplete |'AzureCLI'|
+//@[18:20) NewLine |\r\n|
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+//@[55:59) NewLine |\r\n\r\n|
+
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+//@[66:68) NewLine |\r\n|
+    
+//@[4:6) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(81) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions_if = discriminatorKeySetOne_if.properties.a
+//@[0:3) Identifier |var|
+//@[4:40) Identifier |discriminatorKeySetOneCompletions_if|
+//@[41:42) Assignment |=|
+//@[43:68) Identifier |discriminatorKeySetOne_if|
+//@[68:69) Dot |.|
+//@[69:79) Identifier |properties|
+//@[79:80) Dot |.|
+//@[80:81) Identifier |a|
+//@[81:83) NewLine |\r\n|
+// #completionTest(81) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions2_if = discriminatorKeySetOne_if.properties.
+//@[0:3) Identifier |var|
+//@[4:41) Identifier |discriminatorKeySetOneCompletions2_if|
+//@[42:43) Assignment |=|
+//@[44:69) Identifier |discriminatorKeySetOne_if|
+//@[69:70) Dot |.|
+//@[70:80) Identifier |properties|
+//@[80:81) Dot |.|
+//@[81:85) NewLine |\r\n\r\n|
+
+// #completionTest(81) -> cliPropertyAccessIndexesPlusSymbols_if
+//@[64:66) NewLine |\r\n|
+var discriminatorKeySetOneCompletions3_if = discriminatorKeySetOne_if.properties[]
+//@[0:3) Identifier |var|
+//@[4:41) Identifier |discriminatorKeySetOneCompletions3_if|
+//@[42:43) Assignment |=|
+//@[44:69) Identifier |discriminatorKeySetOne_if|
+//@[69:70) Dot |.|
+//@[70:80) Identifier |properties|
+//@[80:81) LeftSquare |[|
+//@[81:82) RightSquare |]|
+//@[82:86) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 1 (loop)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
+//@[0:8) Identifier |resource|
+//@[9:35) Identifier |discriminatorKeySetOne_for|
+//@[36:86) StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[87:88) Assignment |=|
+//@[89:90) LeftSquare |[|
+//@[91:94) Identifier |for|
+//@[95:100) Identifier |thing|
+//@[101:103) Identifier |in|
+//@[104:105) LeftSquare |[|
+//@[105:106) RightSquare |]|
+//@[106:107) Colon |:|
+//@[108:109) LeftBrace |{|
+//@[109:111) NewLine |\r\n|
+  kind: 'AzureCLI'
+//@[2:6) Identifier |kind|
+//@[6:7) Colon |:|
+//@[8:18) StringComplete |'AzureCLI'|
+//@[18:20) NewLine |\r\n|
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+//@[55:59) NewLine |\r\n\r\n|
+
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
+//@[66:68) NewLine |\r\n|
+    
+//@[4:6) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// #completionTest(86) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions_for = discriminatorKeySetOne_for[0].properties.a
+//@[0:3) Identifier |var|
+//@[4:41) Identifier |discriminatorKeySetOneCompletions_for|
+//@[42:43) Assignment |=|
+//@[44:70) Identifier |discriminatorKeySetOne_for|
+//@[70:71) LeftSquare |[|
+//@[71:72) Integer |0|
+//@[72:73) RightSquare |]|
+//@[73:74) Dot |.|
+//@[74:84) Identifier |properties|
+//@[84:85) Dot |.|
+//@[85:86) Identifier |a|
+//@[86:88) NewLine |\r\n|
+// #completionTest(94) -> cliPropertyAccess
+//@[43:45) NewLine |\r\n|
+var discriminatorKeySetOneCompletions2_for = discriminatorKeySetOne_for[any(true)].properties.
+//@[0:3) Identifier |var|
+//@[4:42) Identifier |discriminatorKeySetOneCompletions2_for|
+//@[43:44) Assignment |=|
+//@[45:71) Identifier |discriminatorKeySetOne_for|
+//@[71:72) LeftSquare |[|
+//@[72:75) Identifier |any|
+//@[75:76) LeftParen |(|
+//@[76:80) TrueKeyword |true|
+//@[80:81) RightParen |)|
+//@[81:82) RightSquare |]|
+//@[82:83) Dot |.|
+//@[83:93) Identifier |properties|
+//@[93:94) Dot |.|
+//@[94:98) NewLine |\r\n\r\n|
+
+// #completionTest(86) -> cliPropertyAccessIndexesPlusSymbols_for
+//@[65:67) NewLine |\r\n|
+var discriminatorKeySetOneCompletions3_for = discriminatorKeySetOne_for[1].properties[]
+//@[0:3) Identifier |var|
+//@[4:42) Identifier |discriminatorKeySetOneCompletions3_for|
+//@[43:44) Assignment |=|
+//@[45:71) Identifier |discriminatorKeySetOne_for|
+//@[71:72) LeftSquare |[|
+//@[72:73) Integer |1|
+//@[73:74) RightSquare |]|
+//@[74:75) Dot |.|
+//@[75:85) Identifier |properties|
+//@[85:86) LeftSquare |[|
+//@[86:87) RightSquare |]|
+//@[87:91) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 2
+*/
+//@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:8) Identifier |resource|
 //@[9:31) Identifier |discriminatorKeySetTwo|
@@ -1954,6 +2324,196 @@ var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['pro
 //@[88:89) RightSquare |]|
 //@[89:90) Dot |.|
 //@[90:94) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 2 (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[0:8) Identifier |resource|
+//@[9:34) Identifier |discriminatorKeySetTwo_if|
+//@[35:85) StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[86:87) Assignment |=|
+//@[88:89) LeftBrace |{|
+//@[89:91) NewLine |\r\n|
+  kind: 'AzurePowerShell'
+//@[2:6) Identifier |kind|
+//@[6:7) Colon |:|
+//@[8:25) StringComplete |'AzurePowerShell'|
+//@[25:27) NewLine |\r\n|
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+//@[55:59) NewLine |\r\n\r\n|
+
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+//@[65:67) NewLine |\r\n|
+    
+//@[4:6) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(81) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions_if = discriminatorKeySetTwo_if.properties.a
+//@[0:3) Identifier |var|
+//@[4:40) Identifier |discriminatorKeySetTwoCompletions_if|
+//@[41:42) Assignment |=|
+//@[43:68) Identifier |discriminatorKeySetTwo_if|
+//@[68:69) Dot |.|
+//@[69:79) Identifier |properties|
+//@[79:80) Dot |.|
+//@[80:81) Identifier |a|
+//@[81:83) NewLine |\r\n|
+// #completionTest(81) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions2_if = discriminatorKeySetTwo_if.properties.
+//@[0:3) Identifier |var|
+//@[4:41) Identifier |discriminatorKeySetTwoCompletions2_if|
+//@[42:43) Assignment |=|
+//@[44:69) Identifier |discriminatorKeySetTwo_if|
+//@[69:70) Dot |.|
+//@[70:80) Identifier |properties|
+//@[80:81) Dot |.|
+//@[81:85) NewLine |\r\n\r\n|
+
+// #completionTest(96) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer_if = discriminatorKeySetTwo_if['properties'].a
+//@[0:3) Identifier |var|
+//@[4:52) Identifier |discriminatorKeySetTwoCompletionsArrayIndexer_if|
+//@[53:54) Assignment |=|
+//@[55:80) Identifier |discriminatorKeySetTwo_if|
+//@[80:81) LeftSquare |[|
+//@[81:93) StringComplete |'properties'|
+//@[93:94) RightSquare |]|
+//@[94:95) Dot |.|
+//@[95:96) Identifier |a|
+//@[96:98) NewLine |\r\n|
+// #completionTest(96) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer2_if = discriminatorKeySetTwo_if['properties'].
+//@[0:3) Identifier |var|
+//@[4:53) Identifier |discriminatorKeySetTwoCompletionsArrayIndexer2_if|
+//@[54:55) Assignment |=|
+//@[56:81) Identifier |discriminatorKeySetTwo_if|
+//@[81:82) LeftSquare |[|
+//@[82:94) StringComplete |'properties'|
+//@[94:95) RightSquare |]|
+//@[95:96) Dot |.|
+//@[96:100) NewLine |\r\n\r\n|
+
+/*
+Discriminator value set 2 (loops)
+*/
+//@[2:4) NewLine |\r\n|
+resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
+//@[0:8) Identifier |resource|
+//@[9:35) Identifier |discriminatorKeySetTwo_for|
+//@[36:86) StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
+//@[87:88) Assignment |=|
+//@[89:90) LeftSquare |[|
+//@[90:93) Identifier |for|
+//@[94:99) Identifier |thing|
+//@[100:102) Identifier |in|
+//@[103:104) LeftSquare |[|
+//@[104:105) RightSquare |]|
+//@[105:106) Colon |:|
+//@[107:108) LeftBrace |{|
+//@[108:110) NewLine |\r\n|
+  kind: 'AzurePowerShell'
+//@[2:6) Identifier |kind|
+//@[6:7) Colon |:|
+//@[8:25) StringComplete |'AzurePowerShell'|
+//@[25:27) NewLine |\r\n|
+  // #completionTest(0,1,2) -> deploymentScriptTopLevel
+//@[55:59) NewLine |\r\n\r\n|
+
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
+//@[65:67) NewLine |\r\n|
+    
+//@[4:6) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// #completionTest(86) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions_for = discriminatorKeySetTwo_for[0].properties.a
+//@[0:3) Identifier |var|
+//@[4:41) Identifier |discriminatorKeySetTwoCompletions_for|
+//@[42:43) Assignment |=|
+//@[44:70) Identifier |discriminatorKeySetTwo_for|
+//@[70:71) LeftSquare |[|
+//@[71:72) Integer |0|
+//@[72:73) RightSquare |]|
+//@[73:74) Dot |.|
+//@[74:84) Identifier |properties|
+//@[84:85) Dot |.|
+//@[85:86) Identifier |a|
+//@[86:88) NewLine |\r\n|
+// #completionTest(86) -> powershellPropertyAccess
+//@[50:52) NewLine |\r\n|
+var discriminatorKeySetTwoCompletions2_for = discriminatorKeySetTwo_for[0].properties.
+//@[0:3) Identifier |var|
+//@[4:42) Identifier |discriminatorKeySetTwoCompletions2_for|
+//@[43:44) Assignment |=|
+//@[45:71) Identifier |discriminatorKeySetTwo_for|
+//@[71:72) LeftSquare |[|
+//@[72:73) Integer |0|
+//@[73:74) RightSquare |]|
+//@[74:75) Dot |.|
+//@[75:85) Identifier |properties|
+//@[85:86) Dot |.|
+//@[86:90) NewLine |\r\n\r\n|
+
+// #completionTest(101) -> powershellPropertyAccess
+//@[51:53) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer_for = discriminatorKeySetTwo_for[0]['properties'].a
+//@[0:3) Identifier |var|
+//@[4:53) Identifier |discriminatorKeySetTwoCompletionsArrayIndexer_for|
+//@[54:55) Assignment |=|
+//@[56:82) Identifier |discriminatorKeySetTwo_for|
+//@[82:83) LeftSquare |[|
+//@[83:84) Integer |0|
+//@[84:85) RightSquare |]|
+//@[85:86) LeftSquare |[|
+//@[86:98) StringComplete |'properties'|
+//@[98:99) RightSquare |]|
+//@[99:100) Dot |.|
+//@[100:101) Identifier |a|
+//@[101:103) NewLine |\r\n|
+// #completionTest(101) -> powershellPropertyAccess
+//@[51:53) NewLine |\r\n|
+var discriminatorKeySetTwoCompletionsArrayIndexer2_for = discriminatorKeySetTwo_for[0]['properties'].
+//@[0:3) Identifier |var|
+//@[4:54) Identifier |discriminatorKeySetTwoCompletionsArrayIndexer2_for|
+//@[55:56) Assignment |=|
+//@[57:83) Identifier |discriminatorKeySetTwo_for|
+//@[83:84) LeftSquare |[|
+//@[84:85) Integer |0|
+//@[85:86) RightSquare |]|
+//@[86:87) LeftSquare |[|
+//@[87:99) StringComplete |'properties'|
+//@[99:100) RightSquare |]|
+//@[100:101) Dot |.|
+//@[101:109) NewLine |\r\n\r\n\r\n\r\n|
+
+
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 //@[0:8) Identifier |resource|
@@ -2143,6 +2703,10 @@ var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
 //@[77:78) Dot |.|
 //@[78:82) NewLine |\r\n\r\n|
 
+/* 
+Nested discriminator missing key
+*/
+//@[2:4) NewLine |\r\n|
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[0:8) Identifier |resource|
 //@[9:38) Identifier |nestedDiscriminatorMissingKey|
@@ -2213,6 +2777,183 @@ var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKe
 //@[95:96) RightSquare |]|
 //@[96:100) NewLine |\r\n\r\n|
 
+/* 
+Nested discriminator missing key (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource nestedDiscriminatorMissingKey_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(bool(1)) {
+//@[0:8) Identifier |resource|
+//@[9:41) Identifier |nestedDiscriminatorMissingKey_if|
+//@[42:100) StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[101:102) Assignment |=|
+//@[103:105) Identifier |if|
+//@[105:106) LeftParen |(|
+//@[106:110) Identifier |bool|
+//@[110:111) LeftParen |(|
+//@[111:112) Integer |1|
+//@[112:113) RightParen |)|
+//@[113:114) RightParen |)|
+//@[115:116) LeftBrace |{|
+//@[116:118) NewLine |\r\n|
+  name: 'test'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) StringComplete |'test'|
+//@[14:16) NewLine |\r\n|
+  location: 'l'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:15) StringComplete |'l'|
+//@[15:17) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    //createMode: 'Default'
+//@[27:31) NewLine |\r\n\r\n|
+
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(96) -> createMode
+//@[36:38) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions_if = nestedDiscriminatorMissingKey_if.properties.cr
+//@[0:3) Identifier |var|
+//@[4:47) Identifier |nestedDiscriminatorMissingKeyCompletions_if|
+//@[48:49) Assignment |=|
+//@[50:82) Identifier |nestedDiscriminatorMissingKey_if|
+//@[82:83) Dot |.|
+//@[83:93) Identifier |properties|
+//@[93:94) Dot |.|
+//@[94:96) Identifier |cr|
+//@[96:98) NewLine |\r\n|
+// #completionTest(98) -> createMode
+//@[36:38) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions2_if = nestedDiscriminatorMissingKey_if['properties'].
+//@[0:3) Identifier |var|
+//@[4:48) Identifier |nestedDiscriminatorMissingKeyCompletions2_if|
+//@[49:50) Assignment |=|
+//@[51:83) Identifier |nestedDiscriminatorMissingKey_if|
+//@[83:84) LeftSquare |[|
+//@[84:96) StringComplete |'properties'|
+//@[96:97) RightSquare |]|
+//@[97:98) Dot |.|
+//@[98:102) NewLine |\r\n\r\n|
+
+// #completionTest(100) -> createModeIndexPlusSymbols_if
+//@[56:58) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyIndexCompletions_if = nestedDiscriminatorMissingKey_if.properties['']
+//@[0:3) Identifier |var|
+//@[4:52) Identifier |nestedDiscriminatorMissingKeyIndexCompletions_if|
+//@[53:54) Assignment |=|
+//@[55:87) Identifier |nestedDiscriminatorMissingKey_if|
+//@[87:88) Dot |.|
+//@[88:98) Identifier |properties|
+//@[98:99) LeftSquare |[|
+//@[99:101) StringComplete |''|
+//@[101:102) RightSquare |]|
+//@[102:106) NewLine |\r\n\r\n|
+
+/* 
+Nested discriminator missing key (loop)
+*/
+//@[2:4) NewLine |\r\n|
+resource nestedDiscriminatorMissingKey_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+//@[0:8) Identifier |resource|
+//@[9:42) Identifier |nestedDiscriminatorMissingKey_for|
+//@[43:101) StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[102:103) Assignment |=|
+//@[104:105) LeftSquare |[|
+//@[105:108) Identifier |for|
+//@[109:114) Identifier |thing|
+//@[115:117) Identifier |in|
+//@[118:119) LeftSquare |[|
+//@[119:120) RightSquare |]|
+//@[120:121) Colon |:|
+//@[122:123) LeftBrace |{|
+//@[123:125) NewLine |\r\n|
+  name: 'test'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) StringComplete |'test'|
+//@[14:16) NewLine |\r\n|
+  location: 'l'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:15) StringComplete |'l'|
+//@[15:17) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    //createMode: 'Default'
+//@[27:31) NewLine |\r\n\r\n|
+
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// #completionTest(101) -> createMode
+//@[37:39) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions_for = nestedDiscriminatorMissingKey_for[0].properties.cr
+//@[0:3) Identifier |var|
+//@[4:48) Identifier |nestedDiscriminatorMissingKeyCompletions_for|
+//@[49:50) Assignment |=|
+//@[51:84) Identifier |nestedDiscriminatorMissingKey_for|
+//@[84:85) LeftSquare |[|
+//@[85:86) Integer |0|
+//@[86:87) RightSquare |]|
+//@[87:88) Dot |.|
+//@[88:98) Identifier |properties|
+//@[98:99) Dot |.|
+//@[99:101) Identifier |cr|
+//@[101:103) NewLine |\r\n|
+// #completionTest(103) -> createMode
+//@[37:39) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyCompletions2_for = nestedDiscriminatorMissingKey_for[0]['properties'].
+//@[0:3) Identifier |var|
+//@[4:49) Identifier |nestedDiscriminatorMissingKeyCompletions2_for|
+//@[50:51) Assignment |=|
+//@[52:85) Identifier |nestedDiscriminatorMissingKey_for|
+//@[85:86) LeftSquare |[|
+//@[86:87) Integer |0|
+//@[87:88) RightSquare |]|
+//@[88:89) LeftSquare |[|
+//@[89:101) StringComplete |'properties'|
+//@[101:102) RightSquare |]|
+//@[102:103) Dot |.|
+//@[103:107) NewLine |\r\n\r\n|
+
+// #completionTest(105) -> createModeIndexPlusSymbols_for
+//@[57:59) NewLine |\r\n|
+var nestedDiscriminatorMissingKeyIndexCompletions_for = nestedDiscriminatorMissingKey_for[0].properties['']
+//@[0:3) Identifier |var|
+//@[4:53) Identifier |nestedDiscriminatorMissingKeyIndexCompletions_for|
+//@[54:55) Assignment |=|
+//@[56:89) Identifier |nestedDiscriminatorMissingKey_for|
+//@[89:90) LeftSquare |[|
+//@[90:91) Integer |0|
+//@[91:92) RightSquare |]|
+//@[92:93) Dot |.|
+//@[93:103) Identifier |properties|
+//@[103:104) LeftSquare |[|
+//@[104:106) StringComplete |''|
+//@[106:107) RightSquare |]|
+//@[107:113) NewLine |\r\n\r\n\r\n|
+
+
+/*
+Nested discriminator
+*/
+//@[2:4) NewLine |\r\n|
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
 //@[0:8) Identifier |resource|
 //@[9:28) Identifier |nestedDiscriminator|
@@ -2309,6 +3050,294 @@ var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
 //@[78:79) Identifier |a|
 //@[79:80) RightSquare |]|
 //@[80:84) NewLine |\r\n\r\n|
+
+/*
+Nested discriminator (conditional)
+*/
+//@[2:4) NewLine |\r\n|
+resource nestedDiscriminator_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(true) {
+//@[0:8) Identifier |resource|
+//@[9:31) Identifier |nestedDiscriminator_if|
+//@[32:90) StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[91:92) Assignment |=|
+//@[93:95) Identifier |if|
+//@[95:96) LeftParen |(|
+//@[96:100) TrueKeyword |true|
+//@[100:101) RightParen |)|
+//@[102:103) LeftBrace |{|
+//@[103:105) NewLine |\r\n|
+  name: 'test'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) StringComplete |'test'|
+//@[14:16) NewLine |\r\n|
+  location: 'l'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:15) StringComplete |'l'|
+//@[15:17) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    createMode: 'Default'
+//@[4:14) Identifier |createMode|
+//@[14:15) Colon |:|
+//@[16:25) StringComplete |'Default'|
+//@[25:29) NewLine |\r\n\r\n|
+
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// #completionTest(75) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions_if = nestedDiscriminator_if.properties.a
+//@[0:3) Identifier |var|
+//@[4:37) Identifier |nestedDiscriminatorCompletions_if|
+//@[38:39) Assignment |=|
+//@[40:62) Identifier |nestedDiscriminator_if|
+//@[62:63) Dot |.|
+//@[63:73) Identifier |properties|
+//@[73:74) Dot |.|
+//@[74:75) Identifier |a|
+//@[75:77) NewLine |\r\n|
+// #completionTest(79) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions2_if = nestedDiscriminator_if['properties'].a
+//@[0:3) Identifier |var|
+//@[4:38) Identifier |nestedDiscriminatorCompletions2_if|
+//@[39:40) Assignment |=|
+//@[41:63) Identifier |nestedDiscriminator_if|
+//@[63:64) LeftSquare |[|
+//@[64:76) StringComplete |'properties'|
+//@[76:77) RightSquare |]|
+//@[77:78) Dot |.|
+//@[78:79) Identifier |a|
+//@[79:81) NewLine |\r\n|
+// #completionTest(75) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions3_if = nestedDiscriminator_if.properties.
+//@[0:3) Identifier |var|
+//@[4:38) Identifier |nestedDiscriminatorCompletions3_if|
+//@[39:40) Assignment |=|
+//@[41:63) Identifier |nestedDiscriminator_if|
+//@[63:64) Dot |.|
+//@[64:74) Identifier |properties|
+//@[74:75) Dot |.|
+//@[75:77) NewLine |\r\n|
+// #completionTest(78) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions4_if = nestedDiscriminator_if['properties'].
+//@[0:3) Identifier |var|
+//@[4:38) Identifier |nestedDiscriminatorCompletions4_if|
+//@[39:40) Assignment |=|
+//@[41:63) Identifier |nestedDiscriminator_if|
+//@[63:64) LeftSquare |[|
+//@[64:76) StringComplete |'properties'|
+//@[76:77) RightSquare |]|
+//@[77:78) Dot |.|
+//@[78:82) NewLine |\r\n\r\n|
+
+// #completionTest(85) -> defaultCreateModeIndexes_if
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorArrayIndexCompletions_if = nestedDiscriminator_if.properties[a]
+//@[0:3) Identifier |var|
+//@[4:47) Identifier |nestedDiscriminatorArrayIndexCompletions_if|
+//@[48:49) Assignment |=|
+//@[50:72) Identifier |nestedDiscriminator_if|
+//@[72:73) Dot |.|
+//@[73:83) Identifier |properties|
+//@[83:84) LeftSquare |[|
+//@[84:85) Identifier |a|
+//@[85:86) RightSquare |]|
+//@[86:92) NewLine |\r\n\r\n\r\n|
+
+
+/*
+Nested discriminator (loop)
+*/
+//@[2:4) NewLine |\r\n|
+resource nestedDiscriminator_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
+//@[0:8) Identifier |resource|
+//@[9:32) Identifier |nestedDiscriminator_for|
+//@[33:91) StringComplete |'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview'|
+//@[92:93) Assignment |=|
+//@[94:95) LeftSquare |[|
+//@[95:98) Identifier |for|
+//@[99:104) Identifier |thing|
+//@[105:107) Identifier |in|
+//@[108:109) LeftSquare |[|
+//@[109:110) RightSquare |]|
+//@[110:111) Colon |:|
+//@[112:113) LeftBrace |{|
+//@[113:115) NewLine |\r\n|
+  name: 'test'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) StringComplete |'test'|
+//@[14:16) NewLine |\r\n|
+  location: 'l'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:15) StringComplete |'l'|
+//@[15:17) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    createMode: 'Default'
+//@[4:14) Identifier |createMode|
+//@[14:15) Colon |:|
+//@[16:25) StringComplete |'Default'|
+//@[25:29) NewLine |\r\n\r\n|
+
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// #completionTest(80) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions_for = nestedDiscriminator_for[0].properties.a
+//@[0:3) Identifier |var|
+//@[4:38) Identifier |nestedDiscriminatorCompletions_for|
+//@[39:40) Assignment |=|
+//@[41:64) Identifier |nestedDiscriminator_for|
+//@[64:65) LeftSquare |[|
+//@[65:66) Integer |0|
+//@[66:67) RightSquare |]|
+//@[67:68) Dot |.|
+//@[68:78) Identifier |properties|
+//@[78:79) Dot |.|
+//@[79:80) Identifier |a|
+//@[80:82) NewLine |\r\n|
+// #completionTest(84) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions2_for = nestedDiscriminator_for[0]['properties'].a
+//@[0:3) Identifier |var|
+//@[4:39) Identifier |nestedDiscriminatorCompletions2_for|
+//@[40:41) Assignment |=|
+//@[42:65) Identifier |nestedDiscriminator_for|
+//@[65:66) LeftSquare |[|
+//@[66:67) Integer |0|
+//@[67:68) RightSquare |]|
+//@[68:69) LeftSquare |[|
+//@[69:81) StringComplete |'properties'|
+//@[81:82) RightSquare |]|
+//@[82:83) Dot |.|
+//@[83:84) Identifier |a|
+//@[84:86) NewLine |\r\n|
+// #completionTest(80) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions3_for = nestedDiscriminator_for[0].properties.
+//@[0:3) Identifier |var|
+//@[4:39) Identifier |nestedDiscriminatorCompletions3_for|
+//@[40:41) Assignment |=|
+//@[42:65) Identifier |nestedDiscriminator_for|
+//@[65:66) LeftSquare |[|
+//@[66:67) Integer |0|
+//@[67:68) RightSquare |]|
+//@[68:69) Dot |.|
+//@[69:79) Identifier |properties|
+//@[79:80) Dot |.|
+//@[80:82) NewLine |\r\n|
+// #completionTest(83) -> defaultCreateModeProperties
+//@[53:55) NewLine |\r\n|
+var nestedDiscriminatorCompletions4_for = nestedDiscriminator_for[0]['properties'].
+//@[0:3) Identifier |var|
+//@[4:39) Identifier |nestedDiscriminatorCompletions4_for|
+//@[40:41) Assignment |=|
+//@[42:65) Identifier |nestedDiscriminator_for|
+//@[65:66) LeftSquare |[|
+//@[66:67) Integer |0|
+//@[67:68) RightSquare |]|
+//@[68:69) LeftSquare |[|
+//@[69:81) StringComplete |'properties'|
+//@[81:82) RightSquare |]|
+//@[82:83) Dot |.|
+//@[83:87) NewLine |\r\n\r\n|
+
+// #completionTest(90) -> defaultCreateModeIndexes_for
+//@[54:56) NewLine |\r\n|
+var nestedDiscriminatorArrayIndexCompletions_for = nestedDiscriminator_for[0].properties[a]
+//@[0:3) Identifier |var|
+//@[4:48) Identifier |nestedDiscriminatorArrayIndexCompletions_for|
+//@[49:50) Assignment |=|
+//@[51:74) Identifier |nestedDiscriminator_for|
+//@[74:75) LeftSquare |[|
+//@[75:76) Integer |0|
+//@[76:77) RightSquare |]|
+//@[77:78) Dot |.|
+//@[78:88) Identifier |properties|
+//@[88:89) LeftSquare |[|
+//@[89:90) Identifier |a|
+//@[90:91) RightSquare |]|
+//@[91:95) NewLine |\r\n\r\n|
+
+// sample resource to validate completions on the next declarations
+//@[67:69) NewLine |\r\n|
+resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@2020-06-01' = if(true) {
+//@[0:8) Identifier |resource|
+//@[9:42) Identifier |nestedPropertyAccessOnConditional|
+//@[43:89) StringComplete |'Microsoft.Compute/virtualMachines@2020-06-01'|
+//@[90:91) Assignment |=|
+//@[92:94) Identifier |if|
+//@[94:95) LeftParen |(|
+//@[95:99) TrueKeyword |true|
+//@[99:100) RightParen |)|
+//@[101:102) LeftBrace |{|
+//@[102:104) NewLine |\r\n|
+  location: 'test'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:18) StringComplete |'test'|
+//@[18:20) NewLine |\r\n|
+  name: 'test'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) StringComplete |'test'|
+//@[14:16) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    additionalCapabilities: {
+//@[4:26) Identifier |additionalCapabilities|
+//@[26:27) Colon |:|
+//@[28:29) LeftBrace |{|
+//@[29:31) NewLine |\r\n|
+      
+//@[6:8) NewLine |\r\n|
+    }
+//@[4:5) RightBrace |}|
+//@[5:7) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
+// this validates that we can get nested property access completions on a conditional resource
+//@[94:96) NewLine |\r\n|
+//#completionTest(56) -> vmProperties
+//@[37:39) NewLine |\r\n|
+var sigh = nestedPropertyAccessOnConditional.properties.
+//@[0:3) Identifier |var|
+//@[4:8) Identifier |sigh|
+//@[9:10) Assignment |=|
+//@[11:44) Identifier |nestedPropertyAccessOnConditional|
+//@[44:45) Dot |.|
+//@[45:55) Identifier |properties|
+//@[55:56) Dot |.|
+//@[56:60) NewLine |\r\n\r\n|
 
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
 //@[0:8) Identifier |resource|
@@ -2593,4 +3622,832 @@ resource cyclicExistingRes 'Mock.Rp/mockExistingResource@2020-01-01' existing = 
 //@[26:28) NewLine |\r\n|
 }
 //@[0:1) RightBrace |}|
-//@[1:1) EndOfFile ||
+//@[1:5) NewLine |\r\n\r\n|
+
+// loop parsing cases
+//@[21:23) NewLine |\r\n|
+resource expectedForKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = []
+//@[0:8) Identifier |resource|
+//@[9:27) Identifier |expectedForKeyword|
+//@[28:74) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[75:76) Assignment |=|
+//@[77:78) LeftSquare |[|
+//@[78:79) RightSquare |]|
+//@[79:83) NewLine |\r\n\r\n|
+
+resource expectedForKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [f]
+//@[0:8) Identifier |resource|
+//@[9:28) Identifier |expectedForKeyword2|
+//@[29:75) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[76:77) Assignment |=|
+//@[78:79) LeftSquare |[|
+//@[79:80) Identifier |f|
+//@[80:81) RightSquare |]|
+//@[81:85) NewLine |\r\n\r\n|
+
+resource expectedLoopVar 'Microsoft.Storage/storageAccounts@2019-06-01' = [for]
+//@[0:8) Identifier |resource|
+//@[9:24) Identifier |expectedLoopVar|
+//@[25:71) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[72:73) Assignment |=|
+//@[74:75) LeftSquare |[|
+//@[75:78) Identifier |for|
+//@[78:79) RightSquare |]|
+//@[79:83) NewLine |\r\n\r\n|
+
+resource expectedInKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x]
+//@[0:8) Identifier |resource|
+//@[9:26) Identifier |expectedInKeyword|
+//@[27:73) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[74:75) Assignment |=|
+//@[76:77) LeftSquare |[|
+//@[77:80) Identifier |for|
+//@[81:82) Identifier |x|
+//@[82:83) RightSquare |]|
+//@[83:87) NewLine |\r\n\r\n|
+
+resource expectedInKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x b]
+//@[0:8) Identifier |resource|
+//@[9:27) Identifier |expectedInKeyword2|
+//@[28:74) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[75:76) Assignment |=|
+//@[77:78) LeftSquare |[|
+//@[78:81) Identifier |for|
+//@[82:83) Identifier |x|
+//@[84:85) Identifier |b|
+//@[85:86) RightSquare |]|
+//@[86:90) NewLine |\r\n\r\n|
+
+resource expectedArrayExpression 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in]
+//@[0:8) Identifier |resource|
+//@[9:32) Identifier |expectedArrayExpression|
+//@[33:79) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[80:81) Assignment |=|
+//@[82:83) LeftSquare |[|
+//@[83:86) Identifier |for|
+//@[87:88) Identifier |x|
+//@[89:91) Identifier |in|
+//@[91:92) RightSquare |]|
+//@[92:96) NewLine |\r\n\r\n|
+
+resource expectedColon 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y]
+//@[0:8) Identifier |resource|
+//@[9:22) Identifier |expectedColon|
+//@[23:69) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[70:71) Assignment |=|
+//@[72:73) LeftSquare |[|
+//@[73:76) Identifier |for|
+//@[77:78) Identifier |x|
+//@[79:81) Identifier |in|
+//@[82:83) Identifier |y|
+//@[83:84) RightSquare |]|
+//@[84:88) NewLine |\r\n\r\n|
+
+resource expectedLoopBody 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y:]
+//@[0:8) Identifier |resource|
+//@[9:25) Identifier |expectedLoopBody|
+//@[26:72) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[73:74) Assignment |=|
+//@[75:76) LeftSquare |[|
+//@[76:79) Identifier |for|
+//@[80:81) Identifier |x|
+//@[82:84) Identifier |in|
+//@[85:86) Identifier |y|
+//@[86:87) Colon |:|
+//@[87:88) RightSquare |]|
+//@[88:92) NewLine |\r\n\r\n|
+
+// loop semantic analysis cases
+//@[31:33) NewLine |\r\n|
+var emptyArray = []
+//@[0:3) Identifier |var|
+//@[4:14) Identifier |emptyArray|
+//@[15:16) Assignment |=|
+//@[17:18) LeftSquare |[|
+//@[18:19) RightSquare |]|
+//@[19:21) NewLine |\r\n|
+resource wrongLoopBodyType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in emptyArray:4]
+//@[0:8) Identifier |resource|
+//@[9:26) Identifier |wrongLoopBodyType|
+//@[27:73) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[74:75) Assignment |=|
+//@[76:77) LeftSquare |[|
+//@[77:80) Identifier |for|
+//@[81:82) Identifier |x|
+//@[83:85) Identifier |in|
+//@[86:96) Identifier |emptyArray|
+//@[96:97) Colon |:|
+//@[97:98) Integer |4|
+//@[98:99) RightSquare |]|
+//@[99:103) NewLine |\r\n\r\n|
+
+// errors in the array expression
+//@[33:35) NewLine |\r\n|
+resource arrayExpressionErrors 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in union([], 2): {
+//@[0:8) Identifier |resource|
+//@[9:30) Identifier |arrayExpressionErrors|
+//@[31:77) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[78:79) Assignment |=|
+//@[80:81) LeftSquare |[|
+//@[81:84) Identifier |for|
+//@[85:92) Identifier |account|
+//@[93:95) Identifier |in|
+//@[96:101) Identifier |union|
+//@[101:102) LeftParen |(|
+//@[102:103) LeftSquare |[|
+//@[103:104) RightSquare |]|
+//@[104:105) Comma |,|
+//@[106:107) Integer |2|
+//@[107:108) RightParen |)|
+//@[108:109) Colon |:|
+//@[110:111) LeftBrace |{|
+//@[111:113) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// wrong array type
+//@[19:21) NewLine |\r\n|
+var notAnArray = true
+//@[0:3) Identifier |var|
+//@[4:14) Identifier |notAnArray|
+//@[15:16) Assignment |=|
+//@[17:21) TrueKeyword |true|
+//@[21:23) NewLine |\r\n|
+resource wrongArrayType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in notAnArray: {
+//@[0:8) Identifier |resource|
+//@[9:23) Identifier |wrongArrayType|
+//@[24:70) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[71:72) Assignment |=|
+//@[73:74) LeftSquare |[|
+//@[74:77) Identifier |for|
+//@[78:85) Identifier |account|
+//@[86:88) Identifier |in|
+//@[89:99) Identifier |notAnArray|
+//@[99:100) Colon |:|
+//@[101:102) LeftBrace |{|
+//@[102:104) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// missing required properties
+//@[30:32) NewLine |\r\n|
+resource missingRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+//@[0:8) Identifier |resource|
+//@[9:34) Identifier |missingRequiredProperties|
+//@[35:81) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[82:83) Assignment |=|
+//@[84:85) LeftSquare |[|
+//@[85:88) Identifier |for|
+//@[89:96) Identifier |account|
+//@[97:99) Identifier |in|
+//@[100:101) LeftSquare |[|
+//@[101:102) RightSquare |]|
+//@[102:103) Colon |:|
+//@[104:105) LeftBrace |{|
+//@[105:107) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// fewer missing required properties and a wrong property
+//@[57:59) NewLine |\r\n|
+resource missingFewerRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
+//@[0:8) Identifier |resource|
+//@[9:39) Identifier |missingFewerRequiredProperties|
+//@[40:86) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[87:88) Assignment |=|
+//@[89:90) LeftSquare |[|
+//@[90:93) Identifier |for|
+//@[94:101) Identifier |account|
+//@[102:104) Identifier |in|
+//@[105:106) LeftSquare |[|
+//@[106:107) RightSquare |]|
+//@[107:108) Colon |:|
+//@[109:110) LeftBrace |{|
+//@[110:112) NewLine |\r\n|
+  name: account
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:15) Identifier |account|
+//@[15:17) NewLine |\r\n|
+  location: 'eastus42'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:22) StringComplete |'eastus42'|
+//@[22:24) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    wrong: 'test'
+//@[4:9) Identifier |wrong|
+//@[9:10) Colon |:|
+//@[11:17) StringComplete |'test'|
+//@[17:19) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// wrong property inside the nested property loop
+//@[49:51) NewLine |\r\n|
+resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[0:8) Identifier |resource|
+//@[9:34) Identifier |wrongPropertyInNestedLoop|
+//@[35:81) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[82:83) Assignment |=|
+//@[84:85) LeftSquare |[|
+//@[85:88) Identifier |for|
+//@[89:90) Identifier |i|
+//@[91:93) Identifier |in|
+//@[94:99) Identifier |range|
+//@[99:100) LeftParen |(|
+//@[100:101) Integer |0|
+//@[101:102) Comma |,|
+//@[103:104) Integer |3|
+//@[104:105) RightParen |)|
+//@[105:106) Colon |:|
+//@[107:108) LeftBrace |{|
+//@[108:110) NewLine |\r\n|
+  name: 'vnet-${i}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:16) StringLeftPiece |'vnet-${|
+//@[16:17) Identifier |i|
+//@[17:19) StringRightPiece |}'|
+//@[19:21) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    subnets: [for j in range(0, 4): {
+//@[4:11) Identifier |subnets|
+//@[11:12) Colon |:|
+//@[13:14) LeftSquare |[|
+//@[14:17) Identifier |for|
+//@[18:19) Identifier |j|
+//@[20:22) Identifier |in|
+//@[23:28) Identifier |range|
+//@[28:29) LeftParen |(|
+//@[29:30) Integer |0|
+//@[30:31) Comma |,|
+//@[32:33) Integer |4|
+//@[33:34) RightParen |)|
+//@[34:35) Colon |:|
+//@[36:37) LeftBrace |{|
+//@[37:39) NewLine |\r\n|
+      doesNotExist: 'test'
+//@[6:18) Identifier |doesNotExist|
+//@[18:19) Colon |:|
+//@[20:26) StringComplete |'test'|
+//@[26:28) NewLine |\r\n|
+      name: 'subnet-${i}-${j}'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:22) StringLeftPiece |'subnet-${|
+//@[22:23) Identifier |i|
+//@[23:27) StringMiddlePiece |}-${|
+//@[27:28) Identifier |j|
+//@[28:30) StringRightPiece |}'|
+//@[30:32) NewLine |\r\n|
+    }]
+//@[4:5) RightBrace |}|
+//@[5:6) RightSquare |]|
+//@[6:8) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// duplicate identifiers within the loop
+//@[40:42) NewLine |\r\n|
+// (these duplicates are self-contained - usage of i above is allowed)
+//@[70:72) NewLine |\r\n|
+resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[0:8) Identifier |resource|
+//@[9:39) Identifier |duplicateIdentifiersWithinLoop|
+//@[40:86) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[87:88) Assignment |=|
+//@[89:90) LeftSquare |[|
+//@[90:93) Identifier |for|
+//@[94:95) Identifier |i|
+//@[96:98) Identifier |in|
+//@[99:104) Identifier |range|
+//@[104:105) LeftParen |(|
+//@[105:106) Integer |0|
+//@[106:107) Comma |,|
+//@[108:109) Integer |3|
+//@[109:110) RightParen |)|
+//@[110:111) Colon |:|
+//@[112:113) LeftBrace |{|
+//@[113:115) NewLine |\r\n|
+  name: 'vnet-${i}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:16) StringLeftPiece |'vnet-${|
+//@[16:17) Identifier |i|
+//@[17:19) StringRightPiece |}'|
+//@[19:21) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    subnets: [for i in range(0, 4): {
+//@[4:11) Identifier |subnets|
+//@[11:12) Colon |:|
+//@[13:14) LeftSquare |[|
+//@[14:17) Identifier |for|
+//@[18:19) Identifier |i|
+//@[20:22) Identifier |in|
+//@[23:28) Identifier |range|
+//@[28:29) LeftParen |(|
+//@[29:30) Integer |0|
+//@[30:31) Comma |,|
+//@[32:33) Integer |4|
+//@[33:34) RightParen |)|
+//@[34:35) Colon |:|
+//@[36:37) LeftBrace |{|
+//@[37:39) NewLine |\r\n|
+      name: 'subnet-${i}-${i}'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:22) StringLeftPiece |'subnet-${|
+//@[22:23) Identifier |i|
+//@[23:27) StringMiddlePiece |}-${|
+//@[27:28) Identifier |i|
+//@[28:30) StringRightPiece |}'|
+//@[30:32) NewLine |\r\n|
+    }]
+//@[4:5) RightBrace |}|
+//@[5:6) RightSquare |]|
+//@[6:8) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// duplicate identifers in global and single loop scope
+//@[55:57) NewLine |\r\n|
+var someDuplicate = 'hello'
+//@[0:3) Identifier |var|
+//@[4:17) Identifier |someDuplicate|
+//@[18:19) Assignment |=|
+//@[20:27) StringComplete |'hello'|
+//@[27:29) NewLine |\r\n|
+resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+//@[0:8) Identifier |resource|
+//@[9:36) Identifier |duplicateInGlobalAndOneLoop|
+//@[37:83) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[84:85) Assignment |=|
+//@[86:87) LeftSquare |[|
+//@[87:90) Identifier |for|
+//@[91:104) Identifier |someDuplicate|
+//@[105:107) Identifier |in|
+//@[108:113) Identifier |range|
+//@[113:114) LeftParen |(|
+//@[114:115) Integer |0|
+//@[115:116) Comma |,|
+//@[117:118) Integer |3|
+//@[118:119) RightParen |)|
+//@[119:120) Colon |:|
+//@[121:122) LeftBrace |{|
+//@[122:124) NewLine |\r\n|
+  name: 'vnet-${someDuplicate}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:16) StringLeftPiece |'vnet-${|
+//@[16:29) Identifier |someDuplicate|
+//@[29:31) StringRightPiece |}'|
+//@[31:33) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    subnets: [for i in range(0, 4): {
+//@[4:11) Identifier |subnets|
+//@[11:12) Colon |:|
+//@[13:14) LeftSquare |[|
+//@[14:17) Identifier |for|
+//@[18:19) Identifier |i|
+//@[20:22) Identifier |in|
+//@[23:28) Identifier |range|
+//@[28:29) LeftParen |(|
+//@[29:30) Integer |0|
+//@[30:31) Comma |,|
+//@[32:33) Integer |4|
+//@[33:34) RightParen |)|
+//@[34:35) Colon |:|
+//@[36:37) LeftBrace |{|
+//@[37:39) NewLine |\r\n|
+      name: 'subnet-${i}-${i}'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:22) StringLeftPiece |'subnet-${|
+//@[22:23) Identifier |i|
+//@[23:27) StringMiddlePiece |}-${|
+//@[27:28) Identifier |i|
+//@[28:30) StringRightPiece |}'|
+//@[30:32) NewLine |\r\n|
+    }]
+//@[4:5) RightBrace |}|
+//@[5:6) RightSquare |]|
+//@[6:8) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// duplicate in global and multiple loop scopes
+//@[47:49) NewLine |\r\n|
+var otherDuplicate = 'hello'
+//@[0:3) Identifier |var|
+//@[4:18) Identifier |otherDuplicate|
+//@[19:20) Assignment |=|
+//@[21:28) StringComplete |'hello'|
+//@[28:30) NewLine |\r\n|
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for otherDuplicate in range(0, 3): {
+//@[0:8) Identifier |resource|
+//@[9:37) Identifier |duplicateInGlobalAndTwoLoops|
+//@[38:84) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[85:86) Assignment |=|
+//@[87:88) LeftSquare |[|
+//@[88:91) Identifier |for|
+//@[92:106) Identifier |otherDuplicate|
+//@[107:109) Identifier |in|
+//@[110:115) Identifier |range|
+//@[115:116) LeftParen |(|
+//@[116:117) Integer |0|
+//@[117:118) Comma |,|
+//@[119:120) Integer |3|
+//@[120:121) RightParen |)|
+//@[121:122) Colon |:|
+//@[123:124) LeftBrace |{|
+//@[124:126) NewLine |\r\n|
+  name: 'vnet-${otherDuplicate}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:16) StringLeftPiece |'vnet-${|
+//@[16:30) Identifier |otherDuplicate|
+//@[30:32) StringRightPiece |}'|
+//@[32:34) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    subnets: [for otherDuplicate in range(0, 4): {
+//@[4:11) Identifier |subnets|
+//@[11:12) Colon |:|
+//@[13:14) LeftSquare |[|
+//@[14:17) Identifier |for|
+//@[18:32) Identifier |otherDuplicate|
+//@[33:35) Identifier |in|
+//@[36:41) Identifier |range|
+//@[41:42) LeftParen |(|
+//@[42:43) Integer |0|
+//@[43:44) Comma |,|
+//@[45:46) Integer |4|
+//@[46:47) RightParen |)|
+//@[47:48) Colon |:|
+//@[49:50) LeftBrace |{|
+//@[50:52) NewLine |\r\n|
+      name: 'subnet-${otherDuplicate}'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:22) StringLeftPiece |'subnet-${|
+//@[22:36) Identifier |otherDuplicate|
+//@[36:38) StringRightPiece |}'|
+//@[38:40) NewLine |\r\n|
+    }]
+//@[4:5) RightBrace |}|
+//@[5:6) RightSquare |]|
+//@[6:8) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+// joining the other duplicates above (we should not be having multiple errors on the same identifier being duplicated)
+//@[119:121) NewLine |\r\n|
+var someDuplicate = true
+//@[0:3) Identifier |var|
+//@[4:17) Identifier |someDuplicate|
+//@[18:19) Assignment |=|
+//@[20:24) TrueKeyword |true|
+//@[24:26) NewLine |\r\n|
+var otherDuplicate = []
+//@[0:3) Identifier |var|
+//@[4:18) Identifier |otherDuplicate|
+//@[19:20) Assignment |=|
+//@[21:22) LeftSquare |[|
+//@[22:23) RightSquare |]|
+//@[23:25) NewLine |\r\n|
+resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for someDuplicate in range(0, 3): {
+//@[0:8) Identifier |resource|
+//@[9:37) Identifier |duplicateInGlobalAndTwoLoops|
+//@[38:84) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[85:86) Assignment |=|
+//@[87:88) LeftSquare |[|
+//@[88:91) Identifier |for|
+//@[92:105) Identifier |someDuplicate|
+//@[106:108) Identifier |in|
+//@[109:114) Identifier |range|
+//@[114:115) LeftParen |(|
+//@[115:116) Integer |0|
+//@[116:117) Comma |,|
+//@[118:119) Integer |3|
+//@[119:120) RightParen |)|
+//@[120:121) Colon |:|
+//@[122:123) LeftBrace |{|
+//@[123:125) NewLine |\r\n|
+  name: 'vnet-${someDuplicate}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:16) StringLeftPiece |'vnet-${|
+//@[16:29) Identifier |someDuplicate|
+//@[29:31) StringRightPiece |}'|
+//@[31:33) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    subnets: [for otherDuplicate in range(0, 4): {
+//@[4:11) Identifier |subnets|
+//@[11:12) Colon |:|
+//@[13:14) LeftSquare |[|
+//@[14:17) Identifier |for|
+//@[18:32) Identifier |otherDuplicate|
+//@[33:35) Identifier |in|
+//@[36:41) Identifier |range|
+//@[41:42) LeftParen |(|
+//@[42:43) Integer |0|
+//@[43:44) Comma |,|
+//@[45:46) Integer |4|
+//@[46:47) RightParen |)|
+//@[47:48) Colon |:|
+//@[49:50) LeftBrace |{|
+//@[50:52) NewLine |\r\n|
+      name: 'subnet-${otherDuplicate}-${someDuplicate}'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:22) StringLeftPiece |'subnet-${|
+//@[22:36) Identifier |otherDuplicate|
+//@[36:40) StringMiddlePiece |}-${|
+//@[40:53) Identifier |someDuplicate|
+//@[53:55) StringRightPiece |}'|
+//@[55:57) NewLine |\r\n|
+    }]
+//@[4:5) RightBrace |}|
+//@[5:6) RightSquare |]|
+//@[6:8) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+/*
+  valid loop cases - this should be moved to Resources_* test case after codegen works
+*/ 
+//@[3:5) NewLine |\r\n|
+var storageAccounts = [
+//@[0:3) Identifier |var|
+//@[4:19) Identifier |storageAccounts|
+//@[20:21) Assignment |=|
+//@[22:23) LeftSquare |[|
+//@[23:25) NewLine |\r\n|
+  {
+//@[2:3) LeftBrace |{|
+//@[3:5) NewLine |\r\n|
+    name: 'one'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:15) StringComplete |'one'|
+//@[15:17) NewLine |\r\n|
+    location: 'eastus2'
+//@[4:12) Identifier |location|
+//@[12:13) Colon |:|
+//@[14:23) StringComplete |'eastus2'|
+//@[23:25) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+  {
+//@[2:3) LeftBrace |{|
+//@[3:5) NewLine |\r\n|
+    name: 'two'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:15) StringComplete |'two'|
+//@[15:17) NewLine |\r\n|
+    location: 'westus'
+//@[4:12) Identifier |location|
+//@[12:13) Colon |:|
+//@[14:22) StringComplete |'westus'|
+//@[22:24) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+]
+//@[0:1) RightSquare |]|
+//@[1:3) NewLine |\r\n|
+// just a storage account loop
+//@[30:32) NewLine |\r\n|
+resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+//@[0:8) Identifier |resource|
+//@[9:25) Identifier |storageResources|
+//@[26:72) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[73:74) Assignment |=|
+//@[75:76) LeftSquare |[|
+//@[76:79) Identifier |for|
+//@[80:87) Identifier |account|
+//@[88:90) Identifier |in|
+//@[91:106) Identifier |storageAccounts|
+//@[106:107) Colon |:|
+//@[108:109) LeftBrace |{|
+//@[109:111) NewLine |\r\n|
+  name: account.name
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:15) Identifier |account|
+//@[15:16) Dot |.|
+//@[16:20) Identifier |name|
+//@[20:22) NewLine |\r\n|
+  location: account.location
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:19) Identifier |account|
+//@[19:20) Dot |.|
+//@[20:28) Identifier |location|
+//@[28:30) NewLine |\r\n|
+  sku: {
+//@[2:5) Identifier |sku|
+//@[5:6) Colon |:|
+//@[7:8) LeftBrace |{|
+//@[8:10) NewLine |\r\n|
+    name: 'Standard_LRS'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:24) StringComplete |'Standard_LRS'|
+//@[24:26) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+  kind: 'StorageV2'
+//@[2:6) Identifier |kind|
+//@[6:7) Colon |:|
+//@[8:19) StringComplete |'StorageV2'|
+//@[19:21) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// using the same loop variable in a new language scope should be allowed
+//@[73:75) NewLine |\r\n|
+resource premiumStorages 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
+//@[0:8) Identifier |resource|
+//@[9:24) Identifier |premiumStorages|
+//@[25:71) StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
+//@[72:73) Assignment |=|
+//@[74:75) LeftSquare |[|
+//@[75:78) Identifier |for|
+//@[79:86) Identifier |account|
+//@[87:89) Identifier |in|
+//@[90:105) Identifier |storageAccounts|
+//@[105:106) Colon |:|
+//@[107:108) LeftBrace |{|
+//@[108:110) NewLine |\r\n|
+  name: account.name
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:15) Identifier |account|
+//@[15:16) Dot |.|
+//@[16:20) Identifier |name|
+//@[20:22) NewLine |\r\n|
+  location: account.location
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:19) Identifier |account|
+//@[19:20) Dot |.|
+//@[20:28) Identifier |location|
+//@[28:30) NewLine |\r\n|
+  sku: {
+//@[2:5) Identifier |sku|
+//@[5:6) Colon |:|
+//@[7:8) LeftBrace |{|
+//@[8:10) NewLine |\r\n|
+    // #completionTest(9,10) -> storageSkuNamePlusSymbols
+//@[57:59) NewLine |\r\n|
+    name: 
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:12) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+  kind: 'StorageV2'
+//@[2:6) Identifier |kind|
+//@[6:7) Colon |:|
+//@[8:19) StringComplete |'StorageV2'|
+//@[19:21) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\r\n|
+// basic nested loop
+//@[20:22) NewLine |\r\n|
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
+//@[0:8) Identifier |resource|
+//@[9:13) Identifier |vnet|
+//@[14:60) StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
+//@[61:62) Assignment |=|
+//@[63:64) LeftSquare |[|
+//@[64:67) Identifier |for|
+//@[68:69) Identifier |i|
+//@[70:72) Identifier |in|
+//@[73:78) Identifier |range|
+//@[78:79) LeftParen |(|
+//@[79:80) Integer |0|
+//@[80:81) Comma |,|
+//@[82:83) Integer |3|
+//@[83:84) RightParen |)|
+//@[84:85) Colon |:|
+//@[86:87) LeftBrace |{|
+//@[87:89) NewLine |\r\n|
+  name: 'vnet-${i}'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:16) StringLeftPiece |'vnet-${|
+//@[16:17) Identifier |i|
+//@[17:19) StringRightPiece |}'|
+//@[19:21) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    subnets: [for j in range(0, 4): {
+//@[4:11) Identifier |subnets|
+//@[11:12) Colon |:|
+//@[13:14) LeftSquare |[|
+//@[14:17) Identifier |for|
+//@[18:19) Identifier |j|
+//@[20:22) Identifier |in|
+//@[23:28) Identifier |range|
+//@[28:29) LeftParen |(|
+//@[29:30) Integer |0|
+//@[30:31) Comma |,|
+//@[32:33) Integer |4|
+//@[33:34) RightParen |)|
+//@[34:35) Colon |:|
+//@[36:37) LeftBrace |{|
+//@[37:39) NewLine |\r\n|
+      // #completionTest(0,1,2,3,4,5,6) -> subnetIdAndProperties
+//@[64:66) NewLine |\r\n|
+      name: 'subnet-${i}-${j}'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:22) StringLeftPiece |'subnet-${|
+//@[22:23) Identifier |i|
+//@[23:27) StringMiddlePiece |}-${|
+//@[27:28) Identifier |j|
+//@[28:30) StringRightPiece |}'|
+//@[30:32) NewLine |\r\n|
+    }]
+//@[4:5) RightBrace |}|
+//@[5:6) RightSquare |]|
+//@[6:8) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:2) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.diagnostics.bicep
@@ -51,6 +51,7 @@ module optionalWithAllParams './child/optionalParams.bicep'= {
 }
 
 resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[29:62) [BCP081 (Warning)] Resource type "Mock.Rp/mockResource@2020-01-01" does not have types available. |'Mock.Rp/mockResource@2020-01-01'|
   name: 'harry'
   properties: {
     modADep: modATest.outputs.stringOutputA
@@ -93,6 +94,7 @@ module moduleWithCalculatedName './child/optionalParams.bicep'= {
 }
 
 resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[43:76) [BCP081 (Warning)] Resource type "Mock.Rp/mockResource@2020-01-01" does not have types available. |'Mock.Rp/mockResource@2020-01-01'|
   name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
   properties: {
     modADep: moduleWithCalculatedName.outputs.outputObj

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
@@ -42,6 +42,7 @@ resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
   properties: {
     supportsHttpsTrafficOnly: !false
     accessTier: true ? 'Hot' : 'Cold'
+//@[16:37) [BCP036 (Warning)] The property "accessTier" expected a value of type "'Cool' | 'Hot'" but the provided value is of type "'Cold' | 'Hot'". |true ? 'Hot' : 'Cold'|
     encryption: {
       keySource: 'Microsoft.Storage'
       services: {
@@ -81,6 +82,7 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
   }
   properties: {
     name: hostingPlanName // just hostingPlanName results in an error
+//@[4:8) [BCP038 (Warning)] The property "name" is not allowed on objects of type "schemas:6_properties". Permissible properties include "freeOfferExpirationTime", "hostingEnvironmentProfile", "hyperV", "isSpot", "isXenon", "maximumElasticWorkerCount", "perSiteScaling", "reserved", "spotExpirationTime", "targetWorkerCount", "targetWorkerSizeId", "workerTierName". |name|
   }
 }
 
@@ -143,6 +145,7 @@ resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
 
 // should be able to access the read only properties
 resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
+//@[37:68) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2019-10-01" does not have types available. |'Microsoft.Foo/foos@2019-10-01'|
   name: 'nestedTemplate1'
   properties: {
     otherId: nested.id
@@ -155,14 +158,17 @@ resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
 }
 
 resource resourceA 'My.Rp/typeA@2020-01-01' = {
+//@[19:43) [BCP081 (Warning)] Resource type "My.Rp/typeA@2020-01-01" does not have types available. |'My.Rp/typeA@2020-01-01'|
   name: 'resourceA'
 }
 
 resource resourceB 'My.Rp/typeA/typeB@2020-01-01' = {
+//@[19:49) [BCP081 (Warning)] Resource type "My.Rp/typeA/typeB@2020-01-01" does not have types available. |'My.Rp/typeA/typeB@2020-01-01'|
   name: '${resourceA.name}/myName'
 }
 
 resource resourceC 'My.Rp/typeA/typeB@2020-01-01' = {
+//@[19:49) [BCP081 (Warning)] Resource type "My.Rp/typeA/typeB@2020-01-01" does not have types available. |'My.Rp/typeA/typeB@2020-01-01'|
   name: '${resourceA.name}/myName'
   properties: {
     aId: resourceA.id
@@ -191,6 +197,7 @@ var resourceCRef = {
 var setResourceCRef = true
 
 resource resourceD 'My.Rp/typeD@2020-01-01' = {
+//@[19:43) [BCP081 (Warning)] Resource type "My.Rp/typeD@2020-01-01" does not have types available. |'My.Rp/typeD@2020-01-01'|
   name: 'constant'
   properties: {
     runtime: varBRuntime
@@ -201,6 +208,7 @@ resource resourceD 'My.Rp/typeD@2020-01-01' = {
 
 var myInterpKey = 'abc'
 resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
+//@[28:53) [BCP081 (Warning)] Resource type "My.Rp/interp@2020-01-01" does not have types available. |'My.Rp/interp@2020-01-01'|
   name: 'interpTest'
   properties: {
     '${myInterpKey}': 1
@@ -210,6 +218,7 @@ resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
 }
 
 resource resourceWithEscaping 'My.Rp/mockResource@2020-01-01' = {
+//@[30:61) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-01-01" does not have types available. |'My.Rp/mockResource@2020-01-01'|
   name: 'test'
   properties: {
     // both key and value should be escaped in template output
@@ -231,20 +240,24 @@ resource vmWithCondition 'Microsoft.Compute/virtualMachines@2020-06-01' = if (sh
 }
 
 resource extension1 'My.Rp/extensionResource@2020-12-01' = {
+//@[20:56) [BCP081 (Warning)] Resource type "My.Rp/extensionResource@2020-12-01" does not have types available. |'My.Rp/extensionResource@2020-12-01'|
   name: 'extension'
   scope: vmWithCondition
 }
 
 resource extension2 'My.Rp/extensionResource@2020-12-01' = {
+//@[20:56) [BCP081 (Warning)] Resource type "My.Rp/extensionResource@2020-12-01" does not have types available. |'My.Rp/extensionResource@2020-12-01'|
   name: 'extension'
   scope: extension1
 }
 
 resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
+//@[31:62) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-01-01" does not have types available. |'My.Rp/mockResource@2020-01-01'|
   name: 'extensionDependencies'
   properties: {
     res1: vmWithCondition.id
     res1runtime: vmWithCondition.properties.something
+//@[44:53) [BCP053 (Warning)] The type "VirtualMachineProperties" does not contain property "something". Available properties include "additionalCapabilities", "availabilitySet", "billingProfile", "diagnosticsProfile", "evictionPolicy", "extensionsTimeBudget", "hardwareProfile", "host", "hostGroup", "instanceView", "licenseType", "networkProfile", "osProfile", "priority", "provisioningState", "proximityPlacementGroup", "securityProfile", "storageProfile", "virtualMachineScaleSet", "vmId". |something|
     res2: extension1.id
     res2runtime: extension1.properties.something
     res3: extension2.id
@@ -253,16 +266,19 @@ resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
 }
 
 resource existing1 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
+//@[19:65) [BCP081 (Warning)] Resource type "Mock.Rp/existingExtensionResource@2020-01-01" does not have types available. |'Mock.Rp/existingExtensionResource@2020-01-01'|
   name: 'existing1'
   scope: extension1
 }
 
 resource existing2 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
+//@[19:65) [BCP081 (Warning)] Resource type "Mock.Rp/existingExtensionResource@2020-01-01" does not have types available. |'Mock.Rp/existingExtensionResource@2020-01-01'|
   name: 'existing2'
   scope: existing1
 }
 
 resource extension3 'My.Rp/extensionResource@2020-12-01' = {
+//@[20:56) [BCP081 (Warning)] Resource type "My.Rp/extensionResource@2020-12-01" does not have types available. |'My.Rp/extensionResource@2020-12-01'|
   name: 'extension3'
   scope: existing1
 }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbols.bicep
@@ -9,7 +9,7 @@ resource basicStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 }
 
 resource dnsZone 'Microsoft.Network/dnszones@2018-05-01' = {
-//@[9:16) Resource dnsZone. Type: Microsoft.Network/dnszones@2018-05-01. Declaration start char: 0, length: 103
+//@[9:16) Resource dnsZone. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 103
   name: 'myZone'
   location: 'global'
 }
@@ -81,7 +81,7 @@ var location = resourceGroup().location
 //@[4:12) Variable location. Type: string. Declaration start char: 0, length: 39
 
 resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
-//@[9:13) Resource farm. Type: Microsoft.Web/serverFarms@2019-08-01. Declaration start char: 0, length: 371
+//@[9:13) Resource farm. Type: Microsoft.Web/serverfarms@2019-08-01. Declaration start char: 0, length: 371
   // dependsOn: resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosAccountName)
   name: hostingPlanName
   location: location

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -680,10 +680,10 @@ namespace Bicep.Core.Diagnostics
                 "An empty indexer is not allowed. Specify a valid expression."
             );
 
-            public ErrorDiagnostic ExpectBodyStartOrIf() => new(
+            public ErrorDiagnostic ExpectBodyStartOrIfOrLoopStart() => new(
                 TextSpan,
                 "BCP118",
-                "Expected the \"{\" character or the \"if\" keyword at this location.");
+                "Expected the \"{\" character, the \"[\" character, or the \"if\" keyword at this location.");
 
             public Diagnostic InvalidExtensionResourceScope() => new(
                 TextSpan,
@@ -778,6 +778,21 @@ namespace Bicep.Core.Diagnostics
                 DiagnosticLevel.Error,
                 "BCP135",
                 $"Scope {ToQuotedString(LanguageConstants.GetResourceScopeDescriptions(suppliedScope))} is not valid for this resource type. Permitted scopes: {ToQuotedString(LanguageConstants.GetResourceScopeDescriptions(supportedScopes))}.");
+
+            public ErrorDiagnostic ExpectedLoopVariableIdentifier() => new(
+                TextSpan,
+                "BCP136",
+                "Expected a loop variable identifier at this location.");
+
+            public ErrorDiagnostic LoopArrayExpressionTypeMismatch(TypeSymbol actualType) => new(
+                TextSpan,
+                "BCP137",
+                $"Loop expected an expression of type \"{LanguageConstants.Array}\" but the provided value is of type \"{actualType}\".");
+
+            public ErrorDiagnostic LoopsNotSupported() => new(
+                TextSpan,
+                "BCP138",
+                "Loops are not currently supported.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -27,6 +27,8 @@ namespace Bicep.Core
         public const string ExistingKeyword = "existing";
 
         public const string IfKeyword = "if";
+        public const string ForKeyword = "for";
+        public const string InKeyword = "in";
 
         public const string TargetScopeTypeTenant = "tenant";
         public const string TargetScopeTypeManagementGroup = "managementGroup";
@@ -37,7 +39,9 @@ namespace Bicep.Core
 
         public static ImmutableSortedSet<string> ContextualKeywords = DeclarationKeywords
             .Add(TargetScopeKeyword)
-            .Add(IfKeyword);
+            .Add(IfKeyword)
+            .Add(ForKeyword)
+            .Add(InKeyword);
 
         public const string TrueKeyword = "true";
         public const string FalseKeyword = "false";

--- a/src/Bicep.Core/Navigation/INamedDeclarationSyntax.cs
+++ b/src/Bicep.Core/Navigation/INamedDeclarationSyntax.cs
@@ -5,11 +5,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Navigation
 {
-    /// <summary>
-    /// Represents a named syntax declaration.
-    /// </summary>
-    /// <remarks>This is used to distinguish a declaration from syntax that references the declaration.</remarks>
-    public interface INamedDeclarationSyntax : IDeclarationSyntax
+    public interface INamedDeclarationSyntax
     {
         IdentifierSyntax Name { get; }
     }

--- a/src/Bicep.Core/Navigation/ITopLevelDeclarationSyntax.cs
+++ b/src/Bicep.Core/Navigation/ITopLevelDeclarationSyntax.cs
@@ -7,10 +7,10 @@ using Bicep.Core.Syntax;
 namespace Bicep.Core.Navigation
 {
     /// <summary>
-    /// Represents a syntax declaration.
+    /// Represents a top-level syntax declaration.
     /// </summary>
     /// <remarks>This is used to identify a program syntax declaration.</remarks>
-    public interface IDeclarationSyntax
+    public interface ITopLevelDeclarationSyntax
     {
         Token Keyword { get; }
     }

--- a/src/Bicep.Core/Navigation/ITopLevelNamedDeclarationSyntax.cs
+++ b/src/Bicep.Core/Navigation/ITopLevelNamedDeclarationSyntax.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Navigation
+{
+    /// <summary>
+    /// Represents a named syntax declaration.
+    /// </summary>
+    /// <remarks>This is used to distinguish a declaration from syntax that references the declaration.</remarks>
+    public interface ITopLevelNamedDeclarationSyntax : ITopLevelDeclarationSyntax, INamedDeclarationSyntax
+    {
+    }
+}

--- a/src/Bicep.Core/Parsing/TokenReader.cs
+++ b/src/Bicep.Core/Parsing/TokenReader.cs
@@ -32,6 +32,12 @@ namespace Bicep.Core.Parsing
             return Tokens[Position];
         }
 
+        public Token? PeekAhead(int charCount = 1)
+        {
+            var effectivePosition = this.Position + charCount;
+            return effectivePosition < this.Tokens.Length ? this.AtPosition(effectivePosition) : null;
+        }
+
         public Token Read()
         {
             var output = Peek();

--- a/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
+++ b/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
@@ -154,6 +154,23 @@ namespace Bicep.Core.PrettyPrint
         public override void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax) =>
             this.BuildWithConcat(() => base.VisitParenthesizedExpressionSyntax(syntax));
 
+        public override void VisitForSyntax(ForSyntax syntax) =>
+            this.Build(() => base.VisitForSyntax(syntax), children =>
+            {
+                Debug.Assert(children.Length == 8);
+
+                ILinkedDocument openBracket = children[0];
+                ILinkedDocument forKeyword = children[1];
+                ILinkedDocument loopVariable = children[2];
+                ILinkedDocument inKeyword = children[3];
+                ILinkedDocument arrayExpression = children[4];
+                ILinkedDocument colon = children[5];
+                ILinkedDocument loopBody = children[6];
+                ILinkedDocument closeBracket = children[7];
+
+                return Concat(openBracket, Spread(forKeyword, loopVariable, inKeyword, arrayExpression), Spread(colon, loopBody), closeBracket);
+            });
+
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax) =>
             this.Build(() => base.VisitFunctionCallSyntax(syntax), children =>
             {

--- a/src/Bicep.Core/Semantics/Binder.cs
+++ b/src/Bicep.Core/Semantics/Binder.cs
@@ -22,7 +22,7 @@ namespace Bicep.Core.Semantics
             // TODO use lazy or some other pattern for init
             this.syntaxTree = syntaxTree;
             this.TargetScope = SyntaxHelper.GetTargetScope(syntaxTree);
-            var (allDeclarations, outermostScopes) = GetAllDeclarations(syntaxTree, symbolContext);
+            var (allDeclarations, outermostScopes) = DeclarationVisitor.GetAllDeclarations(syntaxTree, symbolContext);
             var uniqueDeclarations = GetUniqueDeclarations(allDeclarations);
             var builtInNamespacs = GetBuiltInNamespaces(this.TargetScope);
             this.bindings = GetBindings(syntaxTree, uniqueDeclarations, builtInNamespacs, outermostScopes);
@@ -66,17 +66,6 @@ namespace Bicep.Core.Semantics
 
         public ImmutableArray<DeclaredSymbol>? TryGetCycle(DeclaredSymbol declaredSymbol)
             => this.cyclesBySymbol.TryGetValue(declaredSymbol, out var cycle) ? cycle : null;
-
-        private static (ImmutableArray<DeclaredSymbol>, ImmutableArray<LocalScope>) GetAllDeclarations(SyntaxTree syntaxTree, ISymbolContext symbolContext)
-        {
-            // collect declarations
-            var declarations = new List<DeclaredSymbol>();
-            var childScopes = new List<LocalScope>();
-            var declarationVisitor = new DeclarationVisitor(symbolContext, declarations, childScopes);
-            declarationVisitor.Visit(syntaxTree.ProgramSyntax);
-
-            return (declarations.ToImmutableArray(), childScopes.ToImmutableArray());
-        }
 
         private static ImmutableDictionary<string, DeclaredSymbol> GetUniqueDeclarations(IEnumerable<DeclaredSymbol> allDeclarations)
         {

--- a/src/Bicep.Core/Semantics/DeclarationVisitor.cs
+++ b/src/Bicep.Core/Semantics/DeclarationVisitor.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bicep.Core.Extensions;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Semantics
@@ -11,10 +13,15 @@ namespace Bicep.Core.Semantics
 
         private readonly IList<DeclaredSymbol> declaredSymbols;
 
-        public DeclarationVisitor(ISymbolContext context, IList<DeclaredSymbol> declaredSymbols)
+        private readonly IList<LocalScopeSymbol> outermostScopes;
+
+        private readonly Stack<LocalScopeSymbol> activeScopes = new();
+
+        public DeclarationVisitor(ISymbolContext context, IList<DeclaredSymbol> declaredSymbols, IList<LocalScopeSymbol> outermostScopes)
         {
             this.context = context;
             this.declaredSymbols = declaredSymbols;
+            this.outermostScopes = outermostScopes;
         }
 
         public override void VisitParameterDeclarationSyntax(ParameterDeclarationSyntax syntax)
@@ -55,6 +62,54 @@ namespace Bicep.Core.Semantics
 
             var symbol = new OutputSymbol(this.context, syntax.Name.IdentifierName, syntax, syntax.Value);
             this.declaredSymbols.Add(symbol);
+        }
+
+        public override void VisitForSyntax(ForSyntax syntax)
+        {
+            /*
+             * We cannot add the local symbol to the list of declarations because it will
+             * break name binding at the global namespace level
+             */
+            var itemVariable = new LocalSymbol(this.context, syntax.ItemVariable.Name.IdentifierName, syntax.ItemVariable);
+
+            // create new scope without any descendants
+            var scope = new LocalScopeSymbol(string.Empty, syntax, itemVariable.AsEnumerable(), ImmutableArray<LocalScopeSymbol>.Empty);
+
+            // potentially swap out the top of the stack to append this child (unless we're just starting)
+            AppendChildScope(scope);
+
+            // push it
+            this.activeScopes.Push(scope);
+
+            // visit the children
+            base.VisitForSyntax(syntax);
+
+            // remove from stack
+            var lastPopped = this.activeScopes.Pop();
+
+            if (this.activeScopes.Count <= 0)
+            {
+                // the stack is empty
+                // we must add this scope to the list of outermost scopes
+                // to keep the whole chain reachable
+                // (we also must use what was popped instead of what was pushed since it may have been replaced)
+                this.outermostScopes.Add(lastPopped);
+            }
+        }
+
+        private void AppendChildScope(LocalScopeSymbol newChildScope)
+        {
+            if (this.activeScopes.Count <= 0)
+            {
+                // this is the outermost local scope - no descendants to append
+                return;
+            }
+
+            // pop the parent and append the new child to it
+            var parent = this.activeScopes.Pop().AppendChild(newChildScope);
+
+            // push the parent back
+            this.activeScopes.Push(parent);
         }
     }
 }

--- a/src/Bicep.Core/Semantics/FileSymbol.cs
+++ b/src/Bicep.Core/Semantics/FileSymbol.cs
@@ -2,17 +2,20 @@
 // Licensed under the MIT License.
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
+using Azure.Deployments.Core.Extensions;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Semantics
 {
-    public class FileSymbol : Symbol
+    public class FileSymbol : Symbol, ILanguageScope
     {
         public FileSymbol(string name,
             ProgramSyntax syntax,
             ImmutableDictionary<string, NamespaceSymbol> importedNamespaces,
+            IEnumerable<LocalScopeSymbol> outermostScopes,
             IEnumerable<ParameterSymbol> parameterDeclarations,
             IEnumerable<VariableSymbol> variableDeclarations,
             IEnumerable<ResourceSymbol> resourceDeclarations,
@@ -22,6 +25,7 @@ namespace Bicep.Core.Semantics
         {
             this.Syntax = syntax;
             this.ImportedNamespaces = importedNamespaces;
+            this.LocalScopes = outermostScopes.ToImmutableArray();
             this.ParameterDeclarations = parameterDeclarations.ToImmutableArray();
             this.VariableDeclarations = variableDeclarations.ToImmutableArray();
             this.ResourceDeclarations = resourceDeclarations.ToImmutableArray();
@@ -30,7 +34,8 @@ namespace Bicep.Core.Semantics
         }
 
         public override IEnumerable<Symbol> Descendants => this.ImportedNamespaces.Values
-            .Concat<Symbol>(this.ParameterDeclarations)
+            .Concat<Symbol>(this.LocalScopes)
+            .Concat(this.ParameterDeclarations)
             .Concat(this.VariableDeclarations)
             .Concat(this.ResourceDeclarations)
             .Concat(this.ModuleDeclarations)
@@ -42,6 +47,9 @@ namespace Bicep.Core.Semantics
 
         public ImmutableDictionary<string, NamespaceSymbol> ImportedNamespaces { get; }
 
+        // TODO: Make this hierarchical at some point.
+        public ImmutableArray<LocalScopeSymbol> LocalScopes { get; }
+
         public ImmutableArray<ParameterSymbol> ParameterDeclarations { get; }
 
         public ImmutableArray<VariableSymbol> VariableDeclarations { get; }
@@ -52,6 +60,9 @@ namespace Bicep.Core.Semantics
 
         public ImmutableArray<OutputSymbol> OutputDeclarations { get; }
         
+        /// <summary>
+        /// Returns all the top-level declaration symbols.
+        /// </summary>
         public IEnumerable<DeclaredSymbol> AllDeclarations => this.Descendants.OfType<DeclaredSymbol>();
 
         public override void Accept(SymbolVisitor visitor)
@@ -61,20 +72,12 @@ namespace Bicep.Core.Semantics
 
         public override IEnumerable<ErrorDiagnostic> GetDiagnostics()
         {
-            // only consider declarations with valid identifiers
-            var duplicateSymbols = this.AllDeclarations
-                .Where(decl => decl.NameSyntax.IsValid)
-                .GroupBy(decl => decl.Name)
-                .Where(group => group.Count() > 1);
-
-            foreach (IGrouping<string, DeclaredSymbol> group in duplicateSymbols)
+            foreach (var duplicatedSymbol in DuplicateIdentifierDiagnosticCollectorVisitor.GetDuplicateDeclarations(this))
             {
-                foreach (DeclaredSymbol duplicatedSymbol in group)
-                {
-                    yield return this.CreateError(duplicatedSymbol.NameSyntax, b => b.IdentifierMultipleDeclarations(duplicatedSymbol.Name));
-                }
+                yield return this.CreateError(duplicatedSymbol.NameSyntax, b => b.IdentifierMultipleDeclarations(duplicatedSymbol.Name));
             }
 
+            // TODO: This isn't aware of locals. Fix it.
             var namespaceKeys = this.ImportedNamespaces.Keys;
             var reservedSymbols = this.AllDeclarations
                 .Where(decl => decl.NameSyntax.IsValid)
@@ -87,6 +90,81 @@ namespace Bicep.Core.Semantics
                     b => b.SymbolicNameCannotUseReservedNamespaceName(
                         reservedSymbol.Name,
                         namespaceKeys));
+            }
+        }
+
+        public IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name) => this.AllDeclarations.Where(symbol => symbol.NameSyntax.IsValid && string.Equals(symbol.Name, name, LanguageConstants.IdentifierComparison)).ToList();
+
+        private sealed class DuplicateIdentifierDiagnosticCollectorVisitor : SymbolVisitor
+        {
+            private readonly List<ILanguageScope> activeScopes = new();
+
+            private readonly FileSymbol file;
+
+            private DuplicateIdentifierDiagnosticCollectorVisitor(FileSymbol file)
+            {
+                this.file = file;
+
+                // initialize global scope
+                this.activeScopes.Add(file);
+            }
+
+            private HashSet<DeclaredSymbol> Duplicates { get; } = new();
+            
+            public static IEnumerable<DeclaredSymbol> GetDuplicateDeclarations(FileSymbol file)
+            {
+                var visitor = new DuplicateIdentifierDiagnosticCollectorVisitor(file);
+                visitor.Visit(file);
+
+                return visitor.Duplicates;
+            }
+
+            protected override void VisitInternal(Symbol node)
+            {
+                if (node is DeclaredSymbol declaredSymbol && declaredSymbol.NameSyntax.IsValid)
+                {
+                    // TODO: There's an 
+                    // collect symbols with the same name from current and parent scopes
+                    var symbolsWithMatchingName = FindSymbolsByName(declaredSymbol.Name);
+
+                    // we're visiting the symbol now, so we should have at least 1
+                    // (0 would be possible if we didn't assert on NameSyntax being valid at the top)
+                    Debug.Assert(symbolsWithMatchingName.Count > 0, "symbolsWithMatchingName.Count > 0");
+
+                    // more than 1 in currently active scopes indicates a user error
+                    if (symbolsWithMatchingName.Count > 1)
+                    {
+                        // add to the list of duplicates
+                        this.Duplicates.AddRange(symbolsWithMatchingName);
+                    }
+                }
+
+                base.VisitInternal(node);
+            }
+
+            public override void VisitLocalScopeSymbol(LocalScopeSymbol symbol)
+            {
+                var localSymbols = symbol.DeclaredSymbols.ToLookup(decl => decl.Name, LanguageConstants.IdentifierComparer);
+                this.activeScopes.Add(symbol);
+
+                base.VisitLocalScopeSymbol(symbol);
+
+                this.activeScopes.RemoveAt(this.activeScopes.Count - 1);
+            }
+
+            private IList<DeclaredSymbol> FindSymbolsByName(string name)
+            {
+                var symbols = new List<DeclaredSymbol>();
+
+                // iterating from outer to inner scopes
+                // the order doesn't matter because we are only collecting symbols
+                foreach (var scope in this.activeScopes)
+                {
+                    // lookups return empty for non-existed keys
+                    symbols.AddRange(scope.GetDeclarationsByName(name));
+                }
+
+                return symbols;
             }
         }
     }

--- a/src/Bicep.Core/Semantics/FileSymbol.cs
+++ b/src/Bicep.Core/Semantics/FileSymbol.cs
@@ -17,7 +17,7 @@ namespace Bicep.Core.Semantics
         public FileSymbol(string name,
             ProgramSyntax syntax,
             ImmutableDictionary<string, NamespaceSymbol> importedNamespaces,
-            IEnumerable<LocalScopeSymbol> outermostScopes,
+            IEnumerable<LocalScope> outermostScopes,
             IEnumerable<ParameterSymbol> parameterDeclarations,
             IEnumerable<VariableSymbol> variableDeclarations,
             IEnumerable<ResourceSymbol> resourceDeclarations,
@@ -52,7 +52,7 @@ namespace Bicep.Core.Semantics
 
         public ImmutableDictionary<string, NamespaceSymbol> ImportedNamespaces { get; }
 
-        public ImmutableArray<LocalScopeSymbol> LocalScopes { get; }
+        public ImmutableArray<LocalScope> LocalScopes { get; }
 
         public ImmutableArray<ParameterSymbol> ParameterDeclarations { get; }
 
@@ -146,12 +146,12 @@ namespace Bicep.Core.Semantics
                 base.VisitInternal(node);
             }
 
-            public override void VisitLocalScopeSymbol(LocalScopeSymbol symbol)
+            public override void VisitLocalScope(LocalScope symbol)
             {
                 var localSymbols = symbol.DeclaredSymbols.ToLookup(decl => decl.Name, LanguageConstants.IdentifierComparer);
                 this.activeScopes.Add(symbol);
 
-                base.VisitLocalScopeSymbol(symbol);
+                base.VisitLocalScope(symbol);
 
                 this.activeScopes.RemoveAt(this.activeScopes.Count - 1);
             }

--- a/src/Bicep.Core/Semantics/ILanguageScope.cs
+++ b/src/Bicep.Core/Semantics/ILanguageScope.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Bicep.Core.Semantics
+{
+    public interface ILanguageScope
+    {
+        IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name);
+    }
+}

--- a/src/Bicep.Core/Semantics/ILanguageScope.cs
+++ b/src/Bicep.Core/Semantics/ILanguageScope.cs
@@ -8,5 +8,7 @@ namespace Bicep.Core.Semantics
     public interface ILanguageScope
     {
         IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name);
+
+        IEnumerable<DeclaredSymbol> AllDeclarations { get; }
     }
 }

--- a/src/Bicep.Core/Semantics/LocalScope.cs
+++ b/src/Bicep.Core/Semantics/LocalScope.cs
@@ -11,9 +11,9 @@ namespace Bicep.Core.Semantics
     /// <summary>
     /// Represents a language scope that declares local symbols. (For example the item or index variables in loops are local symbols.)
     /// </summary>
-    public class LocalScopeSymbol : Symbol, ILanguageScope
+    public class LocalScope : Symbol, ILanguageScope
     {
-        public LocalScopeSymbol(string name, SyntaxBase enclosingSyntax, IEnumerable<DeclaredSymbol> declaredSymbols, IEnumerable<LocalScopeSymbol> childScopes)
+        public LocalScope(string name, SyntaxBase enclosingSyntax, IEnumerable<DeclaredSymbol> declaredSymbols, IEnumerable<LocalScope> childScopes)
             : base(name)
         {
             this.EnclosingSyntax = enclosingSyntax;
@@ -25,15 +25,15 @@ namespace Bicep.Core.Semantics
 
         public ImmutableArray<DeclaredSymbol> DeclaredSymbols { get; }
 
-        public ImmutableArray<LocalScopeSymbol> ChildScopes { get; }
+        public ImmutableArray<LocalScope> ChildScopes { get; }
 
-        public override void Accept(SymbolVisitor visitor) => visitor.VisitLocalScopeSymbol(this);
+        public override void Accept(SymbolVisitor visitor) => visitor.VisitLocalScope(this);
 
         public override SymbolKind Kind => SymbolKind.Scope;
 
         public override IEnumerable<Symbol> Descendants => this.ChildScopes.Concat<Symbol>(this.DeclaredSymbols);
 
-        public LocalScopeSymbol AppendChild(LocalScopeSymbol newChild) => new(this.Name, this.EnclosingSyntax, this.DeclaredSymbols, this.ChildScopes.Append(newChild));
+        public LocalScope AppendChild(LocalScope newChild) => new(this.Name, this.EnclosingSyntax, this.DeclaredSymbols, this.ChildScopes.Append(newChild));
 
         public IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name) => this.DeclaredSymbols.Where(symbol => symbol.NameSyntax.IsValid && string.Equals(symbol.Name, name, LanguageConstants.IdentifierComparison)).ToList();
 

--- a/src/Bicep.Core/Semantics/LocalScope.cs
+++ b/src/Bicep.Core/Semantics/LocalScope.cs
@@ -13,17 +13,17 @@ namespace Bicep.Core.Semantics
     /// </summary>
     public class LocalScope : Symbol, ILanguageScope
     {
-        public LocalScope(string name, SyntaxBase enclosingSyntax, IEnumerable<DeclaredSymbol> declaredSymbols, IEnumerable<LocalScope> childScopes)
+        public LocalScope(string name, SyntaxBase enclosingSyntax, IEnumerable<LocalVariableSymbol> locals, IEnumerable<LocalScope> childScopes)
             : base(name)
         {
             this.EnclosingSyntax = enclosingSyntax;
-            this.DeclaredSymbols = declaredSymbols.ToImmutableArray();
+            this.Locals = locals.ToImmutableArray();
             this.ChildScopes = childScopes.ToImmutableArray();
         }
 
         public SyntaxBase EnclosingSyntax { get; }
 
-        public ImmutableArray<DeclaredSymbol> DeclaredSymbols { get; }
+        public ImmutableArray<LocalVariableSymbol> Locals { get; }
 
         public ImmutableArray<LocalScope> ChildScopes { get; }
 
@@ -31,11 +31,13 @@ namespace Bicep.Core.Semantics
 
         public override SymbolKind Kind => SymbolKind.Scope;
 
-        public override IEnumerable<Symbol> Descendants => this.ChildScopes.Concat<Symbol>(this.DeclaredSymbols);
+        public override IEnumerable<Symbol> Descendants => this.ChildScopes.Concat<Symbol>(this.Locals);
 
-        public LocalScope AppendChild(LocalScope newChild) => new(this.Name, this.EnclosingSyntax, this.DeclaredSymbols, this.ChildScopes.Append(newChild));
+        public LocalScope AppendChild(LocalScope newChild) => new(this.Name, this.EnclosingSyntax, this.Locals, this.ChildScopes.Append(newChild));
 
-        public IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name) => this.DeclaredSymbols.Where(symbol => symbol.NameSyntax.IsValid && string.Equals(symbol.Name, name, LanguageConstants.IdentifierComparison)).ToList();
+        public IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name) => this.Locals.Where(symbol => symbol.NameSyntax.IsValid && string.Equals(symbol.Name, name, LanguageConstants.IdentifierComparison)).ToList();
+        
+        public IEnumerable<DeclaredSymbol> AllDeclarations => this.Locals;
 
         public override IEnumerable<ErrorDiagnostic> GetDiagnostics()
         {

--- a/src/Bicep.Core/Semantics/LocalScope.cs
+++ b/src/Bicep.Core/Semantics/LocalScope.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Semantics
 
         public override IEnumerable<Symbol> Descendants => this.ChildScopes.Concat<Symbol>(this.Locals);
 
-        public LocalScope AppendChild(LocalScope newChild) => new(this.Name, this.EnclosingSyntax, this.Locals, this.ChildScopes.Append(newChild));
+        public LocalScope ReplaceChildren(IEnumerable<LocalScope> newChildren) => new(this.Name, this.EnclosingSyntax, this.Locals, newChildren);
 
         public IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name) => this.Locals.Where(symbol => symbol.NameSyntax.IsValid && string.Equals(symbol.Name, name, LanguageConstants.IdentifierComparison)).ToList();
         

--- a/src/Bicep.Core/Semantics/LocalScopeSymbol.cs
+++ b/src/Bicep.Core/Semantics/LocalScopeSymbol.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Semantics
+{
+    /// <summary>
+    /// Represents a language scope that declares local symbols. (For example the item or index variables in loops are local symbols.)
+    /// </summary>
+    public class LocalScopeSymbol : Symbol, ILanguageScope
+    {
+        public LocalScopeSymbol(string name, SyntaxBase enclosingSyntax, IEnumerable<DeclaredSymbol> declaredSymbols, IEnumerable<LocalScopeSymbol> childScopes)
+            : base(name)
+        {
+            this.EnclosingSyntax = enclosingSyntax;
+            this.DeclaredSymbols = declaredSymbols.ToImmutableArray();
+            this.ChildScopes = childScopes.ToImmutableArray();
+        }
+
+        public SyntaxBase EnclosingSyntax { get; }
+
+        public ImmutableArray<DeclaredSymbol> DeclaredSymbols { get; }
+
+        public ImmutableArray<LocalScopeSymbol> ChildScopes { get; }
+
+        public override void Accept(SymbolVisitor visitor) => visitor.VisitLocalScopeSymbol(this);
+
+        public override SymbolKind Kind => SymbolKind.Scope;
+
+        public override IEnumerable<Symbol> Descendants => this.ChildScopes.Concat<Symbol>(this.DeclaredSymbols);
+
+        public LocalScopeSymbol AppendChild(LocalScopeSymbol newChild) => new(this.Name, this.EnclosingSyntax, this.DeclaredSymbols, this.ChildScopes.Append(newChild));
+
+        public IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name) => this.DeclaredSymbols.Where(symbol => symbol.NameSyntax.IsValid && string.Equals(symbol.Name, name, LanguageConstants.IdentifierComparison)).ToList();
+
+        public override IEnumerable<ErrorDiagnostic> GetDiagnostics()
+        {
+            // TODO: Remove when loops codegen is done.
+            yield return DiagnosticBuilder.ForPosition(((ForSyntax) this.EnclosingSyntax).ForKeyword).LoopsNotSupported();
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/LocalSymbol.cs
+++ b/src/Bicep.Core/Semantics/LocalSymbol.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Semantics
+{
+    public class LocalSymbol : DeclaredSymbol
+    {
+        public LocalSymbol(ISymbolContext context, string name, LocalVariableSyntax declaringSyntax)
+            : base(context, name, declaringSyntax, declaringSyntax.Name)
+        {
+        }
+
+        public override void Accept(SymbolVisitor visitor) => visitor.VisitLocalSymbol(this);
+
+        public override SymbolKind Kind => SymbolKind.Local;
+    }
+}

--- a/src/Bicep.Core/Semantics/LocalVariableSymbol.cs
+++ b/src/Bicep.Core/Semantics/LocalVariableSymbol.cs
@@ -7,14 +7,14 @@ using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Semantics
 {
-    public class LocalSymbol : DeclaredSymbol
+    public class LocalVariableSymbol : DeclaredSymbol
     {
-        public LocalSymbol(ISymbolContext context, string name, LocalVariableSyntax declaringSyntax)
+        public LocalVariableSymbol(ISymbolContext context, string name, LocalVariableSyntax declaringSyntax)
             : base(context, name, declaringSyntax, declaringSyntax.Name)
         {
         }
 
-        public override void Accept(SymbolVisitor visitor) => visitor.VisitLocalSymbol(this);
+        public override void Accept(SymbolVisitor visitor) => visitor.VisitLocalVariableSymbol(this);
 
         public override SymbolKind Kind => SymbolKind.Local;
     }

--- a/src/Bicep.Core/Semantics/NameBindingVisitor.cs
+++ b/src/Bicep.Core/Semantics/NameBindingVisitor.cs
@@ -52,7 +52,7 @@ namespace Bicep.Core.Semantics
             // include all the locals in the symbol table as well
             // since we only allow lookups by object and not by name,
             // a flat symbol table should be sufficient
-            foreach (var declaredSymbol in allLocalScopes.Values.SelectMany(scope => scope.DeclaredSymbols))
+            foreach (var declaredSymbol in allLocalScopes.Values.SelectMany(scope => scope.AllDeclarations))
             {
                 this.bindings.Add(declaredSymbol.DeclaringSyntax, declaredSymbol);
             }
@@ -253,7 +253,7 @@ namespace Bicep.Core.Semantics
             // loops currently are the only source of local symbols
             // as a result a local scope can contain between 1 to 2 local symbols
             // linear search should be fine, but this should be revisited if the above is no longer holds true
-            scope.DeclaredSymbols.FirstOrDefault(symbol => string.Equals(identifierSyntax.IdentifierName, symbol.Name, LanguageConstants.IdentifierComparison));
+            scope.AllDeclarations.FirstOrDefault(symbol => string.Equals(identifierSyntax.IdentifierName, symbol.Name, LanguageConstants.IdentifierComparison));
 
         private Symbol LookupGlobalSymbolByName(IdentifierSyntax identifierSyntax, bool isFunctionCall)
         {

--- a/src/Bicep.Core/Semantics/NameBindingVisitor.cs
+++ b/src/Bicep.Core/Semantics/NameBindingVisitor.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
+using Azure.Deployments.Core.Extensions;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Syntax;
@@ -21,11 +24,19 @@ namespace Bicep.Core.Semantics
 
         private readonly ImmutableDictionary<string, NamespaceSymbol> namespaces;
 
-        public NameBindingVisitor(IReadOnlyDictionary<string, DeclaredSymbol> declarations, IDictionary<SyntaxBase, Symbol> bindings, ImmutableDictionary<string, NamespaceSymbol> namespaces)
+        private readonly IReadOnlyDictionary<SyntaxBase, LocalScopeSymbol> localScopes;
+
+        // list of active local scopes - we're using it like a stack but with the ability
+        // to peek at all the items that have been pushed already
+        private readonly IList<LocalScopeSymbol> activeScopes;
+
+        public NameBindingVisitor(IReadOnlyDictionary<string, DeclaredSymbol> declarations, IDictionary<SyntaxBase, Symbol> bindings, ImmutableDictionary<string, NamespaceSymbol> namespaces, ImmutableArray<LocalScopeSymbol> outermostScopes)
         {
             this.declarations = declarations;
             this.bindings = bindings;
             this.namespaces = namespaces;
+            this.localScopes = ScopeCollectorVisitor.Build(outermostScopes);
+            this.activeScopes = new List<LocalScopeSymbol>();
         }
 
         public override void VisitProgramSyntax(ProgramSyntax syntax)
@@ -36,6 +47,14 @@ namespace Bicep.Core.Semantics
             // this is needed to make find all references work correctly
             // (doing this here to avoid side-effects in the constructor)
             foreach (DeclaredSymbol declaredSymbol in this.declarations.Values)
+            {
+                this.bindings.Add(declaredSymbol.DeclaringSyntax, declaredSymbol);
+            }
+
+            // include all the locals in the symbol table as well
+            // since we only allow lookups by object and not by name,
+            // a flat symbol table should be sufficient
+            foreach (var declaredSymbol in localScopes.Values.SelectMany(scope => scope.DeclaredSymbols))
             {
                 this.bindings.Add(declaredSymbol.DeclaringSyntax, declaredSymbol);
             }
@@ -180,7 +199,67 @@ namespace Bicep.Core.Semantics
             }
         }
 
-        private Symbol LookupSymbolByName(IdentifierSyntax identifierSyntax, bool isFunctionCall)
+        public override void VisitForSyntax(ForSyntax syntax)
+        {
+            if (!this.localScopes.TryGetValue(syntax, out var localScope))
+            {
+                // code defect in the declaration visitor
+                throw new InvalidOperationException($"Local scope is missing for {syntax.GetType().Name} at {syntax.Span}");
+            }
+
+            // push it to the stack of active scopes
+            // as a result this scope will be used to resolve symbols first
+            // (then all the previous one and then finally the global scope)
+            this.activeScopes.Add(localScope);
+
+            // visit all the children
+            base.VisitForSyntax(syntax);
+
+            // we are leaving the loop scope
+            // pop the scope - no symbols will be resolved against it ever again
+            Debug.Assert(ReferenceEquals(this.activeScopes[^1], localScope), "ReferenceEquals(this.activeScopes[^1], localScope)");
+            this.activeScopes.RemoveAt(this.activeScopes.Count - 1);
+        }
+
+        private Symbol LookupSymbolByName(IdentifierSyntax identifierSyntax, bool isFunctionCall) => 
+            this.LookupLocalSymbolByName(identifierSyntax, isFunctionCall) ?? LookupGlobalSymbolByName(identifierSyntax, isFunctionCall);
+
+        private Symbol? LookupLocalSymbolByName(IdentifierSyntax identifierSyntax, bool isFunctionCall)
+        {
+            if (isFunctionCall)
+            {
+                // functions can't be local symbols
+                return null;
+            }
+
+            // loop iterates in reverse order
+            for (int depth = this.activeScopes.Count - 1; depth >= 0; depth--)
+            {
+                // resolve symbol against current scope
+                // this has a side-effect of binding to the innermost symbol even if there exists 
+                // a symbol with duplicate name in one of the parent scopes
+                // the duplicate detection errors will be emitted by logic elsewhere
+                var scope = this.activeScopes[depth];
+                var symbol = LookupLocalSymbolByName(scope, identifierSyntax);
+                if (symbol != null)
+                {
+                    // found a symbol - return it
+                    return symbol;
+                }
+            }
+
+            return null;
+        }
+
+        private static Symbol? LookupLocalSymbolByName(LocalScopeSymbol scope, IdentifierSyntax identifierSyntax) => 
+            // bind to first symbol matching the specified identifier
+            // (errors about duplicate identifiers are emitted elsewhere)
+            // loops currently are the only source of local symbols
+            // as a result a local scope can contain between 1 to 2 local symbols
+            // linear search should be fine, but this should be revisited if the above is no longer holds true
+            scope.DeclaredSymbols.FirstOrDefault(symbol => string.Equals(identifierSyntax.IdentifierName, symbol.Name, LanguageConstants.IdentifierComparison));
+
+        private Symbol LookupGlobalSymbolByName(IdentifierSyntax identifierSyntax, bool isFunctionCall)
         {
             // attempt to find name in the imported namespaces
             if (this.namespaces.TryGetValue(identifierSyntax.IdentifierName, out var namespaceSymbol))
@@ -193,10 +272,10 @@ namespace Bicep.Core.Semantics
             // There might be instances where a variable declaration for example uses the same name as one of the imported
             // functions, in this case to differentiate a variable declaration vs a function access we check the namespace value,
             // the former case must have an empty namespace value whereas the latter will have a namespace value.
-            if (this.declarations.TryGetValue(identifierSyntax.IdentifierName, out var localSymbol))
+            if (this.declarations.TryGetValue(identifierSyntax.IdentifierName, out var globalSymbol))
             {
-                // we found the symbol in the local namespace
-                return localSymbol;
+                // we found the symbol in the global namespace
+                return globalSymbol;
             }
 
             // attempt to find function in all imported namespaces
@@ -213,10 +292,30 @@ namespace Bicep.Core.Semantics
                 return new ErrorSymbol(DiagnosticBuilder.ForPosition(identifierSyntax).AmbiguousSymbolReference(identifierSyntax.IdentifierName, this.namespaces.Keys));
             }
 
-            var foundSymbol = foundSymbols.FirstOrDefault();
-            return isFunctionCall ?
-                SymbolValidator.ResolveUnqualifiedFunction(allowedFlags, foundSymbol, identifierSyntax, namespaces.Values) :
-                SymbolValidator.ResolveUnqualifiedSymbol(foundSymbol, identifierSyntax, namespaces.Values, declarations.Keys);
+            var foundSymbol = Enumerable.FirstOrDefault(foundSymbols);
+            return isFunctionCall ? SymbolValidator.ResolveUnqualifiedFunction(allowedFlags, foundSymbol, identifierSyntax, namespaces.Values) : SymbolValidator.ResolveUnqualifiedSymbol(foundSymbol, identifierSyntax, namespaces.Values, declarations.Keys);
+        }
+        
+        private class ScopeCollectorVisitor: SymbolVisitor
+        {
+            private IDictionary<SyntaxBase, LocalScopeSymbol> ScopeMap { get; } = new Dictionary<SyntaxBase, LocalScopeSymbol>();
+
+            public override void VisitLocalScopeSymbol(LocalScopeSymbol symbol)
+            {
+                this.ScopeMap.Add(symbol.EnclosingSyntax, symbol);
+                base.VisitLocalScopeSymbol(symbol);
+            }
+
+            public static IReadOnlyDictionary<SyntaxBase, LocalScopeSymbol> Build(ImmutableArray<LocalScopeSymbol> outermostScopes)
+            {
+                var visitor = new ScopeCollectorVisitor();
+                foreach (LocalScopeSymbol outermostScope in outermostScopes)
+                {
+                    visitor.Visit(outermostScope);
+                }
+
+                return visitor.ScopeMap.AsReadOnly();
+            }
         }
     }
 }

--- a/src/Bicep.Core/Semantics/SemanticDiagnosticVisitor.cs
+++ b/src/Bicep.Core/Semantics/SemanticDiagnosticVisitor.cs
@@ -75,6 +75,12 @@ namespace Bicep.Core.Semantics
             this.CollectDiagnostics(symbol);
         }
 
+        public override void VisitLocalScopeSymbol(LocalScopeSymbol symbol)
+        {
+            base.VisitLocalScopeSymbol(symbol);
+            this.CollectDiagnostics(symbol);
+        }
+
         protected void CollectDiagnostics(Symbol symbol)
         {
             diagnosticWriter.WriteMultiple(symbol.GetDiagnostics());

--- a/src/Bicep.Core/Semantics/SemanticDiagnosticVisitor.cs
+++ b/src/Bicep.Core/Semantics/SemanticDiagnosticVisitor.cs
@@ -75,9 +75,9 @@ namespace Bicep.Core.Semantics
             this.CollectDiagnostics(symbol);
         }
 
-        public override void VisitLocalScopeSymbol(LocalScopeSymbol symbol)
+        public override void VisitLocalScope(LocalScope symbol)
         {
-            base.VisitLocalScopeSymbol(symbol);
+            base.VisitLocalScope(symbol);
             this.CollectDiagnostics(symbol);
         }
 

--- a/src/Bicep.Core/Semantics/SymbolKind.cs
+++ b/src/Bicep.Core/Semantics/SymbolKind.cs
@@ -13,6 +13,8 @@ namespace Bicep.Core.Semantics
         Module,
         Output,
         Namespace,
-        Function
+        Function,
+        Local,
+        Scope
     }
 }

--- a/src/Bicep.Core/Semantics/SymbolVisitor.cs
+++ b/src/Bicep.Core/Semantics/SymbolVisitor.cs
@@ -61,6 +61,16 @@ namespace Bicep.Core.Semantics
             VisitDescendants(symbol);
         }
 
+        public virtual void VisitLocalScopeSymbol(LocalScopeSymbol symbol)
+        {
+            VisitDescendants(symbol);
+        }
+
+        public virtual void VisitLocalSymbol(LocalSymbol symbol)
+        {
+            VisitDescendants(symbol);
+        }
+
         public virtual void VisitErrorSymbol(ErrorSymbol symbol)
         {
             VisitDescendants(symbol);

--- a/src/Bicep.Core/Semantics/SymbolVisitor.cs
+++ b/src/Bicep.Core/Semantics/SymbolVisitor.cs
@@ -61,12 +61,12 @@ namespace Bicep.Core.Semantics
             VisitDescendants(symbol);
         }
 
-        public virtual void VisitLocalScopeSymbol(LocalScopeSymbol symbol)
+        public virtual void VisitLocalScope(LocalScope symbol)
         {
             VisitDescendants(symbol);
         }
 
-        public virtual void VisitLocalSymbol(LocalSymbol symbol)
+        public virtual void VisitLocalVariableSymbol(LocalVariableSymbol symbol)
         {
             VisitDescendants(symbol);
         }

--- a/src/Bicep.Core/Syntax/ForSyntax.cs
+++ b/src/Bicep.Core/Syntax/ForSyntax.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    public class ForSyntax : SyntaxBase
+    {
+        public ForSyntax(
+            Token openSquare,
+            Token forKeyword,
+            LocalVariableSyntax itemVariable,
+            SyntaxBase inKeyword,
+            SyntaxBase expression,
+            SyntaxBase colon,
+            SyntaxBase body,
+            SyntaxBase closeSquare)
+        {
+            AssertTokenType(openSquare, nameof(openSquare), TokenType.LeftSquare);
+            AssertKeyword(forKeyword, nameof(forKeyword), LanguageConstants.ForKeyword);
+            AssertSyntaxType(inKeyword, nameof(inKeyword), typeof(Token), typeof(SkippedTriviaSyntax));
+            AssertKeyword(inKeyword as Token, nameof(inKeyword), LanguageConstants.InKeyword);
+            AssertSyntaxType(colon, nameof(colon), typeof(Token), typeof(SkippedTriviaSyntax));
+            AssertTokenType(colon as Token, nameof(colon), TokenType.Colon);
+            AssertSyntaxType(closeSquare, nameof(closeSquare), typeof(Token), typeof(SkippedTriviaSyntax));
+            AssertTokenType(closeSquare as Token, nameof(closeSquare), TokenType.RightSquare);
+            
+            this.OpenSquare = openSquare;
+            this.ForKeyword = forKeyword;
+            this.ItemVariable = itemVariable;
+            this.InKeyword = inKeyword;
+            this.Expression = expression;
+            this.Colon = colon;
+            this.Body = body;
+            this.CloseSquare = closeSquare;
+        }
+
+        public Token OpenSquare { get; }
+
+        public Token ForKeyword { get; }
+
+        public LocalVariableSyntax ItemVariable { get; }
+
+        public SyntaxBase InKeyword { get; }
+
+        public SyntaxBase Expression { get; }
+
+        public SyntaxBase Colon { get; }
+
+        public SyntaxBase Body { get; }
+
+        public SyntaxBase CloseSquare { get; }
+
+        public override void Accept(ISyntaxVisitor visitor) => visitor.VisitForSyntax(this);
+
+        public override TextSpan Span => TextSpan.Between(this.OpenSquare, this.CloseSquare);
+    }
+}

--- a/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
@@ -68,7 +68,11 @@ namespace Bicep.Core.Syntax
 
         void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax);
 
+        void VisitLocalVariableSyntax(LocalVariableSyntax syntax);
+
         void VisitIfConditionSyntax(IfConditionSyntax syntax);
+
+        void VisitForSyntax(ForSyntax syntax);
 
         void VisitDecoratorSyntax(DecoratorSyntax syntax);
 

--- a/src/Bicep.Core/Syntax/LocalVariableSyntax.cs
+++ b/src/Bicep.Core/Syntax/LocalVariableSyntax.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Navigation;
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    /// <summary>
+    /// Represents a local variable (such as the item or index variable in loops).
+    /// </summary>
+    public class LocalVariableSyntax : SyntaxBase, INamedDeclarationSyntax
+    {
+        public LocalVariableSyntax(IdentifierSyntax name)
+        {
+            this.Name = name;
+        }
+
+        public IdentifierSyntax Name { get; }
+
+        public override void Accept(ISyntaxVisitor visitor) => visitor.VisitLocalVariableSyntax(this);
+
+        public override TextSpan Span => this.Name.Span;
+    }
+}

--- a/src/Bicep.Core/Syntax/ModuleDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ModuleDeclarationSyntax.cs
@@ -10,7 +10,7 @@ using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Syntax
 {
-    public class ModuleDeclarationSyntax : StatementSyntax, INamedDeclarationSyntax
+    public class ModuleDeclarationSyntax : StatementSyntax, ITopLevelNamedDeclarationSyntax
     {
         public ModuleDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, IdentifierSyntax name, SyntaxBase path, SyntaxBase assignment, SyntaxBase value)
             : base(leadingNodes)
@@ -21,7 +21,7 @@ namespace Bicep.Core.Syntax
             AssertTokenType(keyword, nameof(keyword), TokenType.Identifier);
             AssertSyntaxType(assignment, nameof(assignment), typeof(Token), typeof(SkippedTriviaSyntax));
             AssertTokenType(assignment as Token, nameof(assignment), TokenType.Assignment);
-            AssertSyntaxType(value, nameof(value), typeof(SkippedTriviaSyntax), typeof(ObjectSyntax), typeof(IfConditionSyntax));
+            AssertSyntaxType(value, nameof(value), typeof(SkippedTriviaSyntax), typeof(ObjectSyntax), typeof(IfConditionSyntax), typeof(ForSyntax));
 
             this.Keyword = keyword;
             this.Name = name;
@@ -75,6 +75,7 @@ namespace Bicep.Core.Syntax
             {
                 ObjectSyntax @object => @object,
                 IfConditionSyntax ifCondition => ifCondition.Body as ObjectSyntax,
+                ForSyntax @for => @for.Body as ObjectSyntax,
                 SkippedTriviaSyntax => null,
 
                 // blocked by assert in the constructor

--- a/src/Bicep.Core/Syntax/OutputDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/OutputDeclarationSyntax.cs
@@ -8,7 +8,7 @@ using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax
 {
-    public class OutputDeclarationSyntax : StatementSyntax, INamedDeclarationSyntax
+    public class OutputDeclarationSyntax : StatementSyntax, ITopLevelNamedDeclarationSyntax
     {
         public OutputDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, IdentifierSyntax name, SyntaxBase type, SyntaxBase assignment, SyntaxBase value)
             : base(leadingNodes)

--- a/src/Bicep.Core/Syntax/ParameterDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ParameterDeclarationSyntax.cs
@@ -12,7 +12,7 @@ using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Syntax
 {
-    public class ParameterDeclarationSyntax : StatementSyntax, INamedDeclarationSyntax
+    public class ParameterDeclarationSyntax : StatementSyntax, ITopLevelNamedDeclarationSyntax
     {
         public ParameterDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, IdentifierSyntax name, SyntaxBase type, SyntaxBase? modifier)
             : base(leadingNodes)

--- a/src/Bicep.Core/Syntax/ProgramSyntax.cs
+++ b/src/Bicep.Core/Syntax/ProgramSyntax.cs
@@ -30,6 +30,6 @@ namespace Bicep.Core.Syntax
         public override TextSpan Span => TextSpan.Between(new TextSpan(0, 0), this.EndOfFile);
 
         // TODO: Should we have a DeclarationSyntax abstract class?
-        public IEnumerable<SyntaxBase> Declarations => this.Children.Where(c => c is INamedDeclarationSyntax);
+        public IEnumerable<SyntaxBase> Declarations => this.Children.Where(c => c is ITopLevelNamedDeclarationSyntax);
     }
 }

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -143,6 +143,19 @@ namespace Bicep.Core.Syntax
         }
         void ISyntaxVisitor.VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax) => ReplaceCurrent(syntax, ReplaceVariableDeclarationSyntax);
 
+        protected virtual LocalVariableSyntax ReplaceLocalVariableSyntax(LocalVariableSyntax syntax)
+        {
+            var hasChanges = Rewrite(syntax.Name, out var name);
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new LocalVariableSyntax(name);
+        }
+        
+        void ISyntaxVisitor.VisitLocalVariableSyntax(LocalVariableSyntax syntax) => ReplaceCurrent(syntax, ReplaceLocalVariableSyntax);
+
         protected virtual TargetScopeSyntax ReplaceTargetScopeSyntax(TargetScopeSyntax syntax)
         {
             var hasChanges = Rewrite(syntax.LeadingNodes, out var leadingNodes);
@@ -552,6 +565,27 @@ namespace Bicep.Core.Syntax
             return new IfConditionSyntax(keyword, conditionExpression, body);
         }
         void ISyntaxVisitor.VisitIfConditionSyntax(IfConditionSyntax syntax) => ReplaceCurrent(syntax, ReplaceIfExpressionSyntax);
+
+        protected virtual ForSyntax ReplaceForSyntax(ForSyntax syntax)
+        {
+            var hasChanges = Rewrite(syntax.OpenSquare, out var openSquare);
+            hasChanges |= Rewrite(syntax.ForKeyword, out var forKeyword);
+            hasChanges |= Rewrite(syntax.ItemVariable, out var itemVariable);
+            hasChanges |= Rewrite(syntax.InKeyword, out var inKeyword);
+            hasChanges |= Rewrite(syntax.Expression, out var expression);
+            hasChanges |= Rewrite(syntax.Colon, out var colon);
+            hasChanges |= Rewrite(syntax.Body, out var body);
+            hasChanges |= Rewrite(syntax.CloseSquare, out var closeSquare);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new ForSyntax(openSquare, forKeyword, itemVariable, inKeyword, expression, colon, body, closeSquare);
+        }
+
+        void ISyntaxVisitor.VisitForSyntax(ForSyntax syntax) => ReplaceCurrent(syntax, ReplaceForSyntax);
 
         protected virtual DecoratorSyntax ReplaceDecoratorSyntax(DecoratorSyntax syntax)
         {

--- a/src/Bicep.Core/Syntax/SyntaxTreeGroupingBuilder.cs
+++ b/src/Bicep.Core/Syntax/SyntaxTreeGroupingBuilder.cs
@@ -57,7 +57,7 @@ namespace Bicep.Core.Syntax
 
             return new SyntaxTreeGrouping(
                 entryPoint,
-                syntaxTrees.Values.OfType<SyntaxTree>().ToImmutableHashSet(), 
+                syntaxTrees.Values.ToImmutableHashSet(), 
                 moduleLookup.ToImmutableDictionary(),
                 moduleFailureLookup.ToImmutableDictionary());
         }

--- a/src/Bicep.Core/Syntax/SyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxVisitor.cs
@@ -74,6 +74,11 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
+        public virtual void VisitLocalVariableSyntax(LocalVariableSyntax syntax)
+        {
+            this.Visit(syntax.Name);
+        }
+
         public virtual void VisitTargetScopeSyntax(TargetScopeSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
@@ -193,6 +198,18 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Keyword);
             this.Visit(syntax.ConditionExpression);
             this.Visit(syntax.Body);
+        }
+
+        public virtual void VisitForSyntax(ForSyntax syntax)
+        {
+            this.Visit(syntax.OpenSquare);
+            this.Visit(syntax.ForKeyword);
+            this.Visit(syntax.ItemVariable);
+            this.Visit(syntax.InKeyword);
+            this.Visit(syntax.Expression);
+            this.Visit(syntax.Colon);
+            this.Visit(syntax.Body);
+            this.Visit(syntax.CloseSquare);
         }
 
         public virtual void VisitTernaryOperationSyntax(TernaryOperationSyntax syntax)

--- a/src/Bicep.Core/Syntax/TargetScopeSyntax.cs
+++ b/src/Bicep.Core/Syntax/TargetScopeSyntax.cs
@@ -9,7 +9,7 @@ using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Syntax
 {
-    public class TargetScopeSyntax : StatementSyntax, IDeclarationSyntax
+    public class TargetScopeSyntax : StatementSyntax, ITopLevelDeclarationSyntax
     {
         public TargetScopeSyntax(Token keyword, SyntaxBase assignment, SyntaxBase value)
             : base(ImmutableArray<SyntaxBase>.Empty)

--- a/src/Bicep.Core/Syntax/VariableDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/VariableDeclarationSyntax.cs
@@ -8,7 +8,7 @@ using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax
 {
-    public class VariableDeclarationSyntax : StatementSyntax, INamedDeclarationSyntax
+    public class VariableDeclarationSyntax : StatementSyntax, ITopLevelNamedDeclarationSyntax
     {
         public VariableDeclarationSyntax(Token keyword, IdentifierSyntax name, SyntaxBase assignment, SyntaxBase value)
             : base(ImmutableArray<SyntaxBase>.Empty)

--- a/src/Bicep.Core/TypeSystem/CyclicCheckVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CyclicCheckVisitor.cs
@@ -50,7 +50,7 @@ namespace Bicep.Core.TypeSystem
         }
 
         private void VisitDeclaration<TDeclarationSyntax>(TDeclarationSyntax syntax, Action<TDeclarationSyntax> visitBaseFunc)
-            where TDeclarationSyntax : SyntaxBase, INamedDeclarationSyntax
+            where TDeclarationSyntax : SyntaxBase, ITopLevelNamedDeclarationSyntax
         {
             if (!bindings.ContainsKey(syntax))
             {

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -877,7 +877,7 @@ namespace Bicep.Core.TypeSystem
                     case VariableSymbol variable:
                         return new DeferredTypeReference(() => VisitDeclaredSymbol(syntax, variable));
 
-                    case LocalSymbol local:
+                    case LocalVariableSymbol local:
                         return new DeferredTypeReference(() => VisitDeclaredSymbol(syntax, local));
                     
                     case NamespaceSymbol @namespace:

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -211,7 +211,6 @@ namespace Bicep.Core.TypeSystem
 
                 if (syntax.Value is ForSyntax)
                 {
-                    // TODO: Narrowing doesn't work
                     return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, syntax.Value, new TypedArrayType(declaredType, TypeSymbolValidationFlags.Default), diagnostics);
                 }
 
@@ -242,7 +241,6 @@ namespace Bicep.Core.TypeSystem
 
                 if (syntax.Value is ForSyntax)
                 {
-                    // TODO: Narrowing doesn't work
                     return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, syntax.Value, new TypedArrayType(declaredType, TypeSymbolValidationFlags.Default), diagnostics);
                 }
                 

--- a/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
@@ -39,9 +39,11 @@ namespace Bicep.LangServer.IntegrationTests
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
 
-            // filter out symbols that don't have locations
+            // filter out symbols that don't have locations as well as locals with invalid identifiers
+            // (locals are special because their full span is the same as the identifier span,
+            // which makes it impossible to go to definition on a local with invalid identifiers)
             var declaredSymbolBindings = symbolTable
-                .Where(pair => pair.Value is DeclaredSymbol)
+                .Where(pair => pair.Value is DeclaredSymbol && (pair.Value is not LocalSymbol local || local.NameSyntax.IsValid))
                 .Select(pair => new KeyValuePair<SyntaxBase, DeclaredSymbol>(pair.Key, (DeclaredSymbol) pair.Value));
 
             foreach (var (syntax, symbol) in declaredSymbolBindings)

--- a/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
@@ -43,7 +43,7 @@ namespace Bicep.LangServer.IntegrationTests
             // (locals are special because their full span is the same as the identifier span,
             // which makes it impossible to go to definition on a local with invalid identifiers)
             var declaredSymbolBindings = symbolTable
-                .Where(pair => pair.Value is DeclaredSymbol && (pair.Value is not LocalSymbol local || local.NameSyntax.IsValid))
+                .Where(pair => pair.Value is DeclaredSymbol && (pair.Value is not LocalVariableSymbol local || local.NameSyntax.IsValid))
                 .Select(pair => new KeyValuePair<SyntaxBase, DeclaredSymbol>(pair.Key, (DeclaredSymbol) pair.Value));
 
             foreach (var (syntax, symbol) in declaredSymbolBindings)

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
@@ -121,7 +121,7 @@ namespace Bicep.LangServer.IntegrationTests
                 return PositionHelper.GetPosition(lineStarts, instanceFunctionCall.Name.Span.Position);
             }
 
-            if (syntax is IDeclarationSyntax declaration)
+            if (syntax is ITopLevelDeclarationSyntax declaration)
             {
                 return PositionHelper.GetPosition(lineStarts, declaration.Keyword.Span.Position);
             }

--- a/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
@@ -11,8 +11,6 @@ using Bicep.Core.Samples;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
-using Bicep.Core.Text;
-using Bicep.Core.UnitTests.Utils;
 using Bicep.LangServer.IntegrationTests.Extensions;
 using Bicep.LanguageServer.Utils;
 using FluentAssertions;
@@ -42,11 +40,14 @@ namespace Bicep.LangServer.IntegrationTests
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
 
-            var symbolToSyntaxLookup = symbolTable
-                .Where(pair => pair.Value.Kind != SymbolKind.Error)
-                .ToLookup(pair => pair.Value, pair => pair.Key);
+            // filter out binding failures and locals with invalid identifiers
+            // (locals are special because their full span is the same as the identifier span,
+            // which makes it impossible to highlight locals with invalid identifiers)
+            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalSymbol local || local.NameSyntax.IsValid));
 
-            foreach (var (syntax, symbol) in symbolTable.Where(s => s.Value.Kind != SymbolKind.Error))
+            var symbolToSyntaxLookup = filteredSymbolTable.ToLookup(pair => pair.Value, pair => pair.Key);
+
+            foreach (var (syntax, symbol) in filteredSymbolTable)
             {
                 var highlights = await client.RequestDocumentHighlight(new DocumentHighlightParams
                 {
@@ -67,7 +68,7 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task RequestingHighlightsForWrongNodeShouldProduceNoHighlights(DataSet dataSet)
         {
             // local function
-            bool IsWrongNode(SyntaxBase node) => !(node is ISymbolReference) && !(node is INamedDeclarationSyntax) && !(node is Token);
+            bool IsWrongNode(SyntaxBase node) => !(node is ISymbolReference) && !(node is ITopLevelNamedDeclarationSyntax) && !(node is Token);
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 

--- a/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
@@ -43,7 +43,7 @@ namespace Bicep.LangServer.IntegrationTests
             // filter out binding failures and locals with invalid identifiers
             // (locals are special because their full span is the same as the identifier span,
             // which makes it impossible to highlight locals with invalid identifiers)
-            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalSymbol local || local.NameSyntax.IsValid));
+            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalVariableSymbol local || local.NameSyntax.IsValid));
 
             var symbolToSyntaxLookup = filteredSymbolTable.ToLookup(pair => pair.Value, pair => pair.Key);
 

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -192,7 +192,7 @@ namespace Bicep.LangServer.IntegrationTests
                     hover.Contents.MarkupContent.Value.Should().Contain($"function {function.Name}(");
                     break;
 
-                case LocalSymbol local:
+                case LocalVariableSymbol local:
                     hover.Contents.MarkupContent.Value.Should().Contain($"{local.Name}: {local.Type}");
                     break;
 

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Azure.Bicep.Types.Az;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Samples;
@@ -11,6 +12,7 @@ using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.Text;
+using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.LangServer.IntegrationTests.Assertions;
 using Bicep.LangServer.IntegrationTests.Extensions;
@@ -37,7 +39,7 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task HoveringOverSymbolReferencesAndDeclarationsShouldProduceHovers(DataSet dataSet)
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri, resourceTypeProvider: new AzResourceTypeProvider(new TypeLoader()));
 
             // construct a parallel compilation
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
@@ -49,7 +51,7 @@ namespace Bicep.LangServer.IntegrationTests
                 new List<SyntaxBase>(),
                 (accumulated, node) =>
                 {
-                    if (node is ISymbolReference || node is INamedDeclarationSyntax)
+                    if (node is ISymbolReference || node is ITopLevelNamedDeclarationSyntax)
                     {
                         accumulated.Add(node);
                     }
@@ -60,7 +62,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             foreach (SyntaxBase symbolReference in symbolReferences)
             {
-                var syntaxPosition = symbolReference is IDeclarationSyntax declaration
+                var syntaxPosition = symbolReference is ITopLevelDeclarationSyntax declaration
                     ? declaration.Keyword.Span.Position
                     : symbolReference.Span.Position;
 
@@ -110,7 +112,7 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task HoveringOverNonHoverableElementsShouldProduceEmptyHovers(DataSet dataSet)
         {
             // local function
-            bool IsNonHoverable(SyntaxBase node) => !(node is ISymbolReference) && !(node is INamedDeclarationSyntax) && !(node is Token);
+            bool IsNonHoverable(SyntaxBase node) => !(node is ISymbolReference) && !(node is ITopLevelNamedDeclarationSyntax) && !(node is Token);
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
             var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
@@ -188,6 +190,10 @@ namespace Bicep.LangServer.IntegrationTests
 
                 case FunctionSymbol function:
                     hover.Contents.MarkupContent.Value.Should().Contain($"function {function.Name}(");
+                    break;
+
+                case LocalSymbol local:
+                    hover.Contents.MarkupContent.Value.Should().Contain($"{local.Name}: {local.Type}");
                     break;
 
                 default:

--- a/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
@@ -42,11 +42,12 @@ namespace Bicep.LangServer.IntegrationTests
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
 
-            var symbolToSyntaxLookup = symbolTable
-                .Where(pair => pair.Value.Kind != SymbolKind.Error)
-                .ToLookup(pair => pair.Value, pair => pair.Key);
+            // filter out bind failures and locals with invalid identifiers
+            // (locals are special because their span is equal to their identifier span)
+            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalSymbol local || local.NameSyntax.IsValid));
+            var symbolToSyntaxLookup = filteredSymbolTable.ToLookup(pair => pair.Value, pair => pair.Key);
 
-            foreach (var (syntax, symbol) in symbolTable.Where(s => s.Value.Kind != SymbolKind.Error))
+            foreach (var (syntax, symbol) in filteredSymbolTable)
             {
                 var locations = await client.RequestReferences(new ReferenceParams
                 {
@@ -81,11 +82,12 @@ namespace Bicep.LangServer.IntegrationTests
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
 
-            var symbolToSyntaxLookup = symbolTable
-                .Where(pair => pair.Value.Kind != SymbolKind.Error)
-                .ToLookup(pair => pair.Value, pair => pair.Key);
+            // filter out bind failures and locals with invalid identifiers
+            // (locals are special because their span is equal to their identifier span)
+            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalSymbol local || local.NameSyntax.IsValid));
+            var symbolToSyntaxLookup = filteredSymbolTable.ToLookup(pair => pair.Value, pair => pair.Key);
 
-            foreach (var (syntax, symbol) in symbolTable.Where(s => s.Value.Kind != SymbolKind.Error))
+            foreach (var (syntax, symbol) in filteredSymbolTable)
             {
                 var locations = await client.RequestReferences(new ReferenceParams
                 {
@@ -115,7 +117,7 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task FindReferencesOnNonSymbolsShouldProduceEmptyResult(DataSet dataSet)
         {
             // local function
-            bool IsWrongNode(SyntaxBase node) => !(node is ISymbolReference) && !(node is INamedDeclarationSyntax) && !(node is Token);
+            bool IsWrongNode(SyntaxBase node) => !(node is ISymbolReference) && !(node is ITopLevelNamedDeclarationSyntax) && !(node is Token);
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 

--- a/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
@@ -44,7 +44,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             // filter out bind failures and locals with invalid identifiers
             // (locals are special because their span is equal to their identifier span)
-            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalSymbol local || local.NameSyntax.IsValid));
+            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalVariableSymbol local || local.NameSyntax.IsValid));
             var symbolToSyntaxLookup = filteredSymbolTable.ToLookup(pair => pair.Value, pair => pair.Key);
 
             foreach (var (syntax, symbol) in filteredSymbolTable)
@@ -84,7 +84,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             // filter out bind failures and locals with invalid identifiers
             // (locals are special because their span is equal to their identifier span)
-            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalSymbol local || local.NameSyntax.IsValid));
+            var filteredSymbolTable = symbolTable.Where(pair => pair.Value.Kind != SymbolKind.Error && (pair.Value is not LocalVariableSymbol local || local.NameSyntax.IsValid));
             var symbolToSyntaxLookup = filteredSymbolTable.ToLookup(pair => pair.Value, pair => pair.Key);
 
             foreach (var (syntax, symbol) in filteredSymbolTable)

--- a/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
@@ -45,7 +45,7 @@ namespace Bicep.LangServer.IntegrationTests
                 .ToLookup(pair => pair.Value, pair => pair.Key);
 
             var validVariableAccessPairs = symbolTable
-                .Where(pair => (pair.Key is VariableAccessSyntax || pair.Key is INamedDeclarationSyntax)
+                .Where(pair => (pair.Key is VariableAccessSyntax || pair.Key is ITopLevelNamedDeclarationSyntax)
                                && pair.Value.Kind != SymbolKind.Error
                                && pair.Value.Kind != SymbolKind.Function
                                && pair.Value.Kind != SymbolKind.Namespace
@@ -111,7 +111,7 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task RenamingNonSymbolsShouldProduceEmptyEdit(DataSet dataSet)
         {
             // local function
-            bool IsWrongNode(SyntaxBase node) => !(node is ISymbolReference) && !(node is INamedDeclarationSyntax) && !(node is Token);
+            bool IsWrongNode(SyntaxBase node) => !(node is ISymbolReference) && !(node is ITopLevelNamedDeclarationSyntax) && !(node is Token);
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -89,7 +89,7 @@ namespace Bicep.LangServer.UnitTests
                 var parser = new Parser(replaced);
                 var declaration = parser.Declaration();
 
-                declaration.Should().BeAssignableTo<INamedDeclarationSyntax>($"because the snippet for '{detail}' failed to parse after replacements:\n{replaced}");
+                declaration.Should().BeAssignableTo<ITopLevelNamedDeclarationSyntax>($"because the snippet for '{detail}' failed to parse after replacements:\n{replaced}");
             }
         }
 

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -85,7 +85,7 @@ namespace Bicep.LanguageServer.Completions
                 return new BicepCompletionContext(BicepCompletionContextKind.None, replacementRange, null, null, null, null, null, null, null);
             }
 
-            var declarationInfo = SyntaxMatcher.FindLastNodeOfType<INamedDeclarationSyntax, SyntaxBase>(matchingNodes);
+            var topLeveldeclarationInfo = SyntaxMatcher.FindLastNodeOfType<ITopLevelNamedDeclarationSyntax, SyntaxBase>(matchingNodes);
             var objectInfo = SyntaxMatcher.FindLastNodeOfType<ObjectSyntax, ObjectSyntax>(matchingNodes);
             var propertyInfo = SyntaxMatcher.FindLastNodeOfType<ObjectPropertySyntax, ObjectPropertySyntax>(matchingNodes);
             var arrayInfo = SyntaxMatcher.FindLastNodeOfType<ArraySyntax, ArraySyntax>(matchingNodes);
@@ -93,7 +93,7 @@ namespace Bicep.LanguageServer.Completions
             var arrayAccessInfo = SyntaxMatcher.FindLastNodeOfType<ArrayAccessSyntax, ArrayAccessSyntax>(matchingNodes);
             var targetScopeInfo = SyntaxMatcher.FindLastNodeOfType<TargetScopeSyntax, TargetScopeSyntax>(matchingNodes);
 
-            var kind = ConvertFlag(IsDeclarationStartContext(matchingNodes, offset), BicepCompletionContextKind.DeclarationStart) |
+            var kind = ConvertFlag(IsTopLevelDeclarationStartContext(matchingNodes, offset), BicepCompletionContextKind.TopLevelDeclarationStart) |
                        GetDeclarationTypeFlags(matchingNodes, offset) |
                        ConvertFlag(IsObjectPropertyNameContext(matchingNodes, objectInfo), BicepCompletionContextKind.ObjectPropertyName) |
                        ConvertFlag(IsMemberAccessContext(matchingNodes, propertyAccessInfo, offset), BicepCompletionContextKind.MemberAccess) |
@@ -112,7 +112,7 @@ namespace Bicep.LanguageServer.Completions
                 kind |= ConvertFlag(IsInnerExpressionContext(matchingNodes), BicepCompletionContextKind.Expression);
             }
 
-            return new BicepCompletionContext(kind, replacementRange, declarationInfo.node, objectInfo.node, propertyInfo.node, arrayInfo.node, propertyAccessInfo.node, arrayAccessInfo.node, targetScopeInfo.node);
+            return new BicepCompletionContext(kind, replacementRange, topLeveldeclarationInfo.node, objectInfo.node, propertyInfo.node, arrayInfo.node, propertyAccessInfo.node, arrayAccessInfo.node, targetScopeInfo.node);
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace Bicep.LanguageServer.Completions
                 token.Type == TokenType.Assignment &&
                 ReferenceEquals(targetScope.Assignment, token));
 
-        private static bool IsDeclarationStartContext(List<SyntaxBase> matchingNodes, int offset)
+        private static bool IsTopLevelDeclarationStartContext(List<SyntaxBase> matchingNodes, int offset)
         {
             if (matchingNodes.Count == 1 && matchingNodes[0] is ProgramSyntax)
             {
@@ -221,7 +221,7 @@ namespace Bicep.LanguageServer.Completions
                         // (completions will be filtered by the text that is present, so we don't have to be 100% right)
                         return token.Type == TokenType.Identifier && matchingNodes[^3] is ProgramSyntax;
 
-                    case INamedDeclarationSyntax declaration:
+                    case ITopLevelNamedDeclarationSyntax declaration:
                         // we are in a fully or partially parsed declaration
                         // whether we are in a declaration context depends on whether our offset is within the keyword token
                         // (by using exclusive span containment, the cursor position at the end of a keyword token 

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -15,7 +15,7 @@ namespace Bicep.LanguageServer.Completions
         /// <summary>
         /// The current location represents the beginning of a declaration.
         /// </summary>
-        DeclarationStart = 1 << 0,
+        TopLevelDeclarationStart = 1 << 0,
 
         /// <summary>
         /// The current location needs a parameter type.

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -56,7 +56,7 @@ namespace Bicep.LanguageServer.Completions
 
         private IEnumerable<CompletionItem> GetDeclarationCompletions(BicepCompletionContext context)
         {
-            if (context.Kind.HasFlag(BicepCompletionContextKind.DeclarationStart))
+            if (context.Kind.HasFlag(BicepCompletionContextKind.TopLevelDeclarationStart))
             {
                 yield return CreateKeywordCompletion(LanguageConstants.ParameterKeyword, "Parameter keyword", context.ReplacementRange);
                 yield return CreateContextualSnippetCompletion(LanguageConstants.ParameterKeyword, "Parameter declaration", "param ${1:Identifier} ${2:Type}", context.ReplacementRange);

--- a/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
@@ -91,6 +91,9 @@ namespace Bicep.LanguageServer.Handlers
                 case FunctionSymbol function when result.Origin is InstanceFunctionCallSyntax functionCall:
                     return GetFunctionMarkdown(function, functionCall.Arguments, result.Origin, result.Context.Compilation.GetEntrypointSemanticModel());
 
+                case LocalSymbol local:
+                    return $"```bicep\n{local.Name}: {local.Type}\n```";
+
                 default:
                     return null;
             }

--- a/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
@@ -91,7 +91,7 @@ namespace Bicep.LanguageServer.Handlers
                 case FunctionSymbol function when result.Origin is InstanceFunctionCallSyntax functionCall:
                     return GetFunctionMarkdown(function, functionCall.Arguments, result.Origin, result.Context.Compilation.GetEntrypointSemanticModel());
 
-                case LocalSymbol local:
+                case LocalVariableSymbol local:
                     return $"```bicep\n{local.Name}: {local.Type}\n```";
 
                 default:


### PR DESCRIPTION
Added parsing and semantic checks needed to support loops.

Good things:
- North star (nested loops) semantics should be functional.
- Go to def, find refs, rename symbols, highlighs, and hovers should work with loops and variables.
- IntelliSense inside loop bodies should work correctly.
- Language scope capability is fully implemented. Made it somewhat generic so adding new language scopes in other features should be much easier now.
- Formatter works for loops.
- Incorporated Anders' suggestion to hide outer variable by declaring an inner variable.

Bad things:
- No codegen. If you use a loop, we emit a semantic error to block code generation. This will be removed when codegen is implemented.
- Index syntax is not yet implemented.
- Brackets after `resource` and `module` are not yet implemented.
- Accessible symbol completions do not yet include loop variables in current scope. 
- The type checking on for loops should be fully functional, but the experience is not ideal. Some errors get hidden by other errors where they shouldn't. Will be fixed with another PR...

![image](https://user-images.githubusercontent.com/22460039/106992221-c36f3800-672c-11eb-8ef6-dc8be343bcca.png)
