### PR TITLE
Added example for looping outputs

### DIFF
--- a/docs/spec/loops.md
+++ b/docs/spec/loops.md
@@ -140,3 +140,24 @@ resource parentResources 'Microsoft.Example/examples@2020-06-06' = [for parent i
   }
 }]
 ```
+
+### Output loops.
+Directly referencing a resource module or module collection is not currently supported in output loops. In order to loop outputs we need to apply an array indexer to the expression.
+
+```
+var nsgNames = [
+    'nsg1'
+    'nsg2'
+    'nsg3'
+]
+
+resource nsg 'Microsoft.Network/networkSecurityGroups@2020-06-01' = [for name in nsgNames: {
+    name: name
+    location: resourceGroup().location      
+}]
+
+output nsgs array = [for i in range(0, length(nsgNames)): {
+    name: nsg[i].name
+    resourceId: nsg[i].id
+  }]
+```

--- a/docs/spec/loops.md
+++ b/docs/spec/loops.md
@@ -146,18 +146,18 @@ Directly referencing a resource module or module collection is not currently sup
 
 ```
 var nsgNames = [
-    'nsg1'
-    'nsg2'
-    'nsg3'
+  'nsg1'
+  'nsg2'
+  'nsg3'
 ]
 
 resource nsg 'Microsoft.Network/networkSecurityGroups@2020-06-01' = [for name in nsgNames: {
-    name: name
-    location: resourceGroup().location      
+  name: name
+  location: resourceGroup().location      
 }]
 
 output nsgs array = [for i in range(0, length(nsgNames)): {
-    name: nsg[i].name
-    resourceId: nsg[i].id
-  }]
+  name: nsg[i].name
+  resourceId: nsg[i].id
+}]
 ```


### PR DESCRIPTION
Added example on how to use copy loops for outputs.

## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)
