### PR TITLE
Lexically scoped child resources

### DIFF
--- a/docs/examples/101/azure-automation-account/main.json
+++ b/docs/examples/101/azure-automation-account/main.json
@@ -29,8 +29,8 @@
     {
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2020-03-01-preview",
-      "location": "[parameters('location')]",
       "name": "[variables('workspaceName')]",
+      "location": "[parameters('location')]",
       "properties": {
         "sku": {
           "name": "[parameters('sku')]"
@@ -41,8 +41,8 @@
     {
       "type": "Microsoft.Automation/automationAccounts",
       "apiVersion": "2015-10-31",
-      "location": "[parameters('location')]",
       "name": "[variables('automationaccountName')]",
+      "location": "[parameters('location')]",
       "properties": {
         "sku": {
           "name": "Basic"
@@ -73,7 +73,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17352343791615047991"
+      "templateHash": "12561374295951696718"
     }
   }
 }

--- a/docs/examples/101/deployment-script-no-auth/main.json
+++ b/docs/examples/101/deployment-script-no-auth/main.json
@@ -20,8 +20,8 @@
     {
       "type": "Microsoft.Resources/deploymentScripts",
       "apiVersion": "2020-10-01",
-      "kind": "AzurePowerShell",
       "name": "[parameters('dsName')]",
+      "kind": "AzurePowerShell",
       "location": "[parameters('location')]",
       "properties": {
         "azPowerShellVersion": "3.0",
@@ -41,7 +41,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9459865245622089966"
+      "templateHash": "5388873385114824013"
     }
   }
 }

--- a/docs/examples/201/cdn-with-storage-account/main.json
+++ b/docs/examples/201/cdn-with-storage-account/main.json
@@ -17,8 +17,8 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2020-08-01-preview",
-      "location": "[parameters('location')]",
       "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
       "kind": "StorageV2",
       "sku": {
         "name": "Standard_LRS"
@@ -27,8 +27,8 @@
     {
       "type": "Microsoft.Cdn/profiles",
       "apiVersion": "2020-04-15",
-      "location": "[parameters('location')]",
       "name": "[variables('profileName')]",
+      "location": "[parameters('location')]",
       "sku": {
         "name": "Standard_Akamai"
       }
@@ -36,8 +36,8 @@
     {
       "type": "Microsoft.Cdn/profiles/endpoints",
       "apiVersion": "2020-04-15",
-      "location": "[parameters('location')]",
       "name": "[variables('endPointName')]",
+      "location": "[parameters('location')]",
       "properties": {
         "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob, 'https://', ''), '/', '')]",
         "isHttpAllowed": true,
@@ -79,7 +79,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8124028730334468476"
+      "templateHash": "15844009537662063652"
     }
   }
 }

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -72,6 +72,7 @@ memberExpression ->
   memberExpression "[" expression "]" |
   memberExpression "." IDENTIFIER(property) |
   memberExpression "." functionCall
+  memberExpression ":" IDENTIFIER(name)
 
 primaryExpression ->
   functionCall |

--- a/docs/spec/expressions.md
+++ b/docs/spec/expressions.md
@@ -6,7 +6,7 @@ The operators below are listed in descending order of precedence (the higher the
 
 | Symbol | Type of Operation | Associativity |
 |:-|:-|:-|
-| `(` `)` `[` `]` `.` | Parentheses, property accessors and array indexers | Left to right |
+| `(` `)` `[` `]` `.` `:` | Parentheses, array indexers, property accessors, and nested-resource accessor  | Left to right |
 | `!` `-` | Unary | Right to left |
 | `%` `*` `/` | Multiplicative | Left to right |
 | `+` `-` | Additive | Left to right |
@@ -105,6 +105,39 @@ var x = {
 Given the above declaration, the expression `x.y.z` would evaluate to the literal string `'Hello'`. Similarly, the expression `x.q` would evaluate to the integer literal `42`.
 
 Property accessors can be used with any object. This includes parameters and variables of object types and object literals. Using a property accessor on an expression of non-object type is an error.
+
+## Nested resource accessors
+Nested resource accessors are used to access resources that are declared inside another resource. The symbolic name declared by a nested resource can normally only be referenced within the body of the containing resource. To reference a nested resource outside the containing resource, it must be qualified with the containing resource name and the `:` operator. Other resources declared within the same containing resource may used the name without qualification.
+
+```
+resource myParent 'My.Rp/parentType@2020-01-01' = {
+  name: 'myParent'
+  location: 'West US'
+
+  // declares a nested resource inside 'myParent'
+  resource myChild 'childType' = {
+    name: 'myChild'
+    properties: {
+      displayName: 'Child Resource'
+    }
+  }
+
+  // 'myChild' can be referened inside the body of 'myParent'
+  resource mySibling 'childType' = {
+    name: 'mySibling'
+    properties: {
+      displayName: 'Sibling of ${mychild.properties.displayName}'
+    }
+  }
+}
+
+// accessing 'myChild' here requires the resource access operator
+output displayName string = myParent:myChild.properties.displayName
+```
+
+Since the declaration of `myChild` is contained within `myParent` the access to `myChild`'s properties must be qualified with `myParent:`.
+
+The `:` must be parenthesized when it appears inside a ternary expression such as: `useChildValue ? (myParent:myChild.properties.displayName) : 'defaultValue'`.
 
 ## Array indexers
 Array indexers serve two purposes. Most commonly, they are used to access items in an array. However, they can also be used to access properties of objects via expressions or string literals.

--- a/docs/spec/resources.md
+++ b/docs/spec/resources.md
@@ -42,6 +42,35 @@ resource dnsZone 'Microsoft.Network/dnszones@2018-05-01' = {
 }
 ```
 
+## Resource nesting
+
+A resource declaration may appear inside another resource declaration when the inner resource is a child type of the containing resource. A nested resource is considered to have an implicit dependency on its containing resource for creation order. 
+
+```
+resource myParent 'My.Rp/parentType@2020-01-01' = {
+  name: 'myParent'
+  location: 'West US'
+
+  // declares a resource of type 'My.Rp/parentType/childType@2020-01-01' 
+  resource myChild 'childType' = {
+    name: 'myChild'
+    properties: {
+      displayName: 'child in ${parent.location}'
+    }
+  }
+}
+```
+
+A nested resource must specify a single type segment to declare its type. The full type of the nested resource is the containing resource's type with the additional segment appended to the list of types. In the example above `My.Rp/parentType@2020-01-01` is combined with `childType` resulting in `My.Rp/parentType/childType@2020-01-01`. The nested resource may optionally declare an API version using the syntax `<segment>@<version>`. If the nested resource omits the API version the the API version of the containing resource is used. If the nested resource specifies an API version then the API version specified will be used. If the example above were modified so that the nested resource declared its type as `childType@2020-20-20` then the fully-qualified type would be `My.Rp/parentType/childType@2020-20-20`.
+
+Nested resource declarations should specify their `name` property with a single segment. The the example above the nested resource declares its `name` property with the value `myChild`. In ARM-JSON, child resources must declared their `name` property as a `/`-separated string containing multiple segments like: `myParent/myChild` - this is not required with nested resources.
+
+A nested resource declaration must appear at the top level of syntax of the containing resource. Declarations may be nested arbirarily deep, as long as each level is a child type of its containing resource. 
+
+The symbolic name of a nested resource is only accessible inside the body of its containing resource. 
+
+A nested resource may access properties of its containing resource. Other resources declared inside the body of the same containing resource may reference each other and the typical rules about cyclic-dependencies apply. A containing resource may not access properties of the resources it contains, this would cause a cyclic-dependency.
+
 ## Resource dependencies
 All declared resources will be deployed concurrently in the compiled template. Order of resource deployment can be influenced in the following ways:
 ### Explicit dependency
@@ -74,6 +103,20 @@ resource otherResource 'Microsoft.Example/examples@2020-06-01' = {
   properties: {
     // get read-only DNS zone property
     nameServers: dnsZone.properties.nameServers
+  }
+}
+```
+
+A nested resource has an implicit dependency on its containing resource.
+
+```
+resource myParent 'My.Rp/parentType@2020-01-01' = {
+  name: 'myParent'
+  location: 'West US'
+
+  // depends on 'myParent' implicitly
+  resource myChild 'childType' = {
+    name: 'myChild'
   }
 }
 ```

--- a/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
@@ -1,0 +1,585 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.IO;
+using System.Linq;
+using System.Text;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Emit;
+using Bicep.Core.Semantics;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.IntegrationTests
+{
+    [TestClass]
+    public class NestedResourceTests
+    {
+        [TestMethod]
+        public void NestedResources_symbols_are_bound()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+    size: 'large'
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+      style: 'very cool'
+    }
+  }
+
+  resource sibling 'childType@2020-01-02' = {
+    name: 'sibling'
+    properties: {
+      style: child.properties.style
+      size: parent.properties.size
+    }
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+
+            model.GetAllDiagnostics().Should().BeEmpty();
+
+            var expected = new []
+            {
+                new { name = "child", type = "My.RP/parentType/childType@2020-01-01", },
+                new { name = "parent", type = "My.RP/parentType@2020-01-01", },
+                new { name = "sibling", type = "My.RP/parentType/childType@2020-01-02", },
+            };
+
+            model.Root.GetAllResourceDeclarations()
+              .Select(s => new { name = s.Name, type = (s.Type as ResourceType)?.TypeReference.FormatName(), })
+              .OrderBy(n => n.name)
+              .Should().BeEquivalentTo(expected);
+        }
+        
+        [TestMethod]
+        public void NestedResources_resource_can_contain_property_called_resource()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+    size: 'large'
+  }
+  resource: 'yes please'
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+      style: 'very cool'
+    }
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+
+            // The property "resource" is not allowed ...
+            model.GetAllDiagnostics().Should().HaveCount(1);
+            model.GetAllDiagnostics().Single().Should().HaveCodeAndSeverity("BCP038", DiagnosticLevel.Error);
+
+            var expected = new []
+            {
+                new { name = "child", type = "My.RP/parentType/childType@2020-01-01", },
+                new { name = "parent", type = "My.RP/parentType@2020-01-01", },
+            };
+
+            model.Root.GetAllResourceDeclarations()
+              .Select(s => new { name = s.Name, type = (s.Type as ResourceType)?.TypeReference.FormatName(), })
+              .OrderBy(n => n.name)
+              .Should().BeEquivalentTo(expected);
+        }
+
+        [TestMethod]
+        public void NestedResources_valid_resource_references()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+    size: 'large'
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+      style: 'very cool'
+    }
+
+    resource grandchild 'grandchildType' = {
+      name: 'grandchild'
+      properties: {
+        temperature: 'ice-cold'
+      }
+    }
+  }
+
+  resource sibling 'childType@2020-01-02' = {
+    name: 'sibling'
+    properties: {
+      style: parent:child.properties.style
+      size: parent.properties.size
+      temperatureC: child:grandchild.properties.temperature
+      temperatureF: parent:child:grandchild.properties.temperature
+    }
+  }
+}
+
+output fromChild string = parent:child.properties.style
+output fromGrandchild string = parent:child:grandchild.properties.style
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+
+            model.GetAllDiagnostics().Should().BeEmpty();
+
+            var parent = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "parent");
+            var references = model.FindReferences(parent);
+            references.Should().HaveCount(6);
+
+            var child = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "child");
+            references = model.FindReferences(child);
+            references.Should().HaveCount(6);
+
+            var grandchild = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "grandchild");
+            references = model.FindReferences(grandchild);
+            references.Should().HaveCount(4);
+
+            var sibling = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "sibling");
+            references = model.FindReferences(sibling);
+            references.Should().HaveCount(1);
+
+            var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), BicepTestConstants.DevAssemblyFileVersion);
+            using var outputStream = new MemoryStream();
+            emitter.Emit(outputStream);
+
+            outputStream.Seek(0L, SeekOrigin.Begin);
+            var text = Encoding.UTF8.GetString(outputStream.GetBuffer());
+        }
+
+        [TestMethod]
+        public void NestedResources_invalid_resource_references()
+        {
+            var program = @"
+var notResource = 'hi'
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+    size: 'large'
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+      style: 'very cool'
+    }
+
+    resource grandchild 'grandchildType' = {
+      name: 'grandchild'
+      properties: {
+        temperature: 'ice-cold'
+      }
+    }
+  }
+}
+
+output fromVariable string = notResource:child.properties.style
+output fromChildInvalid string = parent:child2.properties.style
+output fromGrandchildInvalid string = parent:child:cousin.properties.temperature
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+
+            model.GetAllDiagnostics().Should().HaveDiagnostics(new []{
+                ("BCP158", DiagnosticLevel.Error, "Cannot access nested resources of type \"'hi'\". A resource type is required."),
+                ("BCP159", DiagnosticLevel.Error, "The resource \"parent\" does not contain a nested resource named \"child2\". Known nested resources are: \"child\"."),
+                ("BCP159", DiagnosticLevel.Error, "The resource \"child\" does not contain a nested resource named \"cousin\". Known nested resources are: \"grandchild\"."),
+            });
+        }
+
+        [TestMethod]
+        public void NestedResources_child_cannot_be_referenced_outside_of_scope()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+      style: 'very cool'
+    }
+  }
+}
+
+resource other 'My.RP/parentType@2020-01-01' = {
+  name: 'other'
+  properties: {
+    style: child.properties.style
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+            diagnostics.Should().HaveDiagnostics(new[] {
+                ("BCP057", DiagnosticLevel.Error, "The name \"child\" does not exist in the current context."),
+            });
+        }
+
+        [TestMethod]
+        public void NestedResources_child_cannot_specify_qualified_type()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+  }
+
+  resource child 'My.RP/parentType/childType@2020-01-01' = {
+    name: 'child'
+    properties: {
+      style: 'very cool'
+    }
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+            diagnostics.Should().HaveDiagnostics(new[] {
+                ("BCP156", DiagnosticLevel.Error, "The resource type segment \"My.RP/parentType/childType@2020-01-01\" is invalid. Nested resources must specify a single type segment, and optionally can specify an api version using the format \"<type>@<apiVersion>\"."),
+            });
+        }
+
+        [TestMethod]
+        public void NestedResources_error_in_base_type()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@invalid-version' = {
+  name: 'parent'
+  properties: {
+  }
+
+  resource child 'My.RP/parentType/childType@2020-01-01' = {
+    name: 'child'
+    properties: {
+      style: 'very cool'
+    }
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+            diagnostics.Should().HaveDiagnostics(new[] {
+                ("BCP029", DiagnosticLevel.Error, "The resource type is not valid. Specify a valid resource type of format \"<provider>/<types>@<apiVersion>\"."),
+                ("BCP157", DiagnosticLevel.Error, "The resource type cannot be determined due to an error in containing resource \"parent\"."),
+            });
+        }
+
+        [TestMethod]
+        public void NestedResources_error_in_parent_type()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+  }
+
+  // Error here
+  resource child 'My.RP/parentType/childType@2020-01-01' = {
+    name: 'child'
+    properties: {
+    }
+
+    resource grandchild 'granchildType' = {
+      name: 'grandchild'
+      properties: {
+      }
+    }
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+            diagnostics.Should().HaveDiagnostics(new[] {
+                ("BCP156", DiagnosticLevel.Error, "The resource type segment \"My.RP/parentType/childType@2020-01-01\" is invalid. Nested resources must specify a single type segment, and optionally can specify an api version using the format \"<type>@<apiVersion>\"."),
+                ("BCP157", DiagnosticLevel.Error, "The resource type cannot be determined due to an error in containing resource \"child\"."),
+            });
+        }
+
+        [TestMethod]
+        public void NestedResources_child_cycle_is_detected_correctly()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+    style: child.properties.style
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+      style: 'very cool'
+    }
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            compilation.GetEntrypointSemanticModel().GetAllDiagnostics().Should().HaveDiagnostics(new[] {
+                ("BCP080", DiagnosticLevel.Error, "The expression is involved in a cycle (\"child\" -> \"parent\")."),
+            });
+        }
+
+        [TestMethod] // With more than one level of nesting the name just isn't visible.
+        public void NestedResources_grandchild_cycle_results_in_binding_failure()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+    style: grandchild.properties.style
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+    }
+
+    resource grandchild 'grandchildType' = {
+      name: 'grandchild'
+      properties: {
+        style: 'very cool'
+      }
+    }
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            compilation.GetEntrypointSemanticModel().GetAllDiagnostics().Should().HaveDiagnostics(new[] {
+                ("BCP057", DiagnosticLevel.Error, "The name \"grandchild\" does not exist in the current context."),
+            });
+        }
+
+        [TestMethod]
+        public void NestedResources_ancestors_are_detected()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+    }
+
+    resource grandchild 'grandchildType' = {
+      name: 'grandchild'
+      properties: {
+      }
+    }
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+            model.GetAllDiagnostics().Should().BeEmpty();
+
+            var parent = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "parent");
+            model.ResourceAncestors.GetAncestors(parent).Should().BeEmpty();
+
+            var child = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "child");
+            model.ResourceAncestors.GetAncestors(child).Should().Equal(new []{ parent, });
+
+            var grandchild = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "grandchild");
+            model.ResourceAncestors.GetAncestors(grandchild).Should().Equal(new []{ parent, child, }); // order matters
+        }
+
+        [TestMethod]
+        public void NestedResources_scopes_isolate_names()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+    }
+
+    resource grandchild 'grandchildType' = {
+      name: 'grandchild'
+      properties: {
+      }
+    }
+  }
+
+  resource sibling 'childType' = {
+    name: 'sibling'
+    properties: {
+    }
+
+    resource grandchild 'grandchildType' = {
+      name: 'grandchild'
+      properties: {
+      }
+    }
+  }
+}
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+            model.GetAllDiagnostics().Should().BeEmpty();
+
+            var parent = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "parent");
+            model.ResourceAncestors.GetAncestors(parent).Should().BeEmpty();
+
+            var child = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "child");
+            model.ResourceAncestors.GetAncestors(child).Should().Equal(new []{ parent, });
+
+            var childGrandChild = (ResourceSymbol)model.GetSymbolInfo(child.DeclaringResource.GetBody().Resources.Single())!;
+            model.ResourceAncestors.GetAncestors(childGrandChild).Should().Equal(new []{ parent, child, });
+
+            var sibling = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "sibling");
+            model.ResourceAncestors.GetAncestors(child).Should().Equal(new []{ parent, });
+
+            var siblingGrandChild = (ResourceSymbol)model.GetSymbolInfo(sibling.DeclaringResource.GetBody().Resources.Single())!;
+            model.ResourceAncestors.GetAncestors(siblingGrandChild).Should().Equal(new []{ parent, sibling, });
+        }
+
+        [TestMethod] // Should turn into positive test when support is added.
+        public void NestedResources_cannot_appear_inside_loops()
+        {
+            var program = @"
+var items = [
+  'a'
+  'b'
+]
+resource parent 'My.RP/parentType@2020-01-01' = [for item in items: {
+  name: 'parent'
+  properties: {
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+    }
+  }
+}]
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+            compilation.GetEntrypointSemanticModel().GetAllDiagnostics().Should().HaveDiagnostics(new[] {
+                ("BCP160", DiagnosticLevel.Error, "A nested resource cannot appear inside of a resource with a for-expression."),
+            });
+        }
+
+        [TestMethod]
+        public void NestedResources_can_have_loops()
+        {
+            var program = @"
+var items = [
+  'a'
+  'b'
+]
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+  }
+
+  resource child 'childType' = [for item in items: {
+    name: 'child'
+    properties: {
+    }
+  }]
+}
+
+output loopy string = parent:child[0].name
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+            compilation.GetEntrypointSemanticModel().GetAllDiagnostics().Should().BeEmpty();
+
+            var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), BicepTestConstants.DevAssemblyFileVersion);
+            using var outputStream = new MemoryStream();
+            emitter.Emit(outputStream);
+
+            outputStream.Seek(0L, SeekOrigin.Begin);
+            var text = Encoding.UTF8.GetString(outputStream.GetBuffer());
+        }
+
+        [TestMethod]
+        public void NestedResources_can_get_declared_type_for_property_completion()
+        {
+            var program = @"
+resource parent 'My.RP/parentType@2020-01-01' = {
+  name: 'parent'
+  properties: {
+  }
+
+  resource child 'childType' = {
+    name: 'child'
+    properties: {
+    }
+  }
+}
+
+output hmmmm string = parent:child.properties
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+
+            var output = model.Root.OutputDeclarations.Single();
+            var expression = output.DeclaringOutput.Value;
+            var type = model.GetDeclaredType(expression);
+            type.Should().BeOfType<ObjectType>();
+        }
+
+        [TestMethod]
+        public void NestedResources_provides_correct_error_for_resource_access_with_broken_body()
+        {
+            var program = @"
+resource broken 'Microsoft.Network/virtualNetworks@2020-06-01' = 
+
+output foo string = broken:fake
+";
+
+            var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
+            var model = compilation.GetEntrypointSemanticModel();
+            model.GetAllDiagnostics().Should().HaveDiagnostics(new[] {
+                ("BCP118", DiagnosticLevel.Error, "Expected the \"{\" character, the \"[\" character, or the \"if\" keyword at this location."),
+                ("BCP159", DiagnosticLevel.Error, "The resource \"broken\" does not contain a nested resource named \"fake\". Known nested resources are: \"(none)\"."),
+            });
+        }
+    }
+}

--- a/src/Bicep.Core.Samples/DataSets.cs
+++ b/src/Bicep.Core.Samples/DataSets.cs
@@ -37,6 +37,8 @@ namespace Bicep.Core.Samples
 
         public static DataSet Outputs_CRLF => CreateDataSet();
 
+        public static DataSet NestedResources_LF => CreateDataSet();
+
         public static DataSet Parameters_CRLF => CreateDataSet();
 
         public static DataSet Parameters_LF => CreateDataSet();

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -1858,7 +1858,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "singleModuleForRuntimeCheck",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
@@ -1393,7 +1393,10 @@
     "textEdit": {
       "range": {},
       "newText": "sampleResource"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sampleVar",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/oneTwoThreePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/oneTwoThreePlusSymbols.json
@@ -1435,7 +1435,10 @@
     "textEdit": {
       "range": {},
       "newText": "sampleResource"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sampleVar",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/symbolsPlusParamDefaultFunctions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/symbolsPlusParamDefaultFunctions.json
@@ -1393,7 +1393,10 @@
     "textEdit": {
       "range": {},
       "newText": "sampleResource"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sampleVar",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -59,7 +59,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -87,7 +90,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -101,7 +107,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -115,7 +124,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -129,7 +141,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -143,7 +158,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -157,7 +175,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -171,7 +192,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -236,7 +260,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -318,7 +345,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -332,7 +362,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -346,7 +379,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -425,7 +461,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -439,7 +478,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -453,7 +495,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -467,7 +512,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -495,7 +543,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -509,7 +560,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -523,7 +577,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -537,7 +594,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -677,7 +737,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -691,7 +754,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -705,7 +771,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -887,7 +956,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -901,7 +973,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -915,7 +990,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1055,7 +1133,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1069,7 +1150,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1229,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1246,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1263,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1280,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1297,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1314,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1331,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1348,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1379,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1430,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1447,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "for",
@@ -1399,7 +1516,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1478,7 +1598,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1492,7 +1615,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1506,7 +1632,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1520,7 +1649,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1534,7 +1666,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1548,7 +1683,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1562,7 +1700,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1576,7 +1717,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1590,7 +1734,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1717,7 +1864,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1731,7 +1881,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1745,7 +1898,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1759,7 +1915,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1852,7 +2011,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1866,7 +2028,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1880,7 +2045,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1894,7 +2062,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1908,7 +2079,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1936,7 +2110,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2160,7 +2337,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2300,7 +2480,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2314,7 +2497,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2328,7 +2514,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2342,7 +2531,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2356,7 +2548,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2370,7 +2565,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2384,7 +2582,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2398,7 +2599,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2474,7 +2678,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2488,7 +2695,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2502,7 +2712,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2702,7 +2915,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2716,7 +2932,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2730,7 +2949,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2744,7 +2966,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2758,7 +2983,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2772,7 +3000,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2786,7 +3017,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2800,7 +3034,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2814,7 +3051,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2828,7 +3068,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2842,7 +3085,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2856,7 +3102,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2870,7 +3119,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2884,7 +3136,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2898,7 +3153,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2912,7 +3170,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2926,7 +3187,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2940,7 +3204,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2968,7 +3235,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2982,7 +3252,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2996,7 +3269,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3010,7 +3286,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3024,7 +3303,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3038,7 +3320,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3052,7 +3337,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3066,7 +3354,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3080,7 +3371,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3150,7 +3444,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3178,7 +3475,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3226,7 +3526,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3240,7 +3543,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3288,7 +3594,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3449,7 +3758,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3480,7 +3792,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3593,7 +3908,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3635,7 +3953,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3649,7 +3970,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3663,7 +3987,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3677,6 +4004,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -87,7 +87,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -115,7 +118,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -129,7 +135,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -143,7 +152,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -157,7 +169,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -171,7 +186,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -185,7 +203,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -199,7 +220,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -264,7 +288,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -346,7 +373,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -360,7 +390,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -374,7 +407,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -453,7 +489,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -467,7 +506,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -481,7 +523,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -495,7 +540,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -523,7 +571,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -537,7 +588,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -551,7 +605,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -565,7 +622,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -705,7 +765,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -719,7 +782,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -733,7 +799,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -915,7 +984,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -929,7 +1001,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -943,7 +1018,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1083,7 +1161,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1097,7 +1178,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1173,7 +1257,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1187,7 +1274,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1201,7 +1291,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1215,7 +1308,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1229,7 +1325,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1243,7 +1342,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1257,7 +1359,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1271,7 +1376,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1299,7 +1407,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1347,7 +1458,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1361,7 +1475,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1409,7 +1526,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1488,7 +1608,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1502,7 +1625,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1516,7 +1642,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1530,7 +1659,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1544,7 +1676,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1558,7 +1693,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1572,7 +1710,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1586,7 +1727,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1600,7 +1744,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1727,7 +1874,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1741,7 +1891,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1755,7 +1908,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1769,7 +1925,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1862,7 +2021,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1876,7 +2038,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1890,7 +2055,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1904,7 +2072,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1918,7 +2089,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1946,7 +2120,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2170,7 +2347,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2310,7 +2490,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2324,7 +2507,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2338,7 +2524,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2352,7 +2541,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2366,7 +2558,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2380,7 +2575,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2394,7 +2592,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2408,7 +2609,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2484,7 +2688,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2498,7 +2705,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2512,7 +2722,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2712,7 +2925,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2726,7 +2942,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2740,7 +2959,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2754,7 +2976,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2768,7 +2993,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2782,7 +3010,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2796,7 +3027,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2810,7 +3044,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2824,7 +3061,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2838,7 +3078,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2852,7 +3095,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2866,7 +3112,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2880,7 +3129,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2894,7 +3146,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2908,7 +3163,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2922,7 +3180,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2936,7 +3197,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2950,7 +3214,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2978,7 +3245,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2992,7 +3262,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3006,7 +3279,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3020,7 +3296,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3034,7 +3313,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3048,7 +3330,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3062,7 +3347,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3076,7 +3364,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3090,7 +3381,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3160,7 +3454,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3188,7 +3485,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3236,7 +3536,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3250,7 +3553,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3298,7 +3604,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3459,7 +3768,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3490,7 +3802,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3603,7 +3918,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3645,7 +3963,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3659,7 +3980,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3673,7 +3997,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3687,6 +4014,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -315,7 +315,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -343,7 +346,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -357,7 +363,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -371,7 +380,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -385,7 +397,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -399,7 +414,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -413,7 +431,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -427,7 +448,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -492,7 +516,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -574,7 +601,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -588,7 +618,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -602,7 +635,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -681,7 +717,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -695,7 +734,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -709,7 +751,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -723,7 +768,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -751,7 +799,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -765,7 +816,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -779,7 +833,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -793,7 +850,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -919,7 +979,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -933,7 +996,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -947,7 +1013,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -1129,7 +1198,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -1143,7 +1215,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -1157,7 +1232,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1297,7 +1375,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1311,7 +1392,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1387,7 +1471,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1401,7 +1488,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1415,7 +1505,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1429,7 +1522,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1443,7 +1539,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1457,7 +1556,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1471,7 +1573,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1485,7 +1590,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1513,7 +1621,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1561,7 +1672,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1575,7 +1689,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1623,7 +1740,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1637,7 +1757,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1716,7 +1839,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1730,7 +1856,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1744,7 +1873,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1758,7 +1890,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1772,7 +1907,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1786,7 +1924,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1800,7 +1941,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1814,7 +1958,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1828,7 +1975,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1955,7 +2105,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1969,7 +2122,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1983,7 +2139,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1997,7 +2156,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -2090,7 +2252,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -2104,7 +2269,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -2118,7 +2286,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -2132,7 +2303,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -2146,7 +2320,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -2174,7 +2351,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2398,7 +2578,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2538,7 +2721,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2552,7 +2738,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2566,7 +2755,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2580,7 +2772,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2594,7 +2789,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2608,7 +2806,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2622,7 +2823,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2636,7 +2840,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2712,7 +2919,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2726,7 +2936,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2740,7 +2953,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2940,7 +3156,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2954,7 +3173,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2968,7 +3190,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2982,7 +3207,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2996,7 +3224,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -3010,7 +3241,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -3024,7 +3258,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -3038,7 +3275,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -3052,7 +3292,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -3066,7 +3309,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -3080,7 +3326,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -3094,7 +3343,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -3108,7 +3360,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -3122,7 +3377,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -3136,7 +3394,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -3150,7 +3411,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -3164,7 +3428,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -3178,7 +3445,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -3206,7 +3476,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -3220,7 +3493,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3234,7 +3510,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3248,7 +3527,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3262,7 +3544,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3276,7 +3561,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3290,7 +3578,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3304,7 +3595,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3318,7 +3612,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3388,7 +3685,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3416,7 +3716,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3464,7 +3767,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3478,7 +3784,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3526,7 +3835,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3687,7 +3999,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3718,7 +4033,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3831,7 +4149,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3873,7 +4194,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3887,7 +4211,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3901,7 +4228,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3915,6 +4245,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -315,7 +315,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -343,7 +346,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -357,7 +363,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -371,7 +380,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -385,7 +397,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -399,7 +414,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -413,7 +431,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -427,7 +448,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -492,7 +516,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -574,7 +601,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -588,7 +618,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -602,7 +635,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -681,7 +717,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -695,7 +734,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -709,7 +751,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -723,7 +768,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -751,7 +799,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -765,7 +816,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -779,7 +833,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -793,7 +850,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -919,7 +979,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -933,7 +996,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -947,7 +1013,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -1129,7 +1198,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -1143,7 +1215,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -1157,7 +1232,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1297,7 +1375,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1311,7 +1392,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1387,7 +1471,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1401,7 +1488,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1415,7 +1505,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1429,7 +1522,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1443,7 +1539,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1457,7 +1556,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1471,7 +1573,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1485,7 +1590,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1513,7 +1621,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1561,7 +1672,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1575,7 +1689,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1623,7 +1740,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1637,7 +1757,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1716,7 +1839,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1730,7 +1856,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1744,7 +1873,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1758,7 +1890,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1772,7 +1907,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1786,7 +1924,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1800,7 +1941,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1814,7 +1958,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1828,7 +1975,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1955,7 +2105,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1969,7 +2122,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1983,7 +2139,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1997,7 +2156,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -2090,7 +2252,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -2104,7 +2269,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -2118,7 +2286,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -2132,7 +2303,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -2146,7 +2320,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -2174,7 +2351,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2398,7 +2578,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2538,7 +2721,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2552,7 +2738,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2566,7 +2755,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2580,7 +2772,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2594,7 +2789,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2608,7 +2806,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2622,7 +2823,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2636,7 +2840,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2712,7 +2919,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2726,7 +2936,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2740,7 +2953,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2940,7 +3156,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2954,7 +3173,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2968,7 +3190,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2982,7 +3207,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2996,7 +3224,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -3010,7 +3241,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -3024,7 +3258,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -3038,7 +3275,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -3052,7 +3292,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -3066,7 +3309,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -3080,7 +3326,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -3094,7 +3343,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -3108,7 +3360,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -3122,7 +3377,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -3136,7 +3394,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -3150,7 +3411,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -3164,7 +3428,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -3178,7 +3445,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -3206,7 +3476,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -3220,7 +3493,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3234,7 +3510,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3248,7 +3527,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3262,7 +3544,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3276,7 +3561,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3290,7 +3578,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3304,7 +3595,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3318,7 +3612,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3388,7 +3685,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3416,7 +3716,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3464,7 +3767,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3478,7 +3784,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3526,7 +3835,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3687,7 +3999,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3718,7 +4033,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3831,7 +4149,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3873,7 +4194,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3887,7 +4211,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3901,7 +4228,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3915,6 +4245,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -315,7 +315,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -343,7 +346,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -357,7 +363,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -371,7 +380,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -385,7 +397,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -399,7 +414,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -413,7 +431,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -427,7 +448,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -492,7 +516,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -574,7 +601,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -588,7 +618,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -602,7 +635,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -681,7 +717,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -695,7 +734,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -709,7 +751,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -723,7 +768,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -751,7 +799,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -765,7 +816,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -779,7 +833,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -793,7 +850,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -919,7 +979,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -933,7 +996,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -947,7 +1013,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -1129,7 +1198,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -1143,7 +1215,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -1157,7 +1232,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1297,7 +1375,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1311,7 +1392,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1387,7 +1471,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1401,7 +1488,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1415,7 +1505,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1429,7 +1522,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1443,7 +1539,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1457,7 +1556,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1471,7 +1573,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1485,7 +1590,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1513,7 +1621,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1561,7 +1672,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1575,7 +1689,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1623,7 +1740,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1637,7 +1757,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1716,7 +1839,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1730,7 +1856,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1744,7 +1873,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1758,7 +1890,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1772,7 +1907,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1786,7 +1924,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1800,7 +1941,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1814,7 +1958,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1828,7 +1975,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1955,7 +2105,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1969,7 +2122,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1983,7 +2139,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1997,7 +2156,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -2090,7 +2252,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -2104,7 +2269,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -2118,7 +2286,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -2132,7 +2303,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -2146,7 +2320,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -2174,7 +2351,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2398,7 +2578,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2538,7 +2721,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2552,7 +2738,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2566,7 +2755,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2580,7 +2772,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2594,7 +2789,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2608,7 +2806,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2622,7 +2823,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2636,7 +2840,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2712,7 +2919,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2726,7 +2936,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2740,7 +2953,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2940,7 +3156,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2954,7 +3173,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2968,7 +3190,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2982,7 +3207,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2996,7 +3224,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -3010,7 +3241,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -3024,7 +3258,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -3038,7 +3275,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -3052,7 +3292,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -3066,7 +3309,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -3080,7 +3326,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -3094,7 +3343,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -3108,7 +3360,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -3122,7 +3377,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -3136,7 +3394,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -3150,7 +3411,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -3164,7 +3428,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -3178,7 +3445,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -3206,7 +3476,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -3220,7 +3493,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3234,7 +3510,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3248,7 +3527,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3262,7 +3544,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3276,7 +3561,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3290,7 +3578,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3304,7 +3595,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3318,7 +3612,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3388,7 +3685,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3416,7 +3716,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3464,7 +3767,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3478,7 +3784,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3526,7 +3835,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3687,7 +3999,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3718,7 +4033,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3831,7 +4149,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3873,7 +4194,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3887,7 +4211,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3901,7 +4228,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3915,6 +4245,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -63,7 +63,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -91,7 +94,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -105,7 +111,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -119,7 +128,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -133,7 +145,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -147,7 +162,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -161,7 +179,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -175,7 +196,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -240,7 +264,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -322,7 +349,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -336,7 +366,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -350,7 +383,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -429,7 +465,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -443,7 +482,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -457,7 +499,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -471,7 +516,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -499,7 +547,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -513,7 +564,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -527,7 +581,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -541,7 +598,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -681,7 +741,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -695,7 +758,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -709,7 +775,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -891,7 +960,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -905,7 +977,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -919,7 +994,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1059,7 +1137,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1073,7 +1154,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1149,7 +1233,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1163,7 +1250,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1177,7 +1267,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1191,7 +1284,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1205,7 +1301,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1219,7 +1318,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1233,7 +1335,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1247,7 +1352,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1275,7 +1383,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1323,7 +1434,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1337,7 +1451,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1385,7 +1502,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1399,7 +1519,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1478,7 +1601,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1492,7 +1618,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1506,7 +1635,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1520,7 +1652,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1534,7 +1669,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1548,7 +1686,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1562,7 +1703,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1576,7 +1720,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1590,7 +1737,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1717,7 +1867,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1731,7 +1884,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1745,7 +1901,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1759,7 +1918,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1852,7 +2014,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1866,7 +2031,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1880,7 +2048,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1894,7 +2065,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1908,7 +2082,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1936,7 +2113,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2160,7 +2340,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2286,7 +2469,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2300,7 +2486,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2314,7 +2503,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2328,7 +2520,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2342,7 +2537,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2356,7 +2554,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2370,7 +2571,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2384,7 +2588,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2460,7 +2667,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2474,7 +2684,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2488,7 +2701,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2688,7 +2904,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2702,7 +2921,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2716,7 +2938,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2730,7 +2955,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2744,7 +2972,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2758,7 +2989,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2772,7 +3006,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2786,7 +3023,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2800,7 +3040,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2814,7 +3057,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2828,7 +3074,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2842,7 +3091,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2856,7 +3108,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2870,7 +3125,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2884,7 +3142,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2898,7 +3159,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2912,7 +3176,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2926,7 +3193,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2954,7 +3224,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2968,7 +3241,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2982,7 +3258,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2996,7 +3275,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3010,7 +3292,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3024,7 +3309,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3038,7 +3326,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3052,7 +3343,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3066,7 +3360,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3136,7 +3433,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3164,7 +3464,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3212,7 +3515,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3226,7 +3532,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3274,7 +3583,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3435,7 +3747,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3466,7 +3781,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3579,7 +3897,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3621,7 +3942,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3635,7 +3959,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3649,7 +3976,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3663,6 +3993,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -63,7 +63,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -91,7 +94,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -105,7 +111,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -119,7 +128,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -133,7 +145,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -147,7 +162,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -161,7 +179,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -175,7 +196,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -240,7 +264,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -322,7 +349,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -336,7 +366,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -350,7 +383,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -429,7 +465,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -443,7 +482,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -457,7 +499,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -471,7 +516,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -499,7 +547,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -513,7 +564,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -527,7 +581,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -541,7 +598,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -681,7 +741,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -695,7 +758,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -709,7 +775,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -891,7 +960,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -905,7 +977,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -919,7 +994,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1059,7 +1137,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1073,7 +1154,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1149,7 +1233,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1163,7 +1250,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1177,7 +1267,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1191,7 +1284,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1205,7 +1301,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1219,7 +1318,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1233,7 +1335,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1247,7 +1352,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1275,7 +1383,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1323,7 +1434,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1337,7 +1451,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1385,7 +1502,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1399,7 +1519,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1478,7 +1601,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1492,7 +1618,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1506,7 +1635,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1520,7 +1652,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1534,7 +1669,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1548,7 +1686,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1562,7 +1703,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1576,7 +1720,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1590,7 +1737,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1717,7 +1867,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1731,7 +1884,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1745,7 +1901,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1759,7 +1918,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1852,7 +2014,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1866,7 +2031,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1880,7 +2048,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1894,7 +2065,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1908,7 +2082,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1936,7 +2113,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2160,7 +2340,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2286,7 +2469,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2300,7 +2486,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2314,7 +2503,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2328,7 +2520,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2342,7 +2537,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2356,7 +2554,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2370,7 +2571,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2384,7 +2588,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2460,7 +2667,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2474,7 +2684,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2488,7 +2701,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2688,7 +2904,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2702,7 +2921,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2716,7 +2938,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2730,7 +2955,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2744,7 +2972,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2758,7 +2989,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2772,7 +3006,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2786,7 +3023,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2800,7 +3040,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2814,7 +3057,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2828,7 +3074,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2842,7 +3091,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2856,7 +3108,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2870,7 +3125,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2884,7 +3142,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2898,7 +3159,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2912,7 +3176,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2926,7 +3193,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2954,7 +3224,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2968,7 +3241,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2982,7 +3258,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2996,7 +3275,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3010,7 +3292,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3024,7 +3309,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3038,7 +3326,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3052,7 +3343,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3066,7 +3360,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3136,7 +3433,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3164,7 +3464,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3212,7 +3515,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3226,7 +3532,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3274,7 +3583,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3435,7 +3747,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3466,7 +3781,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3579,7 +3897,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3621,7 +3942,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3635,7 +3959,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3649,7 +3976,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3663,6 +3993,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -63,7 +63,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -91,7 +94,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -105,7 +111,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -119,7 +128,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -133,7 +145,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -147,7 +162,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -161,7 +179,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -175,7 +196,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -240,7 +264,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -322,7 +349,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -336,7 +366,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -350,7 +383,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -429,7 +465,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -443,7 +482,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -457,7 +499,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -471,7 +516,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -499,7 +547,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -513,7 +564,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -527,7 +581,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -541,7 +598,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -681,7 +741,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -695,7 +758,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -709,7 +775,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -891,7 +960,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -905,7 +977,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -919,7 +994,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1059,7 +1137,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1073,7 +1154,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1149,7 +1233,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1163,7 +1250,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1177,7 +1267,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1191,7 +1284,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1205,7 +1301,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1219,7 +1318,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1233,7 +1335,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1247,7 +1352,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1275,7 +1383,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1323,7 +1434,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1337,7 +1451,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1385,7 +1502,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1399,7 +1519,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1478,7 +1601,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1492,7 +1618,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1506,7 +1635,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1520,7 +1652,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1534,7 +1669,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1548,7 +1686,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1562,7 +1703,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1576,7 +1720,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1590,7 +1737,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1717,7 +1867,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1731,7 +1884,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1745,7 +1901,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1759,7 +1918,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1852,7 +2014,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1866,7 +2031,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1880,7 +2048,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1894,7 +2065,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1908,7 +2082,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1936,7 +2113,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2160,7 +2340,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2286,7 +2469,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2300,7 +2486,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2314,7 +2503,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2328,7 +2520,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2342,7 +2537,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2356,7 +2554,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2370,7 +2571,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2384,7 +2588,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2460,7 +2667,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2474,7 +2684,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2488,7 +2701,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2688,7 +2904,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2702,7 +2921,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2716,7 +2938,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2730,7 +2955,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2744,7 +2972,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2758,7 +2989,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2772,7 +3006,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2786,7 +3023,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2800,7 +3040,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2814,7 +3057,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2828,7 +3074,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2842,7 +3091,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2856,7 +3108,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2870,7 +3125,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2884,7 +3142,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2898,7 +3159,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2912,7 +3176,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2926,7 +3193,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2954,7 +3224,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2968,7 +3241,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2982,7 +3258,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2996,7 +3275,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3010,7 +3292,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3024,7 +3309,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3038,7 +3326,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3052,7 +3343,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3066,7 +3360,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3136,7 +3433,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3164,7 +3464,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3212,7 +3515,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3226,7 +3532,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3274,7 +3583,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3435,7 +3747,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3466,7 +3781,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3579,7 +3897,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3621,7 +3942,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3635,7 +3959,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3649,7 +3976,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3663,6 +3993,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -549,7 +549,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -577,7 +580,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -591,7 +597,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -605,7 +614,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -619,7 +631,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -633,7 +648,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -647,7 +665,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -661,7 +682,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -726,7 +750,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -808,7 +835,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -822,7 +852,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -836,7 +869,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -915,7 +951,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -929,7 +968,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -943,7 +985,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -957,7 +1002,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -985,7 +1033,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -999,7 +1050,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -1013,7 +1067,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -1027,7 +1084,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -1167,7 +1227,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -1181,7 +1244,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -1195,7 +1261,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -1377,7 +1446,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -1391,7 +1463,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -1405,7 +1480,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1545,7 +1623,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1559,7 +1640,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1635,7 +1719,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1649,7 +1736,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1663,7 +1753,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1677,7 +1770,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1691,7 +1787,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1705,7 +1804,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1719,7 +1821,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1733,7 +1838,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1761,7 +1869,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1809,7 +1920,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1823,7 +1937,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1871,7 +1988,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1885,7 +2005,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1964,7 +2087,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1978,7 +2104,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1992,7 +2121,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -2006,7 +2138,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -2020,7 +2155,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -2034,7 +2172,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -2048,7 +2189,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -2062,7 +2206,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -2076,7 +2223,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -2203,7 +2353,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -2217,7 +2370,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -2231,7 +2387,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -2245,7 +2404,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -2338,7 +2500,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -2352,7 +2517,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -2366,7 +2534,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -2380,7 +2551,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -2394,7 +2568,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -2422,7 +2599,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions_for",
@@ -2632,7 +2812,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2772,7 +2955,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2786,7 +2972,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2800,7 +2989,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2814,7 +3006,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2828,7 +3023,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2842,7 +3040,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2856,7 +3057,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2870,7 +3074,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2946,7 +3153,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2960,7 +3170,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2974,7 +3187,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -3174,7 +3390,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -3188,7 +3407,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -3202,7 +3424,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -3216,7 +3441,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -3230,7 +3458,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -3244,7 +3475,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -3258,7 +3492,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -3272,7 +3509,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -3286,7 +3526,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -3300,7 +3543,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -3314,7 +3560,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -3328,7 +3577,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -3342,7 +3594,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -3356,7 +3611,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -3370,7 +3628,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -3384,7 +3645,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -3398,7 +3662,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -3412,7 +3679,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -3440,7 +3710,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -3454,7 +3727,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3468,7 +3744,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3482,7 +3761,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3496,7 +3778,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3510,7 +3795,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3524,7 +3812,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3538,7 +3829,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3552,7 +3846,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3622,7 +3919,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3650,7 +3950,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3698,7 +4001,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3712,7 +4018,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3760,7 +4069,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3921,7 +4233,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3952,7 +4267,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -4065,7 +4383,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -4107,7 +4428,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -4121,7 +4445,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -4135,7 +4462,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -4149,6 +4479,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -549,7 +549,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -577,7 +580,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -591,7 +597,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -605,7 +614,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -619,7 +631,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -633,7 +648,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -647,7 +665,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -661,7 +682,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -726,7 +750,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -808,7 +835,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -822,7 +852,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -836,7 +869,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -915,7 +951,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -929,7 +968,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -943,7 +985,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -957,7 +1002,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -985,7 +1033,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -999,7 +1050,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -1013,7 +1067,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -1027,7 +1084,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -1167,7 +1227,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -1181,7 +1244,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -1195,7 +1261,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -1377,7 +1446,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -1391,7 +1463,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -1405,7 +1480,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1545,7 +1623,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1559,7 +1640,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1635,7 +1719,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1649,7 +1736,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1663,7 +1753,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1677,7 +1770,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1691,7 +1787,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1705,7 +1804,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1719,7 +1821,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1733,7 +1838,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1761,7 +1869,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1809,7 +1920,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1823,7 +1937,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1871,7 +1988,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1885,7 +2005,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1964,7 +2087,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1978,7 +2104,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1992,7 +2121,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -2006,7 +2138,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -2020,7 +2155,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -2034,7 +2172,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -2048,7 +2189,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -2062,7 +2206,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -2076,7 +2223,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -2203,7 +2353,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -2217,7 +2370,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -2231,7 +2387,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -2245,7 +2404,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -2338,7 +2500,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -2352,7 +2517,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -2366,7 +2534,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -2380,7 +2551,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -2394,7 +2568,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -2422,7 +2599,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2632,7 +2812,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2772,7 +2955,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2786,7 +2972,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2800,7 +2989,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2814,7 +3006,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2828,7 +3023,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2842,7 +3040,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2856,7 +3057,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2870,7 +3074,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2946,7 +3153,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2960,7 +3170,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2974,7 +3187,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -3174,7 +3390,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -3188,7 +3407,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -3202,7 +3424,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -3216,7 +3441,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -3230,7 +3458,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -3244,7 +3475,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -3258,7 +3492,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -3272,7 +3509,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -3286,7 +3526,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -3300,7 +3543,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -3314,7 +3560,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -3328,7 +3577,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -3342,7 +3594,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -3356,7 +3611,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -3370,7 +3628,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -3384,7 +3645,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -3398,7 +3662,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -3412,7 +3679,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -3440,7 +3710,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -3454,7 +3727,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3468,7 +3744,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3482,7 +3761,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3496,7 +3778,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3510,7 +3795,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3524,7 +3812,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3538,7 +3829,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3552,7 +3846,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3622,7 +3919,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3650,7 +3950,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3698,7 +4001,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3712,7 +4018,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3760,7 +4069,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3921,7 +4233,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3952,7 +4267,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -4065,7 +4383,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -4107,7 +4428,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -4121,7 +4445,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -4135,7 +4462,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -4149,6 +4479,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -549,7 +549,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -577,7 +580,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -591,7 +597,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -605,7 +614,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -619,7 +631,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -633,7 +648,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -647,7 +665,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -661,7 +682,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -726,7 +750,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -808,7 +835,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -822,7 +852,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -836,7 +869,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -915,7 +951,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -929,7 +968,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -943,7 +985,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -957,7 +1002,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -985,7 +1033,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -999,7 +1050,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -1013,7 +1067,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -1027,7 +1084,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -1167,7 +1227,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -1181,7 +1244,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -1195,7 +1261,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -1377,7 +1446,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -1391,7 +1463,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -1405,7 +1480,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1545,7 +1623,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1559,7 +1640,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1635,7 +1719,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1649,7 +1736,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1663,7 +1753,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1677,7 +1770,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1691,7 +1787,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1705,7 +1804,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1719,7 +1821,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1733,7 +1838,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1761,7 +1869,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1809,7 +1920,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1823,7 +1937,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1871,7 +1988,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1885,7 +2005,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1964,7 +2087,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1978,7 +2104,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1992,7 +2121,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -2006,7 +2138,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -2020,7 +2155,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -2034,7 +2172,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -2048,7 +2189,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -2062,7 +2206,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -2076,7 +2223,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -2203,7 +2353,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -2217,7 +2370,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -2231,7 +2387,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -2245,7 +2404,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -2338,7 +2500,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -2352,7 +2517,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -2366,7 +2534,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -2380,7 +2551,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -2394,7 +2568,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -2422,7 +2599,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2632,7 +2812,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2772,7 +2955,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2786,7 +2972,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2800,7 +2989,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2814,7 +3006,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2828,7 +3023,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2842,7 +3040,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2856,7 +3057,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2870,7 +3074,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2946,7 +3153,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2960,7 +3170,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2974,7 +3187,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -3174,7 +3390,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -3188,7 +3407,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -3202,7 +3424,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -3216,7 +3441,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -3230,7 +3458,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -3244,7 +3475,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -3258,7 +3492,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -3272,7 +3509,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -3286,7 +3526,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -3300,7 +3543,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -3314,7 +3560,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -3328,7 +3577,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -3342,7 +3594,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -3356,7 +3611,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -3370,7 +3628,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -3384,7 +3645,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -3398,7 +3662,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -3412,7 +3679,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -3440,7 +3710,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -3454,7 +3727,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3468,7 +3744,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3482,7 +3761,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3496,7 +3778,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3510,7 +3795,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3524,7 +3812,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3538,7 +3829,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3552,7 +3846,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3622,7 +3919,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3650,7 +3950,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3698,7 +4001,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3712,7 +4018,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3760,7 +4069,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3921,7 +4233,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3952,7 +4267,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -4065,7 +4383,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -4107,7 +4428,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -4121,7 +4445,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -4135,7 +4462,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -4149,6 +4479,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -73,7 +73,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -101,7 +104,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -115,7 +121,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -129,7 +138,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -143,7 +155,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -157,7 +172,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -171,7 +189,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -185,7 +206,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -250,7 +274,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -332,7 +359,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -346,7 +376,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -360,7 +393,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -439,7 +475,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -453,7 +492,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -467,7 +509,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -481,7 +526,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -509,7 +557,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -523,7 +574,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -537,7 +591,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -551,7 +608,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -691,7 +751,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -705,7 +768,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -719,7 +785,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -901,7 +970,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -915,7 +987,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1055,7 +1130,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1069,7 +1147,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1226,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1243,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1260,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1277,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1294,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1311,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1328,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1345,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1376,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1427,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1444,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1381,7 +1495,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1395,7 +1512,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1474,7 +1594,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1488,7 +1611,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1502,7 +1628,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1516,7 +1645,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1530,7 +1662,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1544,7 +1679,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1558,7 +1696,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1572,7 +1713,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1586,7 +1730,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1713,7 +1860,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1727,7 +1877,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1741,7 +1894,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1755,7 +1911,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1848,7 +2007,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1862,7 +2024,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1876,7 +2041,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1890,7 +2058,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1904,7 +2075,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1932,7 +2106,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2156,7 +2333,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2296,7 +2476,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2310,7 +2493,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2324,7 +2510,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2338,7 +2527,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2352,7 +2544,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2366,7 +2561,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2380,7 +2578,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2394,7 +2595,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2470,7 +2674,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2484,7 +2691,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2498,7 +2708,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2698,7 +2911,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2712,7 +2928,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2726,7 +2945,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2740,7 +2962,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2754,7 +2979,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2768,7 +2996,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2782,7 +3013,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2796,7 +3030,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2810,7 +3047,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2824,7 +3064,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2838,7 +3081,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2852,7 +3098,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2866,7 +3115,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2880,7 +3132,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2894,7 +3149,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2908,7 +3166,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2922,7 +3183,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2936,7 +3200,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2964,7 +3231,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2978,7 +3248,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2992,7 +3265,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3006,7 +3282,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3020,7 +3299,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3034,7 +3316,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3048,7 +3333,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3062,7 +3350,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3076,7 +3367,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3146,7 +3440,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3174,7 +3471,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3222,7 +3522,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3236,7 +3539,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3284,7 +3590,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3445,7 +3754,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3476,7 +3788,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3589,7 +3904,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3631,7 +3949,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3645,7 +3966,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3659,7 +3983,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3673,6 +4000,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -73,7 +73,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -101,7 +104,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -115,7 +121,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -129,7 +138,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -143,7 +155,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -157,7 +172,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -171,7 +189,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -185,7 +206,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -250,7 +274,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -332,7 +359,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -346,7 +376,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -360,7 +393,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -439,7 +475,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -453,7 +492,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -467,7 +509,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -481,7 +526,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -509,7 +557,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -523,7 +574,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -537,7 +591,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -551,7 +608,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -691,7 +751,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -705,7 +768,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -719,7 +785,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -901,7 +970,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -915,7 +987,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -929,7 +1004,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1069,7 +1147,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1226,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1243,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1260,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1277,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1294,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1311,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1328,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1345,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1376,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1427,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1444,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1381,7 +1495,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1395,7 +1512,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1474,7 +1594,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1488,7 +1611,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1502,7 +1628,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1516,7 +1645,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1530,7 +1662,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1544,7 +1679,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1558,7 +1696,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1572,7 +1713,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1586,7 +1730,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1713,7 +1860,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1727,7 +1877,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1741,7 +1894,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1755,7 +1911,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1848,7 +2007,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1862,7 +2024,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1876,7 +2041,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1890,7 +2058,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1904,7 +2075,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1932,7 +2106,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2156,7 +2333,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2296,7 +2476,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2310,7 +2493,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2324,7 +2510,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2338,7 +2527,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2352,7 +2544,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2366,7 +2561,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2380,7 +2578,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2394,7 +2595,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2470,7 +2674,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2484,7 +2691,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2498,7 +2708,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2698,7 +2911,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2712,7 +2928,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2726,7 +2945,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2740,7 +2962,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2754,7 +2979,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2768,7 +2996,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2782,7 +3013,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2796,7 +3030,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2810,7 +3047,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2824,7 +3064,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2838,7 +3081,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2852,7 +3098,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2866,7 +3115,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2880,7 +3132,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2894,7 +3149,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2908,7 +3166,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2922,7 +3183,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2936,7 +3200,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2964,7 +3231,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2978,7 +3248,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2992,7 +3265,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3006,7 +3282,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3020,7 +3299,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3034,7 +3316,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3048,7 +3333,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3062,7 +3350,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3076,7 +3367,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3146,7 +3440,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3174,7 +3471,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3222,7 +3522,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3236,7 +3539,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3284,7 +3590,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3459,7 +3768,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3490,7 +3802,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3603,7 +3918,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3645,7 +3963,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3659,7 +3980,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3673,7 +3997,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3687,6 +4014,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -73,7 +73,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -101,7 +104,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -115,7 +121,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -129,7 +138,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -143,7 +155,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -157,7 +172,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -171,7 +189,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -185,7 +206,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -250,7 +274,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -332,7 +359,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -346,7 +376,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -360,7 +393,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -439,7 +475,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -453,7 +492,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -467,7 +509,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -481,7 +526,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -509,7 +557,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -523,7 +574,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -537,7 +591,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -551,7 +608,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -691,7 +751,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -705,7 +768,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -719,7 +785,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -901,7 +970,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -915,7 +987,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -929,7 +1004,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1069,7 +1147,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1226,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1243,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1260,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1277,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1294,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1311,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1328,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1345,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1376,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1427,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1444,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1381,7 +1495,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1395,7 +1512,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1474,7 +1594,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1488,7 +1611,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1502,7 +1628,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1516,7 +1645,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1530,7 +1662,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1544,7 +1679,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1558,7 +1696,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1572,7 +1713,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1586,7 +1730,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1713,7 +1860,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1727,7 +1877,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1741,7 +1894,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1755,7 +1911,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1848,7 +2007,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1862,7 +2024,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1876,7 +2041,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1890,7 +2058,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1904,7 +2075,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1932,7 +2106,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2156,7 +2333,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2296,7 +2476,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2310,7 +2493,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2324,7 +2510,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2338,7 +2527,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2352,7 +2544,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2366,7 +2561,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2380,7 +2578,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2394,7 +2595,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2470,7 +2674,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2484,7 +2691,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2498,7 +2708,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2698,7 +2911,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2712,7 +2928,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2726,7 +2945,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2740,7 +2962,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2754,7 +2979,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2768,7 +2996,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2782,7 +3013,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2796,7 +3030,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2810,7 +3047,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2824,7 +3064,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2838,7 +3081,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2852,7 +3098,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2866,7 +3115,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2880,7 +3132,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2894,7 +3149,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2908,7 +3166,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2922,7 +3183,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2936,7 +3200,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2964,7 +3231,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2978,7 +3248,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2992,7 +3265,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3006,7 +3282,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3020,7 +3299,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3034,7 +3316,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3048,7 +3333,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3062,7 +3350,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3076,7 +3367,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3146,7 +3440,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3174,7 +3471,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3222,7 +3522,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3236,7 +3539,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3284,7 +3590,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3445,7 +3754,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3476,7 +3788,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3589,7 +3904,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3631,7 +3949,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3645,7 +3966,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3659,7 +3983,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3673,6 +4000,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
@@ -84,6 +84,56 @@
     ]
   },
   {
+    "label": "resource",
+    "kind": "keyword",
+    "detail": "Resource keyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resource"
+    }
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Nested resource with defaults",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
+    }
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Nested resource without defaults",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
+    }
+  },
+  {
     "label": "tags",
     "kind": "property",
     "detail": "tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
@@ -19,5 +19,55 @@
     "commitCharacters": [
       ":"
     ]
+  },
+  {
+    "label": "resource",
+    "kind": "keyword",
+    "detail": "Resource keyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resource"
+    }
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Nested resource with defaults",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
+    }
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Nested resource without defaults",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -63,7 +63,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -91,7 +94,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -105,7 +111,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -119,7 +128,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -133,7 +145,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -147,7 +162,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -161,7 +179,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -175,7 +196,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -240,7 +264,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -322,7 +349,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -336,7 +366,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -350,7 +383,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -429,7 +465,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -443,7 +482,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -457,7 +499,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -471,7 +516,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -499,7 +547,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -513,7 +564,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -527,7 +581,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -541,7 +598,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -681,7 +741,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -695,7 +758,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -709,7 +775,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -891,7 +960,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -905,7 +977,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -919,7 +994,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1045,7 +1123,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1059,7 +1140,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1135,7 +1219,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1149,7 +1236,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1163,7 +1253,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1177,7 +1270,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1191,7 +1287,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1205,7 +1304,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1219,7 +1321,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1233,7 +1338,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1261,7 +1369,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1309,7 +1420,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1323,7 +1437,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1371,7 +1488,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1385,7 +1505,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1464,7 +1587,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1478,7 +1604,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1492,7 +1621,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1506,7 +1638,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1520,7 +1655,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1534,7 +1672,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1548,7 +1689,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1562,7 +1706,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1576,7 +1723,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1703,7 +1853,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1717,7 +1870,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1731,7 +1887,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1745,7 +1904,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1838,7 +2000,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1852,7 +2017,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1866,7 +2034,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1880,7 +2051,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1894,7 +2068,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1922,7 +2099,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2146,7 +2326,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2286,7 +2469,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2300,7 +2486,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2314,7 +2503,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2328,7 +2520,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2342,7 +2537,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2356,7 +2554,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2370,7 +2571,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2384,7 +2588,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2460,7 +2667,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2474,7 +2684,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2488,7 +2701,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2688,7 +2904,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2702,7 +2921,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2716,7 +2938,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2730,7 +2955,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2744,7 +2972,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2758,7 +2989,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2772,7 +3006,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2786,7 +3023,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2800,7 +3040,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2814,7 +3057,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2828,7 +3074,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2842,7 +3091,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2856,7 +3108,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2870,7 +3125,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2884,7 +3142,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2898,7 +3159,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2912,7 +3176,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2926,7 +3193,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2954,7 +3224,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2968,7 +3241,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2982,7 +3258,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2996,7 +3275,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3010,7 +3292,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3024,7 +3309,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3038,7 +3326,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3052,7 +3343,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3066,7 +3360,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3136,7 +3433,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3164,7 +3464,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3212,7 +3515,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3226,7 +3532,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3274,7 +3583,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3435,7 +3747,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3466,7 +3781,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3579,7 +3897,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3621,7 +3942,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3635,7 +3959,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3649,7 +3976,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3663,6 +3993,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -63,7 +63,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -91,7 +94,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -105,7 +111,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -119,7 +128,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -133,7 +145,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -147,7 +162,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -161,7 +179,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -175,7 +196,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -240,7 +264,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -322,7 +349,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -336,7 +366,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -350,7 +383,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -429,7 +465,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -443,7 +482,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -457,7 +499,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -471,7 +516,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -499,7 +547,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -513,7 +564,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -527,7 +581,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -541,7 +598,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -681,7 +741,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -695,7 +758,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -709,7 +775,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -891,7 +960,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -905,7 +977,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -919,7 +994,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1045,7 +1123,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1059,7 +1140,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1135,7 +1219,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1149,7 +1236,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1163,7 +1253,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1177,7 +1270,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1191,7 +1287,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1205,7 +1304,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1219,7 +1321,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1233,7 +1338,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1261,7 +1369,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1309,7 +1420,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1323,7 +1437,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1371,7 +1488,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1385,7 +1505,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1464,7 +1587,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1478,7 +1604,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1492,7 +1621,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1506,7 +1638,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1520,7 +1655,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1534,7 +1672,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1548,7 +1689,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1562,7 +1706,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1576,7 +1723,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1703,7 +1853,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1717,7 +1870,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1731,7 +1887,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1745,7 +1904,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1838,7 +2000,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1852,7 +2017,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1866,7 +2034,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1880,7 +2051,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1894,7 +2068,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1922,7 +2099,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2146,7 +2326,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2286,7 +2469,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2300,7 +2486,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2314,7 +2503,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2328,7 +2520,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2342,7 +2537,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2356,7 +2554,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2370,7 +2571,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2384,7 +2588,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2460,7 +2667,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2474,7 +2684,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2488,7 +2701,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2688,7 +2904,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2702,7 +2921,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2716,7 +2938,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2730,7 +2955,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2744,7 +2972,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2758,7 +2989,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2772,7 +3006,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2786,7 +3023,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2800,7 +3040,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2814,7 +3057,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2828,7 +3074,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2842,7 +3091,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2856,7 +3108,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2870,7 +3125,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2884,7 +3142,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2898,7 +3159,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2912,7 +3176,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2926,7 +3193,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2954,7 +3224,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2968,7 +3241,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2982,7 +3258,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2996,7 +3275,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3010,7 +3292,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3024,7 +3309,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3038,7 +3326,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3052,7 +3343,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3066,7 +3360,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3136,7 +3433,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3164,7 +3464,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3212,7 +3515,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3226,7 +3532,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3274,7 +3583,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3435,7 +3747,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3466,7 +3781,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3579,7 +3897,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3621,7 +3942,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3635,7 +3959,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3649,7 +3976,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3663,6 +3993,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -63,7 +63,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -91,7 +94,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -105,7 +111,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -119,7 +128,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -133,7 +145,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -147,7 +162,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -161,7 +179,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -175,7 +196,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -240,7 +264,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -322,7 +349,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -336,7 +366,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -350,7 +383,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -429,7 +465,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -443,7 +482,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -457,7 +499,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -471,7 +516,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -499,7 +547,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -513,7 +564,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -527,7 +581,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -541,7 +598,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -681,7 +741,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -695,7 +758,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -709,7 +775,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -891,7 +960,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -905,7 +977,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -919,7 +994,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1045,7 +1123,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1059,7 +1140,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1135,7 +1219,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1149,7 +1236,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1163,7 +1253,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1177,7 +1270,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1191,7 +1287,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1205,7 +1304,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1219,7 +1321,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1233,7 +1338,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1261,7 +1369,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1309,7 +1420,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1323,7 +1437,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1371,7 +1488,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1385,7 +1505,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1464,7 +1587,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1478,7 +1604,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1492,7 +1621,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1506,7 +1638,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1520,7 +1655,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1534,7 +1672,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1548,7 +1689,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1562,7 +1706,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1576,7 +1723,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1703,7 +1853,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1717,7 +1870,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1731,7 +1887,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1745,7 +1904,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1838,7 +2000,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1852,7 +2017,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1866,7 +2034,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1880,7 +2051,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1894,7 +2068,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1922,7 +2099,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2146,7 +2326,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2286,7 +2469,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2300,7 +2486,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2314,7 +2503,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2328,7 +2520,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2342,7 +2537,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2356,7 +2554,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2370,7 +2571,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2384,7 +2588,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2460,7 +2667,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2474,7 +2684,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2488,7 +2701,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2688,7 +2904,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2702,7 +2921,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2716,7 +2938,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2730,7 +2955,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2744,7 +2972,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2758,7 +2989,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2772,7 +3006,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2786,7 +3023,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2800,7 +3040,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2814,7 +3057,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2828,7 +3074,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2842,7 +3091,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2856,7 +3108,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2870,7 +3125,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2884,7 +3142,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2898,7 +3159,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2912,7 +3176,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2926,7 +3193,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2954,7 +3224,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2968,7 +3241,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2982,7 +3258,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2996,7 +3275,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3010,7 +3292,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3024,7 +3309,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3038,7 +3326,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3052,7 +3343,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3066,7 +3360,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3136,7 +3433,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3164,7 +3464,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3212,7 +3515,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3226,7 +3532,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3274,7 +3583,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3435,7 +3747,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3466,7 +3781,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3579,7 +3897,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3621,7 +3942,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3635,7 +3959,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3649,7 +3976,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3663,6 +3993,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -45,7 +45,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -73,7 +76,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -87,7 +93,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -101,7 +110,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -115,7 +127,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -129,7 +144,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -143,7 +161,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -157,7 +178,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -222,7 +246,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -304,7 +331,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -318,7 +348,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -332,7 +365,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -411,7 +447,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -425,7 +464,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -439,7 +481,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -453,7 +498,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -481,7 +529,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -495,7 +546,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -509,7 +563,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -523,7 +580,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -663,7 +723,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -677,7 +740,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -691,7 +757,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -873,7 +942,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -887,7 +959,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -901,7 +976,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1041,7 +1119,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1055,7 +1136,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1131,7 +1215,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1145,7 +1232,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1159,7 +1249,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1173,7 +1266,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1187,7 +1283,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1201,7 +1300,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1215,7 +1317,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1229,7 +1334,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1257,7 +1365,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1305,7 +1416,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1319,7 +1433,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1367,7 +1484,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1446,7 +1566,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1460,7 +1583,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1474,7 +1600,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1488,7 +1617,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1502,7 +1634,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1516,7 +1651,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1530,7 +1668,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1544,7 +1685,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1558,7 +1702,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1685,7 +1832,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1699,7 +1849,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1713,7 +1866,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1727,7 +1883,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1820,7 +1979,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1834,7 +1996,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1848,7 +2013,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1862,7 +2030,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1876,7 +2047,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1904,7 +2078,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2128,7 +2305,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2268,7 +2448,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2282,7 +2465,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2296,7 +2482,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2310,7 +2499,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2324,7 +2516,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2338,7 +2533,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2352,7 +2550,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2366,7 +2567,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2442,7 +2646,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2456,7 +2663,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2470,7 +2680,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2670,7 +2883,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2684,7 +2900,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2698,7 +2917,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2712,7 +2934,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2726,7 +2951,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2740,7 +2968,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2754,7 +2985,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2768,7 +3002,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2782,7 +3019,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2796,7 +3036,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2810,7 +3053,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2824,7 +3070,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2838,7 +3087,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2852,7 +3104,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2866,7 +3121,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2880,7 +3138,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2894,7 +3155,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2908,7 +3172,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2936,7 +3203,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2950,7 +3220,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2964,7 +3237,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2978,7 +3254,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -2992,7 +3271,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3006,7 +3288,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3020,7 +3305,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3034,7 +3322,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3048,7 +3339,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3118,7 +3412,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3146,7 +3443,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3194,7 +3494,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3208,7 +3511,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3256,7 +3562,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3417,7 +3726,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3448,7 +3760,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3561,7 +3876,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3603,7 +3921,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3617,7 +3938,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3631,7 +3955,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3645,7 +3972,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "{}",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -171,7 +171,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -199,7 +202,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -213,7 +219,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -227,7 +236,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -241,7 +253,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -255,7 +270,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -269,7 +287,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -283,7 +304,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -348,7 +372,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -430,7 +457,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -444,7 +474,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -458,7 +491,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -537,7 +573,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -551,7 +590,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -565,7 +607,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -579,7 +624,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -607,7 +655,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -621,7 +672,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -635,7 +689,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -649,7 +706,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -789,7 +849,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -803,7 +866,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -817,7 +883,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -999,7 +1068,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -1013,7 +1085,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -1027,7 +1102,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1167,7 +1245,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1181,7 +1262,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1257,7 +1341,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1271,7 +1358,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1285,7 +1375,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1299,7 +1392,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1313,7 +1409,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1327,7 +1426,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1341,7 +1443,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1355,7 +1460,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1383,7 +1491,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1431,7 +1542,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1445,7 +1559,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1493,7 +1610,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1507,7 +1627,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1586,7 +1709,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1600,7 +1726,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1614,7 +1743,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1628,7 +1760,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1642,7 +1777,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1656,7 +1794,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1670,7 +1811,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1684,7 +1828,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1698,7 +1845,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1825,7 +1975,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1839,7 +1992,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1853,7 +2009,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1867,7 +2026,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1960,7 +2122,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1974,7 +2139,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1988,7 +2156,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -2002,7 +2173,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -2016,7 +2190,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -2044,7 +2221,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2268,7 +2448,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2408,7 +2591,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2422,7 +2608,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2436,7 +2625,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2450,7 +2642,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2464,7 +2659,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2478,7 +2676,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2492,7 +2693,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2506,7 +2710,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2582,7 +2789,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2596,7 +2806,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2796,7 +3009,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2810,7 +3026,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2824,7 +3043,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2838,7 +3060,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2852,7 +3077,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2866,7 +3094,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2880,7 +3111,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2894,7 +3128,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2908,7 +3145,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2922,7 +3162,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2936,7 +3179,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2950,7 +3196,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2964,7 +3213,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2978,7 +3230,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2992,7 +3247,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -3006,7 +3264,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -3020,7 +3281,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -3034,7 +3298,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -3062,7 +3329,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -3076,7 +3346,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3090,7 +3363,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3104,7 +3380,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3118,7 +3397,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3132,7 +3414,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3146,7 +3431,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3160,7 +3448,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3174,7 +3465,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3244,7 +3538,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3272,7 +3569,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3320,7 +3620,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3334,7 +3637,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3382,7 +3688,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3543,7 +3852,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3574,7 +3886,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3687,7 +4002,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3729,7 +4047,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3743,7 +4064,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3757,7 +4081,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3771,6 +4098,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -45,7 +45,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -73,7 +76,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -87,7 +93,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -101,7 +110,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -115,7 +127,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -129,7 +144,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -143,7 +161,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -157,7 +178,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -222,7 +246,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -304,7 +331,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -318,7 +348,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -332,7 +365,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -411,7 +447,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -425,7 +464,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -439,7 +481,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -453,7 +498,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -481,7 +529,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -495,7 +546,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -509,7 +563,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -523,7 +580,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -663,7 +723,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -677,7 +740,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -691,7 +757,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -873,7 +942,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -887,7 +959,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -901,7 +976,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1041,7 +1119,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1055,7 +1136,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1131,7 +1215,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1145,7 +1232,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1159,7 +1249,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1173,7 +1266,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1187,7 +1283,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1201,7 +1300,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1215,7 +1317,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1229,7 +1334,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1257,7 +1365,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1305,7 +1416,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1319,7 +1433,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1367,7 +1484,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1381,7 +1501,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1460,7 +1583,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1474,7 +1600,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1488,7 +1617,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1502,7 +1634,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1516,7 +1651,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1530,7 +1668,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1544,7 +1685,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1558,7 +1702,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1572,7 +1719,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1699,7 +1849,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1713,7 +1866,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1727,7 +1883,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1741,7 +1900,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1834,7 +1996,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1848,7 +2013,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1862,7 +2030,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1876,7 +2047,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1890,7 +2064,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1918,7 +2095,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2142,7 +2322,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2282,7 +2465,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2296,7 +2482,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2310,7 +2499,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2324,7 +2516,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2338,7 +2533,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2352,7 +2550,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2366,7 +2567,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2380,7 +2584,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2456,7 +2663,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2470,7 +2680,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2484,7 +2697,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2684,7 +2900,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2698,7 +2917,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2712,7 +2934,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2726,7 +2951,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2740,7 +2968,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2754,7 +2985,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2768,7 +3002,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2782,7 +3019,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2796,7 +3036,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2810,7 +3053,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2824,7 +3070,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2838,7 +3087,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2852,7 +3104,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2866,7 +3121,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2880,7 +3138,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2894,7 +3155,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2908,7 +3172,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2922,7 +3189,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2950,7 +3220,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2964,7 +3237,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2978,7 +3254,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2992,7 +3271,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3006,7 +3288,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3020,7 +3305,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3034,7 +3322,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3048,7 +3339,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3062,7 +3356,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3132,7 +3429,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3160,7 +3460,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3208,7 +3511,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3222,7 +3528,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3270,7 +3579,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3431,7 +3743,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3462,7 +3777,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3575,7 +3893,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3617,7 +3938,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3631,7 +3955,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3645,7 +3972,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3659,6 +3989,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
@@ -59,7 +59,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -87,7 +90,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -101,7 +107,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -115,7 +124,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -129,7 +141,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -143,7 +158,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -157,7 +175,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -171,7 +192,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -236,7 +260,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -318,7 +345,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -332,7 +362,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -346,7 +379,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -425,7 +461,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -439,7 +478,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -453,7 +495,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -467,7 +512,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -495,7 +543,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -509,7 +560,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -523,7 +577,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -537,7 +594,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -677,7 +737,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -691,7 +754,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -705,7 +771,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -887,7 +956,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -901,7 +973,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -915,7 +990,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1055,7 +1133,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1069,7 +1150,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1229,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1246,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1263,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1280,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1297,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1314,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1331,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1348,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1379,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1430,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1447,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1381,7 +1498,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1395,7 +1515,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1474,7 +1597,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1488,7 +1614,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1502,7 +1631,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1516,7 +1648,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1530,7 +1665,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1544,7 +1682,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1558,7 +1699,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1572,7 +1716,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1586,7 +1733,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1713,7 +1863,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1727,7 +1880,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1741,7 +1897,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1755,7 +1914,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1848,7 +2010,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1862,7 +2027,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1876,7 +2044,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1890,7 +2061,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1904,7 +2078,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1932,7 +2109,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2156,7 +2336,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2296,7 +2479,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2310,7 +2496,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2324,7 +2513,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2338,7 +2530,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2352,7 +2547,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2366,7 +2564,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2380,7 +2581,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2394,7 +2598,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2470,7 +2677,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2484,7 +2694,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2684,7 +2897,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2698,7 +2914,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2712,7 +2931,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2726,7 +2948,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2740,7 +2965,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2754,7 +2982,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2768,7 +2999,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2782,7 +3016,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2796,7 +3033,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2810,7 +3050,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2824,7 +3067,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2838,7 +3084,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2852,7 +3101,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2866,7 +3118,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2880,7 +3135,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2894,7 +3152,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2908,7 +3169,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2922,7 +3186,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2950,7 +3217,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2964,7 +3234,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2978,7 +3251,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2992,7 +3268,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3006,7 +3285,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3020,7 +3302,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3034,7 +3319,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3048,7 +3336,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3062,7 +3353,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3132,7 +3426,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3160,7 +3457,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3208,7 +3508,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3222,7 +3525,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3270,7 +3576,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3431,7 +3740,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3462,7 +3774,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3575,7 +3890,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3617,7 +3935,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3631,7 +3952,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3645,7 +3969,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3659,6 +3986,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -59,7 +59,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -87,7 +90,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -101,7 +107,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -115,7 +124,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -129,7 +141,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -143,7 +158,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -157,7 +175,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -171,7 +192,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -236,7 +260,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -318,7 +345,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -332,7 +362,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -346,7 +379,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -425,7 +461,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -439,7 +478,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -453,7 +495,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -467,7 +512,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -495,7 +543,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -509,7 +560,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -523,7 +577,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -537,7 +594,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -677,7 +737,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -691,7 +754,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -705,7 +771,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -887,7 +956,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -901,7 +973,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -915,7 +990,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1055,7 +1133,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1069,7 +1150,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1229,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1246,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1263,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1280,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1297,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1314,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1331,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1348,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1379,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1430,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1447,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1381,7 +1498,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1395,7 +1515,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1474,7 +1597,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1488,7 +1614,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1502,7 +1631,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1516,7 +1648,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1530,7 +1665,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1544,7 +1682,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1558,7 +1699,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1572,7 +1716,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1586,7 +1733,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1713,7 +1863,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1727,7 +1880,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1741,7 +1897,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1755,7 +1914,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1848,7 +2010,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1862,7 +2027,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1876,7 +2044,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1890,7 +2061,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1904,7 +2078,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1932,7 +2109,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2156,7 +2336,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2296,7 +2479,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2310,7 +2496,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2324,7 +2513,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2338,7 +2530,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2352,7 +2547,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2366,7 +2564,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2380,7 +2581,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2394,7 +2598,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2470,7 +2677,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2484,7 +2694,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2684,7 +2897,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2698,7 +2914,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2712,7 +2931,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2726,7 +2948,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2740,7 +2965,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2754,7 +2982,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2768,7 +2999,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2782,7 +3016,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2796,7 +3033,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2810,7 +3050,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2824,7 +3067,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2838,7 +3084,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2852,7 +3101,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2866,7 +3118,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2880,7 +3135,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2894,7 +3152,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2908,7 +3169,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2922,7 +3186,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2950,7 +3217,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2964,7 +3234,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2978,7 +3251,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -2992,7 +3268,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3006,7 +3285,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3020,7 +3302,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3034,7 +3319,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3048,7 +3336,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3062,7 +3353,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3132,7 +3426,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3160,7 +3457,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3208,7 +3508,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3222,7 +3525,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3270,7 +3576,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3431,7 +3740,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3462,7 +3774,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3575,7 +3890,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3617,7 +3935,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3631,7 +3952,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3645,7 +3969,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3659,6 +3986,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -59,7 +59,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -87,7 +90,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -101,7 +107,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -115,7 +124,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -129,7 +141,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -143,7 +158,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -157,7 +175,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -171,7 +192,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -236,7 +260,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -318,7 +345,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -332,7 +362,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -346,7 +379,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -425,7 +461,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -439,7 +478,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -453,7 +495,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -467,7 +512,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -495,7 +543,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -509,7 +560,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -523,7 +577,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -537,7 +594,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -677,7 +737,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -691,7 +754,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -705,7 +771,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -887,7 +956,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -901,7 +973,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -915,7 +990,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1055,7 +1133,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1069,7 +1150,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1229,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1246,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1263,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1280,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1297,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1314,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1331,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1348,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1379,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1430,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1447,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1381,7 +1498,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1395,7 +1515,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1474,7 +1597,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1488,7 +1614,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1502,7 +1631,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1516,7 +1648,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1530,7 +1665,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1544,7 +1682,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1558,7 +1699,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1572,7 +1716,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1586,7 +1733,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1713,7 +1863,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1727,7 +1880,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1741,7 +1897,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1755,7 +1914,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1848,7 +2010,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1862,7 +2027,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1876,7 +2044,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1890,7 +2061,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1904,7 +2078,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1932,7 +2109,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2156,7 +2336,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2296,7 +2479,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2310,7 +2496,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2324,7 +2513,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2338,7 +2530,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2352,7 +2547,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2366,7 +2564,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2380,7 +2581,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2394,7 +2598,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2470,7 +2677,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2484,7 +2694,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2698,7 +2911,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2712,7 +2928,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2726,7 +2945,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2740,7 +2962,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2754,7 +2979,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2768,7 +2996,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2782,7 +3013,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2796,7 +3030,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2810,7 +3047,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2824,7 +3064,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2838,7 +3081,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2852,7 +3098,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2866,7 +3115,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2880,7 +3132,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2894,7 +3149,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2908,7 +3166,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2922,7 +3183,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2936,7 +3200,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2964,7 +3231,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2978,7 +3248,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2992,7 +3265,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3006,7 +3282,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3020,7 +3299,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3034,7 +3316,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3048,7 +3333,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3062,7 +3350,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3076,7 +3367,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3146,7 +3440,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3174,7 +3471,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3222,7 +3522,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3236,7 +3539,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3298,7 +3604,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3459,7 +3768,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3490,7 +3802,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3603,7 +3918,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3645,7 +3963,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3659,7 +3980,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3673,7 +3997,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3687,6 +4014,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleStateSomething.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleStateSomething.json
@@ -59,7 +59,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -87,7 +90,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -101,7 +107,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -115,7 +124,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -129,7 +141,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -143,7 +158,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -157,7 +175,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -171,7 +192,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -236,7 +260,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -318,7 +345,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -332,7 +362,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -346,7 +379,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -425,7 +461,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -439,7 +478,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -453,7 +495,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -467,7 +512,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -495,7 +543,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -509,7 +560,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -523,7 +577,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -537,7 +594,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -677,7 +737,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -691,7 +754,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -705,7 +771,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -887,7 +956,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -901,7 +973,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -915,7 +990,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1055,7 +1133,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1069,7 +1150,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1229,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1246,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1263,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1280,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1297,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1314,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1331,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1348,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1379,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1430,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1447,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1381,7 +1498,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1395,7 +1515,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1474,7 +1597,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1488,7 +1614,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1502,7 +1631,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1516,7 +1648,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1530,7 +1665,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1544,7 +1682,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1558,7 +1699,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1572,7 +1716,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1586,7 +1733,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1713,7 +1863,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1727,7 +1880,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1741,7 +1897,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1755,7 +1914,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1848,7 +2010,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1862,7 +2027,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1876,7 +2044,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1890,7 +2061,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1904,7 +2078,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1932,7 +2109,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2156,7 +2336,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2296,7 +2479,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2310,7 +2496,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2324,7 +2513,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2338,7 +2530,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2352,7 +2547,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2366,7 +2564,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2380,7 +2581,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2394,7 +2598,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2470,7 +2677,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2484,7 +2694,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2698,7 +2911,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2712,7 +2928,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2726,7 +2945,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2740,7 +2962,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2754,7 +2979,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2768,7 +2996,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2782,7 +3013,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2796,7 +3030,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2810,7 +3047,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2824,7 +3064,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2838,7 +3081,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2852,7 +3098,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2866,7 +3115,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2880,7 +3132,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2894,7 +3149,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2908,7 +3166,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2922,7 +3183,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2936,7 +3200,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2964,7 +3231,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2978,7 +3248,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2992,7 +3265,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3006,7 +3282,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3020,7 +3299,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3034,7 +3316,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3048,7 +3333,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3062,7 +3350,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3076,7 +3367,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3146,7 +3440,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3174,7 +3471,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3236,7 +3536,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3250,7 +3553,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3312,7 +3618,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3473,7 +3782,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3504,7 +3816,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3617,7 +3932,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3659,7 +3977,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3673,7 +3994,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3687,7 +4011,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3701,6 +4028,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -59,7 +59,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -87,7 +90,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -101,7 +107,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -115,7 +124,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -129,7 +141,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -143,7 +158,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -157,7 +175,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -171,7 +192,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -236,7 +260,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -318,7 +345,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -332,7 +362,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -346,7 +379,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -425,7 +461,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -439,7 +478,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -453,7 +495,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -467,7 +512,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -495,7 +543,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -509,7 +560,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -523,7 +577,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -537,7 +594,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -677,7 +737,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -691,7 +754,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -705,7 +771,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -887,7 +956,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -901,7 +973,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -915,7 +990,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1055,7 +1133,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1069,7 +1150,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1229,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1246,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1263,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1280,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1297,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1314,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1331,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1348,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1379,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1430,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1447,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "for",
@@ -1399,7 +1516,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1413,7 +1533,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1492,7 +1615,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1506,7 +1632,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1520,7 +1649,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1534,7 +1666,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1548,7 +1683,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1562,7 +1700,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1576,7 +1717,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1590,7 +1734,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1604,7 +1751,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "item",
@@ -1745,7 +1895,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1759,7 +1912,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1773,7 +1929,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1787,7 +1946,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1880,7 +2042,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1894,7 +2059,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1908,7 +2076,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1922,7 +2093,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1936,7 +2110,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1964,7 +2141,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2188,7 +2368,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2328,7 +2511,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2342,7 +2528,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2356,7 +2545,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2370,7 +2562,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2384,7 +2579,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2398,7 +2596,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2412,7 +2613,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2426,7 +2630,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2502,7 +2709,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2516,7 +2726,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2530,7 +2743,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2730,7 +2946,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2744,7 +2963,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2758,7 +2980,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2772,7 +2997,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2786,7 +3014,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2800,7 +3031,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2814,7 +3048,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2828,7 +3065,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2842,7 +3082,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2856,7 +3099,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2870,7 +3116,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2884,7 +3133,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2898,7 +3150,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2912,7 +3167,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2926,7 +3184,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2940,7 +3201,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2954,7 +3218,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2968,7 +3235,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2996,7 +3266,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -3010,7 +3283,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3024,7 +3300,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3038,7 +3317,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3052,7 +3334,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3066,7 +3351,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3080,7 +3368,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3094,7 +3385,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3108,7 +3402,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3178,7 +3475,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3206,7 +3506,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3254,7 +3557,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3268,7 +3574,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3316,7 +3625,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3477,7 +3789,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3508,7 +3823,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3621,7 +3939,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3663,7 +3984,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3677,7 +4001,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3691,7 +4018,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3705,6 +4035,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -59,7 +59,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -87,7 +90,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -101,7 +107,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -115,7 +124,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -129,7 +141,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -143,7 +158,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -157,7 +175,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -171,7 +192,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -236,7 +260,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -318,7 +345,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -332,7 +362,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -346,7 +379,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -425,7 +461,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -439,7 +478,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -453,7 +495,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -467,7 +512,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -495,7 +543,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -509,7 +560,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -523,7 +577,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -537,7 +594,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -677,7 +737,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -691,7 +754,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -705,7 +771,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -887,7 +956,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -901,7 +973,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -915,7 +990,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1055,7 +1133,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1069,7 +1150,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1229,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1246,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1263,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1280,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1297,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1314,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1331,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1348,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1379,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1430,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1447,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1381,7 +1498,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1395,7 +1515,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1474,7 +1597,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1488,7 +1614,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1502,7 +1631,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1516,7 +1648,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1530,7 +1665,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1544,7 +1682,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1558,7 +1699,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1572,7 +1716,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1586,7 +1733,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "item",
@@ -1727,7 +1877,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1741,7 +1894,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1755,7 +1911,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1769,7 +1928,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1862,7 +2024,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1876,7 +2041,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1890,7 +2058,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1904,7 +2075,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1918,7 +2092,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1946,7 +2123,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2170,7 +2350,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2310,7 +2493,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2324,7 +2510,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2338,7 +2527,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2352,7 +2544,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2366,7 +2561,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2380,7 +2578,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2394,7 +2595,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2408,7 +2612,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2484,7 +2691,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2498,7 +2708,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest2",
@@ -2512,7 +2725,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2712,7 +2928,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2726,7 +2945,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2740,7 +2962,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2754,7 +2979,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2768,7 +2996,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2782,7 +3013,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2796,7 +3030,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2810,7 +3047,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2824,7 +3064,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2838,7 +3081,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2852,7 +3098,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2866,7 +3115,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2880,7 +3132,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2894,7 +3149,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2908,7 +3166,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2922,7 +3183,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2936,7 +3200,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2950,7 +3217,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2978,7 +3248,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2992,7 +3265,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -3006,7 +3282,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3020,7 +3299,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3034,7 +3316,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3048,7 +3333,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3062,7 +3350,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3076,7 +3367,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3090,7 +3384,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3160,7 +3457,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3188,7 +3488,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3236,7 +3539,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3250,7 +3556,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3298,7 +3607,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3459,7 +3771,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3490,7 +3805,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3603,7 +3921,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3645,7 +3966,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3659,7 +3983,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3673,6 +4000,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -59,7 +59,10 @@
     "textEdit": {
       "range": {},
       "newText": "arrayExpressionErrors"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "az",
@@ -87,7 +90,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends2",
@@ -101,7 +107,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends3",
@@ -115,7 +124,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends4",
@@ -129,7 +141,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badDepends5",
@@ -143,7 +158,10 @@
     "textEdit": {
       "range": {},
       "newText": "badDepends5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "badInterp",
@@ -157,7 +175,10 @@
     "textEdit": {
       "range": {},
       "newText": "badInterp"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bar",
@@ -171,7 +192,10 @@
     "textEdit": {
       "range": {},
       "newText": "bar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "base64",
@@ -236,7 +260,10 @@
     "textEdit": {
       "range": {},
       "newText": "baz"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "bool",
@@ -318,7 +345,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicExistingRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "cyclicRes",
@@ -332,7 +362,10 @@
     "textEdit": {
       "range": {},
       "newText": "cyclicRes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dashesInPropertyNames",
@@ -346,7 +379,10 @@
     "textEdit": {
       "range": {},
       "newText": "dashesInPropertyNames"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "dataUri",
@@ -425,7 +461,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleConditionalResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBody",
@@ -439,7 +478,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleLoopResourceBodyWithExtraDependsOn",
@@ -453,7 +495,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleLoopResourceBodyWithExtraDependsOn"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaSingleResourceBody",
@@ -467,7 +512,10 @@
     "textEdit": {
       "range": {},
       "newText": "directRefViaSingleResourceBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "directRefViaVar",
@@ -495,7 +543,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_for",
@@ -509,7 +560,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyMissing_if",
@@ -523,7 +577,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne",
@@ -537,7 +594,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOneCompletions",
@@ -677,7 +737,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetOne_if",
@@ -691,7 +754,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetOne_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo",
@@ -705,7 +771,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwoCompletions",
@@ -887,7 +956,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeySetTwo_if",
@@ -901,7 +973,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeySetTwo_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing",
@@ -915,7 +990,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissingCompletions",
@@ -1055,7 +1133,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "discriminatorKeyValueMissing_if",
@@ -1069,7 +1150,10 @@
     "textEdit": {
       "range": {},
       "newText": "discriminatorKeyValueMissing_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "empty",
@@ -1145,7 +1229,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedArrayExpression"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedColon",
@@ -1159,7 +1246,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedColon"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword",
@@ -1173,7 +1263,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedForKeyword2",
@@ -1187,7 +1280,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedForKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword",
@@ -1201,7 +1297,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedInKeyword2",
@@ -1215,7 +1314,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedInKeyword2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopBody",
@@ -1229,7 +1331,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expectedLoopVar",
@@ -1243,7 +1348,10 @@
     "textEdit": {
       "range": {},
       "newText": "expectedLoopVar"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "expressionInPropertyLoopVar",
@@ -1271,7 +1379,10 @@
     "textEdit": {
       "range": {},
       "newText": "expressionsInPropertyLoopName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "extensionResourceId",
@@ -1319,7 +1430,10 @@
     "textEdit": {
       "range": {},
       "newText": "fo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "foo",
@@ -1333,7 +1447,10 @@
     "textEdit": {
       "range": {},
       "newText": "foo"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "format",
@@ -1381,7 +1498,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "incorrectPropertiesKey2",
@@ -1395,7 +1515,10 @@
     "textEdit": {
       "range": {},
       "newText": "incorrectPropertiesKey2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "indexOf",
@@ -1474,7 +1597,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDecorator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName1",
@@ -1488,7 +1614,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName2",
@@ -1502,7 +1631,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidDuplicateName3",
@@ -1516,7 +1648,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidDuplicateName3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName1",
@@ -1530,7 +1665,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidExtensionResourceDuplicateName2",
@@ -1544,7 +1682,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidExtensionResourceDuplicateName2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope",
@@ -1558,7 +1699,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope2",
@@ -1572,7 +1716,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "invalidScope3",
@@ -1586,7 +1733,10 @@
     "textEdit": {
       "range": {},
       "newText": "invalidScope3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "json",
@@ -1713,7 +1863,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck2",
@@ -1727,7 +1880,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck3",
@@ -1741,7 +1897,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "loopForRuntimeCheck4",
@@ -1755,7 +1914,10 @@
     "textEdit": {
       "range": {},
       "newText": "loopForRuntimeCheck4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "magicString1",
@@ -1848,7 +2010,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingFewerRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingRequiredProperties",
@@ -1862,7 +2027,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingRequiredProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelProperties",
@@ -1876,7 +2044,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelProperties"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingTopLevelPropertiesExceptName",
@@ -1890,7 +2061,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingTopLevelPropertiesExceptName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "missingType",
@@ -1904,7 +2078,10 @@
     "textEdit": {
       "range": {},
       "newText": "missingType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "mock",
@@ -1932,7 +2109,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorArrayIndexCompletions",
@@ -2156,7 +2336,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKeyCompletions",
@@ -2296,7 +2479,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminatorMissingKey_if",
@@ -2310,7 +2496,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminatorMissingKey_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_for",
@@ -2324,7 +2513,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_for"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedDiscriminator_if",
@@ -2338,7 +2530,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedDiscriminator_if"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nestedPropertyAccessOnConditional",
@@ -2352,7 +2547,10 @@
     "textEdit": {
       "range": {},
       "newText": "nestedPropertyAccessOnConditional"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody",
@@ -2366,7 +2564,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonObjectResourceLoopBody2",
@@ -2380,7 +2581,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonObjectResourceLoopBody2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "nonexistentArrays",
@@ -2394,7 +2598,10 @@
     "textEdit": {
       "range": {},
       "newText": "nonexistentArrays"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "notAResource",
@@ -2470,7 +2677,10 @@
     "textEdit": {
       "range": {},
       "newText": "premiumStorages"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "propertyLoopsCannotNest",
@@ -2484,7 +2694,10 @@
     "textEdit": {
       "range": {},
       "newText": "propertyLoopsCannotNest"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "providers",
@@ -2698,7 +2911,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes10",
@@ -2712,7 +2928,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes10"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes11",
@@ -2726,7 +2945,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes11"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes12",
@@ -2740,7 +2962,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes12"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes13",
@@ -2754,7 +2979,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes13"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes14",
@@ -2768,7 +2996,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes14"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes15",
@@ -2782,7 +3013,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes15"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes16",
@@ -2796,7 +3030,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes16"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes17",
@@ -2810,7 +3047,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes17"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes18",
@@ -2824,7 +3064,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes18"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes2",
@@ -2838,7 +3081,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes3",
@@ -2852,7 +3098,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes4",
@@ -2866,7 +3115,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes5",
@@ -2880,7 +3132,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes6",
@@ -2894,7 +3149,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes7",
@@ -2908,7 +3166,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes8",
@@ -2922,7 +3183,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeInvalidRes9",
@@ -2936,7 +3200,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeInvalidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValid",
@@ -2964,7 +3231,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes2",
@@ -2978,7 +3248,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes2"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes3",
@@ -2992,7 +3265,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes3"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes4",
@@ -3006,7 +3282,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes4"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes5",
@@ -3020,7 +3299,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes5"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes6",
@@ -3034,7 +3316,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes6"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes7",
@@ -3048,7 +3333,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes7"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes8",
@@ -3062,7 +3350,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes8"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimeValidRes9",
@@ -3076,7 +3367,10 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes9"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "runtimefoo1",
@@ -3146,7 +3440,10 @@
     "textEdit": {
       "range": {},
       "newText": "selfScope"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "sigh",
@@ -3174,7 +3471,10 @@
     "textEdit": {
       "range": {},
       "newText": "singleResourceForRuntimeCheck"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "skip",
@@ -3222,7 +3522,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startedTypingTypeWithoutQuotes",
@@ -3236,7 +3539,10 @@
     "textEdit": {
       "range": {},
       "newText": "startedTypingTypeWithoutQuotes"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "startsWith",
@@ -3284,7 +3590,10 @@
     "textEdit": {
       "range": {},
       "newText": "stuffs"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "subscription",
@@ -3445,7 +3754,10 @@
     "textEdit": {
       "range": {},
       "newText": "trailingSpace"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "trim",
@@ -3476,7 +3788,10 @@
     "textEdit": {
       "range": {},
       "newText": "unfinishedVnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "union",
@@ -3589,7 +3904,10 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "varForRuntimeCheck4a",
@@ -3631,7 +3949,10 @@
     "textEdit": {
       "range": {},
       "newText": "vnet"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongArrayType",
@@ -3645,7 +3966,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongArrayType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongLoopBodyType",
@@ -3659,7 +3983,10 @@
     "textEdit": {
       "range": {},
       "newText": "wrongLoopBodyType"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   },
   {
     "label": "wrongPropertyInNestedLoop",
@@ -3673,6 +4000,9 @@
     "textEdit": {
       "range": {},
       "newText": "wrongPropertyInNestedLoop"
-    }
+    },
+    "commitCharacters": [
+      ":"
+    ]
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
@@ -147,6 +147,56 @@
     ]
   },
   {
+    "label": "resource",
+    "kind": "keyword",
+    "detail": "Resource keyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resource"
+    }
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Nested resource with defaults",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
+    }
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Nested resource without defaults",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
+    }
+  },
+  {
     "label": "sku",
     "kind": "property",
     "detail": "sku (Required)",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
@@ -126,6 +126,56 @@
     ]
   },
   {
+    "label": "resource",
+    "kind": "keyword",
+    "detail": "Resource keyword",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "resource"
+    }
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Nested resource with defaults",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
+    }
+  },
+  {
+    "label": "resource",
+    "kind": "snippet",
+    "detail": "Nested resource without defaults",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_resource",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
+    }
+  },
+  {
     "label": "sku",
     "kind": "property",
     "detail": "sku (Required)",

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.bicep
@@ -1,0 +1,82 @@
+resource basicParent 'My.Rp/parentType@2020-12-01' = {
+  name: 'basicParent'
+  properties: {
+    size: 'large'
+  }
+
+  resource basicChild 'childType' = {
+    name: 'basicChild'
+    properties: {
+      size: basicParent.properties.large
+      style: 'cool'
+    }
+
+    resource basicGrandchild 'grandchildType' = {
+      name: 'basicGrandchild'
+      properties: {
+        size: basicParent.properties.size
+        style: basicChild.properties.style
+      }
+    }
+  }
+
+  resource basicSibling 'childType' = {
+    name: 'basicSibling'
+    properties: {
+      size: basicParent.properties.size
+      style: basicChild:basicGrandchild.properties.style
+    }
+  }
+}
+
+output referenceBasicChild string = basicParent:basicChild.properties.size
+output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+
+resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
+  name: 'existingParent'
+
+  resource existingChild 'childType' existing = {
+    name: 'existingChild'
+
+    resource existingGrandchild 'grandchildType' = {
+      name: 'existingGrandchild'
+      properties: {
+        size: existingParent.properties.size
+        style: existingChild.properties.style
+      }
+    }
+  }
+}
+
+param createParent bool
+param createChild bool
+param createGrandchild bool
+resource conditionParent 'My.Rp/parentType@2020-12-01' = if (createParent) {
+  name: 'conditionParent'
+
+  resource conditionChild 'childType' = if (createChild) {
+    name: 'conditionChild'
+
+    resource conditionGrandchild 'grandchildType' = if (createGrandchild) {
+      name: 'conditionGrandchild'
+      properties: {
+        size: conditionParent.properties.size
+        style: conditionChild.properties.style
+      }
+    }
+  }
+}
+
+var items = [
+  'a'
+  'b'
+]
+resource loopParent 'My.Rp/parentType@2020-12-01' = {
+  name: 'loopParent'
+
+  resource loopChild 'childType' = [for item in items: {
+    name: 'loopChild'
+  }]
+}
+
+output loopChildOutput string = loopParent:loopChild[0].name

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.diagnostics.bicep
@@ -1,0 +1,94 @@
+resource basicParent 'My.Rp/parentType@2020-12-01' = {
+//@[21:50) [BCP081 (Warning)] Resource type "My.Rp/parentType@2020-12-01" does not have types available. |'My.Rp/parentType@2020-12-01'|
+  name: 'basicParent'
+  properties: {
+    size: 'large'
+  }
+
+  resource basicChild 'childType' = {
+//@[22:33) [BCP081 (Warning)] Resource type "My.Rp/parentType/childType@2020-12-01" does not have types available. |'childType'|
+    name: 'basicChild'
+    properties: {
+      size: basicParent.properties.large
+      style: 'cool'
+    }
+
+    resource basicGrandchild 'grandchildType' = {
+//@[29:45) [BCP081 (Warning)] Resource type "My.Rp/parentType/childType/grandchildType@2020-12-01" does not have types available. |'grandchildType'|
+      name: 'basicGrandchild'
+      properties: {
+        size: basicParent.properties.size
+        style: basicChild.properties.style
+      }
+    }
+  }
+
+  resource basicSibling 'childType' = {
+//@[24:35) [BCP081 (Warning)] Resource type "My.Rp/parentType/childType@2020-12-01" does not have types available. |'childType'|
+    name: 'basicSibling'
+    properties: {
+      size: basicParent.properties.size
+      style: basicChild:basicGrandchild.properties.style
+    }
+  }
+}
+
+output referenceBasicChild string = basicParent:basicChild.properties.size
+output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+
+resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
+//@[24:53) [BCP081 (Warning)] Resource type "My.Rp/parentType@2020-12-01" does not have types available. |'My.Rp/parentType@2020-12-01'|
+  name: 'existingParent'
+
+  resource existingChild 'childType' existing = {
+//@[25:36) [BCP081 (Warning)] Resource type "My.Rp/parentType/childType@2020-12-01" does not have types available. |'childType'|
+    name: 'existingChild'
+
+    resource existingGrandchild 'grandchildType' = {
+//@[32:48) [BCP081 (Warning)] Resource type "My.Rp/parentType/childType/grandchildType@2020-12-01" does not have types available. |'grandchildType'|
+      name: 'existingGrandchild'
+      properties: {
+        size: existingParent.properties.size
+        style: existingChild.properties.style
+      }
+    }
+  }
+}
+
+param createParent bool
+param createChild bool
+param createGrandchild bool
+resource conditionParent 'My.Rp/parentType@2020-12-01' = if (createParent) {
+//@[25:54) [BCP081 (Warning)] Resource type "My.Rp/parentType@2020-12-01" does not have types available. |'My.Rp/parentType@2020-12-01'|
+  name: 'conditionParent'
+
+  resource conditionChild 'childType' = if (createChild) {
+//@[26:37) [BCP081 (Warning)] Resource type "My.Rp/parentType/childType@2020-12-01" does not have types available. |'childType'|
+    name: 'conditionChild'
+
+    resource conditionGrandchild 'grandchildType' = if (createGrandchild) {
+//@[33:49) [BCP081 (Warning)] Resource type "My.Rp/parentType/childType/grandchildType@2020-12-01" does not have types available. |'grandchildType'|
+      name: 'conditionGrandchild'
+      properties: {
+        size: conditionParent.properties.size
+        style: conditionChild.properties.style
+      }
+    }
+  }
+}
+
+var items = [
+  'a'
+  'b'
+]
+resource loopParent 'My.Rp/parentType@2020-12-01' = {
+//@[20:49) [BCP081 (Warning)] Resource type "My.Rp/parentType@2020-12-01" does not have types available. |'My.Rp/parentType@2020-12-01'|
+  name: 'loopParent'
+
+  resource loopChild 'childType' = [for item in items: {
+//@[21:32) [BCP081 (Warning)] Resource type "My.Rp/parentType/childType@2020-12-01" does not have types available. |'childType'|
+    name: 'loopChild'
+  }]
+}
+
+output loopChildOutput string = loopParent:loopChild[0].name

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.formatted.bicep
@@ -1,0 +1,82 @@
+resource basicParent 'My.Rp/parentType@2020-12-01' = {
+  name: 'basicParent'
+  properties: {
+    size: 'large'
+  }
+
+  resource basicChild 'childType' = {
+    name: 'basicChild'
+    properties: {
+      size: basicParent.properties.large
+      style: 'cool'
+    }
+
+    resource basicGrandchild 'grandchildType' = {
+      name: 'basicGrandchild'
+      properties: {
+        size: basicParent.properties.size
+        style: basicChild.properties.style
+      }
+    }
+  }
+
+  resource basicSibling 'childType' = {
+    name: 'basicSibling'
+    properties: {
+      size: basicParent.properties.size
+      style: basicChild:basicGrandchild.properties.style
+    }
+  }
+}
+
+output referenceBasicChild string = basicParent:basicChild.properties.size
+output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+
+resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
+  name: 'existingParent'
+
+  resource existingChild 'childType' existing = {
+    name: 'existingChild'
+
+    resource existingGrandchild 'grandchildType' = {
+      name: 'existingGrandchild'
+      properties: {
+        size: existingParent.properties.size
+        style: existingChild.properties.style
+      }
+    }
+  }
+}
+
+param createParent bool
+param createChild bool
+param createGrandchild bool
+resource conditionParent 'My.Rp/parentType@2020-12-01' = if (createParent) {
+  name: 'conditionParent'
+
+  resource conditionChild 'childType' = if (createChild) {
+    name: 'conditionChild'
+
+    resource conditionGrandchild 'grandchildType' = if (createGrandchild) {
+      name: 'conditionGrandchild'
+      properties: {
+        size: conditionParent.properties.size
+        style: conditionChild.properties.style
+      }
+    }
+  }
+}
+
+var items = [
+  'a'
+  'b'
+]
+resource loopParent 'My.Rp/parentType@2020-12-01' = {
+  name: 'loopParent'
+
+  resource loopChild 'childType' = [for item in items: {
+    name: 'loopChild'
+  }]
+}
+
+output loopChildOutput string = loopParent:loopChild[0].name

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "createParent": {
+      "type": "bool"
+    },
+    "createChild": {
+      "type": "bool"
+    },
+    "createGrandchild": {
+      "type": "bool"
+    }
+  },
+  "functions": [],
+  "variables": {
+    "items": [
+      "a",
+      "b"
+    ]
+  },
+  "resources": [
+    {
+      "type": "My.Rp/parentType/childType/grandchildType",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild')]",
+      "properties": {
+        "size": "[reference(resourceId('My.Rp/parentType', 'basicParent')).size]",
+        "style": "[reference(resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[0], split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[1])).style]"
+      },
+      "dependsOn": [
+        "[resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[0], split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[1])]",
+        "[resourceId('My.Rp/parentType', 'basicParent')]"
+      ]
+    },
+    {
+      "type": "My.Rp/parentType/childType",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', 'basicParent', 'basicChild')]",
+      "properties": {
+        "size": "[reference(resourceId('My.Rp/parentType', 'basicParent')).large]",
+        "style": "cool"
+      },
+      "dependsOn": [
+        "[resourceId('My.Rp/parentType', 'basicParent')]"
+      ]
+    },
+    {
+      "type": "My.Rp/parentType/childType",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', 'basicParent', 'basicSibling')]",
+      "properties": {
+        "size": "[reference(resourceId('My.Rp/parentType', 'basicParent')).size]",
+        "style": "[reference(resourceId('My.Rp/parentType/childType/grandchildType', split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[0], split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[1], split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[2])).style]"
+      },
+      "dependsOn": [
+        "[resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[0], split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[1])]",
+        "[resourceId('My.Rp/parentType', 'basicParent')]"
+      ]
+    },
+    {
+      "type": "My.Rp/parentType/childType/grandchildType",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}/{2}', 'existingParent', 'existingChild', 'existingGrandchild')]",
+      "properties": {
+        "size": "[reference(resourceId('My.Rp/parentType', 'existingParent'), '2020-12-01').size]",
+        "style": "[reference(resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'existingParent', 'existingChild'), '/')[0], split(format('{0}/{1}', 'existingParent', 'existingChild'), '/')[1]), '2020-12-01').style]"
+      },
+      "dependsOn": []
+    },
+    {
+      "condition": "[and(and(parameters('createParent'), parameters('createChild')), parameters('createGrandchild'))]",
+      "type": "My.Rp/parentType/childType/grandchildType",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}/{2}', 'conditionParent', 'conditionChild', 'conditionGrandchild')]",
+      "properties": {
+        "size": "[reference(resourceId('My.Rp/parentType', 'conditionParent')).size]",
+        "style": "[reference(resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'conditionParent', 'conditionChild'), '/')[0], split(format('{0}/{1}', 'conditionParent', 'conditionChild'), '/')[1])).style]"
+      },
+      "dependsOn": [
+        "[resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'conditionParent', 'conditionChild'), '/')[0], split(format('{0}/{1}', 'conditionParent', 'conditionChild'), '/')[1])]",
+        "[resourceId('My.Rp/parentType', 'conditionParent')]"
+      ]
+    },
+    {
+      "condition": "[and(parameters('createParent'), parameters('createChild'))]",
+      "type": "My.Rp/parentType/childType",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', 'conditionParent', 'conditionChild')]",
+      "dependsOn": [
+        "[resourceId('My.Rp/parentType', 'conditionParent')]"
+      ]
+    },
+    {
+      "copy": {
+        "name": "loopChild",
+        "count": "[length(variables('items'))]"
+      },
+      "type": "My.Rp/parentType/childType",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', 'loopParent', 'loopChild')]",
+      "dependsOn": [
+        "[resourceId('My.Rp/parentType', 'loopParent')]"
+      ]
+    },
+    {
+      "type": "My.Rp/parentType",
+      "apiVersion": "2020-12-01",
+      "name": "basicParent",
+      "properties": {
+        "size": "large"
+      }
+    },
+    {
+      "condition": "[parameters('createParent')]",
+      "type": "My.Rp/parentType",
+      "apiVersion": "2020-12-01",
+      "name": "conditionParent"
+    },
+    {
+      "type": "My.Rp/parentType",
+      "apiVersion": "2020-12-01",
+      "name": "loopParent"
+    }
+  ],
+  "outputs": {
+    "referenceBasicChild": {
+      "type": "string",
+      "value": "[reference(resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[0], split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[1])).size]"
+    },
+    "referenceBasicGrandchild": {
+      "type": "string",
+      "value": "[reference(resourceId('My.Rp/parentType/childType/grandchildType', split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[0], split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[1], split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[2])).style]"
+    },
+    "loopChildOutput": {
+      "type": "string",
+      "value": "[format('{0}/{1}', 'loopParent', 'loopChild')]"
+    }
+  },
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "16251729290247853382"
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbols.bicep
@@ -1,0 +1,102 @@
+resource basicParent 'My.Rp/parentType@2020-12-01' = {
+//@[9:20) Resource basicParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 658
+  name: 'basicParent'
+  properties: {
+    size: 'large'
+  }
+
+  resource basicChild 'childType' = {
+//@[11:21) Resource basicChild. Type: My.Rp/parentType/childType@2020-12-01. Declaration start char: 2, length: 347
+    name: 'basicChild'
+    properties: {
+      size: basicParent.properties.large
+      style: 'cool'
+    }
+
+    resource basicGrandchild 'grandchildType' = {
+//@[13:28) Resource basicGrandchild. Type: My.Rp/parentType/childType/grandchildType@2020-12-01. Declaration start char: 4, length: 194
+      name: 'basicGrandchild'
+      properties: {
+        size: basicParent.properties.size
+        style: basicChild.properties.style
+      }
+    }
+  }
+
+  resource basicSibling 'childType' = {
+//@[11:23) Resource basicSibling. Type: My.Rp/parentType/childType@2020-12-01. Declaration start char: 2, length: 187
+    name: 'basicSibling'
+    properties: {
+      size: basicParent.properties.size
+      style: basicChild:basicGrandchild.properties.style
+    }
+  }
+}
+
+output referenceBasicChild string = basicParent:basicChild.properties.size
+//@[7:26) Output referenceBasicChild. Type: string. Declaration start char: 0, length: 74
+output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+//@[7:31) Output referenceBasicGrandchild. Type: string. Declaration start char: 0, length: 96
+
+resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
+//@[9:23) Resource existingParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 386
+  name: 'existingParent'
+
+  resource existingChild 'childType' existing = {
+//@[11:24) Resource existingChild. Type: My.Rp/parentType/childType@2020-12-01. Declaration start char: 2, length: 289
+    name: 'existingChild'
+
+    resource existingGrandchild 'grandchildType' = {
+//@[13:31) Resource existingGrandchild. Type: My.Rp/parentType/childType/grandchildType@2020-12-01. Declaration start char: 4, length: 206
+      name: 'existingGrandchild'
+      properties: {
+        size: existingParent.properties.size
+        style: existingChild.properties.style
+      }
+    }
+  }
+}
+
+param createParent bool
+//@[6:18) Parameter createParent. Type: bool. Declaration start char: 0, length: 23
+param createChild bool
+//@[6:17) Parameter createChild. Type: bool. Declaration start char: 0, length: 22
+param createGrandchild bool
+//@[6:22) Parameter createGrandchild. Type: bool. Declaration start char: 0, length: 27
+resource conditionParent 'My.Rp/parentType@2020-12-01' = if (createParent) {
+//@[9:24) Resource conditionParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 433
+  name: 'conditionParent'
+
+  resource conditionChild 'childType' = if (createChild) {
+//@[11:25) Resource conditionChild. Type: My.Rp/parentType/childType@2020-12-01. Declaration start char: 2, length: 325
+    name: 'conditionChild'
+
+    resource conditionGrandchild 'grandchildType' = if (createGrandchild) {
+//@[13:32) Resource conditionGrandchild. Type: My.Rp/parentType/childType/grandchildType@2020-12-01. Declaration start char: 4, length: 232
+      name: 'conditionGrandchild'
+      properties: {
+        size: conditionParent.properties.size
+        style: conditionChild.properties.style
+      }
+    }
+  }
+}
+
+var items = [
+//@[4:9) Variable items. Type: array. Declaration start char: 0, length: 27
+  'a'
+  'b'
+]
+resource loopParent 'My.Rp/parentType@2020-12-01' = {
+//@[9:19) Resource loopParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 161
+  name: 'loopParent'
+
+  resource loopChild 'childType' = [for item in items: {
+//@[40:44) Local item. Type: any. Declaration start char: 40, length: 4
+//@[11:20) Resource loopChild. Type: My.Rp/parentType/childType@2020-12-01[]. Declaration start char: 2, length: 81
+    name: 'loopChild'
+  }]
+}
+
+output loopChildOutput string = loopParent:loopChild[0].name
+//@[7:22) Output loopChildOutput. Type: string. Declaration start char: 0, length: 60

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.syntax.bicep
@@ -1,0 +1,677 @@
+resource basicParent 'My.Rp/parentType@2020-12-01' = {
+//@[0:658) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:20)  IdentifierSyntax
+//@[9:20)   Identifier |basicParent|
+//@[21:50)  StringSyntax
+//@[21:50)   StringComplete |'My.Rp/parentType@2020-12-01'|
+//@[51:52)  Assignment |=|
+//@[53:658)  ObjectSyntax
+//@[53:54)   LeftBrace |{|
+//@[54:55)   NewLine |\n|
+  name: 'basicParent'
+//@[2:21)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:21)    StringSyntax
+//@[8:21)     StringComplete |'basicParent'|
+//@[21:22)   NewLine |\n|
+  properties: {
+//@[2:37)   ObjectPropertySyntax
+//@[2:12)    IdentifierSyntax
+//@[2:12)     Identifier |properties|
+//@[12:13)    Colon |:|
+//@[14:37)    ObjectSyntax
+//@[14:15)     LeftBrace |{|
+//@[15:16)     NewLine |\n|
+    size: 'large'
+//@[4:17)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |size|
+//@[8:9)      Colon |:|
+//@[10:17)      StringSyntax
+//@[10:17)       StringComplete |'large'|
+//@[17:18)     NewLine |\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\n\n|
+
+  resource basicChild 'childType' = {
+//@[2:349)   ResourceDeclarationSyntax
+//@[2:10)    Identifier |resource|
+//@[11:21)    IdentifierSyntax
+//@[11:21)     Identifier |basicChild|
+//@[22:33)    StringSyntax
+//@[22:33)     StringComplete |'childType'|
+//@[34:35)    Assignment |=|
+//@[36:349)    ObjectSyntax
+//@[36:37)     LeftBrace |{|
+//@[37:38)     NewLine |\n|
+    name: 'basicChild'
+//@[4:22)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:22)      StringSyntax
+//@[10:22)       StringComplete |'basicChild'|
+//@[22:23)     NewLine |\n|
+    properties: {
+//@[4:84)     ObjectPropertySyntax
+//@[4:14)      IdentifierSyntax
+//@[4:14)       Identifier |properties|
+//@[14:15)      Colon |:|
+//@[16:84)      ObjectSyntax
+//@[16:17)       LeftBrace |{|
+//@[17:18)       NewLine |\n|
+      size: basicParent.properties.large
+//@[6:40)       ObjectPropertySyntax
+//@[6:10)        IdentifierSyntax
+//@[6:10)         Identifier |size|
+//@[10:11)        Colon |:|
+//@[12:40)        PropertyAccessSyntax
+//@[12:34)         PropertyAccessSyntax
+//@[12:23)          VariableAccessSyntax
+//@[12:23)           IdentifierSyntax
+//@[12:23)            Identifier |basicParent|
+//@[23:24)          Dot |.|
+//@[24:34)          IdentifierSyntax
+//@[24:34)           Identifier |properties|
+//@[34:35)         Dot |.|
+//@[35:40)         IdentifierSyntax
+//@[35:40)          Identifier |large|
+//@[40:41)       NewLine |\n|
+      style: 'cool'
+//@[6:19)       ObjectPropertySyntax
+//@[6:11)        IdentifierSyntax
+//@[6:11)         Identifier |style|
+//@[11:12)        Colon |:|
+//@[13:19)        StringSyntax
+//@[13:19)         StringComplete |'cool'|
+//@[19:20)       NewLine |\n|
+    }
+//@[4:5)       RightBrace |}|
+//@[5:7)     NewLine |\n\n|
+
+    resource basicGrandchild 'grandchildType' = {
+//@[4:198)     ResourceDeclarationSyntax
+//@[4:12)      Identifier |resource|
+//@[13:28)      IdentifierSyntax
+//@[13:28)       Identifier |basicGrandchild|
+//@[29:45)      StringSyntax
+//@[29:45)       StringComplete |'grandchildType'|
+//@[46:47)      Assignment |=|
+//@[48:198)      ObjectSyntax
+//@[48:49)       LeftBrace |{|
+//@[49:50)       NewLine |\n|
+      name: 'basicGrandchild'
+//@[6:29)       ObjectPropertySyntax
+//@[6:10)        IdentifierSyntax
+//@[6:10)         Identifier |name|
+//@[10:11)        Colon |:|
+//@[12:29)        StringSyntax
+//@[12:29)         StringComplete |'basicGrandchild'|
+//@[29:30)       NewLine |\n|
+      properties: {
+//@[6:112)       ObjectPropertySyntax
+//@[6:16)        IdentifierSyntax
+//@[6:16)         Identifier |properties|
+//@[16:17)        Colon |:|
+//@[18:112)        ObjectSyntax
+//@[18:19)         LeftBrace |{|
+//@[19:20)         NewLine |\n|
+        size: basicParent.properties.size
+//@[8:41)         ObjectPropertySyntax
+//@[8:12)          IdentifierSyntax
+//@[8:12)           Identifier |size|
+//@[12:13)          Colon |:|
+//@[14:41)          PropertyAccessSyntax
+//@[14:36)           PropertyAccessSyntax
+//@[14:25)            VariableAccessSyntax
+//@[14:25)             IdentifierSyntax
+//@[14:25)              Identifier |basicParent|
+//@[25:26)            Dot |.|
+//@[26:36)            IdentifierSyntax
+//@[26:36)             Identifier |properties|
+//@[36:37)           Dot |.|
+//@[37:41)           IdentifierSyntax
+//@[37:41)            Identifier |size|
+//@[41:42)         NewLine |\n|
+        style: basicChild.properties.style
+//@[8:42)         ObjectPropertySyntax
+//@[8:13)          IdentifierSyntax
+//@[8:13)           Identifier |style|
+//@[13:14)          Colon |:|
+//@[15:42)          PropertyAccessSyntax
+//@[15:36)           PropertyAccessSyntax
+//@[15:25)            VariableAccessSyntax
+//@[15:25)             IdentifierSyntax
+//@[15:25)              Identifier |basicChild|
+//@[25:26)            Dot |.|
+//@[26:36)            IdentifierSyntax
+//@[26:36)             Identifier |properties|
+//@[36:37)           Dot |.|
+//@[37:42)           IdentifierSyntax
+//@[37:42)            Identifier |style|
+//@[42:43)         NewLine |\n|
+      }
+//@[6:7)         RightBrace |}|
+//@[7:8)       NewLine |\n|
+    }
+//@[4:5)       RightBrace |}|
+//@[5:6)     NewLine |\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\n\n|
+
+  resource basicSibling 'childType' = {
+//@[2:189)   ResourceDeclarationSyntax
+//@[2:10)    Identifier |resource|
+//@[11:23)    IdentifierSyntax
+//@[11:23)     Identifier |basicSibling|
+//@[24:35)    StringSyntax
+//@[24:35)     StringComplete |'childType'|
+//@[36:37)    Assignment |=|
+//@[38:189)    ObjectSyntax
+//@[38:39)     LeftBrace |{|
+//@[39:40)     NewLine |\n|
+    name: 'basicSibling'
+//@[4:24)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:24)      StringSyntax
+//@[10:24)       StringComplete |'basicSibling'|
+//@[24:25)     NewLine |\n|
+    properties: {
+//@[4:120)     ObjectPropertySyntax
+//@[4:14)      IdentifierSyntax
+//@[4:14)       Identifier |properties|
+//@[14:15)      Colon |:|
+//@[16:120)      ObjectSyntax
+//@[16:17)       LeftBrace |{|
+//@[17:18)       NewLine |\n|
+      size: basicParent.properties.size
+//@[6:39)       ObjectPropertySyntax
+//@[6:10)        IdentifierSyntax
+//@[6:10)         Identifier |size|
+//@[10:11)        Colon |:|
+//@[12:39)        PropertyAccessSyntax
+//@[12:34)         PropertyAccessSyntax
+//@[12:23)          VariableAccessSyntax
+//@[12:23)           IdentifierSyntax
+//@[12:23)            Identifier |basicParent|
+//@[23:24)          Dot |.|
+//@[24:34)          IdentifierSyntax
+//@[24:34)           Identifier |properties|
+//@[34:35)         Dot |.|
+//@[35:39)         IdentifierSyntax
+//@[35:39)          Identifier |size|
+//@[39:40)       NewLine |\n|
+      style: basicChild:basicGrandchild.properties.style
+//@[6:56)       ObjectPropertySyntax
+//@[6:11)        IdentifierSyntax
+//@[6:11)         Identifier |style|
+//@[11:12)        Colon |:|
+//@[13:56)        PropertyAccessSyntax
+//@[13:50)         PropertyAccessSyntax
+//@[13:39)          ResourceAccessSyntax
+//@[13:23)           VariableAccessSyntax
+//@[13:23)            IdentifierSyntax
+//@[13:23)             Identifier |basicChild|
+//@[23:24)           Colon |:|
+//@[24:39)           IdentifierSyntax
+//@[24:39)            Identifier |basicGrandchild|
+//@[39:40)          Dot |.|
+//@[40:50)          IdentifierSyntax
+//@[40:50)           Identifier |properties|
+//@[50:51)         Dot |.|
+//@[51:56)         IdentifierSyntax
+//@[51:56)          Identifier |style|
+//@[56:57)       NewLine |\n|
+    }
+//@[4:5)       RightBrace |}|
+//@[5:6)     NewLine |\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:4)   NewLine |\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+output referenceBasicChild string = basicParent:basicChild.properties.size
+//@[0:74) OutputDeclarationSyntax
+//@[0:6)  Identifier |output|
+//@[7:26)  IdentifierSyntax
+//@[7:26)   Identifier |referenceBasicChild|
+//@[27:33)  TypeSyntax
+//@[27:33)   Identifier |string|
+//@[34:35)  Assignment |=|
+//@[36:74)  PropertyAccessSyntax
+//@[36:69)   PropertyAccessSyntax
+//@[36:58)    ResourceAccessSyntax
+//@[36:47)     VariableAccessSyntax
+//@[36:47)      IdentifierSyntax
+//@[36:47)       Identifier |basicParent|
+//@[47:48)     Colon |:|
+//@[48:58)     IdentifierSyntax
+//@[48:58)      Identifier |basicChild|
+//@[58:59)    Dot |.|
+//@[59:69)    IdentifierSyntax
+//@[59:69)     Identifier |properties|
+//@[69:70)   Dot |.|
+//@[70:74)   IdentifierSyntax
+//@[70:74)    Identifier |size|
+//@[74:75) NewLine |\n|
+output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+//@[0:96) OutputDeclarationSyntax
+//@[0:6)  Identifier |output|
+//@[7:31)  IdentifierSyntax
+//@[7:31)   Identifier |referenceBasicGrandchild|
+//@[32:38)  TypeSyntax
+//@[32:38)   Identifier |string|
+//@[39:40)  Assignment |=|
+//@[41:96)  PropertyAccessSyntax
+//@[41:90)   PropertyAccessSyntax
+//@[41:79)    ResourceAccessSyntax
+//@[41:63)     ResourceAccessSyntax
+//@[41:52)      VariableAccessSyntax
+//@[41:52)       IdentifierSyntax
+//@[41:52)        Identifier |basicParent|
+//@[52:53)      Colon |:|
+//@[53:63)      IdentifierSyntax
+//@[53:63)       Identifier |basicChild|
+//@[63:64)     Colon |:|
+//@[64:79)     IdentifierSyntax
+//@[64:79)      Identifier |basicGrandchild|
+//@[79:80)    Dot |.|
+//@[80:90)    IdentifierSyntax
+//@[80:90)     Identifier |properties|
+//@[90:91)   Dot |.|
+//@[91:96)   IdentifierSyntax
+//@[91:96)    Identifier |style|
+//@[96:98) NewLine |\n\n|
+
+resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
+//@[0:386) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:23)  IdentifierSyntax
+//@[9:23)   Identifier |existingParent|
+//@[24:53)  StringSyntax
+//@[24:53)   StringComplete |'My.Rp/parentType@2020-12-01'|
+//@[54:62)  Identifier |existing|
+//@[63:64)  Assignment |=|
+//@[65:386)  ObjectSyntax
+//@[65:66)   LeftBrace |{|
+//@[66:67)   NewLine |\n|
+  name: 'existingParent'
+//@[2:24)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:24)    StringSyntax
+//@[8:24)     StringComplete |'existingParent'|
+//@[24:26)   NewLine |\n\n|
+
+  resource existingChild 'childType' existing = {
+//@[2:291)   ResourceDeclarationSyntax
+//@[2:10)    Identifier |resource|
+//@[11:24)    IdentifierSyntax
+//@[11:24)     Identifier |existingChild|
+//@[25:36)    StringSyntax
+//@[25:36)     StringComplete |'childType'|
+//@[37:45)    Identifier |existing|
+//@[46:47)    Assignment |=|
+//@[48:291)    ObjectSyntax
+//@[48:49)     LeftBrace |{|
+//@[49:50)     NewLine |\n|
+    name: 'existingChild'
+//@[4:25)     ObjectPropertySyntax
+//@[4:8)      IdentifierSyntax
+//@[4:8)       Identifier |name|
+//@[8:9)      Colon |:|
+//@[10:25)      StringSyntax
+//@[10:25)       StringComplete |'existingChild'|
+//@[25:27)     NewLine |\n\n|
+
+    resource existingGrandchild 'grandchildType' = {
+//@[4:210)     ResourceDeclarationSyntax
+//@[4:12)      Identifier |resource|
+//@[13:31)      IdentifierSyntax
+//@[13:31)       Identifier |existingGrandchild|
+//@[32:48)      StringSyntax
+//@[32:48)       StringComplete |'grandchildType'|
+//@[49:50)      Assignment |=|
+//@[51:210)      ObjectSyntax
+//@[51:52)       LeftBrace |{|
+//@[52:53)       NewLine |\n|
+      name: 'existingGrandchild'
+//@[6:32)       ObjectPropertySyntax
+//@[6:10)        IdentifierSyntax
+//@[6:10)         Identifier |name|
+//@[10:11)        Colon |:|
+//@[12:32)        StringSyntax
+//@[12:32)         StringComplete |'existingGrandchild'|
+//@[32:33)       NewLine |\n|
+      properties: {
+//@[6:118)       ObjectPropertySyntax
+//@[6:16)        IdentifierSyntax
+//@[6:16)         Identifier |properties|
+//@[16:17)        Colon |:|
+//@[18:118)        ObjectSyntax
+//@[18:19)         LeftBrace |{|
+//@[19:20)         NewLine |\n|
+        size: existingParent.properties.size
+//@[8:44)         ObjectPropertySyntax
+//@[8:12)          IdentifierSyntax
+//@[8:12)           Identifier |size|
+//@[12:13)          Colon |:|
+//@[14:44)          PropertyAccessSyntax
+//@[14:39)           PropertyAccessSyntax
+//@[14:28)            VariableAccessSyntax
+//@[14:28)             IdentifierSyntax
+//@[14:28)              Identifier |existingParent|
+//@[28:29)            Dot |.|
+//@[29:39)            IdentifierSyntax
+//@[29:39)             Identifier |properties|
+//@[39:40)           Dot |.|
+//@[40:44)           IdentifierSyntax
+//@[40:44)            Identifier |size|
+//@[44:45)         NewLine |\n|
+        style: existingChild.properties.style
+//@[8:45)         ObjectPropertySyntax
+//@[8:13)          IdentifierSyntax
+//@[8:13)           Identifier |style|
+//@[13:14)          Colon |:|
+//@[15:45)          PropertyAccessSyntax
+//@[15:39)           PropertyAccessSyntax
+//@[15:28)            VariableAccessSyntax
+//@[15:28)             IdentifierSyntax
+//@[15:28)              Identifier |existingChild|
+//@[28:29)            Dot |.|
+//@[29:39)            IdentifierSyntax
+//@[29:39)             Identifier |properties|
+//@[39:40)           Dot |.|
+//@[40:45)           IdentifierSyntax
+//@[40:45)            Identifier |style|
+//@[45:46)         NewLine |\n|
+      }
+//@[6:7)         RightBrace |}|
+//@[7:8)       NewLine |\n|
+    }
+//@[4:5)       RightBrace |}|
+//@[5:6)     NewLine |\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:4)   NewLine |\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+param createParent bool
+//@[0:23) ParameterDeclarationSyntax
+//@[0:5)  Identifier |param|
+//@[6:18)  IdentifierSyntax
+//@[6:18)   Identifier |createParent|
+//@[19:23)  TypeSyntax
+//@[19:23)   Identifier |bool|
+//@[23:24) NewLine |\n|
+param createChild bool
+//@[0:22) ParameterDeclarationSyntax
+//@[0:5)  Identifier |param|
+//@[6:17)  IdentifierSyntax
+//@[6:17)   Identifier |createChild|
+//@[18:22)  TypeSyntax
+//@[18:22)   Identifier |bool|
+//@[22:23) NewLine |\n|
+param createGrandchild bool
+//@[0:27) ParameterDeclarationSyntax
+//@[0:5)  Identifier |param|
+//@[6:22)  IdentifierSyntax
+//@[6:22)   Identifier |createGrandchild|
+//@[23:27)  TypeSyntax
+//@[23:27)   Identifier |bool|
+//@[27:28) NewLine |\n|
+resource conditionParent 'My.Rp/parentType@2020-12-01' = if (createParent) {
+//@[0:433) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:24)  IdentifierSyntax
+//@[9:24)   Identifier |conditionParent|
+//@[25:54)  StringSyntax
+//@[25:54)   StringComplete |'My.Rp/parentType@2020-12-01'|
+//@[55:56)  Assignment |=|
+//@[57:433)  IfConditionSyntax
+//@[57:59)   Identifier |if|
+//@[60:74)   ParenthesizedExpressionSyntax
+//@[60:61)    LeftParen |(|
+//@[61:73)    VariableAccessSyntax
+//@[61:73)     IdentifierSyntax
+//@[61:73)      Identifier |createParent|
+//@[73:74)    RightParen |)|
+//@[75:433)   ObjectSyntax
+//@[75:76)    LeftBrace |{|
+//@[76:77)    NewLine |\n|
+  name: 'conditionParent'
+//@[2:25)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:25)     StringSyntax
+//@[8:25)      StringComplete |'conditionParent'|
+//@[25:27)    NewLine |\n\n|
+
+  resource conditionChild 'childType' = if (createChild) {
+//@[2:327)    ResourceDeclarationSyntax
+//@[2:10)     Identifier |resource|
+//@[11:25)     IdentifierSyntax
+//@[11:25)      Identifier |conditionChild|
+//@[26:37)     StringSyntax
+//@[26:37)      StringComplete |'childType'|
+//@[38:39)     Assignment |=|
+//@[40:327)     IfConditionSyntax
+//@[40:42)      Identifier |if|
+//@[43:56)      ParenthesizedExpressionSyntax
+//@[43:44)       LeftParen |(|
+//@[44:55)       VariableAccessSyntax
+//@[44:55)        IdentifierSyntax
+//@[44:55)         Identifier |createChild|
+//@[55:56)       RightParen |)|
+//@[57:327)      ObjectSyntax
+//@[57:58)       LeftBrace |{|
+//@[58:59)       NewLine |\n|
+    name: 'conditionChild'
+//@[4:26)       ObjectPropertySyntax
+//@[4:8)        IdentifierSyntax
+//@[4:8)         Identifier |name|
+//@[8:9)        Colon |:|
+//@[10:26)        StringSyntax
+//@[10:26)         StringComplete |'conditionChild'|
+//@[26:28)       NewLine |\n\n|
+
+    resource conditionGrandchild 'grandchildType' = if (createGrandchild) {
+//@[4:236)       ResourceDeclarationSyntax
+//@[4:12)        Identifier |resource|
+//@[13:32)        IdentifierSyntax
+//@[13:32)         Identifier |conditionGrandchild|
+//@[33:49)        StringSyntax
+//@[33:49)         StringComplete |'grandchildType'|
+//@[50:51)        Assignment |=|
+//@[52:236)        IfConditionSyntax
+//@[52:54)         Identifier |if|
+//@[55:73)         ParenthesizedExpressionSyntax
+//@[55:56)          LeftParen |(|
+//@[56:72)          VariableAccessSyntax
+//@[56:72)           IdentifierSyntax
+//@[56:72)            Identifier |createGrandchild|
+//@[72:73)          RightParen |)|
+//@[74:236)         ObjectSyntax
+//@[74:75)          LeftBrace |{|
+//@[75:76)          NewLine |\n|
+      name: 'conditionGrandchild'
+//@[6:33)          ObjectPropertySyntax
+//@[6:10)           IdentifierSyntax
+//@[6:10)            Identifier |name|
+//@[10:11)           Colon |:|
+//@[12:33)           StringSyntax
+//@[12:33)            StringComplete |'conditionGrandchild'|
+//@[33:34)          NewLine |\n|
+      properties: {
+//@[6:120)          ObjectPropertySyntax
+//@[6:16)           IdentifierSyntax
+//@[6:16)            Identifier |properties|
+//@[16:17)           Colon |:|
+//@[18:120)           ObjectSyntax
+//@[18:19)            LeftBrace |{|
+//@[19:20)            NewLine |\n|
+        size: conditionParent.properties.size
+//@[8:45)            ObjectPropertySyntax
+//@[8:12)             IdentifierSyntax
+//@[8:12)              Identifier |size|
+//@[12:13)             Colon |:|
+//@[14:45)             PropertyAccessSyntax
+//@[14:40)              PropertyAccessSyntax
+//@[14:29)               VariableAccessSyntax
+//@[14:29)                IdentifierSyntax
+//@[14:29)                 Identifier |conditionParent|
+//@[29:30)               Dot |.|
+//@[30:40)               IdentifierSyntax
+//@[30:40)                Identifier |properties|
+//@[40:41)              Dot |.|
+//@[41:45)              IdentifierSyntax
+//@[41:45)               Identifier |size|
+//@[45:46)            NewLine |\n|
+        style: conditionChild.properties.style
+//@[8:46)            ObjectPropertySyntax
+//@[8:13)             IdentifierSyntax
+//@[8:13)              Identifier |style|
+//@[13:14)             Colon |:|
+//@[15:46)             PropertyAccessSyntax
+//@[15:40)              PropertyAccessSyntax
+//@[15:29)               VariableAccessSyntax
+//@[15:29)                IdentifierSyntax
+//@[15:29)                 Identifier |conditionChild|
+//@[29:30)               Dot |.|
+//@[30:40)               IdentifierSyntax
+//@[30:40)                Identifier |properties|
+//@[40:41)              Dot |.|
+//@[41:46)              IdentifierSyntax
+//@[41:46)               Identifier |style|
+//@[46:47)            NewLine |\n|
+      }
+//@[6:7)            RightBrace |}|
+//@[7:8)          NewLine |\n|
+    }
+//@[4:5)          RightBrace |}|
+//@[5:6)       NewLine |\n|
+  }
+//@[2:3)       RightBrace |}|
+//@[3:4)    NewLine |\n|
+}
+//@[0:1)    RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+var items = [
+//@[0:27) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:9)  IdentifierSyntax
+//@[4:9)   Identifier |items|
+//@[10:11)  Assignment |=|
+//@[12:27)  ArraySyntax
+//@[12:13)   LeftSquare |[|
+//@[13:14)   NewLine |\n|
+  'a'
+//@[2:5)   ArrayItemSyntax
+//@[2:5)    StringSyntax
+//@[2:5)     StringComplete |'a'|
+//@[5:6)   NewLine |\n|
+  'b'
+//@[2:5)   ArrayItemSyntax
+//@[2:5)    StringSyntax
+//@[2:5)     StringComplete |'b'|
+//@[5:6)   NewLine |\n|
+]
+//@[0:1)   RightSquare |]|
+//@[1:2) NewLine |\n|
+resource loopParent 'My.Rp/parentType@2020-12-01' = {
+//@[0:161) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:19)  IdentifierSyntax
+//@[9:19)   Identifier |loopParent|
+//@[20:49)  StringSyntax
+//@[20:49)   StringComplete |'My.Rp/parentType@2020-12-01'|
+//@[50:51)  Assignment |=|
+//@[52:161)  ObjectSyntax
+//@[52:53)   LeftBrace |{|
+//@[53:54)   NewLine |\n|
+  name: 'loopParent'
+//@[2:20)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:20)    StringSyntax
+//@[8:20)     StringComplete |'loopParent'|
+//@[20:22)   NewLine |\n\n|
+
+  resource loopChild 'childType' = [for item in items: {
+//@[2:83)   ResourceDeclarationSyntax
+//@[2:10)    Identifier |resource|
+//@[11:20)    IdentifierSyntax
+//@[11:20)     Identifier |loopChild|
+//@[21:32)    StringSyntax
+//@[21:32)     StringComplete |'childType'|
+//@[33:34)    Assignment |=|
+//@[35:83)    ForSyntax
+//@[35:36)     LeftSquare |[|
+//@[36:39)     Identifier |for|
+//@[40:44)     LocalVariableSyntax
+//@[40:44)      IdentifierSyntax
+//@[40:44)       Identifier |item|
+//@[45:47)     Identifier |in|
+//@[48:53)     VariableAccessSyntax
+//@[48:53)      IdentifierSyntax
+//@[48:53)       Identifier |items|
+//@[53:54)     Colon |:|
+//@[55:82)     ObjectSyntax
+//@[55:56)      LeftBrace |{|
+//@[56:57)      NewLine |\n|
+    name: 'loopChild'
+//@[4:21)      ObjectPropertySyntax
+//@[4:8)       IdentifierSyntax
+//@[4:8)        Identifier |name|
+//@[8:9)       Colon |:|
+//@[10:21)       StringSyntax
+//@[10:21)        StringComplete |'loopChild'|
+//@[21:22)      NewLine |\n|
+  }]
+//@[2:3)      RightBrace |}|
+//@[3:4)     RightSquare |]|
+//@[4:5)   NewLine |\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+output loopChildOutput string = loopParent:loopChild[0].name
+//@[0:60) OutputDeclarationSyntax
+//@[0:6)  Identifier |output|
+//@[7:22)  IdentifierSyntax
+//@[7:22)   Identifier |loopChildOutput|
+//@[23:29)  TypeSyntax
+//@[23:29)   Identifier |string|
+//@[30:31)  Assignment |=|
+//@[32:60)  PropertyAccessSyntax
+//@[32:55)   ArrayAccessSyntax
+//@[32:52)    ResourceAccessSyntax
+//@[32:42)     VariableAccessSyntax
+//@[32:42)      IdentifierSyntax
+//@[32:42)       Identifier |loopParent|
+//@[42:43)     Colon |:|
+//@[43:52)     IdentifierSyntax
+//@[43:52)      Identifier |loopChild|
+//@[52:53)    LeftSquare |[|
+//@[53:54)    IntegerLiteralSyntax
+//@[53:54)     Integer |0|
+//@[54:55)    RightSquare |]|
+//@[55:56)   Dot |.|
+//@[56:60)   IdentifierSyntax
+//@[56:60)    Identifier |name|
+//@[60:60) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.tokens.bicep
@@ -1,0 +1,427 @@
+resource basicParent 'My.Rp/parentType@2020-12-01' = {
+//@[0:8) Identifier |resource|
+//@[9:20) Identifier |basicParent|
+//@[21:50) StringComplete |'My.Rp/parentType@2020-12-01'|
+//@[51:52) Assignment |=|
+//@[53:54) LeftBrace |{|
+//@[54:55) NewLine |\n|
+  name: 'basicParent'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:21) StringComplete |'basicParent'|
+//@[21:22) NewLine |\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:16) NewLine |\n|
+    size: 'large'
+//@[4:8) Identifier |size|
+//@[8:9) Colon |:|
+//@[10:17) StringComplete |'large'|
+//@[17:18) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\n\n|
+
+  resource basicChild 'childType' = {
+//@[2:10) Identifier |resource|
+//@[11:21) Identifier |basicChild|
+//@[22:33) StringComplete |'childType'|
+//@[34:35) Assignment |=|
+//@[36:37) LeftBrace |{|
+//@[37:38) NewLine |\n|
+    name: 'basicChild'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:22) StringComplete |'basicChild'|
+//@[22:23) NewLine |\n|
+    properties: {
+//@[4:14) Identifier |properties|
+//@[14:15) Colon |:|
+//@[16:17) LeftBrace |{|
+//@[17:18) NewLine |\n|
+      size: basicParent.properties.large
+//@[6:10) Identifier |size|
+//@[10:11) Colon |:|
+//@[12:23) Identifier |basicParent|
+//@[23:24) Dot |.|
+//@[24:34) Identifier |properties|
+//@[34:35) Dot |.|
+//@[35:40) Identifier |large|
+//@[40:41) NewLine |\n|
+      style: 'cool'
+//@[6:11) Identifier |style|
+//@[11:12) Colon |:|
+//@[13:19) StringComplete |'cool'|
+//@[19:20) NewLine |\n|
+    }
+//@[4:5) RightBrace |}|
+//@[5:7) NewLine |\n\n|
+
+    resource basicGrandchild 'grandchildType' = {
+//@[4:12) Identifier |resource|
+//@[13:28) Identifier |basicGrandchild|
+//@[29:45) StringComplete |'grandchildType'|
+//@[46:47) Assignment |=|
+//@[48:49) LeftBrace |{|
+//@[49:50) NewLine |\n|
+      name: 'basicGrandchild'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:29) StringComplete |'basicGrandchild'|
+//@[29:30) NewLine |\n|
+      properties: {
+//@[6:16) Identifier |properties|
+//@[16:17) Colon |:|
+//@[18:19) LeftBrace |{|
+//@[19:20) NewLine |\n|
+        size: basicParent.properties.size
+//@[8:12) Identifier |size|
+//@[12:13) Colon |:|
+//@[14:25) Identifier |basicParent|
+//@[25:26) Dot |.|
+//@[26:36) Identifier |properties|
+//@[36:37) Dot |.|
+//@[37:41) Identifier |size|
+//@[41:42) NewLine |\n|
+        style: basicChild.properties.style
+//@[8:13) Identifier |style|
+//@[13:14) Colon |:|
+//@[15:25) Identifier |basicChild|
+//@[25:26) Dot |.|
+//@[26:36) Identifier |properties|
+//@[36:37) Dot |.|
+//@[37:42) Identifier |style|
+//@[42:43) NewLine |\n|
+      }
+//@[6:7) RightBrace |}|
+//@[7:8) NewLine |\n|
+    }
+//@[4:5) RightBrace |}|
+//@[5:6) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\n\n|
+
+  resource basicSibling 'childType' = {
+//@[2:10) Identifier |resource|
+//@[11:23) Identifier |basicSibling|
+//@[24:35) StringComplete |'childType'|
+//@[36:37) Assignment |=|
+//@[38:39) LeftBrace |{|
+//@[39:40) NewLine |\n|
+    name: 'basicSibling'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:24) StringComplete |'basicSibling'|
+//@[24:25) NewLine |\n|
+    properties: {
+//@[4:14) Identifier |properties|
+//@[14:15) Colon |:|
+//@[16:17) LeftBrace |{|
+//@[17:18) NewLine |\n|
+      size: basicParent.properties.size
+//@[6:10) Identifier |size|
+//@[10:11) Colon |:|
+//@[12:23) Identifier |basicParent|
+//@[23:24) Dot |.|
+//@[24:34) Identifier |properties|
+//@[34:35) Dot |.|
+//@[35:39) Identifier |size|
+//@[39:40) NewLine |\n|
+      style: basicChild:basicGrandchild.properties.style
+//@[6:11) Identifier |style|
+//@[11:12) Colon |:|
+//@[13:23) Identifier |basicChild|
+//@[23:24) Colon |:|
+//@[24:39) Identifier |basicGrandchild|
+//@[39:40) Dot |.|
+//@[40:50) Identifier |properties|
+//@[50:51) Dot |.|
+//@[51:56) Identifier |style|
+//@[56:57) NewLine |\n|
+    }
+//@[4:5) RightBrace |}|
+//@[5:6) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+output referenceBasicChild string = basicParent:basicChild.properties.size
+//@[0:6) Identifier |output|
+//@[7:26) Identifier |referenceBasicChild|
+//@[27:33) Identifier |string|
+//@[34:35) Assignment |=|
+//@[36:47) Identifier |basicParent|
+//@[47:48) Colon |:|
+//@[48:58) Identifier |basicChild|
+//@[58:59) Dot |.|
+//@[59:69) Identifier |properties|
+//@[69:70) Dot |.|
+//@[70:74) Identifier |size|
+//@[74:75) NewLine |\n|
+output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+//@[0:6) Identifier |output|
+//@[7:31) Identifier |referenceBasicGrandchild|
+//@[32:38) Identifier |string|
+//@[39:40) Assignment |=|
+//@[41:52) Identifier |basicParent|
+//@[52:53) Colon |:|
+//@[53:63) Identifier |basicChild|
+//@[63:64) Colon |:|
+//@[64:79) Identifier |basicGrandchild|
+//@[79:80) Dot |.|
+//@[80:90) Identifier |properties|
+//@[90:91) Dot |.|
+//@[91:96) Identifier |style|
+//@[96:98) NewLine |\n\n|
+
+resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
+//@[0:8) Identifier |resource|
+//@[9:23) Identifier |existingParent|
+//@[24:53) StringComplete |'My.Rp/parentType@2020-12-01'|
+//@[54:62) Identifier |existing|
+//@[63:64) Assignment |=|
+//@[65:66) LeftBrace |{|
+//@[66:67) NewLine |\n|
+  name: 'existingParent'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:24) StringComplete |'existingParent'|
+//@[24:26) NewLine |\n\n|
+
+  resource existingChild 'childType' existing = {
+//@[2:10) Identifier |resource|
+//@[11:24) Identifier |existingChild|
+//@[25:36) StringComplete |'childType'|
+//@[37:45) Identifier |existing|
+//@[46:47) Assignment |=|
+//@[48:49) LeftBrace |{|
+//@[49:50) NewLine |\n|
+    name: 'existingChild'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:25) StringComplete |'existingChild'|
+//@[25:27) NewLine |\n\n|
+
+    resource existingGrandchild 'grandchildType' = {
+//@[4:12) Identifier |resource|
+//@[13:31) Identifier |existingGrandchild|
+//@[32:48) StringComplete |'grandchildType'|
+//@[49:50) Assignment |=|
+//@[51:52) LeftBrace |{|
+//@[52:53) NewLine |\n|
+      name: 'existingGrandchild'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:32) StringComplete |'existingGrandchild'|
+//@[32:33) NewLine |\n|
+      properties: {
+//@[6:16) Identifier |properties|
+//@[16:17) Colon |:|
+//@[18:19) LeftBrace |{|
+//@[19:20) NewLine |\n|
+        size: existingParent.properties.size
+//@[8:12) Identifier |size|
+//@[12:13) Colon |:|
+//@[14:28) Identifier |existingParent|
+//@[28:29) Dot |.|
+//@[29:39) Identifier |properties|
+//@[39:40) Dot |.|
+//@[40:44) Identifier |size|
+//@[44:45) NewLine |\n|
+        style: existingChild.properties.style
+//@[8:13) Identifier |style|
+//@[13:14) Colon |:|
+//@[15:28) Identifier |existingChild|
+//@[28:29) Dot |.|
+//@[29:39) Identifier |properties|
+//@[39:40) Dot |.|
+//@[40:45) Identifier |style|
+//@[45:46) NewLine |\n|
+      }
+//@[6:7) RightBrace |}|
+//@[7:8) NewLine |\n|
+    }
+//@[4:5) RightBrace |}|
+//@[5:6) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+param createParent bool
+//@[0:5) Identifier |param|
+//@[6:18) Identifier |createParent|
+//@[19:23) Identifier |bool|
+//@[23:24) NewLine |\n|
+param createChild bool
+//@[0:5) Identifier |param|
+//@[6:17) Identifier |createChild|
+//@[18:22) Identifier |bool|
+//@[22:23) NewLine |\n|
+param createGrandchild bool
+//@[0:5) Identifier |param|
+//@[6:22) Identifier |createGrandchild|
+//@[23:27) Identifier |bool|
+//@[27:28) NewLine |\n|
+resource conditionParent 'My.Rp/parentType@2020-12-01' = if (createParent) {
+//@[0:8) Identifier |resource|
+//@[9:24) Identifier |conditionParent|
+//@[25:54) StringComplete |'My.Rp/parentType@2020-12-01'|
+//@[55:56) Assignment |=|
+//@[57:59) Identifier |if|
+//@[60:61) LeftParen |(|
+//@[61:73) Identifier |createParent|
+//@[73:74) RightParen |)|
+//@[75:76) LeftBrace |{|
+//@[76:77) NewLine |\n|
+  name: 'conditionParent'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:25) StringComplete |'conditionParent'|
+//@[25:27) NewLine |\n\n|
+
+  resource conditionChild 'childType' = if (createChild) {
+//@[2:10) Identifier |resource|
+//@[11:25) Identifier |conditionChild|
+//@[26:37) StringComplete |'childType'|
+//@[38:39) Assignment |=|
+//@[40:42) Identifier |if|
+//@[43:44) LeftParen |(|
+//@[44:55) Identifier |createChild|
+//@[55:56) RightParen |)|
+//@[57:58) LeftBrace |{|
+//@[58:59) NewLine |\n|
+    name: 'conditionChild'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:26) StringComplete |'conditionChild'|
+//@[26:28) NewLine |\n\n|
+
+    resource conditionGrandchild 'grandchildType' = if (createGrandchild) {
+//@[4:12) Identifier |resource|
+//@[13:32) Identifier |conditionGrandchild|
+//@[33:49) StringComplete |'grandchildType'|
+//@[50:51) Assignment |=|
+//@[52:54) Identifier |if|
+//@[55:56) LeftParen |(|
+//@[56:72) Identifier |createGrandchild|
+//@[72:73) RightParen |)|
+//@[74:75) LeftBrace |{|
+//@[75:76) NewLine |\n|
+      name: 'conditionGrandchild'
+//@[6:10) Identifier |name|
+//@[10:11) Colon |:|
+//@[12:33) StringComplete |'conditionGrandchild'|
+//@[33:34) NewLine |\n|
+      properties: {
+//@[6:16) Identifier |properties|
+//@[16:17) Colon |:|
+//@[18:19) LeftBrace |{|
+//@[19:20) NewLine |\n|
+        size: conditionParent.properties.size
+//@[8:12) Identifier |size|
+//@[12:13) Colon |:|
+//@[14:29) Identifier |conditionParent|
+//@[29:30) Dot |.|
+//@[30:40) Identifier |properties|
+//@[40:41) Dot |.|
+//@[41:45) Identifier |size|
+//@[45:46) NewLine |\n|
+        style: conditionChild.properties.style
+//@[8:13) Identifier |style|
+//@[13:14) Colon |:|
+//@[15:29) Identifier |conditionChild|
+//@[29:30) Dot |.|
+//@[30:40) Identifier |properties|
+//@[40:41) Dot |.|
+//@[41:46) Identifier |style|
+//@[46:47) NewLine |\n|
+      }
+//@[6:7) RightBrace |}|
+//@[7:8) NewLine |\n|
+    }
+//@[4:5) RightBrace |}|
+//@[5:6) NewLine |\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:4) NewLine |\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+var items = [
+//@[0:3) Identifier |var|
+//@[4:9) Identifier |items|
+//@[10:11) Assignment |=|
+//@[12:13) LeftSquare |[|
+//@[13:14) NewLine |\n|
+  'a'
+//@[2:5) StringComplete |'a'|
+//@[5:6) NewLine |\n|
+  'b'
+//@[2:5) StringComplete |'b'|
+//@[5:6) NewLine |\n|
+]
+//@[0:1) RightSquare |]|
+//@[1:2) NewLine |\n|
+resource loopParent 'My.Rp/parentType@2020-12-01' = {
+//@[0:8) Identifier |resource|
+//@[9:19) Identifier |loopParent|
+//@[20:49) StringComplete |'My.Rp/parentType@2020-12-01'|
+//@[50:51) Assignment |=|
+//@[52:53) LeftBrace |{|
+//@[53:54) NewLine |\n|
+  name: 'loopParent'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:20) StringComplete |'loopParent'|
+//@[20:22) NewLine |\n\n|
+
+  resource loopChild 'childType' = [for item in items: {
+//@[2:10) Identifier |resource|
+//@[11:20) Identifier |loopChild|
+//@[21:32) StringComplete |'childType'|
+//@[33:34) Assignment |=|
+//@[35:36) LeftSquare |[|
+//@[36:39) Identifier |for|
+//@[40:44) Identifier |item|
+//@[45:47) Identifier |in|
+//@[48:53) Identifier |items|
+//@[53:54) Colon |:|
+//@[55:56) LeftBrace |{|
+//@[56:57) NewLine |\n|
+    name: 'loopChild'
+//@[4:8) Identifier |name|
+//@[8:9) Colon |:|
+//@[10:21) StringComplete |'loopChild'|
+//@[21:22) NewLine |\n|
+  }]
+//@[2:3) RightBrace |}|
+//@[3:4) RightSquare |]|
+//@[4:5) NewLine |\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+output loopChildOutput string = loopParent:loopChild[0].name
+//@[0:6) Identifier |output|
+//@[7:22) Identifier |loopChildOutput|
+//@[23:29) Identifier |string|
+//@[30:31) Assignment |=|
+//@[32:42) Identifier |loopParent|
+//@[42:43) Colon |:|
+//@[43:52) Identifier |loopChild|
+//@[52:53) LeftSquare |[|
+//@[53:54) Integer |0|
+//@[54:55) RightSquare |]|
+//@[55:56) Dot |.|
+//@[56:60) Identifier |name|
+//@[60:60) EndOfFile ||

--- a/src/Bicep.Core.UnitTests/Assertions/DiagnosticCollectionExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/DiagnosticCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Bicep.Core.Diagnostics;
 using FluentAssertions;
 using FluentAssertions.Collections;
@@ -21,6 +22,13 @@ namespace Bicep.Core.UnitTests.Assertions
         public DiagnosticCollectionAssertions(IEnumerable<Diagnostic> diagnostics)
             : base(diagnostics)
         {
+        }
+
+        public AndConstraint<DiagnosticCollectionAssertions> BeEmpty()
+        {
+            AssertionExtensions.Should(Subject).BeEmpty("contained diagnostics: {0}", string.Join(Environment.NewLine, Subject.Select(d => d.ToString())));
+
+            return new AndConstraint<DiagnosticCollectionAssertions>(this);
         }
 
         public AndConstraint<DiagnosticCollectionAssertions> ContainDiagnostic(string code, DiagnosticLevel level, string message, string because = "", params object[] becauseArgs)

--- a/src/Bicep.Core.UnitTests/Parsing/ExpressionTestVisitor.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/ExpressionTestVisitor.cs
@@ -45,6 +45,13 @@ namespace Bicep.Core.UnitTests.Parsing
             this.buffer.Append(')');
         }
 
+        public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
+        {
+            this.buffer.Append('(');
+            base.VisitResourceAccessSyntax(syntax);
+            this.buffer.Append(')');
+        }
+
         public override void VisitArrayAccessSyntax(ArrayAccessSyntax syntax)
         {
             this.buffer.Append('(');

--- a/src/Bicep.Core.UnitTests/Resource/ResourceTypeReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Resource/ResourceTypeReferenceTests.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System;
 using Bicep.Core.Resources;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -57,6 +56,58 @@ namespace Bicep.Core.UnitTests.Resource
 
             actual.Should().NotBeNull();
             actual!.FullyQualifiedType.Should().Be(expectedFullyQualifiedType);
+        }
+
+        [DataTestMethod]
+        [DataRow("Microsoft.Compute/virtualMachines@2019-06-01")] // has a slash
+        [DataRow("Microsoft.Blueprint/blueprints/versions/artifacts@2018-11-01-preview")] // full type name
+        [DataRow("/artifacts@2018-11-01-preview")] // leading slash
+        [DataRow("artifacts@")] // version delimiter but no version
+        [DataRow("artifacts@2018-11-012222-preview")] // invalid version
+        public void TryParseSingleTypeSegment_InvalidTypeSegmentIsRejected(string value)
+        {
+            var success = ResourceTypeReference.TryParseSingleTypeSegment(value, out var type, out var version);
+            success.Should().BeFalse($"For input '{value}': type was '{type}', version was '{version}'");
+            type.Should().BeNull();
+            version.Should().BeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("virtualMachines", "virtualMachines", (string?)null)]
+        [DataRow("virtualMachines@2019-06-01", "virtualMachines", "2019-06-01")]
+        [DataRow("artifacts@2018-11-01-preview", "artifacts", "2018-11-01-preview")]
+        public void TryParseSingleTypeSegment_TypeSegmentIsParsed(string value, string expectedType, string expectedVersion)
+        {
+            var success = ResourceTypeReference.TryParseSingleTypeSegment(value, out var type, out var version);
+            success.Should().BeTrue($"For input '{value}': type was '{type}', version was '{version}'");
+            type.Should().BeEquivalentTo(expectedType);
+            version.Should().BeEquivalentTo(expectedVersion);
+        }
+
+        [TestMethod]
+        public void TryCombine_RejectsInvalidTypeSegment()
+        {
+            var baseType = ResourceTypeReference.Parse("My.RP/someType@2020-01-01");
+            var typeSegments = new [] { "childType@2019-06-01", "childType/grandChildType", };
+            var actual = ResourceTypeReference.TryCombine(baseType, typeSegments);
+
+            actual.Should().BeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("My.RP/someType@2020-01-01", new string[]{ "childType", }, "My.RP/someType/childType@2020-01-01")]
+        [DataRow("My.RP/someType@2020-01-01", new string[]{ "childType", "grandchildType",}, "My.RP/someType/childType/grandchildType@2020-01-01")]
+        [DataRow("My.RP/someType@2020-01-01", new string[]{ "childType", "grandchildType", "greatGrandchildType"}, "My.RP/someType/childType/grandchildType/greatGrandchildType@2020-01-01")]
+        [DataRow("My.RP/someType@2020-01-01", new string[]{ "childType@2020-01-02", }, "My.RP/someType/childType@2020-01-02")]
+        [DataRow("My.RP/someType@2020-01-01", new string[]{ "childType", "grandchildType@2020-01-03", }, "My.RP/someType/childType/grandchildType@2020-01-03")]
+        [DataRow("My.RP/someType@2020-01-01", new string[]{ "childType@2020-01-02", "grandchildType", }, "My.RP/someType/childType/grandchildType@2020-01-02")]
+        public void TryCombine_CombinesValidTypeSegments(string baseTypeText, string[] typeSegments, string expected)
+        {
+            var baseType = ResourceTypeReference.Parse(baseTypeText);
+            var actual = ResourceTypeReference.TryCombine(baseType, typeSegments);
+
+            actual.Should().NotBeNull();
+            actual!.FormatName().Should().BeEquivalentTo(expected);
         }
     }
 }

--- a/src/Bicep.Core.UnitTests/Utils/ParserHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/ParserHelper.cs
@@ -15,7 +15,7 @@ namespace Bicep.Core.UnitTests.Utils
             return parser.Program();
         }
 
-        public static SyntaxBase ParseExpression(string text, bool allowComplexLiterals = true) => new Parser(text).Expression(allowComplexLiterals);
+        public static SyntaxBase ParseExpression(string text, ExpressionFlags expressionFlags = ExpressionFlags.AllowComplexLiterals) => new Parser(text).Expression(expressionFlags);
     }
 }
 

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -10,6 +10,7 @@ using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
 using Bicep.Core.Resources;
 using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Diagnostics
@@ -879,6 +880,31 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP155",
                 $"The decorator \"{decoratorName}\" can only be attached to resource or module collections.");
+       
+            public ErrorDiagnostic InvalidResourceTypeSegment(string typeSegment) => new(
+                TextSpan,
+                "BCP156",
+                $"The resource type segment \"{typeSegment}\" is invalid. Nested resources must specify a single type segment, and optionally can specify an api version using the format \"<type>@<apiVersion>\".");
+
+            public ErrorDiagnostic InvalidAncestorResourceType(string resourceName) => new(
+                TextSpan,
+                "BCP157",
+                $"The resource type cannot be determined due to an error in containing resource \"{resourceName}\".");
+
+            public ErrorDiagnostic ResourceRequiredForResourceAccess(string wrongType) => new(
+                TextSpan,
+                "BCP158",
+                $"Cannot access nested resources of type \"{wrongType}\". A resource type is required.");
+
+            public ErrorDiagnostic NestedResourceNotFound(string resourceName, string identifierName, IEnumerable<string> nestedResourceNames) => new(
+                TextSpan,
+                "BCP159",
+                $"The resource \"{resourceName}\" does not contain a nested resource named \"{identifierName}\". Known nested resources are: {ToQuotedString(nestedResourceNames)}.");
+
+            public ErrorDiagnostic NestedResourceNotAllowedInLoop() => new(
+                TextSpan,
+                "BCP160",
+                $"A nested resource cannot appear inside of a resource with a for-expression.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -83,7 +83,7 @@ namespace Bicep.Core.Emit
 
         private static IEnumerable<ResourceDefinition> GetResourceDefinitions(SemanticModel semanticModel, ImmutableDictionary<ResourceSymbol, ScopeHelper.ScopeData> resourceScopeData)
         {
-            foreach (var resource in semanticModel.Root.ResourceDeclarations)
+            foreach (var resource in semanticModel.Root.GetAllResourceDeclarations())
             {
                 if (resource.DeclaringResource.IsExistingResource())
                 {
@@ -91,9 +91,15 @@ namespace Bicep.Core.Emit
                     continue;
                 }
 
-                if (!resourceScopeData.TryGetValue(resource, out var scopeData))
+                // Determine the scope - this is either something like a resource group/subscription or another resource
+                ResourceSymbol? scopeSymbol;
+                if (resourceScopeData.TryGetValue(resource, out var scopeData) && scopeData.ResourceScopeSymbol is ResourceSymbol)
                 {
-                    scopeData = null;
+                    scopeSymbol = scopeData.ResourceScopeSymbol;
+                }
+                else
+                {
+                    scopeSymbol = semanticModel.ResourceAncestors.GetAncestors(resource).LastOrDefault();
                 }
 
                 if (resource.Type is not ResourceType resourceType || resource.SafeGetBodyPropertyValue(LanguageConstants.ResourceNamePropertyName) is not StringSyntax namePropertyValue)
@@ -102,7 +108,7 @@ namespace Bicep.Core.Emit
                     continue;
                 }
 
-                yield return new ResourceDefinition(resource.Name, scopeData?.ResourceScopeSymbol, resourceType.TypeReference.FullyQualifiedType, namePropertyValue);
+                yield return new ResourceDefinition(resource.Name, scopeSymbol, resourceType.TypeReference.FullyQualifiedType, namePropertyValue);
             }
         }
     }

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Azure.Deployments.Core.Extensions;
 using Azure.Deployments.Expression.Expressions;
 using Bicep.Core.Extensions;
+using Bicep.Core.Parsing;
 using Bicep.Core.Resources;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
@@ -98,6 +99,9 @@ namespace Bicep.Core.Emit
                 case ArrayAccessSyntax arrayAccess:
                     return ConvertArrayAccess(arrayAccess);
 
+                case ResourceAccessSyntax resourceAccess:
+                    return ConvertResourceAccess(resourceAccess);
+
                 case PropertyAccessSyntax propertyAccess:
                     return ConvertPropertyAccess(propertyAccess);
 
@@ -123,7 +127,7 @@ namespace Bicep.Core.Emit
             }
 
             var inaccessibleLocals = this.context.DataFlowAnalyzer.GetInaccessibleLocalsAfterSyntaxMove(nameSyntax, newContext);
-            switch(inaccessibleLocals.Count)
+            switch (inaccessibleLocals.Count)
             {
                 case 0:
                     // moving the name expression does not produce any inaccessible locals
@@ -146,13 +150,13 @@ namespace Bicep.Core.Emit
             // if there is an array access on a resource/module reference, we have to generate differently
             // when constructing the reference() function call, the resource name expression needs to have its local
             // variable replaced with <loop array expression>[this array access' index expression]
-            if (arrayAccess.BaseExpression is VariableAccessSyntax variableAccess)
+            if (arrayAccess.BaseExpression is VariableAccessSyntax || arrayAccess.BaseExpression is ResourceAccessSyntax)
             {
-                switch (this.context.SemanticModel.GetSymbolInfo(variableAccess))
+                switch (this.context.SemanticModel.GetSymbolInfo(arrayAccess.BaseExpression))
                 {
-                    case ResourceSymbol {IsCollection: true} resourceSymbol:
+                    case ResourceSymbol { IsCollection: true } resourceSymbol:
                         var resourceConverter = this.CreateConverterForIndexReplacement(ExpressionConverter.GetResourceNameSyntax(resourceSymbol), arrayAccess.IndexExpression, arrayAccess);
-                        
+
                         // TODO: Can this return a language expression?
                         return resourceConverter.ToFunctionExpression(arrayAccess.BaseExpression);
 
@@ -206,8 +210,8 @@ namespace Bicep.Core.Emit
                 return null;
             }
 
-            if (propertyAccess.BaseExpression is VariableAccessSyntax propVariableAccess &&
-                context.SemanticModel.GetSymbolInfo(propVariableAccess) is ResourceSymbol resourceSymbol &&
+            if ((propertyAccess.BaseExpression is VariableAccessSyntax || propertyAccess.BaseExpression is ResourceAccessSyntax) &&
+                context.SemanticModel.GetSymbolInfo(propertyAccess.BaseExpression) is ResourceSymbol resourceSymbol &&
                 ConvertResourcePropertyAccess(resourceSymbol, indexExpression: null) is { } convertedSingle)
             {
                 // we are doing property access on a single resource
@@ -215,9 +219,9 @@ namespace Bicep.Core.Emit
                 return convertedSingle;
             }
 
-            if(propertyAccess.BaseExpression is ArrayAccessSyntax propArrayAccess &&
-                propArrayAccess.BaseExpression is VariableAccessSyntax arrayVariableAccess &&
-                context.SemanticModel.GetSymbolInfo(arrayVariableAccess) is ResourceSymbol resourceCollectionSymbol && 
+            if (propertyAccess.BaseExpression is ArrayAccessSyntax propArrayAccess &&
+                (propArrayAccess.BaseExpression is VariableAccessSyntax || propArrayAccess.BaseExpression is ResourceAccessSyntax) && 
+                context.SemanticModel.GetSymbolInfo(propArrayAccess.BaseExpression) is ResourceSymbol resourceCollectionSymbol &&
                 ConvertResourcePropertyAccess(resourceCollectionSymbol, propArrayAccess.IndexExpression) is { } convertedCollection)
             {
 
@@ -257,16 +261,45 @@ namespace Bicep.Core.Emit
                 new JTokenExpression(propertyAccess.PropertyName.IdentifierName));
         }
 
-        private LanguageExpression GetResourceNameExpression(ResourceSymbol resourceSymbol)
+        public LanguageExpression GetResourceNameExpression(ResourceSymbol resourceSymbol)
         {
-            SyntaxBase nameValueSyntax = GetResourceNameSyntax(resourceSymbol);
-            return this.ConvertExpression(nameValueSyntax);
+            var nameValueSyntax = GetResourceNameSyntax(resourceSymbol);
+
+            // For a nested resource we need to compute the name
+            var ancestors = this.context.SemanticModel.ResourceAncestors.GetAncestors(resourceSymbol);
+            if (ancestors.Length == 0)
+            {
+                return ConvertExpression(nameValueSyntax);
+            }
+
+            // Build an expression like '${parent.name}/${child.name}'
+            //
+            // This is a call to the `format` function with the first arg as a format string
+            // and the remaining args the actual name segments.
+            //
+            // args.Length = 1 (format string) + N (ancestor names) + 1 (resource name)
+            var args = new LanguageExpression[ancestors.Length + 2];
+
+            // {0}/{1}/{2}....
+            var format = string.Join("/", Enumerable.Range(0, ancestors.Length + 1).Select(i => $"{{{i}}}"));
+            args[0] = new JTokenExpression(format);
+
+            for (var i = 0; i < ancestors.Length; i++)
+            {
+                var ancestor = ancestors[i];
+                var segment = GetResourceNameSyntax(ancestor);
+                args[i + 1] = ConvertExpression(segment);
+            }
+
+            args[args.Length - 1] = ConvertExpression(nameValueSyntax);
+
+            return CreateFunction("format", args);
         }
 
         public static SyntaxBase GetResourceNameSyntax(ResourceSymbol resourceSymbol)
         {
             // this condition should have already been validated by the type checker
-            return resourceSymbol.SafeGetBodyPropertyValue(LanguageConstants.ResourceNamePropertyName) ?? throw new ArgumentException($"Expected resource syntax body to contain property 'name'");
+            return resourceSymbol.UnsafeGetBodyPropertyValue(LanguageConstants.ResourceNamePropertyName);
         }
 
         private LanguageExpression GetModuleNameExpression(ModuleSymbol moduleSymbol)
@@ -374,14 +407,14 @@ namespace Bicep.Core.Emit
                 case ForSyntax @for when ReferenceEquals(@for.ItemVariable, localVariableSymbol.DeclaringLocalVariable):
                     // this is the "item" variable of a for-expression
                     // to emit this we need to basically index the array expression by the copyIndex() function
-                    
-                    if(this.localReplacements.TryGetValue(localVariableSymbol, out var replacement))
+
+                    if (this.localReplacements.TryGetValue(localVariableSymbol, out var replacement))
                     {
                         // the current context has specified an expression to be used for this local variable symbol
                         // to override the regular conversion to copyIndex()
                         return replacement;
                     }
-                    
+
                     var arrayExpression = ToFunctionExpression(@for.Expression);
 
                     var copyIndexName = this.context.SemanticModel.Binder.GetParent(@for) switch
@@ -399,7 +432,7 @@ namespace Bicep.Core.Emit
                     };
 
                     var copyIndexFunction = copyIndexName == null ? CreateFunction("copyIndex") : CreateFunction("copyIndex", new JTokenExpression(copyIndexName));
-                    
+
                     return AppendProperties(arrayExpression, copyIndexFunction);
 
                 default:
@@ -440,6 +473,18 @@ namespace Bicep.Core.Emit
                 default:
                     throw new NotImplementedException($"Encountered an unexpected symbol kind '{symbol?.Kind}' when generating a variable access expression.");
             }
+        }
+
+        private LanguageExpression ConvertResourceAccess(ResourceAccessSyntax resourceAccessSyntax)
+        {
+            var symbol = context.SemanticModel.GetSymbolInfo(resourceAccessSyntax);
+            if (symbol is ResourceSymbol resourceSymbol)
+            {
+                var typeReference = EmitHelpers.GetTypeReference(resourceSymbol);
+                return GetReferenceExpression(resourceSymbol, typeReference, true);
+            }
+
+            throw new NotImplementedException($"Encountered an unexpected symbol kind '{symbol?.Kind}' when generating a resource access expression.");
         }
 
         private LanguageExpression ConvertString(StringSyntax syntax)

--- a/src/Bicep.Core/Emit/ExpressionEmitter.cs
+++ b/src/Bicep.Core/Emit/ExpressionEmitter.cs
@@ -79,6 +79,7 @@ namespace Bicep.Core.Emit
                 case FunctionCallSyntax _:
                 case ArrayAccessSyntax _:
                 case PropertyAccessSyntax _:
+                case ResourceAccessSyntax _:
                 case VariableAccessSyntax _:
                     EmitLanguageExpression(syntax);
                     
@@ -115,6 +116,11 @@ namespace Bicep.Core.Emit
             var serialized = ExpressionSerializer.SerializeExpression(resourceIdExpression);
 
             writer.WriteValue(serialized);
+        }
+
+        public LanguageExpression GetResourceNameExpression(ResourceSymbol resourceSymbol)
+        {
+            return converter.GetResourceNameExpression(resourceSymbol);
         }
 
         public LanguageExpression GetManagementGroupResourceId(SyntaxBase managementGroupNameProperty, bool fullyQualified)

--- a/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
@@ -55,11 +55,14 @@ namespace Bicep.Core.Emit
                 throw new InvalidOperationException("Unbound declaration");
             }
 
+            // Resource ancestors are always dependencies.
+            var ancestors = this.model.ResourceAncestors.GetAncestors(resourceSymbol);
+
             // save previous declaration as we may call this recursively
             var prevDeclaration = this.currentDeclaration;
 
             this.currentDeclaration = resourceSymbol;
-            this.resourceDependencies[resourceSymbol] = new HashSet<ResourceDependency>();
+            this.resourceDependencies[resourceSymbol] = new HashSet<ResourceDependency>(ancestors.Select(a => new ResourceDependency(a, null)));
             base.VisitResourceDeclarationSyntax(syntax);
 
             // restore previous declaration

--- a/src/Bicep.Core/Emit/ScopeHelper.cs
+++ b/src/Bicep.Core/Emit/ScopeHelper.cs
@@ -354,7 +354,7 @@ namespace Bicep.Core.Emit
 
             var scopeInfo = new Dictionary<ResourceSymbol, ScopeData>();
 
-            foreach (var resourceSymbol in semanticModel.Root.ResourceDeclarations)
+            foreach (var resourceSymbol in semanticModel.Root.GetAllResourceDeclarations())
             {
                 var resourceType = GetResourceType(resourceSymbol);
                 if (resourceType is null)

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.IO;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Azure.Deployments.Core.Extensions;
 using Azure.Deployments.Expression.Expressions;
 using Bicep.Core.Extensions;
+using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
@@ -36,6 +38,7 @@ namespace Bicep.Core.Emit
         private static readonly ImmutableHashSet<string> ResourcePropertiesToOmit = new [] {
             LanguageConstants.ResourceScopePropertyName,
             LanguageConstants.ResourceDependsOnPropertyName,
+            LanguageConstants.ResourceNamePropertyName,
         }.ToImmutableHashSet();
 
         private static readonly ImmutableHashSet<string> ModulePropertiesToOmit = new [] {
@@ -294,7 +297,7 @@ namespace Bicep.Core.Emit
             memoryWriter.WritePropertyName("resources");
             memoryWriter.WriteStartArray();
 
-            foreach (var resourceSymbol in this.context.SemanticModel.Root.ResourceDeclarations)
+            foreach (var resourceSymbol in this.context.SemanticModel.Root.GetAllResourceDeclarations())
             {
                 if (resourceSymbol.DeclaringResource.IsExistingResource())
                 {
@@ -329,22 +332,73 @@ namespace Bicep.Core.Emit
             memoryWriter.WriteStartObject();
 
             var typeReference = EmitHelpers.GetTypeReference(resourceSymbol);
-            SyntaxBase body = resourceSymbol.DeclaringResource.Value;
+
+            // Note: conditions STACK with nesting.
+            //
+            // Children inherit the conditions of their parents, etc. This avoids a problem
+            // where we emit a dependsOn to something that's not in the template, or not
+            // being evaulated i the template. 
+            var conditions = new List<SyntaxBase>();
+            var loops = new List<(string name, ForSyntax @for, SyntaxBase? input)>();
+
+            var ancestors = this.context.SemanticModel.ResourceAncestors.GetAncestors(resourceSymbol);
+            foreach (var ancestor in ancestors)
+            {
+                if (ancestor.DeclaringResource.Value is IfConditionSyntax ifCondition)
+                {
+                    conditions.Add(ifCondition.ConditionExpression);
+                }
+
+                if (ancestor.DeclaringResource.Value is ForSyntax @for)
+                {
+                    loops.Add((ancestor.Name, @for, null));
+                }
+            }
+
+            // Unwrap the 'real' resource body if there's a condition
+            var body = resourceSymbol.DeclaringResource.Value;
             switch (body)
             {
                 case IfConditionSyntax ifCondition:
                     body = ifCondition.Body;
-                    emitter.EmitProperty("condition", ifCondition.ConditionExpression);
+                    conditions.Add(ifCondition.ConditionExpression);
                     break;
 
                 case ForSyntax @for:
                     body = @for.Body;
-                    emitter.EmitProperty("copy", () =>
-                    {
-                        var batchSize = GetBatchSize(resourceSymbol.DeclaringResource);
-                        emitter.EmitCopyObject(resourceSymbol.Name, @for, input: null, batchSize: batchSize);
-                    });
+                    loops.Add((resourceSymbol.Name, @for, null));
                     break;
+            }
+
+            if (conditions.Count == 1)
+            {
+                emitter.EmitProperty("condition", conditions[0]);
+            }
+            else if (conditions.Count > 1)
+            {
+                var @operator = new BinaryOperationSyntax(
+                    conditions[0], 
+                    SyntaxFactory.CreateToken(TokenType.LogicalAnd),
+                    conditions[1]);
+                for (var i = 2; i < conditions.Count; i++)
+                {
+                    @operator = new BinaryOperationSyntax(
+                        @operator,
+                        SyntaxFactory.CreateToken(TokenType.LogicalAnd),
+                        conditions[i]);
+                }
+
+                emitter.EmitProperty("condition", @operator);
+            }
+
+            if (loops.Count == 1)
+            {
+                var batchSize = GetBatchSize(resourceSymbol.DeclaringResource);
+                emitter.EmitProperty("copy", () => emitter.EmitCopyObject(loops[0].name, loops[0].@for, loops[0].input, batchSize: batchSize));
+            }
+            else if (loops.Count > 1)
+            {
+                throw new InvalidOperationException("nested loops are not supported");
             }
 
             emitter.EmitProperty("type", typeReference.FullyQualifiedType);
@@ -353,6 +407,9 @@ namespace Bicep.Core.Emit
             {
                 emitter.EmitProperty("scope", () => emitter.EmitUnqualifiedResourceId(scopeResource));
             }
+
+            emitter.EmitProperty("name", emitter.GetResourceNameExpression(resourceSymbol));
+
             emitter.EmitObjectProperties((ObjectSyntax)body, ResourcePropertiesToOmit);
 
             this.EmitDependsOn(memoryWriter, resourceSymbol, emitter, body);

--- a/src/Bicep.Core/Parsing/ExpressionFlags.cs
+++ b/src/Bicep.Core/Parsing/ExpressionFlags.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Extensions;
+using Bicep.Core.Navigation;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Parsing
+{
+    [Flags]
+    public enum ExpressionFlags
+    {
+        None = 0,
+        AllowComplexLiterals = 1,
+        AllowResourceDeclarations = 2,
+
+        /// <summary>
+        /// Used to indicate that the expression appears directly within a colon-delimited context such as the 
+        /// 'true' part of a ternary operator. This is used to resolve an ambiuity with the ':' operator for
+        /// nested resource access.
+        /// </summary>
+        InsideColonDelimitedContext = 4,
+    }
+}

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -148,11 +148,27 @@ namespace Bicep.Core.Parsing
             return predicate ? RecoveryFlags.None : RecoveryFlags.SuppressDiagnostics;
         }
 
+        private static bool HasExpressionFlag(ExpressionFlags flags, ExpressionFlags check)
+        {
+            // Use this instead of Enum.HasFlag which boxes the enum and allocates.
+            return (flags & check) == check;
+        }
+
+        private static ExpressionFlags WithExpressionFlag(ExpressionFlags flags, ExpressionFlags set)
+        {
+            return flags | set;
+        }
+
+        private static ExpressionFlags WithoutExpressionFlag(ExpressionFlags flags, ExpressionFlags unset)
+        {
+            return flags & ~unset;
+        }
+
         private SyntaxBase TargetScope(IEnumerable<SyntaxBase> leadingNodes)
         {
             var keyword = ExpectKeyword(LanguageConstants.TargetScopeKeyword);
             var assignment = this.WithRecovery(this.Assignment, RecoveryFlags.None, TokenType.NewLine);
-            var value = this.WithRecovery(() => this.Expression(allowComplexLiterals: true), RecoveryFlags.None, TokenType.NewLine);
+            var value = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), RecoveryFlags.None, TokenType.NewLine);
 
             return new TargetScopeSyntax(leadingNodes, keyword, assignment, value);
         }
@@ -167,7 +183,7 @@ namespace Bicep.Core.Parsing
 
                 if (Check(TokenType.LeftParen))
                 {
-                    var functionCall = FunctionCallAccess(identifier, true);
+                    var functionCall = FunctionCallAccess(identifier, ExpressionFlags.AllowComplexLiterals);
 
                     current = new FunctionCallSyntax(
                         functionCall.Identifier,
@@ -188,7 +204,7 @@ namespace Bicep.Core.Parsing
 
                     if (Check(TokenType.LeftParen))
                     {
-                        var functionCall = FunctionCallAccess(identifier, true);
+                        var functionCall = FunctionCallAccess(identifier, ExpressionFlags.AllowComplexLiterals);
 
                         current = new InstanceFunctionCallSyntax(
                             current,
@@ -233,7 +249,7 @@ namespace Bicep.Core.Parsing
                         TokenType.Assignment => this.ParameterDefaultValue(),
 
                         // modifier is specified
-                        TokenType.LeftBrace => this.Object(),
+                        TokenType.LeftBrace => this.Object(ExpressionFlags.AllowComplexLiterals),
 
                         _ => throw new ExpectedTokenException(current, b => b.ExpectedParameterContinuation())
                     };
@@ -247,7 +263,7 @@ namespace Bicep.Core.Parsing
         private SyntaxBase ParameterDefaultValue()
         {
             var assignmentToken = this.Expect(TokenType.Assignment, b => b.ExpectedCharacter("="));
-            SyntaxBase defaultValue = this.WithRecovery(() => this.Expression(allowComplexLiterals: true), RecoveryFlags.None, TokenType.NewLine);
+            SyntaxBase defaultValue = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), RecoveryFlags.None, TokenType.NewLine);
 
             return new ParameterDefaultValueSyntax(assignmentToken, defaultValue);
         }
@@ -257,7 +273,7 @@ namespace Bicep.Core.Parsing
             var keyword = ExpectKeyword(LanguageConstants.VariableKeyword);
             var name = this.IdentifierWithRecovery(b => b.ExpectedVariableIdentifier(), TokenType.Assignment, TokenType.NewLine);
             var assignment = this.WithRecovery(this.Assignment, GetSuppressionFlag(name), TokenType.NewLine);
-            var value = this.WithRecovery(() => this.Expression(allowComplexLiterals: true), GetSuppressionFlag(assignment), TokenType.NewLine);
+            var value = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), GetSuppressionFlag(assignment), TokenType.NewLine);
 
             return new VariableDeclarationSyntax(leadingNodes, keyword, name, assignment, value);
         }
@@ -268,7 +284,7 @@ namespace Bicep.Core.Parsing
             var name = this.IdentifierWithRecovery(b => b.ExpectedOutputIdentifier(), TokenType.Identifier, TokenType.NewLine);
             var type = this.WithRecovery(() => Type(b => b.ExpectedOutputType()), GetSuppressionFlag(name), TokenType.Assignment, TokenType.NewLine);
             var assignment = this.WithRecovery(this.Assignment, GetSuppressionFlag(type), TokenType.NewLine);
-            var value = this.WithRecovery(() => this.Expression(allowComplexLiterals: true), GetSuppressionFlag(assignment), TokenType.NewLine);
+            var value = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), GetSuppressionFlag(assignment), TokenType.NewLine);
 
             return new OutputDeclarationSyntax(leadingNodes, keyword, name, type, assignment, value);
         }
@@ -298,9 +314,9 @@ namespace Bicep.Core.Parsing
                     var current = reader.Peek();
                     return current.Type switch
                     {
-                        TokenType.Identifier when current.Text == LanguageConstants.IfKeyword => this.IfCondition(),
-                        TokenType.LeftBrace => this.Object(),
-                        TokenType.LeftSquare => this.ForExpression(requireObjectLiteral: true),
+                        TokenType.Identifier when current.Text == LanguageConstants.IfKeyword => this.IfCondition(ExpressionFlags.AllowResourceDeclarations | ExpressionFlags.AllowComplexLiterals),
+                        TokenType.LeftBrace => this.Object(ExpressionFlags.AllowResourceDeclarations | ExpressionFlags.AllowComplexLiterals),
+                        TokenType.LeftSquare => this.ForExpression(ExpressionFlags.AllowResourceDeclarations | ExpressionFlags.AllowComplexLiterals, requireObjectLiteral: true),
                         _ => throw new ExpectedTokenException(current, b => b.ExpectBodyStartOrIfOrLoopStart())
                     };
                 },
@@ -327,9 +343,9 @@ namespace Bicep.Core.Parsing
                     var current = reader.Peek();
                     return current.Type switch
                     {
-                        TokenType.Identifier when current.Text == LanguageConstants.IfKeyword => this.IfCondition(),
-                        TokenType.LeftBrace => this.Object(),
-                        TokenType.LeftSquare => this.ForExpression(requireObjectLiteral: true),
+                        TokenType.Identifier when current.Text == LanguageConstants.IfKeyword => this.IfCondition(ExpressionFlags.AllowComplexLiterals),
+                        TokenType.LeftBrace => this.Object(ExpressionFlags.AllowComplexLiterals),
+                        TokenType.LeftSquare => this.ForExpression(ExpressionFlags.AllowComplexLiterals, requireObjectLiteral: true),
                         _ => throw new ExpectedTokenException(current, b => b.ExpectBodyStartOrIfOrLoopStart())
                     };
                 },
@@ -355,16 +371,16 @@ namespace Bicep.Core.Parsing
             return Expect(TokenType.NewLine, b => b.ExpectedNewLine());
         }
 
-        public SyntaxBase Expression(bool allowComplexLiterals)
+        public SyntaxBase Expression(ExpressionFlags expressionFlags)
         {
-            var candidate = this.BinaryExpression(allowComplexLiterals);
+            var candidate = this.BinaryExpression(expressionFlags);
 
             if (this.Check(TokenType.Question))
             {
                 var question = this.reader.Read();
-                var trueExpression = this.Expression(allowComplexLiterals);
+                var trueExpression = this.Expression(WithExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext));
                 var colon = this.Expect(TokenType.Colon, b => b.ExpectedCharacter(":"));
-                var falseExpression = this.Expression(allowComplexLiterals);
+                var falseExpression = this.Expression(expressionFlags);
 
                 return new TernaryOperationSyntax(candidate, question, trueExpression, colon, falseExpression);
             }
@@ -372,9 +388,9 @@ namespace Bicep.Core.Parsing
             return candidate;
         }
 
-        private SyntaxBase BinaryExpression(bool allowComplexLiterals, int precedence = 0)
+        private SyntaxBase BinaryExpression(ExpressionFlags expressionFlags, int precedence = 0)
         {
-            var current = this.UnaryExpression(allowComplexLiterals);
+            var current = this.UnaryExpression(expressionFlags);
 
             while (true)
             {
@@ -391,14 +407,14 @@ namespace Bicep.Core.Parsing
 
                 this.reader.Read();
 
-                SyntaxBase rightExpression = this.BinaryExpression(allowComplexLiterals, operatorPrecedence);
+                SyntaxBase rightExpression = this.BinaryExpression(expressionFlags, operatorPrecedence);
                 current = new BinaryOperationSyntax(current, candidateOperatorToken, rightExpression);
             }
 
             return current;
         }
 
-        private SyntaxBase UnaryExpression(bool allowComplexLiterals)
+        private SyntaxBase UnaryExpression(ExpressionFlags expressionFlags)
         {
             Token operatorToken = this.reader.Peek();
 
@@ -406,16 +422,16 @@ namespace Bicep.Core.Parsing
             {
                 this.reader.Read();
 
-                var expression = this.MemberExpression(allowComplexLiterals);
+                var expression = this.MemberExpression(expressionFlags);
                 return new UnaryOperationSyntax(operatorToken, expression);
             }
 
-            return this.MemberExpression(allowComplexLiterals);
+            return this.MemberExpression(expressionFlags);
         }
 
-        private SyntaxBase MemberExpression(bool allowComplexLiterals)
+        private SyntaxBase MemberExpression(ExpressionFlags expressionFlags)
         {
-            var current = this.PrimaryExpression(allowComplexLiterals);
+            var current = this.PrimaryExpression(expressionFlags);
 
             while (true)
             {
@@ -434,7 +450,7 @@ namespace Bicep.Core.Parsing
                     }
                     else
                     {
-                        SyntaxBase indexExpression = this.Expression(allowComplexLiterals);
+                        SyntaxBase indexExpression = this.Expression(expressionFlags);
                         Token closeSquare = this.Expect(TokenType.RightSquare, b => b.ExpectedCharacter("]"));
 
                         current = new ArrayAccessSyntax(current, openSquare, indexExpression, closeSquare);
@@ -452,7 +468,7 @@ namespace Bicep.Core.Parsing
 
                     if (Check(TokenType.LeftParen))
                     {
-                        var functionCall = FunctionCallAccess(identifier, allowComplexLiterals);
+                        var functionCall = FunctionCallAccess(identifier, expressionFlags);
 
                         // gets instance function call
                         current = new InstanceFunctionCallSyntax(
@@ -471,13 +487,32 @@ namespace Bicep.Core.Parsing
                     continue;
                 }
 
+                if (this.Check(TokenType.Colon) && !HasExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext))
+                {
+                    // colon operator (nested resource lookup)
+                    //
+                    // We want a ternary to bind with higher precedance than a resource-access inside the "true" part
+                    // ex: a ? b : c -> a ? (b) : (c) and NOT a ? (b:c) 
+                    // this implies that a resource-access expression will require parenthesis inside a ternary's "true" part
+                    //
+                    // We can't easily do this the other way because a ternary is right-associative and member/resource access
+                    // are left-associative.
+                    //
+                    // The same is true of a for-expression. A colon is used as the right-delimiter.
+                    var colon = this.reader.Read();
+                    var identifier = this.IdentifierOrSkip(b => b.ExpectedFunctionOrPropertyName());
+                    current = new ResourceAccessSyntax(current, colon, identifier);
+
+                    continue;
+                }
+
                 break;
             }
 
             return current;
         }
 
-        private SyntaxBase PrimaryExpression(bool allowComplexLiterals)
+        private SyntaxBase PrimaryExpression(ExpressionFlags expressionFlags)
         {
             Token nextToken = this.reader.Peek();
 
@@ -496,12 +531,12 @@ namespace Bicep.Core.Parsing
                 case TokenType.MultilineString:
                     return this.MultilineString();
 
-                case TokenType.LeftBrace when allowComplexLiterals:
-                    return this.Object();
+                case TokenType.LeftBrace when HasExpressionFlag(expressionFlags, ExpressionFlags.AllowComplexLiterals):
+                    return this.Object(WithoutExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext));
 
-                case TokenType.LeftSquare when allowComplexLiterals:
+                case TokenType.LeftSquare when HasExpressionFlag(expressionFlags, ExpressionFlags.AllowComplexLiterals):
                     return CheckKeyword(this.reader.PeekAhead(), LanguageConstants.ForKeyword) 
-                        ? this.ForExpression(requireObjectLiteral: false) 
+                        ? this.ForExpression(WithoutExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext), requireObjectLiteral: false) 
                         : this.Array();
 
                 case TokenType.LeftBrace:
@@ -509,32 +544,32 @@ namespace Bicep.Core.Parsing
                     throw new ExpectedTokenException(nextToken, b => b.ComplexLiteralsNotAllowed());
 
                 case TokenType.LeftParen:
-                    return this.ParenthesizedExpression(allowComplexLiterals);
+                    return this.ParenthesizedExpression(WithoutExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext));
 
                 case TokenType.Identifier:
-                    return this.FunctionCallOrVariableAccess(allowComplexLiterals);
+                    return this.FunctionCallOrVariableAccess(expressionFlags);
 
                 default:
                     throw new ExpectedTokenException(nextToken, b => b.UnrecognizedExpression());
             }
         }
 
-        private SyntaxBase ParenthesizedExpression(bool allowComplexLiterals)
+        private SyntaxBase ParenthesizedExpression(ExpressionFlags expressionFlags)
         {
             var openParen = this.Expect(TokenType.LeftParen, b => b.ExpectedCharacter("("));
-            var expression = this.WithRecovery(() => this.Expression(allowComplexLiterals), RecoveryFlags.None, TokenType.RightParen, TokenType.NewLine);
+            var expression = this.WithRecovery(() => this.Expression(expressionFlags), RecoveryFlags.None, TokenType.RightParen, TokenType.NewLine);
             var closeParen = this.WithRecovery(() => this.Expect(TokenType.RightParen, b => b.ExpectedCharacter(")")), GetSuppressionFlag(expression), TokenType.NewLine);
 
             return new ParenthesizedExpressionSyntax(openParen, expression, closeParen);
         }
 
-        private SyntaxBase FunctionCallOrVariableAccess(bool allowComplexLiterals)
+        private SyntaxBase FunctionCallOrVariableAccess(ExpressionFlags expressionFlags)
         {
             var identifier = this.Identifier(b => b.ExpectedVariableOrFunctionName());
 
             if (Check(TokenType.LeftParen))
             {
-                var functionCall = FunctionCallAccess(identifier, allowComplexLiterals);
+                var functionCall = FunctionCallAccess(identifier, expressionFlags);
 
                 return new FunctionCallSyntax(
                     functionCall.Identifier,
@@ -549,11 +584,11 @@ namespace Bicep.Core.Parsing
         /// <summary>
         /// Method that gets a function call identifier, its arguments plus open and close parens
         /// </summary>
-        private (IdentifierSyntax Identifier, Token OpenParen, IEnumerable<FunctionArgumentSyntax> ArgumentNodes, Token CloseParen) FunctionCallAccess(IdentifierSyntax functionName, bool allowComplexLiterals)
+        private (IdentifierSyntax Identifier, Token OpenParen, IEnumerable<FunctionArgumentSyntax> ArgumentNodes, Token CloseParen) FunctionCallAccess(IdentifierSyntax functionName, ExpressionFlags expressionFlags)
         {
             var openParen = this.Expect(TokenType.LeftParen, b => b.ExpectedCharacter("("));
 
-            var argumentNodes = FunctionCallArguments(allowComplexLiterals);
+            var argumentNodes = FunctionCallArguments(expressionFlags);
 
             var closeParen = this.Expect(TokenType.RightParen, b => b.ExpectedCharacter(")"));
 
@@ -566,7 +601,7 @@ namespace Bicep.Core.Parsing
         /// consume the right paren token.
         /// </summary>
         /// <param name="allowComplexLiterals"></param>
-        private IEnumerable<FunctionArgumentSyntax> FunctionCallArguments(bool allowComplexLiterals)
+        private IEnumerable<FunctionArgumentSyntax> FunctionCallArguments(ExpressionFlags expressionFlags)
         {
             SkippedTriviaSyntax CreateDummyArgument(Token current) =>
                 new SkippedTriviaSyntax(current.ToZeroLengthSpan(), ImmutableArray<SyntaxBase>.Empty, DiagnosticBuilder.ForPosition(current.ToZeroLengthSpan()).UnrecognizedExpression().AsEnumerable());
@@ -632,7 +667,7 @@ namespace Bicep.Core.Parsing
                             throw new ExpectedTokenException(current, b => b.ExpectedCharacter(","));
                         }
 
-                        var expression = this.Expression(allowComplexLiterals);
+                        var expression = this.Expression(expressionFlags);
                         arguments.Add((expression, null));
 
                         break;
@@ -772,7 +807,7 @@ namespace Bicep.Core.Parsing
                     // Look for an expression syntax inside the interpolation 'hole' (between "${" and "}").
                     // The lexer doesn't allow an expression contained inside an interpolation to span multiple lines, so we can safely use recovery to look for a NewLine character.
                     // We are also blocking complex literals (arrays and objects) from inside string interpolation
-                    var interpExpression = WithRecovery(() => Expression(allowComplexLiterals: false), RecoveryFlags.None, TokenType.StringMiddlePiece, TokenType.StringRightPiece, TokenType.NewLine);
+                    var interpExpression = WithRecovery(() => Expression(ExpressionFlags.None), RecoveryFlags.None, TokenType.StringMiddlePiece, TokenType.StringRightPiece, TokenType.NewLine);
                     if (!Check(TokenType.StringMiddlePiece, TokenType.StringRightPiece, TokenType.NewLine))
                     {
                         // We may have successfully parsed the expression, but have not reached the end of the expression hole. Skip to the end of the hole.
@@ -882,16 +917,16 @@ namespace Bicep.Core.Parsing
             }
         }
 
-        private SyntaxBase ForExpression(bool requireObjectLiteral)
+        private SyntaxBase ForExpression(ExpressionFlags expressionFlags, bool requireObjectLiteral)
         {
             var openBracket = this.Expect(TokenType.LeftSquare, b => b.ExpectedCharacter("["));
             var forKeyword = this.ExpectKeyword(LanguageConstants.ForKeyword);
             var identifier = new LocalVariableSyntax(this.IdentifierWithRecovery(b => b.ExpectedLoopVariableIdentifier(), TokenType.Identifier, TokenType.RightSquare, TokenType.NewLine));
             var inKeyword = this.WithRecovery(() => this.ExpectKeyword(LanguageConstants.InKeyword), GetSuppressionFlag(identifier.Name), TokenType.RightSquare, TokenType.NewLine);
-            var expression = this.WithRecovery(() => this.Expression(allowComplexLiterals: true), GetSuppressionFlag(inKeyword), TokenType.Colon, TokenType.RightSquare, TokenType.NewLine);
+            var expression = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals | ExpressionFlags.InsideColonDelimitedContext), GetSuppressionFlag(inKeyword), TokenType.Colon, TokenType.RightSquare, TokenType.NewLine);
             var colon = this.WithRecovery(() => this.Expect(TokenType.Colon, b => b.ExpectedCharacter(":")), GetSuppressionFlag(expression), TokenType.RightSquare, TokenType.NewLine);
             var body = this.WithRecovery(
-                () => requireObjectLiteral ? this.Object() : this.Expression(allowComplexLiterals: true),
+                () => requireObjectLiteral ? this.Object(expressionFlags) : this.Expression(WithExpressionFlag(expressionFlags, ExpressionFlags.AllowComplexLiterals)),
                 GetSuppressionFlag(colon),
                 TokenType.RightSquare, TokenType.NewLine);
             var closeBracket = this.WithRecovery(() => this.Expect(TokenType.RightSquare, b => b.ExpectedCharacter("]")), GetSuppressionFlag(body), TokenType.RightSquare, TokenType.NewLine);
@@ -958,12 +993,12 @@ namespace Bicep.Core.Parsing
                     return this.NewLine();
                 }
 
-                var value = this.Expression(allowComplexLiterals: true);
+                var value = this.Expression(ExpressionFlags.AllowComplexLiterals);
                 return new ArrayItemSyntax(value);
             }, RecoveryFlags.None, TokenType.NewLine);
         }
 
-        private ObjectSyntax Object()
+        private ObjectSyntax Object(ExpressionFlags expressionFlags)
         {
             var openBrace = Expect(TokenType.LeftBrace, b => b.ExpectedCharacter("{"));
 
@@ -974,16 +1009,16 @@ namespace Bicep.Core.Parsing
                 return new ObjectSyntax(openBrace, ImmutableArray<SyntaxBase>.Empty, emptyCloseBrace);
             }
 
-            var propertiesOrTokens = new List<SyntaxBase>();
+            var propertiesOrResourcesTokens = new List<SyntaxBase>();
             while (!this.IsAtEnd() && this.reader.Peek().Type != TokenType.RightBrace)
             {
                 // this produces a property node, skipped tokens node, or just a newline token
-                var propertyOrToken = this.ObjectProperty();
-                propertiesOrTokens.Add(propertyOrToken);
+                var propertyOrResourceOrToken = this.ObjectProperty(expressionFlags);
+                propertiesOrResourcesTokens.Add(propertyOrResourceOrToken);
 
                 // if skipped tokens node is returned above, the newline is not consumed
                 // if newline token is returned, we must not expect another (could be beginning of a new property)
-                if (propertyOrToken is ObjectPropertySyntax)
+                if (propertyOrResourceOrToken is ObjectPropertySyntax)
                 {
                     if (Check(TokenType.Comma))
                     {
@@ -993,24 +1028,24 @@ namespace Bicep.Core.Parsing
                             token.AsEnumerable(),
                             DiagnosticBuilder.ForPosition(token.Span).UnexpectedCommaSeparator().AsEnumerable()
                         );
-                        propertiesOrTokens.Add(skippedSyntax);
+                        propertiesOrResourcesTokens.Add(skippedSyntax);
                     }
 
                     // properties must be followed by newlines
                     var newLine = this.WithRecoveryNullable(this.NewLineOrEof, RecoveryFlags.ConsumeTerminator, TokenType.NewLine);
                     if (newLine != null)
                     {
-                        propertiesOrTokens.Add(newLine);
+                        propertiesOrResourcesTokens.Add(newLine);
                     }
                 }
             }
 
             var closeBrace = Expect(TokenType.RightBrace, b => b.ExpectedCharacter("}"));
 
-            return new ObjectSyntax(openBrace, propertiesOrTokens, closeBrace);
+            return new ObjectSyntax(openBrace, propertiesOrResourcesTokens, closeBrace);
         }
 
-        private SyntaxBase ObjectProperty()
+        private SyntaxBase ObjectProperty(ExpressionFlags expressionFlags)
         {
             return this.WithRecovery<SyntaxBase>(() =>
             {
@@ -1019,6 +1054,20 @@ namespace Bicep.Core.Parsing
                 if (current.Type == TokenType.NewLine)
                 {
                     return this.NewLine();
+                }
+
+                // Nested resource declarations may be allowed - but we need lookahead to avoid
+                // treating 'resource' as a reserved property name.
+                if (HasExpressionFlag(expressionFlags, ExpressionFlags.AllowResourceDeclarations) && 
+                    CheckKeyword(LanguageConstants.ResourceKeyword) &&
+
+                    // You are here: |resource <name> ...
+                    //
+                    // If we see a non-identifier then it's not a resource declaration,
+                    // fall back to the property parser.
+                    Check(this.reader.PeekAhead(), TokenType.Identifier))
+                {
+                    return this.Declaration();
                 }
 
                 var key = this.WithRecovery(
@@ -1035,18 +1084,22 @@ namespace Bicep.Core.Parsing
                     TokenType.Colon, TokenType.NewLine);
 
                 var colon = this.WithRecovery(() => Expect(TokenType.Colon, b => b.ExpectedCharacter(":")), GetSuppressionFlag(key), TokenType.NewLine);
-                var value = this.WithRecovery(() => Expression(allowComplexLiterals: true), GetSuppressionFlag(colon), TokenType.NewLine);
+                var value = this.WithRecovery(() => Expression(ExpressionFlags.AllowComplexLiterals), GetSuppressionFlag(colon), TokenType.NewLine);
 
                 return new ObjectPropertySyntax(key, colon, value);
             }, RecoveryFlags.None, TokenType.NewLine);
         }
 
-        private SyntaxBase IfCondition()
+        private SyntaxBase IfCondition(ExpressionFlags expressionFlags)
         {
             var keyword = this.ExpectKeyword(LanguageConstants.IfKeyword);
-            var conditionExpression = this.WithRecovery(() => this.ParenthesizedExpression(true), RecoveryFlags.None, TokenType.LeftBrace, TokenType.NewLine);
+            var conditionExpression = this.WithRecovery(
+                () => this.ParenthesizedExpression(WithoutExpressionFlag(expressionFlags, ExpressionFlags.AllowResourceDeclarations)), 
+                RecoveryFlags.None, 
+                TokenType.LeftBrace, 
+                TokenType.NewLine);
             var body = this.WithRecovery(
-                this.Object,
+                () => this.Object(expressionFlags),
                 GetSuppressionFlag(conditionExpression, conditionExpression is ParenthesizedExpressionSyntax { CloseParen: not SkippedTriviaSyntax }),
                 TokenType.NewLine);
             return new IfConditionSyntax(keyword, conditionExpression, body);
@@ -1174,6 +1227,16 @@ namespace Bicep.Core.Parsing
             }
 
             return false;
+        }
+
+        private bool Check(Token? token, params TokenType[] types)
+        {
+            if (token is null)
+            {
+                return false;
+            }
+
+            return types.Contains(token.Type);
         }
 
         private bool Check(params TokenType[] types)

--- a/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
+++ b/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
@@ -150,6 +150,9 @@ namespace Bicep.Core.PrettyPrint
         public override void VisitPropertyAccessSyntax(PropertyAccessSyntax syntax) =>
             this.BuildWithConcat(() => base.VisitPropertyAccessSyntax(syntax));
 
+        public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax) =>
+            this.BuildWithConcat(() => base.VisitResourceAccessSyntax(syntax));
+
         public override void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax) =>
             this.BuildWithConcat(() => base.VisitParenthesizedExpressionSyntax(syntax));
 

--- a/src/Bicep.Core/Resources/ResourceTypeReference.cs
+++ b/src/Bicep.Core/Resources/ResourceTypeReference.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Bicep.Core.Extensions;
@@ -12,6 +13,8 @@ namespace Bicep.Core.Resources
     public class ResourceTypeReference
     {
         private static readonly Regex ResourceTypePattern = new Regex(@"^(?<namespace>[a-z0-9][a-z0-9\.]*)(/(?<type>[a-z0-9\-]+))+@(?<version>(\d{4}-\d{2}-\d{2})(-(preview|alpha|beta|rc|privatepreview))?$)", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex SingleTypePattern = new Regex(@"^(?<type>[a-z0-9\-]+)(@(?<version>(\d{4}-\d{2}-\d{2})(-(preview|alpha|beta|rc|privatepreview))?))?$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         public ResourceTypeReference(string @namespace, IEnumerable<string> types, string apiVersion)
         {
@@ -48,6 +51,39 @@ namespace Bicep.Core.Resources
         public string FormatName()
             => $"{this.FullyQualifiedType}@{this.ApiVersion}";
 
+        public bool IsParentOf(ResourceTypeReference other)
+        {
+            return 
+                StringComparer.OrdinalIgnoreCase.Equals(this.Namespace, other.Namespace) &&
+
+                // Parent should have N types, child should have N+1, first N types should be equal
+                this.Types.Length + 1 == other.Types.Length &&
+                Enumerable.SequenceEqual(this.Types, other.Types.Take(this.Types.Length), StringComparer.OrdinalIgnoreCase);
+        }
+
+        public static ResourceTypeReference? TryCombine(ResourceTypeReference baseType, IEnumerable<string> typeSegments)
+        {
+            var types = new List<string>(baseType.Types);
+
+            var bestVersion = baseType.ApiVersion;
+            foreach (var typeSegment in typeSegments)
+            {
+                if (!TryParseSingleTypeSegment(typeSegment, out var type, out var version))
+                {
+                    return null;
+                }
+
+                types.Add(type);
+
+                if (!string.IsNullOrEmpty(version))
+                {
+                    bestVersion = version;
+                }
+            }
+
+            return new ResourceTypeReference(baseType.Namespace, types, bestVersion);
+        }
+
         public static ResourceTypeReference? TryParse(string resourceType)
         {
             var match = ResourceTypePattern.Match(resourceType);
@@ -65,5 +101,25 @@ namespace Bicep.Core.Resources
 
         public static ResourceTypeReference Parse(string resourceType)
             => TryParse(resourceType) ?? throw new ArgumentException($"Unable to parse '{resourceType}'", nameof(resourceType));
+
+        public static bool TryParseSingleTypeSegment(string typeSegment, [NotNullWhen(true)] out string? type, out string? version)
+        {
+            var match = SingleTypePattern.Match(typeSegment);
+            if (match.Success == false)
+            {
+                type = null;
+                version = null;
+                return false;
+            }
+
+            type = match.Groups["type"].Value;
+            version = match.Groups["version"].Value;
+            if (version == "")
+            {
+                version = null;
+            }
+            
+            return true;
+        }
     }
 }

--- a/src/Bicep.Core/Semantics/DeclarationVisitor.cs
+++ b/src/Bicep.Core/Semantics/DeclarationVisitor.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Bicep.Core.Extensions;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Semantics
@@ -12,20 +12,21 @@ namespace Bicep.Core.Semantics
     {
         private readonly ISymbolContext context;
 
-        private readonly IList<DeclaredSymbol> declaredSymbols;
+        private readonly IList<DeclaredSymbol> declarations;
 
         private readonly IList<ScopeInfo> childScopes;
 
         private readonly Stack<ScopeInfo> activeScopes = new();
 
-        private DeclarationVisitor(ISymbolContext context, IList<DeclaredSymbol> declaredSymbols, IList<ScopeInfo> childScopes)
+        private DeclarationVisitor(ISymbolContext context, IList<DeclaredSymbol> declarations, IList<ScopeInfo> childScopes)
         {
             this.context = context;
-            this.declaredSymbols = declaredSymbols;
+            this.declarations = declarations;
             this.childScopes = childScopes;
         }
 
-        public static (ImmutableArray<DeclaredSymbol>, ImmutableArray<LocalScope>) GetAllDeclarations(SyntaxTree syntaxTree, ISymbolContext symbolContext)
+        // Returns the list of top level declarations as well as top level scopes.
+        public static (ImmutableArray<DeclaredSymbol>, ImmutableArray<LocalScope>) GetDeclarations(SyntaxTree syntaxTree, ISymbolContext symbolContext)
         {
             // collect declarations
             var declarations = new List<DeclaredSymbol>();
@@ -41,7 +42,7 @@ namespace Bicep.Core.Semantics
             base.VisitParameterDeclarationSyntax(syntax);
 
             var symbol = new ParameterSymbol(this.context, syntax.Name.IdentifierName, syntax, syntax.Modifier);
-            this.declaredSymbols.Add(symbol);
+            DeclareSymbol(symbol);
         }
 
         public override void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax)
@@ -49,15 +50,28 @@ namespace Bicep.Core.Semantics
             base.VisitVariableDeclarationSyntax(syntax);
 
             var symbol = new VariableSymbol(this.context, syntax.Name.IdentifierName, syntax, syntax.Value);
-            this.declaredSymbols.Add(symbol);
+            DeclareSymbol(symbol);
         }
 
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
         {
+            // Create a scope for each resource body - this ensures that nested resources 
+            // are contained within the appropriate scope.
+            //
+            // There may be additional scopes nested inside this between the resource declaration
+            // and the actual object body (for-loop). That's OK, in that case, this scope will
+            // be empty and we'll use the `for` scope for lookups.
+            var scope = new LocalScope(string.Empty, syntax, syntax.Value, ImmutableArray<DeclaredSymbol>.Empty, ImmutableArray<LocalScope>.Empty);
+            this.PushScope(scope);
+
             base.VisitResourceDeclarationSyntax(syntax);
 
+            this.PopScope();
+
+            // The resource itself should be declared in the enclosing scope - it's accessible to nested
+            // resource, but also siblings.
             var symbol = new ResourceSymbol(this.context, syntax.Name.IdentifierName, syntax);
-            this.declaredSymbols.Add(symbol);
+            DeclareSymbol(symbol);
         }
 
         public override void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax)
@@ -65,7 +79,7 @@ namespace Bicep.Core.Semantics
             base.VisitModuleDeclarationSyntax(syntax);
 
             var symbol = new ModuleSymbol(this.context, syntax.Name.IdentifierName, syntax);
-            this.declaredSymbols.Add(symbol);
+            DeclareSymbol(symbol);
         }
 
         public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
@@ -73,26 +87,38 @@ namespace Bicep.Core.Semantics
             base.VisitOutputDeclarationSyntax(syntax);
 
             var symbol = new OutputSymbol(this.context, syntax.Name.IdentifierName, syntax, syntax.Value);
-            this.declaredSymbols.Add(symbol);
+            DeclareSymbol(symbol);
         }
 
         public override void VisitForSyntax(ForSyntax syntax)
         {
+            // create new scope without any descendants
+            var scope = new LocalScope(string.Empty, syntax, syntax.Body, ImmutableArray<DeclaredSymbol>.Empty, ImmutableArray<LocalScope>.Empty);
+            this.PushScope(scope);
+
             /*
              * We cannot add the local symbol to the list of declarations because it will
              * break name binding at the global namespace level
              */
             var itemVariable = new LocalVariableSymbol(this.context, syntax.ItemVariable.Name.IdentifierName, syntax.ItemVariable);
-
-            // create new scope without any descendants
-            var scope = new LocalScope(string.Empty, syntax, syntax.Body, itemVariable.AsEnumerable(), ImmutableArray<LocalScope>.Empty);
-
-            this.PushScope(scope);
+            DeclareSymbol(itemVariable);
 
             // visit the children
             base.VisitForSyntax(syntax);
 
             this.PopScope();
+        }
+
+        private void DeclareSymbol(DeclaredSymbol symbol)
+        {
+            if (this.activeScopes.TryPeek(out var current))
+            {
+                current.Locals.Add(symbol);
+            }
+            else
+            {
+                this.declarations.Add(symbol);
+            }
         }
 
         private void PushScope(LocalScope scope)
@@ -101,6 +127,11 @@ namespace Bicep.Core.Semantics
 
             if (this.activeScopes.TryPeek(out var current))
             {
+                if (object.ReferenceEquals(current.Scope.BindingSyntax, scope.BindingSyntax))
+                {
+                    throw new InvalidOperationException($"Attempting to redefine the scope for {current.Scope.BindingSyntax}");
+                }
+
                 // add this one to the parent
                 current.Children.Add(item);
             }
@@ -120,7 +151,7 @@ namespace Bicep.Core.Semantics
 
         private static LocalScope MakeImmutable(ScopeInfo info)
         {
-            return info.Scope.ReplaceChildren(info.Children.Select(MakeImmutable));
+            return info.Scope.ReplaceChildren(info.Children.Select(MakeImmutable)).ReplaceLocals(info.Locals);
         }
 
         /// <summary>
@@ -136,6 +167,8 @@ namespace Bicep.Core.Semantics
             }
 
             public LocalScope Scope { get; }
+
+            public IList<DeclaredSymbol> Locals { get; } = new List<DeclaredSymbol>();
 
             public IList<ScopeInfo> Children { get; } = new List<ScopeInfo>();
         }

--- a/src/Bicep.Core/Semantics/FileSymbol.cs
+++ b/src/Bicep.Core/Semantics/FileSymbol.cs
@@ -34,7 +34,7 @@ namespace Bicep.Core.Semantics
             this.ModuleDeclarations = moduleDeclarations.ToImmutableArray();
             this.OutputDeclarations = outputDeclarations.ToImmutableArray();
 
-            this.declarationsByName = this.AllDeclarations.ToLookup(decl => decl.Name, LanguageConstants.IdentifierComparer);
+            this.declarationsByName = this.Declarations.ToLookup(decl => decl.Name, LanguageConstants.IdentifierComparer);
         }
 
         public override IEnumerable<Symbol> Descendants => this.ImportedNamespaces.Values
@@ -66,7 +66,7 @@ namespace Bicep.Core.Semantics
         /// <summary>
         /// Returns all the top-level declaration symbols.
         /// </summary>
-        public IEnumerable<DeclaredSymbol> AllDeclarations => this.Descendants.OfType<DeclaredSymbol>();
+        public IEnumerable<DeclaredSymbol> Declarations => this.Descendants.OfType<DeclaredSymbol>();
 
         public override void Accept(SymbolVisitor visitor)
         {
@@ -76,6 +76,8 @@ namespace Bicep.Core.Semantics
         public override IEnumerable<ErrorDiagnostic> GetDiagnostics() => DuplicateIdentifierValidatorVisitor.GetDiagnostics(this);
 
         public IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name) => this.declarationsByName[name];
+
+        public IEnumerable<ResourceSymbol> GetAllResourceDeclarations() => ResourceSymbolVisitor.GetAllResources(this);
 
         private sealed class DuplicateIdentifierValidatorVisitor : SymbolVisitor
         {
@@ -111,8 +113,8 @@ namespace Bicep.Core.Semantics
                 // collect duplicate identifiers at this scope
                 // declaring a variable in a local scope hides the parent scope variables,
                 // so we don't need to look at other levels
-                var outputDeclarations = scope.AllDeclarations.Where(decl => decl is OutputSymbol);
-                var nonOutputDeclarations = scope.AllDeclarations.Where(decl => decl is not OutputSymbol);
+                var outputDeclarations = scope.Declarations.Where(decl => decl is OutputSymbol);
+                var nonOutputDeclarations = scope.Declarations.Where(decl => decl is not OutputSymbol);
 
                 // all symbols apart from outputs are in the same namespace, so check for uniqueness.
                 this.Diagnostics.AddRange(

--- a/src/Bicep.Core/Semantics/IBinder.cs
+++ b/src/Bicep.Core/Semantics/IBinder.cs
@@ -7,14 +7,12 @@ using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Semantics
 {
-    public interface IBinder
+    public interface IBinder : ISyntaxHierarchy
     {
         ResourceScope TargetScope { get; }
 
         FileSymbol FileSymbol { get; }
-
-        SyntaxBase? GetParent(SyntaxBase syntax);
-
+        
         IEnumerable<SyntaxBase> FindReferences(Symbol symbol);
 
         Symbol? GetSymbolInfo(SyntaxBase syntax);

--- a/src/Bicep.Core/Semantics/ILanguageScope.cs
+++ b/src/Bicep.Core/Semantics/ILanguageScope.cs
@@ -9,6 +9,6 @@ namespace Bicep.Core.Semantics
     {
         IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name);
 
-        IEnumerable<DeclaredSymbol> AllDeclarations { get; }
+        IEnumerable<DeclaredSymbol> Declarations { get; }
     }
 }

--- a/src/Bicep.Core/Semantics/LocalScope.cs
+++ b/src/Bicep.Core/Semantics/LocalScope.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Bicep.Core.Diagnostics;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Semantics
@@ -13,7 +12,7 @@ namespace Bicep.Core.Semantics
     /// </summary>
     public class LocalScope : Symbol, ILanguageScope
     {
-        public LocalScope(string name, SyntaxBase declaringSyntax, SyntaxBase bindingSyntax, IEnumerable<LocalVariableSymbol> locals, IEnumerable<LocalScope> childScopes)
+        public LocalScope(string name, SyntaxBase declaringSyntax, SyntaxBase bindingSyntax, IEnumerable<DeclaredSymbol> locals, IEnumerable<LocalScope> childScopes)
             : base(name)
         {
             this.DeclaringSyntax = declaringSyntax;
@@ -33,7 +32,7 @@ namespace Bicep.Core.Semantics
         /// <remarks>Identifiers within this node will first bind to symbols in this scope. Identifiers above this node will bind to the parent scope.</remarks>
         public SyntaxBase BindingSyntax { get; }
 
-        public ImmutableArray<LocalVariableSymbol> Locals { get; }
+        public ImmutableArray<DeclaredSymbol> Locals { get; }
 
         public ImmutableArray<LocalScope> ChildScopes { get; }
 
@@ -43,10 +42,12 @@ namespace Bicep.Core.Semantics
 
         public override IEnumerable<Symbol> Descendants => this.ChildScopes.Concat<Symbol>(this.Locals);
 
+        public LocalScope ReplaceLocals(IEnumerable<DeclaredSymbol> newLocals) => new(this.Name, this.DeclaringSyntax, this.BindingSyntax, newLocals, this.ChildScopes);
+
         public LocalScope ReplaceChildren(IEnumerable<LocalScope> newChildren) => new(this.Name, this.DeclaringSyntax, this.BindingSyntax, this.Locals, newChildren);
 
         public IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name) => this.Locals.Where(symbol => symbol.NameSyntax.IsValid && string.Equals(symbol.Name, name, LanguageConstants.IdentifierComparison)).ToList();
         
-        public IEnumerable<DeclaredSymbol> AllDeclarations => this.Locals;
+        public IEnumerable<DeclaredSymbol> Declarations => this.Locals;
     }
 }

--- a/src/Bicep.Core/Semantics/NameBindingVisitor.cs
+++ b/src/Bicep.Core/Semantics/NameBindingVisitor.cs
@@ -52,7 +52,7 @@ namespace Bicep.Core.Semantics
             // include all the locals in the symbol table as well
             // since we only allow lookups by object and not by name,
             // a flat symbol table should be sufficient
-            foreach (var declaredSymbol in allLocalScopes.Values.SelectMany(scope => scope.AllDeclarations))
+            foreach (var declaredSymbol in allLocalScopes.Values.SelectMany(scope => scope.Declarations))
             {
                 this.bindings.Add(declaredSymbol.DeclaringSyntax, declaredSymbol);
             }
@@ -66,6 +66,57 @@ namespace Bicep.Core.Semantics
 
             // bind what we got - the type checker will validate if it fits
             this.bindings.Add(syntax, symbol);
+        }
+
+        public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
+        {
+            base.VisitResourceAccessSyntax(syntax);
+
+            // we need to resolve which resource delaration the LHS is pointing to - and then 
+            // validate that we can resolve the name.
+            this.bindings.TryGetValue(syntax.BaseExpression, out var symbol);
+
+            if (symbol is ErrorSymbol)
+            {
+                this.bindings.Add(syntax, symbol);
+                return;
+            }
+            else if (symbol is null || symbol is not ResourceSymbol)
+            {
+                // symbol could be null in the case of an incomplete expression during parsing like `a:`
+                var error = new ErrorSymbol(DiagnosticBuilder.ForPosition(syntax.ResourceName).ResourceRequiredForResourceAccess(symbol?.Kind.ToString() ?? LanguageConstants.ErrorName));
+                this.bindings.Add(syntax, error);
+                return;
+            }
+
+            // This is the symbol of LHS and it's a valid resource.
+            var resourceSymbol = (ResourceSymbol)symbol;
+            var resourceBody = resourceSymbol.DeclaringResource.TryGetBody();
+            if (resourceBody == null)
+            {
+                // If we have no body then there will be nothing to reference.
+                var error = new ErrorSymbol(DiagnosticBuilder.ForPosition(syntax.ResourceName).NestedResourceNotFound(resourceSymbol.Name, syntax.ResourceName.IdentifierName, nestedResourceNames: new []{ "(none)", }));
+                this.bindings.Add(syntax, error);
+                return;
+            }
+
+            if (!this.allLocalScopes.TryGetValue(resourceBody, out var localScope))
+            {
+                // code defect in the declaration visitor
+                throw new InvalidOperationException($"Local scope is missing for {syntax.GetType().Name} at {syntax.Span}");
+            }
+
+            var referencedResource = LookupResourceSymbolByName(localScope, syntax.ResourceName);
+            if (referencedResource is null)
+            {
+                var nestedResourceNames = localScope.Declarations.OfType<ResourceSymbol>().Select(r => r.Name);
+                var error = new ErrorSymbol(DiagnosticBuilder.ForPosition(syntax.ResourceName).NestedResourceNotFound(resourceSymbol.Name, syntax.ResourceName.IdentifierName, nestedResourceNames));
+                this.bindings.Add(syntax, error);
+                return;
+            }
+            
+            // This is valid.
+            this.bindings.Add(syntax, referencedResource);
         }
 
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
@@ -277,7 +328,12 @@ namespace Bicep.Core.Semantics
             // loops currently are the only source of local symbols
             // as a result a local scope can contain between 1 to 2 local symbols
             // linear search should be fine, but this should be revisited if the above is no longer holds true
-            scope.AllDeclarations.FirstOrDefault(symbol => string.Equals(identifierSyntax.IdentifierName, symbol.Name, LanguageConstants.IdentifierComparison));
+            scope.Declarations.FirstOrDefault(symbol => string.Equals(identifierSyntax.IdentifierName, symbol.Name, LanguageConstants.IdentifierComparison));
+
+        private static ResourceSymbol? LookupResourceSymbolByName(ILanguageScope scope, IdentifierSyntax identifierSyntax) =>
+            scope.Declarations
+                .OfType<ResourceSymbol>()
+                .FirstOrDefault(symbol => string.Equals(identifierSyntax.IdentifierName, symbol.Name, LanguageConstants.IdentifierComparison));
 
         private Symbol LookupGlobalSymbolByName(IdentifierSyntax identifierSyntax, bool isFunctionCall)
         {
@@ -319,6 +375,19 @@ namespace Bicep.Core.Semantics
         private class ScopeCollectorVisitor: SymbolVisitor
         {
             private IDictionary<SyntaxBase, LocalScope> ScopeMap { get; } = new Dictionary<SyntaxBase, LocalScope>();
+
+
+            protected override void VisitInternal(Symbol node)
+            {
+                // We haven't typed checked yet, so don't visit anything that isn't a scope.
+                // 
+                // Now that resources can appear in a scope, this causes problems if we visit them and try
+                // to get type info.
+                if (node is ILanguageScope)
+                {
+                    base.VisitInternal(node);
+                }
+            }
 
             public override void VisitLocalScope(LocalScope symbol)
             {

--- a/src/Bicep.Core/Semantics/ResourceAncestorGraph.cs
+++ b/src/Bicep.Core/Semantics/ResourceAncestorGraph.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Semantics
+{
+    public sealed class ResourceAncestorGraph
+    {
+        private readonly ImmutableDictionary<ResourceSymbol, ImmutableArray<ResourceSymbol>> data;
+
+        public ResourceAncestorGraph(ImmutableDictionary<ResourceSymbol, ImmutableArray<ResourceSymbol>> data)
+        {
+            this.data = data;
+        }
+
+        // Gets the ordered list of ancestors of this resource in order from 'oldest' to 'youngest'
+        // this is the same order we need to compute the name of a resource using `/` separated segments in a string.
+        public ImmutableArray<ResourceSymbol> GetAncestors(ResourceSymbol resource)
+        {
+            if (data.TryGetValue(resource, out var results))
+            {
+                return results;
+            }
+            else
+            {
+                return ImmutableArray<ResourceSymbol>.Empty;
+            }
+        }
+
+        public static ResourceAncestorGraph Compute(SyntaxTree syntaxTree, IBinder binder)
+        {
+            var visitor = new ResourceAncestorVisitor(binder);
+            visitor.Visit(syntaxTree.ProgramSyntax);
+            return new ResourceAncestorGraph(visitor.Ancestry);
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/ResourceAncestorVisitor.cs
+++ b/src/Bicep.Core/Semantics/ResourceAncestorVisitor.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Semantics
+{
+    public sealed class ResourceAncestorVisitor : SyntaxVisitor
+    {
+        private readonly IBinder binder;
+        private readonly Stack<ResourceSymbol> ancestorResources;
+        private readonly ImmutableDictionary<ResourceSymbol, ImmutableArray<ResourceSymbol>>.Builder ancestry;
+
+        public ResourceAncestorVisitor(IBinder binder)
+        {
+            this.binder = binder;
+            this.ancestorResources = new Stack<ResourceSymbol>();
+            this.ancestry = ImmutableDictionary.CreateBuilder<ResourceSymbol, ImmutableArray<ResourceSymbol>>();
+        }
+
+        public ImmutableDictionary<ResourceSymbol, ImmutableArray<ResourceSymbol>> Ancestry 
+            => this.ancestry.ToImmutableDictionary();
+
+        public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
+        {
+            // Skip analysis for ErrorSymbol and similar cases, these are invalid cases, and won't be emitted.
+            var symbol = this.binder.GetSymbolInfo(syntax) as ResourceSymbol;
+            if (symbol is null)
+            {
+                base.VisitResourceDeclarationSyntax(syntax);
+                return;
+            }
+
+            // We don't need to do anything here to validate types and their relationships, that was handled during type assignment.
+            this.ancestry.Add(symbol, ImmutableArray.CreateRange(this.ancestorResources.Reverse()));
+
+            try
+            {
+                // This will recursively process the resource body - capture the 'current' declaration's declared resource
+                // type so we can validate nesting.
+                this.ancestorResources.Push(symbol);
+                base.VisitResourceDeclarationSyntax(syntax);
+            }
+            finally
+            {
+                this.ancestorResources.Pop();
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/ResourceSymbol.cs
+++ b/src/Bicep.Core/Semantics/ResourceSymbol.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
+using Bicep.Core.Resources;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 
@@ -28,5 +29,20 @@ namespace Bicep.Core.Semantics
         }
 
         public bool IsCollection => this.Context.TypeManager.GetTypeInfo(this.DeclaringResource) is ArrayType;
+
+        public ResourceTypeReference? TryGetResourceTypeReference()
+        {
+            if (this.Type is ResourceType resourceType)
+            {
+                return resourceType.TypeReference;
+            }
+
+            if (this.Type is ArrayType arrayType && arrayType.Item.Type is ResourceType itemType)
+            {
+                return itemType.TypeReference;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Bicep.Core/Semantics/ResourceSymbolVisitor.cs
+++ b/src/Bicep.Core/Semantics/ResourceSymbolVisitor.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Semantics
+{
+    public class ResourceSymbolVisitor : SymbolVisitor
+    {
+        public static ImmutableArray<ResourceSymbol> GetAllResources(Symbol symbol)
+        {
+            var resources = new List<ResourceSymbol>();
+            var visitor = new ResourceSymbolVisitor(resources);
+            visitor.Visit(symbol);
+
+            return resources.ToImmutableArray();
+        }
+
+        private readonly List<ResourceSymbol> resources;
+
+        public ResourceSymbolVisitor(List<ResourceSymbol> resources)
+        {
+            this.resources = resources;
+        }
+
+        public override void VisitResourceSymbol(ResourceSymbol symbol)
+        {
+            resources.Add(symbol);
+            base.VisitResourceSymbol(symbol);
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -15,6 +15,7 @@ namespace Bicep.Core.Semantics
     {
         private readonly Lazy<EmitLimitationInfo> emitLimitationInfoLazy;
         private readonly Lazy<SymbolHierarchy> symbolHierarchyLazy;
+        private readonly Lazy<ResourceAncestorGraph> resourceAncestorsLazy;
 
         public SemanticModel(Compilation compilation, SyntaxTree syntaxTree)
         {
@@ -42,6 +43,8 @@ namespace Bicep.Core.Semantics
 
                 return hierarchy;
             });
+            this.resourceAncestorsLazy = new Lazy<ResourceAncestorGraph>(() => ResourceAncestorGraph.Compute(syntaxTree, Binder));
+
         }
 
         public SyntaxTree SyntaxTree { get; }
@@ -55,6 +58,8 @@ namespace Bicep.Core.Semantics
         public ITypeManager TypeManager { get; }
 
         public EmitLimitationInfo EmitLimitationInfo => emitLimitationInfoLazy.Value;
+
+        public ResourceAncestorGraph ResourceAncestors => resourceAncestorsLazy.Value;
 
         /// <summary>
         /// Gets all the parser and lexer diagnostics unsorted. Does not include diagnostics from the semantic model.

--- a/src/Bicep.Core/Semantics/SymbolExtensions.cs
+++ b/src/Bicep.Core/Semantics/SymbolExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Semantics
@@ -12,6 +13,12 @@ namespace Bicep.Core.Semantics
 
         public static SyntaxBase? SafeGetBodyPropertyValue(this ResourceSymbol resourceSymbol, string propertyName)
             => SafeGetBodyProperty(resourceSymbol, propertyName)?.Value;
+
+        public static ObjectPropertySyntax UnsafeGetBodyProperty(this ResourceSymbol resourceSymbol, string propertyName)
+            => resourceSymbol.SafeGetBodyProperty(propertyName) ?? throw new ArgumentException($"Expected resource syntax body to contain property '{propertyName}'");
+
+        public static SyntaxBase UnsafeGetBodyPropertyValue(this ResourceSymbol resourceSymbol, string propertyName)
+            => resourceSymbol.SafeGetBodyPropertyValue(propertyName) ?? throw new ArgumentException($"Expected resource syntax body to contain property '{propertyName}'");
 
         public static ObjectPropertySyntax? SafeGetBodyProperty(this ModuleSymbol moduleSymbol, string propertyName)
             => moduleSymbol.DeclaringModule.TryGetBody()?.SafeGetPropertyByName(propertyName);

--- a/src/Bicep.Core/Syntax/ISyntaxHierarchy.cs
+++ b/src/Bicep.Core/Syntax/ISyntaxHierarchy.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Syntax
+{
+    public interface ISyntaxHierarchy
+    {
+        /// <summary>
+        /// Gets the parent of the specified node. Returns null for root nodes. Throws an exception for nodes that have not been indexed.
+        /// </summary>
+        /// <param name="node">The node</param>
+        SyntaxBase? GetParent(SyntaxBase node);
+
+        /// <summary>
+        /// Gets all ancestor nodes assignable to <typeparamref name="TSyntax" /> in descending order
+        /// from the top of the tree.
+        /// </summary>
+        /// <param name="syntax">The syntax node.</param>
+        /// <typeparam name="TSyntax">The type of node to query.</typeparam>
+        /// <returns>The list of ancestors.</returns>
+        public ImmutableArray<TSyntax> GetAllAncestors<TSyntax>(SyntaxBase syntax) where TSyntax : SyntaxBase
+        {
+            var ancestors = new List<TSyntax>();
+
+            SyntaxBase? next = syntax;
+            do
+            {
+                next = GetParent(next);
+                if (next is TSyntax match)
+                {
+                    ancestors.Insert(0, match);
+                }
+            }
+            while (next is not null);
+
+            return ancestors.ToImmutableArray();
+        }
+
+        /// <summary>
+        /// Gets the nearest ancestor assignable to <typeparamref name="TSyntax" /> above <paramref name="syntax" />
+        /// in an ascending walk towards the root of the syntax tree.
+        /// </summary>
+        /// <param name="syntax">The syntax node.</param>
+        /// <typeparam name="TSyntax">The type of node to query.</typeparam>
+        /// <returns>The nearest ancestor or <c>null</c>.</returns>
+        public TSyntax? GetNearestAncestor<TSyntax>(SyntaxBase syntax) where TSyntax : SyntaxBase
+        {
+            SyntaxBase? next = syntax;
+            do
+            {
+                next = GetParent(next);
+                if (next is TSyntax match)
+                {
+                    return match;
+                }
+            }
+            while (next is not null);
+
+            // Reached the top without finding a match.
+            return null;
+        }
+    }
+}

--- a/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
@@ -46,6 +46,8 @@ namespace Bicep.Core.Syntax
 
         void VisitPropertyAccessSyntax(PropertyAccessSyntax syntax);
 
+        void VisitResourceAccessSyntax(ResourceAccessSyntax syntax);
+
         void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax);
 
         void VisitSeparatedSyntaxList(SeparatedSyntaxList syntax);

--- a/src/Bicep.Core/Syntax/ObjectSyntax.cs
+++ b/src/Bicep.Core/Syntax/ObjectSyntax.cs
@@ -37,5 +37,10 @@ namespace Bicep.Core.Syntax
         /// Gets the object properties. May return duplicate properties.
         /// </summary>
         public IEnumerable<ObjectPropertySyntax> Properties => this.Children.OfType<ObjectPropertySyntax>();
+
+        /// <summary>
+        /// Gets the child resources of this object.
+        /// </summary>
+        public IEnumerable<ResourceDeclarationSyntax> Resources => this.Children.OfType<ResourceDeclarationSyntax>();
     }
 }

--- a/src/Bicep.Core/Syntax/ResourceAccessSyntax.cs
+++ b/src/Bicep.Core/Syntax/ResourceAccessSyntax.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Navigation;
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    public class ResourceAccessSyntax : ExpressionSyntax, ISymbolReference
+    {
+        public ResourceAccessSyntax(SyntaxBase baseExpression, Token colon, IdentifierSyntax resourceName)
+        {
+            AssertTokenType(colon, nameof(colon), TokenType.Colon);
+
+            this.BaseExpression = baseExpression;
+            this.Colon = colon;
+            this.ResourceName = resourceName;
+        }
+
+        public SyntaxBase BaseExpression { get; }
+
+        public Token Colon { get; }
+
+        public IdentifierSyntax ResourceName { get; }
+
+        IdentifierSyntax ISymbolReference.Name => ResourceName;
+
+        public override void Accept(ISyntaxVisitor visitor) => visitor.VisitResourceAccessSyntax(this);
+
+        public override TextSpan Span => TextSpan.Between(BaseExpression, ResourceName);
+    }
+}

--- a/src/Bicep.Core/Syntax/SyntaxHierarchy.cs
+++ b/src/Bicep.Core/Syntax/SyntaxHierarchy.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Bicep.Core.Syntax
 {
-    public class SyntaxHierarchy
+    public class SyntaxHierarchy : ISyntaxHierarchy
     {
         private readonly Dictionary<SyntaxBase, SyntaxBase?> parentMap = new Dictionary<SyntaxBase, SyntaxBase?>();
 
@@ -36,10 +37,10 @@ namespace Bicep.Core.Syntax
         public bool IsDescendant(SyntaxBase node, SyntaxBase potentialAncestor)
         {
             var current = node;
-            while(current != null)
+            while (current != null)
             {
                 current = this.GetParent(current);
-                if(ReferenceEquals(current,potentialAncestor))
+                if (ReferenceEquals(current, potentialAncestor))
                 {
                     return true;
                 }
@@ -48,7 +49,29 @@ namespace Bicep.Core.Syntax
             return false;
         }
 
-        private sealed class ParentTrackingVisitor: SyntaxVisitor
+        /// <summary>
+        /// Gets all ancestor nodes assignable to <typeparamref name="TSyntax" /> in descending order
+        /// from the top of the tree.
+        /// </summary>
+        /// <param name="syntax">The syntax node.</param>
+        /// <typeparam name="TSyntax">The type of node to query.</typeparam>
+        /// <returns>The list of ancestors.</returns>
+        public ImmutableArray<TSyntax> GetAllAncestors<TSyntax>(SyntaxBase syntax) where TSyntax : SyntaxBase =>
+            // Use default implementation
+            ((ISyntaxHierarchy)this).GetAllAncestors<TSyntax>(syntax);
+
+        /// <summary>
+        /// Gets the nearest ancestor assignable to <typeparamref name="TSyntax" /> above <paramref name="syntax" />
+        /// in an ascending walk towards the root of the syntax tree.
+        /// </summary>
+        /// <param name="syntax">The syntax node.</param>
+        /// <typeparam name="TSyntax">The type of node to query.</typeparam>
+        /// <returns>The nearest ancestor or <c>null</c>.</returns>
+        public TSyntax? GetNearestAncestor<TSyntax>(SyntaxBase syntax) where TSyntax : SyntaxBase =>
+            // Use default implementation
+            ((ISyntaxHierarchy)this).GetNearestAncestor<TSyntax>(syntax);
+
+        private sealed class ParentTrackingVisitor : SyntaxVisitor
         {
             private readonly Dictionary<SyntaxBase, SyntaxBase?> parentMap;
             private readonly Stack<SyntaxBase> currentParents = new Stack<SyntaxBase>();

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -474,6 +474,21 @@ namespace Bicep.Core.Syntax
         }
         void ISyntaxVisitor.VisitPropertyAccessSyntax(PropertyAccessSyntax syntax) => ReplaceCurrent(syntax, ReplacePropertyAccessSyntax);
 
+        protected virtual ResourceAccessSyntax ReplaceResourceAccessSyntax(ResourceAccessSyntax syntax)
+        {
+            var hasChanges = Rewrite(syntax.BaseExpression, out var baseExpression);
+            hasChanges |= Rewrite(syntax.Colon, out var colon);
+            hasChanges |= Rewrite(syntax.ResourceName, out var propertyName);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new ResourceAccessSyntax(baseExpression, colon, propertyName);
+        }
+        void ISyntaxVisitor.VisitResourceAccessSyntax(ResourceAccessSyntax syntax) => ReplaceCurrent(syntax, ReplaceResourceAccessSyntax);
+
         protected virtual ParenthesizedExpressionSyntax ReplaceParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax)
         {
             var hasChanges = Rewrite(syntax.OpenParen, out var openParen);

--- a/src/Bicep.Core/Syntax/SyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxVisitor.cs
@@ -249,6 +249,13 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.PropertyName);
         }
 
+        public virtual void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
+        {
+            this.Visit(syntax.BaseExpression);
+            this.Visit(syntax.Colon);
+            this.Visit(syntax.ResourceName);
+        }
+
         public virtual void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax)
         {
             this.Visit(syntax.OpenParen);

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantVisitor.cs
@@ -37,7 +37,7 @@ namespace Bicep.Core.TypeSystem
         public static void ValidateDeployTimeConstants(SemanticModel model, IDiagnosticWriter diagnosticWriter)
         {
             var deploymentTimeConstantVisitor = new DeployTimeConstantVisitor(model, diagnosticWriter);
-            foreach (var declaredSymbol in model.Root.ResourceDeclarations)
+            foreach (var declaredSymbol in model.Root.GetAllResourceDeclarations())
             {
                 deploymentTimeConstantVisitor.Visit(declaredSymbol.DeclaringSyntax);
             }
@@ -54,6 +54,7 @@ namespace Bicep.Core.TypeSystem
             // in certain cases, errors will cause this visitor to short-circuit, 
             // which causes state to be left over after processing a peer declaration
             // let's clean it up
+            var previousBodyType = this.bodyType;
             this.bodyType = null;
             ResetState();
 
@@ -74,7 +75,7 @@ namespace Bicep.Core.TypeSystem
             }
 
             base.VisitResourceDeclarationSyntax(syntax);
-            this.bodyType = null;
+            this.bodyType = previousBodyType;
         }
 
         public override void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax)

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -200,7 +200,7 @@ namespace Bicep.Core.TypeSystem
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
             => AssignTypeWithDiagnostics(syntax, diagnostics =>
             {
-                var singleResourceDeclaredType = syntax.GetDeclaredType(resourceTypeProvider);
+                var singleResourceDeclaredType = syntax.GetDeclaredType(binder, resourceTypeProvider);
                 var singleOrCollectionDeclaredType = syntax.Value is ForSyntax
                     ? new TypedArrayType(singleResourceDeclaredType, TypeSymbolValidationFlags.Default)
                     : singleResourceDeclaredType;
@@ -766,6 +766,51 @@ namespace Bicep.Core.TypeSystem
                         // can only access properties of objects
                         return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.PropertyName).ObjectRequiredForPropertyAccess(baseType));
                 }
+            });
+
+        public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
+            => AssignTypeWithDiagnostics(syntax, diagnostics => {
+                var errors = new List<ErrorDiagnostic>();
+
+                var baseType = typeManager.GetTypeInfo(syntax.BaseExpression);
+                CollectErrors(errors, baseType);
+
+                if (PropagateErrorType(errors, baseType))
+                {
+                    return ErrorType.Create(errors);
+                }
+
+                if (baseType is not ResourceType)
+                {
+                    // can only access children of resources
+                    return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.ResourceName).ResourceRequiredForResourceAccess(baseType.Name));
+                }
+
+                if (!syntax.ResourceName.IsValid)
+                {
+                    // the resource name is not valid
+                    // there's already a parse error for it, so we don't need to add a type error as well
+                    return ErrorType.Empty();
+                }
+
+                // Should have a symbol from name binding.
+                var symbol = binder.GetSymbolInfo(syntax);
+                if (symbol == null)
+                {
+                    throw new InvalidOperationException("ResourceAccessSyntax was not assigned a symbol during name binding.");
+                }
+
+                if (symbol is ErrorSymbol error)
+                {
+                    return ErrorType.Create(error.GetDiagnostics());
+                }
+                else if (symbol is not ResourceSymbol)
+                {
+                    return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.ResourceName).ResourceRequiredForResourceAccess(baseType.Kind.ToString()));
+                }
+
+                // This is a valid nested resource. Return its type.
+                return typeManager.GetTypeInfo(((ResourceSymbol)symbol).DeclaringResource);
             });
 
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)

--- a/src/Bicep.Decompiler/Rewriters/ParentChildResourceNameRewriter.cs
+++ b/src/Bicep.Decompiler/Rewriters/ParentChildResourceNameRewriter.cs
@@ -41,7 +41,7 @@ namespace Bicep.Core.Decompiler.Rewriters
                 return syntax;
             }
 
-            foreach (var otherResourceSymbol in semanticModel.Root.ResourceDeclarations)
+            foreach (var otherResourceSymbol in semanticModel.Root.GetAllResourceDeclarations())
             {
                 if (otherResourceSymbol.Type is not ResourceType otherResourceType ||
                     otherResourceType.TypeReference.Types.Length != resourceType.TypeReference.Types.Length - 1 ||

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
@@ -112,13 +112,13 @@ namespace Bicep.LangServer.IntegrationTests
 
         public static Position GetPosition(ImmutableArray<int> lineStarts, SyntaxBase syntax)
         {
-            if (syntax is InstanceFunctionCallSyntax instanceFunctionCall)
+            if (syntax is ISymbolReference reference)
             {
                 // get identifier span otherwise syntax.Span returns the position from the starting position of the whole expression.
                 // e.g. in an instance function call such as: az.resourceGroup(), syntax.Span position starts at 'az',
                 // whereas instanceFunctionCall.Name.Span the position will start in resourceGroup() which is what it should be in this
                 // case.
-                return PositionHelper.GetPosition(lineStarts, instanceFunctionCall.Name.Span.Position);
+                return PositionHelper.GetPosition(lineStarts, reference.Name.Span.Position);
             }
 
             if (syntax is ITopLevelDeclarationSyntax declaration)

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -63,9 +63,12 @@ namespace Bicep.LangServer.IntegrationTests
 
             foreach (SyntaxBase symbolReference in symbolReferences)
             {
-                var syntaxPosition = symbolReference is ITopLevelDeclarationSyntax declaration
-                    ? declaration.Keyword.Span.Position
-                    : symbolReference.Span.Position;
+                var syntaxPosition = symbolReference switch
+                {
+                    ITopLevelDeclarationSyntax d => d.Keyword.Span.Position,
+                    ResourceAccessSyntax r => r.ResourceName.Span.Position,
+                    _ => symbolReference.Span.Position,
+                };
 
                 var hover = await client.RequestHover(new HoverParams
                 {

--- a/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
@@ -45,13 +45,13 @@ namespace Bicep.LangServer.IntegrationTests
                 .ToLookup(pair => pair.Value, pair => pair.Key);
 
             var validVariableAccessPairs = symbolTable
-                .Where(pair => (pair.Key is VariableAccessSyntax || pair.Key is ITopLevelNamedDeclarationSyntax)
+                .Where(pair => (pair.Key is VariableAccessSyntax || pair.Key is ResourceAccessSyntax || pair.Key is ITopLevelNamedDeclarationSyntax)
                                && pair.Value.Kind != SymbolKind.Error
                                && pair.Value.Kind != SymbolKind.Function
                                && pair.Value.Kind != SymbolKind.Namespace
                                // symbols whose identifiers have parse errors will have a name like <error> or <missing>
                                && pair.Value.Name.Contains("<") == false);
-
+            
             const string expectedNewText = "NewIdentifier";
             foreach (var (syntax, symbol) in validVariableAccessPairs)
             {

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -198,7 +198,7 @@ output o int = 42
             resourceCompletion.Kind.Should().Be(CompletionItemKind.Interface);
             resourceCompletion.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
             resourceCompletion.TextEdit!.NewText.Should().Be(expectedResource);
-            resourceCompletion.CommitCharacters.Should().BeNull();
+            resourceCompletion.CommitCharacters.Should().BeEquivalentTo(new[]{ ":", });
             resourceCompletion.Detail.Should().Be(expectedResource);
 
             const string expectedParam = "p";
@@ -305,7 +305,7 @@ output length int =
             resourceCompletion.Kind.Should().Be(CompletionItemKind.Interface);
             resourceCompletion.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
             resourceCompletion.TextEdit!.NewText.Should().Be(expectedResource);
-            resourceCompletion.CommitCharacters.Should().BeNull();
+            resourceCompletion.CommitCharacters.Should().BeEquivalentTo(new []{ ":", });
             resourceCompletion.Detail.Should().Be(expectedResource);
 
             const string expectedParam = "concat";

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -71,20 +71,30 @@ namespace Bicep.LanguageServer.Completions
         /// The current location is accessing properties or methods.
         /// </summary>
         MemberAccess = 1 << 11,
+
+        /// <summary>
+        /// The current location is accessing a nested resource.
+        /// </summary>
+        ResourceAccess = 1 << 12,
         
         /// <summary>
         /// The current location needs target scope value.
         /// </summary>
-        TargetScope = 1 << 12,
+        TargetScope = 1 << 13,
 
         /// <summary>
         /// The current location needs an array index.
         /// </summary>
-        ArrayIndex = 1 << 13,
+        ArrayIndex = 1 << 14,
 
         /// <summary>
         /// The current location needs a decorator name.
         /// </summary>
-        DecoratorName = 1 << 14,
+        DecoratorName = 1 << 15,
+
+        /// <summary>
+        /// The current location could be the start of a nested resource declaration.
+        /// </summary>
+        NestedResourceDeclarationStart = 1 << 16,
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepDocumentSymbolHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDocumentSymbolHandler.cs
@@ -52,7 +52,7 @@ namespace Bicep.LanguageServer.Handlers
 
         private IEnumerable<SymbolInformationOrDocumentSymbol> GetSymbols(CompilationContext context)
         {
-            return context.Compilation.GetEntrypointSemanticModel().Root.AllDeclarations
+            return context.Compilation.GetEntrypointSemanticModel().Root.Declarations
                 .OrderBy(symbol=>symbol.DeclaringSyntax.Span.Position)
                 .Select(symbol => new SymbolInformationOrDocumentSymbol(CreateDocumentSymbol(symbol, context.LineStarts)));
         }

--- a/src/Bicep.LangServer/SemanticTokenVisitor.cs
+++ b/src/Bicep.LangServer/SemanticTokenVisitor.cs
@@ -132,6 +132,12 @@ namespace Bicep.LanguageServer
             base.VisitPropertyAccessSyntax(syntax);
         }
 
+        public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
+        {
+            AddTokenType(syntax.ResourceName, SemanticTokenType.Property);
+            base.VisitResourceAccessSyntax(syntax);
+        }
+
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
         {
             AddTokenType(syntax.Keyword, SemanticTokenType.Keyword);

--- a/src/Bicep.Wasm/LanguageHelpers/SemanticTokenVisitor.cs
+++ b/src/Bicep.Wasm/LanguageHelpers/SemanticTokenVisitor.cs
@@ -128,6 +128,12 @@ namespace Bicep.Wasm.LanguageHelpers
             base.VisitPropertyAccessSyntax(syntax);
         }
 
+        public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
+        {
+            AddTokenType(syntax.ResourceName, SemanticTokenType.Property);
+            base.VisitResourceAccessSyntax(syntax);
+        }
+
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
         {
             AddTokenType(syntax.Keyword, SemanticTokenType.Keyword);


### PR DESCRIPTION
Fixes: #1363

This change add support for lexical scoping/nesting of child resources.
That it, for a resource type: `My.RP/someType@2020-01-01` there's now a
simplified syntax for including a resource:
`My.RP/someType/childType@2020-01-01` inside the body of the parent.

This syntax also allows simplication of the type name of the child,
limits its scope/visibility and implies an automatic `dependsOn` to the
parent resource. The goal is to be the most idiomatic way to declare
multiple resources to be deployed with a parent/child/grandchild/etc
relationship.

This also includes the new "nested resource access" operator which
allows lookup of a nested resource:

```
output someOutput string = parent:child.properties.size
```

I still need to:

- [x] Update documentation
- [x] Add completion for `resource` keyword inside an `ObjectSyntax`
- [x] Make `:` into a commit character for variables when the completion refers to a resource name
- [x] Update completion for a nested resource to use a single type segment
- [x] Add completion for resource access operator
- [x] Address nesting + for loops by blocking it for now in ForSyntaxValidatorVisitor
- [x] Look into DeployTimeConstantVisitor
- [x] Address PR feedback about `LanguageExpression` instead of syntax
- [x] Address some issues with failing integration tests

## Contributing a feature

* [X] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the bicep maintainers are good with the design of the feature being implemented
* [X] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [X] I have appropriate test coverage of my new feature
