### PR TITLE
fixed 'via Az CLI' link

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -12,7 +12,7 @@ To get the best Bicep authoring experience, you will need two components:
 ## Options for installing the Bicep CLI
 
 * cross-plat
-  * [via Az CLI](#install-and-manage-via-azure-cli-(easiest))
+  * [via Az CLI](#install-and-manage-via-azure-cli-easiest)
   * via Az PowerShell (coming soon)
 * Windows
   * [Windows Installer](#windows-installer)


### PR DESCRIPTION
## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

This PR is to fix the link to the 'via Az CLI' section
