### PR TITLE
Fix E2E test failures

### DIFF
--- a/src/vscode-bicep/src/test/e2e/runner.ts
+++ b/src/vscode-bicep/src/test/e2e/runner.ts
@@ -12,18 +12,19 @@ export type TestRunner = () => Promise<void>;
 async function captureWriteStreams<T>(
   fn: () => Promise<T>,
   writeStreams: WriteStream[] = [process.stdout, process.stderr]
-): Promise<T> {
+): Promise<[T, string]> {
   const originalWrites = writeStreams.map((ws) => ws.write);
+  const outputs: string[] = [];
 
   try {
     const write = (chunk: Uint8Array | string) => {
-      if (typeof chunk === "string") {
-        console.log(chunk.endsWith("\n") ? chunk.slice(0, -1) : chunk);
+      if (typeof chunk === "string" && chunk.length > 0) {
+        outputs.push(chunk);
       }
       return true;
     };
     writeStreams.forEach((ws) => (ws.write = write));
-    return await fn();
+    return [await fn(), outputs.join()];
   } finally {
     writeStreams.forEach((ws, i) => (ws.write = originalWrites[i]));
   }
@@ -33,9 +34,11 @@ export function createTestRunner(configFile: string): TestRunner {
   return async () => {
     const workspaceRoot = path.resolve(__dirname, "../../..");
     const config = require(path.join(workspaceRoot, configFile)); // eslint-disable-line @typescript-eslint/no-var-requires
-    const { results } = await captureWriteStreams(
+    const [{ results }, outputs] = await captureWriteStreams(
       async () => await runCLI({ _: [], $0: "", ...config }, [workspaceRoot])
     );
+
+    console.log(outputs);
 
     if (results.numFailedTestSuites > 0 || results.numFailedTests > 0) {
       throw new Error(`Tests failed.`);


### PR DESCRIPTION
This fixes the VSCode e2e test failures on Linux and macOS. Calling `console.log` in the test runner leads to stack overflow in VSCode 1.53.0. I can't explain the reason, but I don't think is our fault. I changed it to log once at the end of test and it worked.