### PR TITLE
non-DTC expression detection now works for loops

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -881,18 +881,13 @@ module stamp_1_secrets './kevault-secrets.bicep' = [for secret in secrets: {
 
             template!.Should().BeNull();
 
-            diags.Should().HaveDiagnostics(new[]
-            {
-                ("BCP057", DiagnosticLevel.Error, "The name \"rg_global\" does not exist in the current context."),
-                ("BCP057", DiagnosticLevel.Error, "The name \"rg_global\" does not exist in the current context."),
-                ("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context."),
-                ("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context."),
-                ("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context."),
-                ("BCP052", DiagnosticLevel.Error, "The type \"outputs\" does not contain property \"cosmosDbEndpoint\"."),
-                ("BCP052", DiagnosticLevel.Error, "The type \"outputs\" does not contain property \"cosmosDbKey\"."),
-                ("BCP091", DiagnosticLevel.Error, "An error occurred reading file. Could not find a part of the path 'C:\\path\\to\\kevault-secrets.bicep'."),
-                ("BCP091", DiagnosticLevel.Error, "An error occurred reading file. Could not find a part of the path 'C:\\path\\to\\kevault-secrets.bicep'.")
-            });
+            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"rg_global\" does not exist in the current context.");
+            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"rg_global\" does not exist in the current context.");
+            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context.");
+            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context.");
+            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context.");
+            diags.Should().ContainDiagnostic("BCP052", DiagnosticLevel.Error, "The type \"outputs\" does not contain property \"cosmosDbEndpoint\".");
+            diags.Should().ContainDiagnostic("BCP052", DiagnosticLevel.Error, "The type \"outputs\" does not contain property \"cosmosDbKey\".");
         }
     }
 }

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -1081,6 +1081,48 @@
     }
   },
   {
+    "label": "moduleLoopForRuntimeCheck",
+    "kind": "module",
+    "detail": "moduleLoopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_moduleLoopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "moduleLoopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "moduleLoopForRuntimeCheck2",
+    "kind": "module",
+    "detail": "moduleLoopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_moduleLoopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "moduleLoopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "moduleLoopForRuntimeCheck3",
+    "kind": "module",
+    "detail": "moduleLoopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_moduleLoopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "moduleLoopForRuntimeCheck3"
+    }
+  },
+  {
     "label": "moduleOutputsCompletions",
     "kind": "variable",
     "detail": "moduleOutputsCompletions",
@@ -1106,6 +1148,62 @@
     "textEdit": {
       "range": {},
       "newText": "modulePropertyAccessCompletions"
+    }
+  },
+  {
+    "label": "moduleRuntimeCheck",
+    "kind": "variable",
+    "detail": "moduleRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_moduleRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "moduleRuntimeCheck"
+    }
+  },
+  {
+    "label": "moduleRuntimeCheck2",
+    "kind": "variable",
+    "detail": "moduleRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_moduleRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "moduleRuntimeCheck2"
+    }
+  },
+  {
+    "label": "moduleRuntimeCheck3",
+    "kind": "variable",
+    "detail": "moduleRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_moduleRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "moduleRuntimeCheck3"
+    }
+  },
+  {
+    "label": "moduleRuntimeCheck4",
+    "kind": "variable",
+    "detail": "moduleRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_moduleRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "moduleRuntimeCheck4"
     }
   },
   {
@@ -1760,6 +1858,20 @@
     "textEdit": {
       "range": {},
       "newText": "runtimeValidRes1"
+    }
+  },
+  {
+    "label": "singleModuleForRuntimeCheck",
+    "kind": "module",
+    "detail": "singleModuleForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleModuleForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleModuleForRuntimeCheck"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
@@ -233,6 +233,27 @@ module runtimeInvalidModule6 'empty.bicep' = {
   name: runtimeValidRes1['sku'].name
 }
 
+module singleModuleForRuntimeCheck 'modulea.bicep' = {
+  name: 'test'
+}
+
+var moduleRuntimeCheck = singleModuleForRuntimeCheck.outputs.stringOutputA
+var moduleRuntimeCheck2 = moduleRuntimeCheck
+
+module moduleLoopForRuntimeCheck 'modulea.bicep' = [for thing in []: {
+  name: moduleRuntimeCheck2
+}]
+
+var moduleRuntimeCheck3 = moduleLoopForRuntimeCheck[1].outputs.stringOutputB
+var moduleRuntimeCheck4 = moduleRuntimeCheck3
+module moduleLoopForRuntimeCheck2 'modulea.bicep' = [for thing in []: {
+  name: moduleRuntimeCheck4
+}]
+
+module moduleLoopForRuntimeCheck3 'modulea.bicep' = [for thing in []: {
+  name: concat(moduleLoopForRuntimeCheck[1].outputs.stringOutputB, moduleLoopForRuntimeCheck[1].outputs.stringOutputA )
+}]
+
 module moduleWithDuplicateName1 './empty.bicep' = {
   name: 'moduleWithDuplicateName'
   scope: resourceGroup()

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
@@ -305,6 +305,35 @@ module runtimeInvalidModule6 'empty.bicep' = {
 //@[8:36) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of runtimeValidRes1 are "apiVersion", "id", "name", "type". |runtimeValidRes1['sku'].name|
 }
 
+module singleModuleForRuntimeCheck 'modulea.bicep' = {
+//@[7:34) [BCP035 (Error)] The specified "module" declaration is missing the following required properties: "params". |singleModuleForRuntimeCheck|
+  name: 'test'
+}
+
+var moduleRuntimeCheck = singleModuleForRuntimeCheck.outputs.stringOutputA
+var moduleRuntimeCheck2 = moduleRuntimeCheck
+
+module moduleLoopForRuntimeCheck 'modulea.bicep' = [for thing in []: {
+//@[7:32) [BCP035 (Error)] The specified "module" declaration is missing the following required properties: "params". |moduleLoopForRuntimeCheck|
+  name: moduleRuntimeCheck2
+//@[8:27) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("moduleRuntimeCheck2" -> "moduleRuntimeCheck" -> "singleModuleForRuntimeCheck"). Accessible properties of singleModuleForRuntimeCheck are "name", "scope". |moduleRuntimeCheck2|
+}]
+
+var moduleRuntimeCheck3 = moduleLoopForRuntimeCheck[1].outputs.stringOutputB
+var moduleRuntimeCheck4 = moduleRuntimeCheck3
+module moduleLoopForRuntimeCheck2 'modulea.bicep' = [for thing in []: {
+//@[7:33) [BCP035 (Error)] The specified "module" declaration is missing the following required properties: "params". |moduleLoopForRuntimeCheck2|
+  name: moduleRuntimeCheck4
+//@[8:27) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("moduleRuntimeCheck4" -> "moduleRuntimeCheck3" -> "moduleLoopForRuntimeCheck"). Accessible properties of moduleLoopForRuntimeCheck are "name", "scope". |moduleRuntimeCheck4|
+}]
+
+module moduleLoopForRuntimeCheck3 'modulea.bicep' = [for thing in []: {
+//@[7:33) [BCP035 (Error)] The specified "module" declaration is missing the following required properties: "params". |moduleLoopForRuntimeCheck3|
+  name: concat(moduleLoopForRuntimeCheck[1].outputs.stringOutputB, moduleLoopForRuntimeCheck[1].outputs.stringOutputA )
+//@[15:65) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of moduleLoopForRuntimeCheck are "name", "scope". |moduleLoopForRuntimeCheck[1].outputs.stringOutputB|
+//@[67:117) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of moduleLoopForRuntimeCheck are "name", "scope". |moduleLoopForRuntimeCheck[1].outputs.stringOutputA|
+}]
+
 module moduleWithDuplicateName1 './empty.bicep' = {
   name: 'moduleWithDuplicateName'
 //@[8:33) [BCP122 (Error)] Modules: "moduleWithDuplicateName1", "moduleWithDuplicateName2" are defined with this same name and this same scope in a file. Rename them or split into different modules. |'moduleWithDuplicateName'|

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.formatted.bicep
@@ -201,6 +201,27 @@ module runtimeInvalidModule6 'empty.bicep' = {
   name: runtimeValidRes1['sku'].name
 }
 
+module singleModuleForRuntimeCheck 'modulea.bicep' = {
+  name: 'test'
+}
+
+var moduleRuntimeCheck = singleModuleForRuntimeCheck.outputs.stringOutputA
+var moduleRuntimeCheck2 = moduleRuntimeCheck
+
+module moduleLoopForRuntimeCheck 'modulea.bicep' = [for thing in []: {
+  name: moduleRuntimeCheck2
+}]
+
+var moduleRuntimeCheck3 = moduleLoopForRuntimeCheck[1].outputs.stringOutputB
+var moduleRuntimeCheck4 = moduleRuntimeCheck3
+module moduleLoopForRuntimeCheck2 'modulea.bicep' = [for thing in []: {
+  name: moduleRuntimeCheck4
+}]
+
+module moduleLoopForRuntimeCheck3 'modulea.bicep' = [for thing in []: {
+  name: concat(moduleLoopForRuntimeCheck[1].outputs.stringOutputB, moduleLoopForRuntimeCheck[1].outputs.stringOutputA)
+}]
+
 module moduleWithDuplicateName1 './empty.bicep' = {
   name: 'moduleWithDuplicateName'
   scope: resourceGroup()

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
@@ -289,6 +289,38 @@ module runtimeInvalidModule6 'empty.bicep' = {
   name: runtimeValidRes1['sku'].name
 }
 
+module singleModuleForRuntimeCheck 'modulea.bicep' = {
+//@[7:34) Module singleModuleForRuntimeCheck. Type: module. Declaration start char: 0, length: 71
+  name: 'test'
+}
+
+var moduleRuntimeCheck = singleModuleForRuntimeCheck.outputs.stringOutputA
+//@[4:22) Variable moduleRuntimeCheck. Type: string. Declaration start char: 0, length: 74
+var moduleRuntimeCheck2 = moduleRuntimeCheck
+//@[4:23) Variable moduleRuntimeCheck2. Type: string. Declaration start char: 0, length: 44
+
+module moduleLoopForRuntimeCheck 'modulea.bicep' = [for thing in []: {
+//@[56:61) Local thing. Type: any. Declaration start char: 56, length: 5
+//@[7:32) Module moduleLoopForRuntimeCheck. Type: module[]. Declaration start char: 0, length: 101
+  name: moduleRuntimeCheck2
+}]
+
+var moduleRuntimeCheck3 = moduleLoopForRuntimeCheck[1].outputs.stringOutputB
+//@[4:23) Variable moduleRuntimeCheck3. Type: string. Declaration start char: 0, length: 76
+var moduleRuntimeCheck4 = moduleRuntimeCheck3
+//@[4:23) Variable moduleRuntimeCheck4. Type: string. Declaration start char: 0, length: 45
+module moduleLoopForRuntimeCheck2 'modulea.bicep' = [for thing in []: {
+//@[57:62) Local thing. Type: any. Declaration start char: 57, length: 5
+//@[7:33) Module moduleLoopForRuntimeCheck2. Type: module[]. Declaration start char: 0, length: 102
+  name: moduleRuntimeCheck4
+}]
+
+module moduleLoopForRuntimeCheck3 'modulea.bicep' = [for thing in []: {
+//@[57:62) Local thing. Type: any. Declaration start char: 57, length: 5
+//@[7:33) Module moduleLoopForRuntimeCheck3. Type: module[]. Declaration start char: 0, length: 194
+  name: concat(moduleLoopForRuntimeCheck[1].outputs.stringOutputB, moduleLoopForRuntimeCheck[1].outputs.stringOutputA )
+}]
+
 module moduleWithDuplicateName1 './empty.bicep' = {
 //@[7:31) Module moduleWithDuplicateName1. Type: module. Declaration start char: 0, length: 112
   name: 'moduleWithDuplicateName'

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
@@ -1476,6 +1476,236 @@ module runtimeInvalidModule6 'empty.bicep' = {
 //@[0:1)   RightBrace |}|
 //@[1:3) NewLine |\n\n|
 
+module singleModuleForRuntimeCheck 'modulea.bicep' = {
+//@[0:71) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:34)  IdentifierSyntax
+//@[7:34)   Identifier |singleModuleForRuntimeCheck|
+//@[35:50)  StringSyntax
+//@[35:50)   StringComplete |'modulea.bicep'|
+//@[51:52)  Assignment |=|
+//@[53:71)  ObjectSyntax
+//@[53:54)   LeftBrace |{|
+//@[54:55)   NewLine |\n|
+  name: 'test'
+//@[2:14)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:14)    StringSyntax
+//@[8:14)     StringComplete |'test'|
+//@[14:15)   NewLine |\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+var moduleRuntimeCheck = singleModuleForRuntimeCheck.outputs.stringOutputA
+//@[0:74) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:22)  IdentifierSyntax
+//@[4:22)   Identifier |moduleRuntimeCheck|
+//@[23:24)  Assignment |=|
+//@[25:74)  PropertyAccessSyntax
+//@[25:60)   PropertyAccessSyntax
+//@[25:52)    VariableAccessSyntax
+//@[25:52)     IdentifierSyntax
+//@[25:52)      Identifier |singleModuleForRuntimeCheck|
+//@[52:53)    Dot |.|
+//@[53:60)    IdentifierSyntax
+//@[53:60)     Identifier |outputs|
+//@[60:61)   Dot |.|
+//@[61:74)   IdentifierSyntax
+//@[61:74)    Identifier |stringOutputA|
+//@[74:75) NewLine |\n|
+var moduleRuntimeCheck2 = moduleRuntimeCheck
+//@[0:44) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:23)  IdentifierSyntax
+//@[4:23)   Identifier |moduleRuntimeCheck2|
+//@[24:25)  Assignment |=|
+//@[26:44)  VariableAccessSyntax
+//@[26:44)   IdentifierSyntax
+//@[26:44)    Identifier |moduleRuntimeCheck|
+//@[44:46) NewLine |\n\n|
+
+module moduleLoopForRuntimeCheck 'modulea.bicep' = [for thing in []: {
+//@[0:101) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:32)  IdentifierSyntax
+//@[7:32)   Identifier |moduleLoopForRuntimeCheck|
+//@[33:48)  StringSyntax
+//@[33:48)   StringComplete |'modulea.bicep'|
+//@[49:50)  Assignment |=|
+//@[51:101)  ForSyntax
+//@[51:52)   LeftSquare |[|
+//@[52:55)   Identifier |for|
+//@[56:61)   LocalVariableSyntax
+//@[56:61)    IdentifierSyntax
+//@[56:61)     Identifier |thing|
+//@[62:64)   Identifier |in|
+//@[65:67)   ArraySyntax
+//@[65:66)    LeftSquare |[|
+//@[66:67)    RightSquare |]|
+//@[67:68)   Colon |:|
+//@[69:100)   ObjectSyntax
+//@[69:70)    LeftBrace |{|
+//@[70:71)    NewLine |\n|
+  name: moduleRuntimeCheck2
+//@[2:27)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:27)     VariableAccessSyntax
+//@[8:27)      IdentifierSyntax
+//@[8:27)       Identifier |moduleRuntimeCheck2|
+//@[27:28)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+var moduleRuntimeCheck3 = moduleLoopForRuntimeCheck[1].outputs.stringOutputB
+//@[0:76) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:23)  IdentifierSyntax
+//@[4:23)   Identifier |moduleRuntimeCheck3|
+//@[24:25)  Assignment |=|
+//@[26:76)  PropertyAccessSyntax
+//@[26:62)   PropertyAccessSyntax
+//@[26:54)    ArrayAccessSyntax
+//@[26:51)     VariableAccessSyntax
+//@[26:51)      IdentifierSyntax
+//@[26:51)       Identifier |moduleLoopForRuntimeCheck|
+//@[51:52)     LeftSquare |[|
+//@[52:53)     IntegerLiteralSyntax
+//@[52:53)      Integer |1|
+//@[53:54)     RightSquare |]|
+//@[54:55)    Dot |.|
+//@[55:62)    IdentifierSyntax
+//@[55:62)     Identifier |outputs|
+//@[62:63)   Dot |.|
+//@[63:76)   IdentifierSyntax
+//@[63:76)    Identifier |stringOutputB|
+//@[76:77) NewLine |\n|
+var moduleRuntimeCheck4 = moduleRuntimeCheck3
+//@[0:45) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:23)  IdentifierSyntax
+//@[4:23)   Identifier |moduleRuntimeCheck4|
+//@[24:25)  Assignment |=|
+//@[26:45)  VariableAccessSyntax
+//@[26:45)   IdentifierSyntax
+//@[26:45)    Identifier |moduleRuntimeCheck3|
+//@[45:46) NewLine |\n|
+module moduleLoopForRuntimeCheck2 'modulea.bicep' = [for thing in []: {
+//@[0:102) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:33)  IdentifierSyntax
+//@[7:33)   Identifier |moduleLoopForRuntimeCheck2|
+//@[34:49)  StringSyntax
+//@[34:49)   StringComplete |'modulea.bicep'|
+//@[50:51)  Assignment |=|
+//@[52:102)  ForSyntax
+//@[52:53)   LeftSquare |[|
+//@[53:56)   Identifier |for|
+//@[57:62)   LocalVariableSyntax
+//@[57:62)    IdentifierSyntax
+//@[57:62)     Identifier |thing|
+//@[63:65)   Identifier |in|
+//@[66:68)   ArraySyntax
+//@[66:67)    LeftSquare |[|
+//@[67:68)    RightSquare |]|
+//@[68:69)   Colon |:|
+//@[70:101)   ObjectSyntax
+//@[70:71)    LeftBrace |{|
+//@[71:72)    NewLine |\n|
+  name: moduleRuntimeCheck4
+//@[2:27)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:27)     VariableAccessSyntax
+//@[8:27)      IdentifierSyntax
+//@[8:27)       Identifier |moduleRuntimeCheck4|
+//@[27:28)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+module moduleLoopForRuntimeCheck3 'modulea.bicep' = [for thing in []: {
+//@[0:194) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:33)  IdentifierSyntax
+//@[7:33)   Identifier |moduleLoopForRuntimeCheck3|
+//@[34:49)  StringSyntax
+//@[34:49)   StringComplete |'modulea.bicep'|
+//@[50:51)  Assignment |=|
+//@[52:194)  ForSyntax
+//@[52:53)   LeftSquare |[|
+//@[53:56)   Identifier |for|
+//@[57:62)   LocalVariableSyntax
+//@[57:62)    IdentifierSyntax
+//@[57:62)     Identifier |thing|
+//@[63:65)   Identifier |in|
+//@[66:68)   ArraySyntax
+//@[66:67)    LeftSquare |[|
+//@[67:68)    RightSquare |]|
+//@[68:69)   Colon |:|
+//@[70:193)   ObjectSyntax
+//@[70:71)    LeftBrace |{|
+//@[71:72)    NewLine |\n|
+  name: concat(moduleLoopForRuntimeCheck[1].outputs.stringOutputB, moduleLoopForRuntimeCheck[1].outputs.stringOutputA )
+//@[2:119)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:119)     FunctionCallSyntax
+//@[8:14)      IdentifierSyntax
+//@[8:14)       Identifier |concat|
+//@[14:15)      LeftParen |(|
+//@[15:66)      FunctionArgumentSyntax
+//@[15:65)       PropertyAccessSyntax
+//@[15:51)        PropertyAccessSyntax
+//@[15:43)         ArrayAccessSyntax
+//@[15:40)          VariableAccessSyntax
+//@[15:40)           IdentifierSyntax
+//@[15:40)            Identifier |moduleLoopForRuntimeCheck|
+//@[40:41)          LeftSquare |[|
+//@[41:42)          IntegerLiteralSyntax
+//@[41:42)           Integer |1|
+//@[42:43)          RightSquare |]|
+//@[43:44)         Dot |.|
+//@[44:51)         IdentifierSyntax
+//@[44:51)          Identifier |outputs|
+//@[51:52)        Dot |.|
+//@[52:65)        IdentifierSyntax
+//@[52:65)         Identifier |stringOutputB|
+//@[65:66)       Comma |,|
+//@[67:117)      FunctionArgumentSyntax
+//@[67:117)       PropertyAccessSyntax
+//@[67:103)        PropertyAccessSyntax
+//@[67:95)         ArrayAccessSyntax
+//@[67:92)          VariableAccessSyntax
+//@[67:92)           IdentifierSyntax
+//@[67:92)            Identifier |moduleLoopForRuntimeCheck|
+//@[92:93)          LeftSquare |[|
+//@[93:94)          IntegerLiteralSyntax
+//@[93:94)           Integer |1|
+//@[94:95)          RightSquare |]|
+//@[95:96)         Dot |.|
+//@[96:103)         IdentifierSyntax
+//@[96:103)          Identifier |outputs|
+//@[103:104)        Dot |.|
+//@[104:117)        IdentifierSyntax
+//@[104:117)         Identifier |stringOutputA|
+//@[118:119)      RightParen |)|
+//@[119:120)    NewLine |\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
 module moduleWithDuplicateName1 './empty.bicep' = {
 //@[0:112) ModuleDeclarationSyntax
 //@[0:6)  Identifier |module|

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
@@ -972,6 +972,149 @@ module runtimeInvalidModule6 'empty.bicep' = {
 //@[0:1) RightBrace |}|
 //@[1:3) NewLine |\n\n|
 
+module singleModuleForRuntimeCheck 'modulea.bicep' = {
+//@[0:6) Identifier |module|
+//@[7:34) Identifier |singleModuleForRuntimeCheck|
+//@[35:50) StringComplete |'modulea.bicep'|
+//@[51:52) Assignment |=|
+//@[53:54) LeftBrace |{|
+//@[54:55) NewLine |\n|
+  name: 'test'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) StringComplete |'test'|
+//@[14:15) NewLine |\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
+var moduleRuntimeCheck = singleModuleForRuntimeCheck.outputs.stringOutputA
+//@[0:3) Identifier |var|
+//@[4:22) Identifier |moduleRuntimeCheck|
+//@[23:24) Assignment |=|
+//@[25:52) Identifier |singleModuleForRuntimeCheck|
+//@[52:53) Dot |.|
+//@[53:60) Identifier |outputs|
+//@[60:61) Dot |.|
+//@[61:74) Identifier |stringOutputA|
+//@[74:75) NewLine |\n|
+var moduleRuntimeCheck2 = moduleRuntimeCheck
+//@[0:3) Identifier |var|
+//@[4:23) Identifier |moduleRuntimeCheck2|
+//@[24:25) Assignment |=|
+//@[26:44) Identifier |moduleRuntimeCheck|
+//@[44:46) NewLine |\n\n|
+
+module moduleLoopForRuntimeCheck 'modulea.bicep' = [for thing in []: {
+//@[0:6) Identifier |module|
+//@[7:32) Identifier |moduleLoopForRuntimeCheck|
+//@[33:48) StringComplete |'modulea.bicep'|
+//@[49:50) Assignment |=|
+//@[51:52) LeftSquare |[|
+//@[52:55) Identifier |for|
+//@[56:61) Identifier |thing|
+//@[62:64) Identifier |in|
+//@[65:66) LeftSquare |[|
+//@[66:67) RightSquare |]|
+//@[67:68) Colon |:|
+//@[69:70) LeftBrace |{|
+//@[70:71) NewLine |\n|
+  name: moduleRuntimeCheck2
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:27) Identifier |moduleRuntimeCheck2|
+//@[27:28) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+var moduleRuntimeCheck3 = moduleLoopForRuntimeCheck[1].outputs.stringOutputB
+//@[0:3) Identifier |var|
+//@[4:23) Identifier |moduleRuntimeCheck3|
+//@[24:25) Assignment |=|
+//@[26:51) Identifier |moduleLoopForRuntimeCheck|
+//@[51:52) LeftSquare |[|
+//@[52:53) Integer |1|
+//@[53:54) RightSquare |]|
+//@[54:55) Dot |.|
+//@[55:62) Identifier |outputs|
+//@[62:63) Dot |.|
+//@[63:76) Identifier |stringOutputB|
+//@[76:77) NewLine |\n|
+var moduleRuntimeCheck4 = moduleRuntimeCheck3
+//@[0:3) Identifier |var|
+//@[4:23) Identifier |moduleRuntimeCheck4|
+//@[24:25) Assignment |=|
+//@[26:45) Identifier |moduleRuntimeCheck3|
+//@[45:46) NewLine |\n|
+module moduleLoopForRuntimeCheck2 'modulea.bicep' = [for thing in []: {
+//@[0:6) Identifier |module|
+//@[7:33) Identifier |moduleLoopForRuntimeCheck2|
+//@[34:49) StringComplete |'modulea.bicep'|
+//@[50:51) Assignment |=|
+//@[52:53) LeftSquare |[|
+//@[53:56) Identifier |for|
+//@[57:62) Identifier |thing|
+//@[63:65) Identifier |in|
+//@[66:67) LeftSquare |[|
+//@[67:68) RightSquare |]|
+//@[68:69) Colon |:|
+//@[70:71) LeftBrace |{|
+//@[71:72) NewLine |\n|
+  name: moduleRuntimeCheck4
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:27) Identifier |moduleRuntimeCheck4|
+//@[27:28) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
+module moduleLoopForRuntimeCheck3 'modulea.bicep' = [for thing in []: {
+//@[0:6) Identifier |module|
+//@[7:33) Identifier |moduleLoopForRuntimeCheck3|
+//@[34:49) StringComplete |'modulea.bicep'|
+//@[50:51) Assignment |=|
+//@[52:53) LeftSquare |[|
+//@[53:56) Identifier |for|
+//@[57:62) Identifier |thing|
+//@[63:65) Identifier |in|
+//@[66:67) LeftSquare |[|
+//@[67:68) RightSquare |]|
+//@[68:69) Colon |:|
+//@[70:71) LeftBrace |{|
+//@[71:72) NewLine |\n|
+  name: concat(moduleLoopForRuntimeCheck[1].outputs.stringOutputB, moduleLoopForRuntimeCheck[1].outputs.stringOutputA )
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) Identifier |concat|
+//@[14:15) LeftParen |(|
+//@[15:40) Identifier |moduleLoopForRuntimeCheck|
+//@[40:41) LeftSquare |[|
+//@[41:42) Integer |1|
+//@[42:43) RightSquare |]|
+//@[43:44) Dot |.|
+//@[44:51) Identifier |outputs|
+//@[51:52) Dot |.|
+//@[52:65) Identifier |stringOutputB|
+//@[65:66) Comma |,|
+//@[67:92) Identifier |moduleLoopForRuntimeCheck|
+//@[92:93) LeftSquare |[|
+//@[93:94) Integer |1|
+//@[94:95) RightSquare |]|
+//@[95:96) Dot |.|
+//@[96:103) Identifier |outputs|
+//@[103:104) Dot |.|
+//@[104:117) Identifier |stringOutputA|
+//@[118:119) RightParen |)|
+//@[119:120) NewLine |\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:4) NewLine |\n\n|
+
 module moduleWithDuplicateName1 './empty.bicep' = {
 //@[0:6) Identifier |module|
 //@[7:31) Identifier |moduleWithDuplicateName1|

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -1706,6 +1706,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2593,6 +2649,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3083,6 +3167,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3495,6 +3593,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -1716,6 +1716,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2603,6 +2659,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3093,6 +3177,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3505,6 +3603,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -1944,6 +1944,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2831,6 +2887,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3321,6 +3405,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3733,6 +3831,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -1944,6 +1944,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2831,6 +2887,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3321,6 +3405,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3733,6 +3831,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -1944,6 +1944,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2831,6 +2887,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3321,6 +3405,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3733,6 +3831,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -1706,6 +1706,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2579,6 +2635,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3069,6 +3153,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3481,6 +3579,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -1706,6 +1706,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2579,6 +2635,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3069,6 +3153,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3481,6 +3579,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -1706,6 +1706,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2579,6 +2635,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3069,6 +3153,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3481,6 +3579,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -2192,6 +2192,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -3065,6 +3121,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3555,6 +3639,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3967,6 +4065,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -2192,6 +2192,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -3065,6 +3121,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3555,6 +3639,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3967,6 +4065,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -2192,6 +2192,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -3065,6 +3121,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3555,6 +3639,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3967,6 +4065,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -1702,6 +1702,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2589,6 +2645,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3079,6 +3163,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3491,6 +3589,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -1702,6 +1702,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2589,6 +2645,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3079,6 +3163,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3505,6 +3603,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -1702,6 +1702,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2589,6 +2645,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3079,6 +3163,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3491,6 +3589,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -1692,6 +1692,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2579,6 +2635,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3069,6 +3153,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3481,6 +3579,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -1692,6 +1692,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2579,6 +2635,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3069,6 +3153,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3481,6 +3579,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -1692,6 +1692,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2579,6 +2635,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3069,6 +3153,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3481,6 +3579,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -1674,6 +1674,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2561,6 +2617,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3051,6 +3135,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3463,6 +3561,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -1814,6 +1814,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2687,6 +2743,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3177,6 +3261,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3589,6 +3687,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -1688,6 +1688,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2575,6 +2631,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3065,6 +3149,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3477,6 +3575,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
@@ -1702,6 +1702,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2575,6 +2631,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3065,6 +3149,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3477,6 +3575,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -1702,6 +1702,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2575,6 +2631,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3065,6 +3149,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3477,6 +3575,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -1702,6 +1702,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2589,6 +2645,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3079,6 +3163,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3505,6 +3603,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleStateSomething.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleStateSomething.json
@@ -1702,6 +1702,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2589,6 +2645,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3079,6 +3163,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3519,6 +3617,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -1734,6 +1734,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2621,6 +2677,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3111,6 +3195,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3523,6 +3621,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -1716,6 +1716,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2603,6 +2659,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3093,6 +3177,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3505,6 +3603,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -1702,6 +1702,62 @@
     }
   },
   {
+    "label": "loopForRuntimeCheck",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck2",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck2"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck3",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck3"
+    }
+  },
+  {
+    "label": "loopForRuntimeCheck4",
+    "kind": "interface",
+    "detail": "loopForRuntimeCheck4",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_loopForRuntimeCheck4",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "loopForRuntimeCheck4"
+    }
+  },
+  {
     "label": "magicString1",
     "kind": "variable",
     "detail": "magicString1",
@@ -2589,6 +2645,34 @@
     }
   },
   {
+    "label": "runtimeCheckVar",
+    "kind": "variable",
+    "detail": "runtimeCheckVar",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar"
+    }
+  },
+  {
+    "label": "runtimeCheckVar2",
+    "kind": "variable",
+    "detail": "runtimeCheckVar2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_runtimeCheckVar2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "runtimeCheckVar2"
+    }
+  },
+  {
     "label": "runtimeInvalid",
     "kind": "variable",
     "detail": "runtimeInvalid",
@@ -3079,6 +3163,20 @@
     }
   },
   {
+    "label": "singleResourceForRuntimeCheck",
+    "kind": "interface",
+    "detail": "singleResourceForRuntimeCheck",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_singleResourceForRuntimeCheck",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "singleResourceForRuntimeCheck"
+    }
+  },
+  {
     "label": "skip",
     "kind": "function",
     "detail": "skip()",
@@ -3491,6 +3589,34 @@
     "textEdit": {
       "range": {},
       "newText": "validResourceForInvalidExtensionResourceDuplicateName"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4a",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4a",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4a",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4a"
+    }
+  },
+  {
+    "label": "varForRuntimeCheck4b",
+    "kind": "variable",
+    "detail": "varForRuntimeCheck4b",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_varForRuntimeCheck4b",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "varForRuntimeCheck4b"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -338,6 +338,37 @@ resource runtimeValidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-0
   name: runtimeValid.foo4
 }
 
+
+resource loopForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+  name: 'test'
+  location: 'test'
+}]
+
+var runtimeCheckVar = loopForRuntimeCheck[0].properties.zoneType
+var runtimeCheckVar2 = runtimeCheckVar
+
+resource singleResourceForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: runtimeCheckVar2
+  location: 'test'
+}
+
+resource loopForRuntimeCheck2 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+  name: runtimeCheckVar2
+  location: 'test'
+}]
+
+resource loopForRuntimeCheck3 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+  name: loopForRuntimeCheck[0].properties.zoneType
+  location: 'test'
+}]
+
+var varForRuntimeCheck4a = loopForRuntimeCheck[0].properties.zoneType
+var varForRuntimeCheck4b = varForRuntimeCheck4a
+resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+  name: varForRuntimeCheck4b
+  location: 'test'
+}]
+
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
   // #completionTest(0, 1, 2) -> topLevelProperties
 

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -496,6 +496,41 @@ resource runtimeValidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-0
   name: runtimeValid.foo4
 }
 
+
+resource loopForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+  name: 'test'
+  location: 'test'
+}]
+
+var runtimeCheckVar = loopForRuntimeCheck[0].properties.zoneType
+var runtimeCheckVar2 = runtimeCheckVar
+
+resource singleResourceForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: runtimeCheckVar2
+//@[8:24) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeCheckVar2" -> "runtimeCheckVar" -> "loopForRuntimeCheck"). Accessible properties of loopForRuntimeCheck are "apiVersion", "id", "name", "type". |runtimeCheckVar2|
+  location: 'test'
+}
+
+resource loopForRuntimeCheck2 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+  name: runtimeCheckVar2
+//@[8:24) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("runtimeCheckVar2" -> "runtimeCheckVar" -> "loopForRuntimeCheck"). Accessible properties of loopForRuntimeCheck are "apiVersion", "id", "name", "type". |runtimeCheckVar2|
+  location: 'test'
+}]
+
+resource loopForRuntimeCheck3 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+  name: loopForRuntimeCheck[0].properties.zoneType
+//@[8:50) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. Accessible properties of loopForRuntimeCheck are "apiVersion", "id", "name", "type". |loopForRuntimeCheck[0].properties.zoneType|
+  location: 'test'
+}]
+
+var varForRuntimeCheck4a = loopForRuntimeCheck[0].properties.zoneType
+var varForRuntimeCheck4b = varForRuntimeCheck4a
+resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+  name: varForRuntimeCheck4b
+//@[8:28) [BCP120 (Error)] The property "name" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time ("varForRuntimeCheck4b" -> "varForRuntimeCheck4a" -> "loopForRuntimeCheck"). Accessible properties of loopForRuntimeCheck are "apiVersion", "id", "name", "type". |varForRuntimeCheck4b|
+  location: 'test'
+}]
+
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
 //@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "kind", "location", "name", "sku". |missingTopLevelProperties|
   // #completionTest(0, 1, 2) -> topLevelProperties

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
@@ -330,6 +330,36 @@ resource runtimeValidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-0
   name: runtimeValid.foo4
 }
 
+resource loopForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+  name: 'test'
+  location: 'test'
+}]
+
+var runtimeCheckVar = loopForRuntimeCheck[0].properties.zoneType
+var runtimeCheckVar2 = runtimeCheckVar
+
+resource singleResourceForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: runtimeCheckVar2
+  location: 'test'
+}
+
+resource loopForRuntimeCheck2 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+  name: runtimeCheckVar2
+  location: 'test'
+}]
+
+resource loopForRuntimeCheck3 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+  name: loopForRuntimeCheck[0].properties.zoneType
+  location: 'test'
+}]
+
+var varForRuntimeCheck4a = loopForRuntimeCheck[0].properties.zoneType
+var varForRuntimeCheck4b = varForRuntimeCheck4a
+resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+  name: varForRuntimeCheck4b
+  location: 'test'
+}]
+
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
   // #completionTest(0, 1, 2) -> topLevelProperties
 }

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -414,6 +414,50 @@ resource runtimeValidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-0
   name: runtimeValid.foo4
 }
 
+
+resource loopForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+//@[76:81) Local thing. Type: any. Declaration start char: 76, length: 5
+//@[9:28) Resource loopForRuntimeCheck. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 130
+  name: 'test'
+  location: 'test'
+}]
+
+var runtimeCheckVar = loopForRuntimeCheck[0].properties.zoneType
+//@[4:19) Variable runtimeCheckVar. Type: 'Private' | 'Public'. Declaration start char: 0, length: 64
+var runtimeCheckVar2 = runtimeCheckVar
+//@[4:20) Variable runtimeCheckVar2. Type: 'Private' | 'Public'. Declaration start char: 0, length: 38
+
+resource singleResourceForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[9:38) Resource singleResourceForRuntimeCheck. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 131
+  name: runtimeCheckVar2
+  location: 'test'
+}
+
+resource loopForRuntimeCheck2 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+//@[77:82) Local thing. Type: any. Declaration start char: 77, length: 5
+//@[9:29) Resource loopForRuntimeCheck2. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 141
+  name: runtimeCheckVar2
+  location: 'test'
+}]
+
+resource loopForRuntimeCheck3 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+//@[77:87) Local otherThing. Type: any. Declaration start char: 77, length: 10
+//@[9:29) Resource loopForRuntimeCheck3. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 172
+  name: loopForRuntimeCheck[0].properties.zoneType
+  location: 'test'
+}]
+
+var varForRuntimeCheck4a = loopForRuntimeCheck[0].properties.zoneType
+//@[4:24) Variable varForRuntimeCheck4a. Type: 'Private' | 'Public'. Declaration start char: 0, length: 69
+var varForRuntimeCheck4b = varForRuntimeCheck4a
+//@[4:24) Variable varForRuntimeCheck4b. Type: 'Private' | 'Public'. Declaration start char: 0, length: 47
+resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+//@[77:87) Local otherThing. Type: any. Declaration start char: 77, length: 10
+//@[9:29) Resource loopForRuntimeCheck4. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 150
+  name: varForRuntimeCheck4b
+  location: 'test'
+}]
+
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
 //@[9:34) Resource missingTopLevelProperties. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 151
   // #completionTest(0, 1, 2) -> topLevelProperties

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -2571,7 +2571,295 @@ resource runtimeValidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-0
 //@[25:27)   NewLine |\r\n|
 }
 //@[0:1)   RightBrace |}|
+//@[1:7) NewLine |\r\n\r\n\r\n|
+
+
+resource loopForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+//@[0:130) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:28)  IdentifierSyntax
+//@[9:28)   Identifier |loopForRuntimeCheck|
+//@[29:68)  StringSyntax
+//@[29:68)   StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[69:70)  Assignment |=|
+//@[71:130)  ForSyntax
+//@[71:72)   LeftSquare |[|
+//@[72:75)   Identifier |for|
+//@[76:81)   LocalVariableSyntax
+//@[76:81)    IdentifierSyntax
+//@[76:81)     Identifier |thing|
+//@[82:84)   Identifier |in|
+//@[85:87)   ArraySyntax
+//@[85:86)    LeftSquare |[|
+//@[86:87)    RightSquare |]|
+//@[87:88)   Colon |:|
+//@[89:129)   ObjectSyntax
+//@[89:90)    LeftBrace |{|
+//@[90:92)    NewLine |\r\n|
+  name: 'test'
+//@[2:14)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:14)     StringSyntax
+//@[8:14)      StringComplete |'test'|
+//@[14:16)    NewLine |\r\n|
+  location: 'test'
+//@[2:18)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:18)     StringSyntax
+//@[12:18)      StringComplete |'test'|
+//@[18:20)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+var runtimeCheckVar = loopForRuntimeCheck[0].properties.zoneType
+//@[0:64) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:19)  IdentifierSyntax
+//@[4:19)   Identifier |runtimeCheckVar|
+//@[20:21)  Assignment |=|
+//@[22:64)  PropertyAccessSyntax
+//@[22:55)   PropertyAccessSyntax
+//@[22:44)    ArrayAccessSyntax
+//@[22:41)     VariableAccessSyntax
+//@[22:41)      IdentifierSyntax
+//@[22:41)       Identifier |loopForRuntimeCheck|
+//@[41:42)     LeftSquare |[|
+//@[42:43)     IntegerLiteralSyntax
+//@[42:43)      Integer |0|
+//@[43:44)     RightSquare |]|
+//@[44:45)    Dot |.|
+//@[45:55)    IdentifierSyntax
+//@[45:55)     Identifier |properties|
+//@[55:56)   Dot |.|
+//@[56:64)   IdentifierSyntax
+//@[56:64)    Identifier |zoneType|
+//@[64:66) NewLine |\r\n|
+var runtimeCheckVar2 = runtimeCheckVar
+//@[0:38) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:20)  IdentifierSyntax
+//@[4:20)   Identifier |runtimeCheckVar2|
+//@[21:22)  Assignment |=|
+//@[23:38)  VariableAccessSyntax
+//@[23:38)   IdentifierSyntax
+//@[23:38)    Identifier |runtimeCheckVar|
+//@[38:42) NewLine |\r\n\r\n|
+
+resource singleResourceForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[0:131) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:38)  IdentifierSyntax
+//@[9:38)   Identifier |singleResourceForRuntimeCheck|
+//@[39:78)  StringSyntax
+//@[39:78)   StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[79:80)  Assignment |=|
+//@[81:131)  ObjectSyntax
+//@[81:82)   LeftBrace |{|
+//@[82:84)   NewLine |\r\n|
+  name: runtimeCheckVar2
+//@[2:24)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:24)    VariableAccessSyntax
+//@[8:24)     IdentifierSyntax
+//@[8:24)      Identifier |runtimeCheckVar2|
+//@[24:26)   NewLine |\r\n|
+  location: 'test'
+//@[2:18)   ObjectPropertySyntax
+//@[2:10)    IdentifierSyntax
+//@[2:10)     Identifier |location|
+//@[10:11)    Colon |:|
+//@[12:18)    StringSyntax
+//@[12:18)     StringComplete |'test'|
+//@[18:20)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
+
+resource loopForRuntimeCheck2 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+//@[0:141) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:29)  IdentifierSyntax
+//@[9:29)   Identifier |loopForRuntimeCheck2|
+//@[30:69)  StringSyntax
+//@[30:69)   StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[70:71)  Assignment |=|
+//@[72:141)  ForSyntax
+//@[72:73)   LeftSquare |[|
+//@[73:76)   Identifier |for|
+//@[77:82)   LocalVariableSyntax
+//@[77:82)    IdentifierSyntax
+//@[77:82)     Identifier |thing|
+//@[83:85)   Identifier |in|
+//@[86:88)   ArraySyntax
+//@[86:87)    LeftSquare |[|
+//@[87:88)    RightSquare |]|
+//@[88:89)   Colon |:|
+//@[90:140)   ObjectSyntax
+//@[90:91)    LeftBrace |{|
+//@[91:93)    NewLine |\r\n|
+  name: runtimeCheckVar2
+//@[2:24)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:24)     VariableAccessSyntax
+//@[8:24)      IdentifierSyntax
+//@[8:24)       Identifier |runtimeCheckVar2|
+//@[24:26)    NewLine |\r\n|
+  location: 'test'
+//@[2:18)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:18)     StringSyntax
+//@[12:18)      StringComplete |'test'|
+//@[18:20)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+resource loopForRuntimeCheck3 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+//@[0:172) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:29)  IdentifierSyntax
+//@[9:29)   Identifier |loopForRuntimeCheck3|
+//@[30:69)  StringSyntax
+//@[30:69)   StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[70:71)  Assignment |=|
+//@[72:172)  ForSyntax
+//@[72:73)   LeftSquare |[|
+//@[73:76)   Identifier |for|
+//@[77:87)   LocalVariableSyntax
+//@[77:87)    IdentifierSyntax
+//@[77:87)     Identifier |otherThing|
+//@[88:90)   Identifier |in|
+//@[91:93)   ArraySyntax
+//@[91:92)    LeftSquare |[|
+//@[92:93)    RightSquare |]|
+//@[93:94)   Colon |:|
+//@[95:171)   ObjectSyntax
+//@[95:96)    LeftBrace |{|
+//@[96:98)    NewLine |\r\n|
+  name: loopForRuntimeCheck[0].properties.zoneType
+//@[2:50)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:50)     PropertyAccessSyntax
+//@[8:41)      PropertyAccessSyntax
+//@[8:30)       ArrayAccessSyntax
+//@[8:27)        VariableAccessSyntax
+//@[8:27)         IdentifierSyntax
+//@[8:27)          Identifier |loopForRuntimeCheck|
+//@[27:28)        LeftSquare |[|
+//@[28:29)        IntegerLiteralSyntax
+//@[28:29)         Integer |0|
+//@[29:30)        RightSquare |]|
+//@[30:31)       Dot |.|
+//@[31:41)       IdentifierSyntax
+//@[31:41)        Identifier |properties|
+//@[41:42)      Dot |.|
+//@[42:50)      IdentifierSyntax
+//@[42:50)       Identifier |zoneType|
+//@[50:52)    NewLine |\r\n|
+  location: 'test'
+//@[2:18)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:18)     StringSyntax
+//@[12:18)      StringComplete |'test'|
+//@[18:20)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+var varForRuntimeCheck4a = loopForRuntimeCheck[0].properties.zoneType
+//@[0:69) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:24)  IdentifierSyntax
+//@[4:24)   Identifier |varForRuntimeCheck4a|
+//@[25:26)  Assignment |=|
+//@[27:69)  PropertyAccessSyntax
+//@[27:60)   PropertyAccessSyntax
+//@[27:49)    ArrayAccessSyntax
+//@[27:46)     VariableAccessSyntax
+//@[27:46)      IdentifierSyntax
+//@[27:46)       Identifier |loopForRuntimeCheck|
+//@[46:47)     LeftSquare |[|
+//@[47:48)     IntegerLiteralSyntax
+//@[47:48)      Integer |0|
+//@[48:49)     RightSquare |]|
+//@[49:50)    Dot |.|
+//@[50:60)    IdentifierSyntax
+//@[50:60)     Identifier |properties|
+//@[60:61)   Dot |.|
+//@[61:69)   IdentifierSyntax
+//@[61:69)    Identifier |zoneType|
+//@[69:71) NewLine |\r\n|
+var varForRuntimeCheck4b = varForRuntimeCheck4a
+//@[0:47) VariableDeclarationSyntax
+//@[0:3)  Identifier |var|
+//@[4:24)  IdentifierSyntax
+//@[4:24)   Identifier |varForRuntimeCheck4b|
+//@[25:26)  Assignment |=|
+//@[27:47)  VariableAccessSyntax
+//@[27:47)   IdentifierSyntax
+//@[27:47)    Identifier |varForRuntimeCheck4a|
+//@[47:49) NewLine |\r\n|
+resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+//@[0:150) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:29)  IdentifierSyntax
+//@[9:29)   Identifier |loopForRuntimeCheck4|
+//@[30:69)  StringSyntax
+//@[30:69)   StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[70:71)  Assignment |=|
+//@[72:150)  ForSyntax
+//@[72:73)   LeftSquare |[|
+//@[73:76)   Identifier |for|
+//@[77:87)   LocalVariableSyntax
+//@[77:87)    IdentifierSyntax
+//@[77:87)     Identifier |otherThing|
+//@[88:90)   Identifier |in|
+//@[91:93)   ArraySyntax
+//@[91:92)    LeftSquare |[|
+//@[92:93)    RightSquare |]|
+//@[93:94)   Colon |:|
+//@[95:149)   ObjectSyntax
+//@[95:96)    LeftBrace |{|
+//@[96:98)    NewLine |\r\n|
+  name: varForRuntimeCheck4b
+//@[2:28)    ObjectPropertySyntax
+//@[2:6)     IdentifierSyntax
+//@[2:6)      Identifier |name|
+//@[6:7)     Colon |:|
+//@[8:28)     VariableAccessSyntax
+//@[8:28)      IdentifierSyntax
+//@[8:28)       Identifier |varForRuntimeCheck4b|
+//@[28:30)    NewLine |\r\n|
+  location: 'test'
+//@[2:18)    ObjectPropertySyntax
+//@[2:10)     IdentifierSyntax
+//@[2:10)      Identifier |location|
+//@[10:11)     Colon |:|
+//@[12:18)     StringSyntax
+//@[12:18)      StringComplete |'test'|
+//@[18:20)    NewLine |\r\n|
+}]
+//@[0:1)    RightBrace |}|
+//@[1:2)   RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
 //@[0:151) ResourceDeclarationSyntax

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -1633,7 +1633,191 @@ resource runtimeValidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-0
 //@[25:27) NewLine |\r\n|
 }
 //@[0:1) RightBrace |}|
+//@[1:7) NewLine |\r\n\r\n\r\n|
+
+
+resource loopForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+//@[0:8) Identifier |resource|
+//@[9:28) Identifier |loopForRuntimeCheck|
+//@[29:68) StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[69:70) Assignment |=|
+//@[71:72) LeftSquare |[|
+//@[72:75) Identifier |for|
+//@[76:81) Identifier |thing|
+//@[82:84) Identifier |in|
+//@[85:86) LeftSquare |[|
+//@[86:87) RightSquare |]|
+//@[87:88) Colon |:|
+//@[89:90) LeftBrace |{|
+//@[90:92) NewLine |\r\n|
+  name: 'test'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:14) StringComplete |'test'|
+//@[14:16) NewLine |\r\n|
+  location: 'test'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:18) StringComplete |'test'|
+//@[18:20) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+var runtimeCheckVar = loopForRuntimeCheck[0].properties.zoneType
+//@[0:3) Identifier |var|
+//@[4:19) Identifier |runtimeCheckVar|
+//@[20:21) Assignment |=|
+//@[22:41) Identifier |loopForRuntimeCheck|
+//@[41:42) LeftSquare |[|
+//@[42:43) Integer |0|
+//@[43:44) RightSquare |]|
+//@[44:45) Dot |.|
+//@[45:55) Identifier |properties|
+//@[55:56) Dot |.|
+//@[56:64) Identifier |zoneType|
+//@[64:66) NewLine |\r\n|
+var runtimeCheckVar2 = runtimeCheckVar
+//@[0:3) Identifier |var|
+//@[4:20) Identifier |runtimeCheckVar2|
+//@[21:22) Assignment |=|
+//@[23:38) Identifier |runtimeCheckVar|
+//@[38:42) NewLine |\r\n\r\n|
+
+resource singleResourceForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[0:8) Identifier |resource|
+//@[9:38) Identifier |singleResourceForRuntimeCheck|
+//@[39:78) StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[79:80) Assignment |=|
+//@[81:82) LeftBrace |{|
+//@[82:84) NewLine |\r\n|
+  name: runtimeCheckVar2
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:24) Identifier |runtimeCheckVar2|
+//@[24:26) NewLine |\r\n|
+  location: 'test'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:18) StringComplete |'test'|
+//@[18:20) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
+
+resource loopForRuntimeCheck2 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
+//@[0:8) Identifier |resource|
+//@[9:29) Identifier |loopForRuntimeCheck2|
+//@[30:69) StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[70:71) Assignment |=|
+//@[72:73) LeftSquare |[|
+//@[73:76) Identifier |for|
+//@[77:82) Identifier |thing|
+//@[83:85) Identifier |in|
+//@[86:87) LeftSquare |[|
+//@[87:88) RightSquare |]|
+//@[88:89) Colon |:|
+//@[90:91) LeftBrace |{|
+//@[91:93) NewLine |\r\n|
+  name: runtimeCheckVar2
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:24) Identifier |runtimeCheckVar2|
+//@[24:26) NewLine |\r\n|
+  location: 'test'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:18) StringComplete |'test'|
+//@[18:20) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+resource loopForRuntimeCheck3 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+//@[0:8) Identifier |resource|
+//@[9:29) Identifier |loopForRuntimeCheck3|
+//@[30:69) StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[70:71) Assignment |=|
+//@[72:73) LeftSquare |[|
+//@[73:76) Identifier |for|
+//@[77:87) Identifier |otherThing|
+//@[88:90) Identifier |in|
+//@[91:92) LeftSquare |[|
+//@[92:93) RightSquare |]|
+//@[93:94) Colon |:|
+//@[95:96) LeftBrace |{|
+//@[96:98) NewLine |\r\n|
+  name: loopForRuntimeCheck[0].properties.zoneType
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:27) Identifier |loopForRuntimeCheck|
+//@[27:28) LeftSquare |[|
+//@[28:29) Integer |0|
+//@[29:30) RightSquare |]|
+//@[30:31) Dot |.|
+//@[31:41) Identifier |properties|
+//@[41:42) Dot |.|
+//@[42:50) Identifier |zoneType|
+//@[50:52) NewLine |\r\n|
+  location: 'test'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:18) StringComplete |'test'|
+//@[18:20) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
+
+var varForRuntimeCheck4a = loopForRuntimeCheck[0].properties.zoneType
+//@[0:3) Identifier |var|
+//@[4:24) Identifier |varForRuntimeCheck4a|
+//@[25:26) Assignment |=|
+//@[27:46) Identifier |loopForRuntimeCheck|
+//@[46:47) LeftSquare |[|
+//@[47:48) Integer |0|
+//@[48:49) RightSquare |]|
+//@[49:50) Dot |.|
+//@[50:60) Identifier |properties|
+//@[60:61) Dot |.|
+//@[61:69) Identifier |zoneType|
+//@[69:71) NewLine |\r\n|
+var varForRuntimeCheck4b = varForRuntimeCheck4a
+//@[0:3) Identifier |var|
+//@[4:24) Identifier |varForRuntimeCheck4b|
+//@[25:26) Assignment |=|
+//@[27:47) Identifier |varForRuntimeCheck4a|
+//@[47:49) NewLine |\r\n|
+resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
+//@[0:8) Identifier |resource|
+//@[9:29) Identifier |loopForRuntimeCheck4|
+//@[30:69) StringComplete |'Microsoft.Network/dnsZones@2018-05-01'|
+//@[70:71) Assignment |=|
+//@[72:73) LeftSquare |[|
+//@[73:76) Identifier |for|
+//@[77:87) Identifier |otherThing|
+//@[88:90) Identifier |in|
+//@[91:92) LeftSquare |[|
+//@[92:93) RightSquare |]|
+//@[93:94) Colon |:|
+//@[95:96) LeftBrace |{|
+//@[96:98) NewLine |\r\n|
+  name: varForRuntimeCheck4b
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:28) Identifier |varForRuntimeCheck4b|
+//@[28:30) NewLine |\r\n|
+  location: 'test'
+//@[2:10) Identifier |location|
+//@[10:11) Colon |:|
+//@[12:18) StringComplete |'test'|
+//@[18:20) NewLine |\r\n|
+}]
+//@[0:1) RightBrace |}|
+//@[1:2) RightSquare |]|
+//@[2:6) NewLine |\r\n\r\n|
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
 //@[0:8) Identifier |resource|

--- a/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
@@ -8,7 +8,6 @@ using Bicep.Core.Emit;
 using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Assertions;
-using FluentAssertions.Execution;
 using FluentAssertions;
 using System;
 using Bicep.Core.TypeSystem;

--- a/src/Bicep.Core/Syntax/IdentifierSyntax.cs
+++ b/src/Bicep.Core/Syntax/IdentifierSyntax.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Bicep.Core.Parsing;
 
@@ -10,6 +11,7 @@ namespace Bicep.Core.Syntax
     /// <summary>
     /// Represents a well-formed identifier.
     /// </summary>
+    [DebuggerDisplay("IdentifierName = {" + nameof(IdentifierName) +"}")]
     public class IdentifierSyntax : SyntaxBase
     {
         public IdentifierSyntax(SyntaxBase child)

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantVariableVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantVariableVisitor.cs
@@ -20,7 +20,7 @@ namespace Bicep.Core.TypeSystem
             this.VisitedStack = new Stack<string>();
         }
 
-        public Stack<string> VisitedStack { get; private set; }
+        public Stack<string> VisitedStack { get; }
 
         public ObjectType? InvalidReferencedBodyType { get; private set; }
 

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantVisitor.cs
@@ -15,7 +15,6 @@ namespace Bicep.Core.TypeSystem
     /// </summary>
     public sealed class DeployTimeConstantVisitor : SyntaxVisitor
     {
-
         private readonly SemanticModel model;
         private readonly IDiagnosticWriter diagnosticWriter;
 
@@ -23,11 +22,10 @@ namespace Bicep.Core.TypeSystem
         private SyntaxBase? errorSyntax;
         private string? currentProperty;
         private string? accessedSymbol;
-        private ObjectType? bodyObj;
-        private ObjectType? referencedBodyObj;
+        private ObjectType? bodyType;
+        private ObjectType? referencedBodyType;
 
         private Stack<string>? variableVisitorStack;
-
 
         private DeployTimeConstantVisitor(SemanticModel model, IDiagnosticWriter diagnosticWriter)
         {
@@ -53,47 +51,71 @@ namespace Bicep.Core.TypeSystem
         // these need to be kept synchronized
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
         {
+            // in certain cases, errors will cause this visitor to short-circuit, 
+            // which causes state to be left over after processing a peer declaration
+            // let's clean it up
+            this.bodyType = null;
+            ResetState();
+
             // Once https://github.com/Azure/bicep/issues/1177 is fixed,
             // it should be possible to use 
             // model.GetSymbolInfo(syntax.Body) is ObectType
             // Currently propertyFlags are not propagated
-            if (model.GetSymbolInfo(syntax) is ResourceSymbol resourceSymbol &&
-                resourceSymbol.Type is ResourceType resourceType &&
-                resourceType.Body is ObjectType bodyObj)
+            var symbol = model.GetSymbolInfo(syntax);
+            switch(symbol)
             {
-                this.bodyObj = bodyObj;
+                case ResourceSymbol { IsCollection: false, Type: ResourceType { Body: ObjectType bodyObj } }:
+                    this.bodyType = bodyObj;
+                    break;
+
+                case ResourceSymbol { IsCollection: true, Type: ArrayType { Item: ResourceType { Body: ObjectType bodyObj } } }:
+                    this.bodyType = bodyObj;
+                    break;
             }
+
             base.VisitResourceDeclarationSyntax(syntax);
-            this.bodyObj = null;
+            this.bodyType = null;
         }
 
         public override void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax)
         {
+            // in certain cases, errors will cause this visitor to short-circuit, 
+            // which causes state to be left over after processing a peer declaration
+            // let's clean it up
+            this.bodyType = null;
+            ResetState();
+
             // Once https://github.com/Azure/bicep/issues/1177 is fixed,
             // it should be possible to use 
             // model.GetSymbolInfo(syntax.Body) is ObectType
             // Currently propertyFlags are not propagated
-            if (model.GetSymbolInfo(syntax) is ModuleSymbol moduleSymbol &&
-                moduleSymbol.Type is ModuleType moduleType &&
-                moduleType.Body is ObjectType bodyObj)
+            var symbol = model.GetSymbolInfo(syntax);
+            switch(symbol)
             {
-                this.bodyObj = bodyObj;
+                case ModuleSymbol { IsCollection: false, Type: ModuleType { Body: ObjectType bodyType } }:
+                    this.bodyType = bodyType;
+                    break;
+
+                case ModuleSymbol { IsCollection: true, Type: ArrayType { Item: ModuleType { Body: ObjectType bodyType } } }:
+                    this.bodyType = bodyType;
+                    break;
             }
+
             base.VisitModuleDeclarationSyntax(syntax);
-            this.bodyObj = null;
+            this.bodyType = null;
         }
         #endregion
 
         public override void VisitObjectSyntax(ObjectSyntax syntax)
         {
-            if (this.bodyObj == null)
+            if (this.bodyType == null)
             {
                 return;
             }
             // Only visit the object properties if they are required to be deploy time constant.
             foreach (var deployTimeIdentifier in ObjectSyntaxExtensions.ToNamedPropertyDictionary(syntax))
             {
-                if (this.bodyObj.Properties.TryGetValue(deployTimeIdentifier.Key, out var propertyType) &&
+                if (this.bodyType.Properties.TryGetValue(deployTimeIdentifier.Key, out var propertyType) &&
                     propertyType.Flags.HasFlag(TypePropertyFlags.DeployTimeConstant))
                 {
                     this.currentProperty = deployTimeIdentifier.Key;
@@ -127,12 +149,12 @@ namespace Bicep.Core.TypeSystem
                     }
                     var variableVisitor = new DeployTimeConstantVariableVisitor(this.model);
                     variableVisitor.Visit(variableSymbol.DeclaringSyntax);
-                    if (variableVisitor.invalidReferencedBodyObj != null)
+                    if (variableVisitor.InvalidReferencedBodyType != null)
                     {
                         this.errorSyntax = syntax;
-                        this.referencedBodyObj = variableVisitor.invalidReferencedBodyObj;
-                        this.variableVisitorStack = variableVisitor.visitedStack;
-                        this.accessedSymbol = variableVisitor.visitedStack.Peek();
+                        this.referencedBodyType = variableVisitor.InvalidReferencedBodyType;
+                        this.variableVisitorStack = variableVisitor.VisitedStack;
+                        this.accessedSymbol = variableVisitor.VisitedStack.Peek();
                     }
                     break;
             }
@@ -158,24 +180,24 @@ namespace Bicep.Core.TypeSystem
                 }
 
                 // validate only on resource and module symbols
-                if (ExtractResourceOrModuleSymbolAndBodyObj(this.model, variableAccessSyntax) is ({ } declaredSymbol, { } referencedBodyObj))
+                if (ExtractResourceOrModuleSymbolAndBodyType(this.model, variableAccessSyntax) is ({ } declaredSymbol, { } referencedBodyType))
                 {
                     switch (syntax.IndexExpression)
                     {
                         case StringSyntax stringSyntax when stringSyntax.TryGetLiteralValue() is string literalValue:
-                            if (referencedBodyObj.Properties.TryGetValue(literalValue, out var propertyType) &&
+                            if (referencedBodyType.Properties.TryGetValue(literalValue, out var propertyType) &&
                             !propertyType.Flags.HasFlag(TypePropertyFlags.DeployTimeConstant))
                             {
                                 this.errorSyntax = syntax;
                                 this.accessedSymbol = declaredSymbol.Name;
-                                this.referencedBodyObj = referencedBodyObj;
+                                this.referencedBodyType = referencedBodyType;
                             }
                             break;
                         default:
                             // we will block referencing module and resource properties using string interpolation and number indexing
                             this.errorSyntax = syntax;
                             this.accessedSymbol = declaredSymbol!.Name;
-                            this.referencedBodyObj = referencedBodyObj;
+                            this.referencedBodyType = referencedBodyType;
                             break;
                     }
                 }
@@ -191,20 +213,48 @@ namespace Bicep.Core.TypeSystem
                 // nested errorSyntax up the stack.
                 this.errorSyntax = syntax;
             }
-            else if (syntax.BaseExpression is VariableAccessSyntax variableAccessSyntax)
+            else
             {
-                // This is a non-overlapping error, which means that there's two or more runtime properties being referenced
-                if (this.errorSyntax != null)
+                switch (syntax.BaseExpression)
                 {
-                    this.AppendError();
-                }
-                if (ExtractResourceOrModuleSymbolAndBodyObj(this.model, variableAccessSyntax) is ({ } declaredSymbol, { } referencedBodyObj) &&
-                    referencedBodyObj.Properties.TryGetValue(syntax.PropertyName.IdentifierName, out var propertyType) &&
-                    !propertyType.Flags.HasFlag(TypePropertyFlags.DeployTimeConstant))
-                {
-                    this.errorSyntax = syntax;
-                    this.accessedSymbol = declaredSymbol.Name;
-                    this.referencedBodyObj = referencedBodyObj;
+                    case VariableAccessSyntax variableAccessSyntax:
+                        {
+                            // This is a non-overlapping error, which means that there's two or more runtime properties being referenced
+                            if (this.errorSyntax != null)
+                            {
+                                this.AppendError();
+                            }
+
+                            if (ExtractResourceOrModuleSymbolAndBodyType(this.model, variableAccessSyntax) is ({ } declaredSymbol, { } referencedBodyType) &&
+                                referencedBodyType.Properties.TryGetValue(syntax.PropertyName.IdentifierName, out var propertyType) &&
+                                !propertyType.Flags.HasFlag(TypePropertyFlags.DeployTimeConstant))
+                            {
+                                this.errorSyntax = syntax;
+                                this.accessedSymbol = declaredSymbol.Name;
+                                this.referencedBodyType = referencedBodyType;
+                            }
+
+                            break;
+                        }
+
+                    case ArrayAccessSyntax { BaseExpression: VariableAccessSyntax baseVariableAccess }:
+                        {
+                            if (this.errorSyntax != null)
+                            {
+                                this.AppendError();
+                            }
+
+                            if (ExtractResourceOrModuleCollectionSymbolAndBodyType(this.model, baseVariableAccess) is ({ } declaredSymbol, { } referencedBodyType) &&
+                                referencedBodyType.Properties.TryGetValue(syntax.PropertyName.IdentifierName, out var propertyType) &&
+                                !propertyType.Flags.HasFlag(TypePropertyFlags.DeployTimeConstant))
+                            {
+                                this.errorSyntax = syntax;
+                                this.accessedSymbol = declaredSymbol.Name;
+                                this.referencedBodyType = referencedBodyType;
+                            }
+
+                            break;
+                        }
                 }
             }
         }
@@ -214,44 +264,62 @@ namespace Bicep.Core.TypeSystem
         {
             if (this.errorSyntax == null)
             {
-                throw new NullReferenceException($"{nameof(this.errorSyntax)} is null in {this.GetType().Name}");
+                throw new InvalidOperationException($"{nameof(this.errorSyntax)} is null in {this.GetType().Name}");
             }
             if (this.currentProperty == null)
             {
-                throw new NullReferenceException($"{nameof(this.currentProperty)} is null in {this.GetType().Name} for syntax {this.errorSyntax.ToString()}");
+                throw new InvalidOperationException($"{nameof(this.currentProperty)} is null in {this.GetType().Name} for syntax {this.errorSyntax.ToString()}");
             }
-            if (this.bodyObj == null)
+            if (this.bodyType == null)
             {
-                throw new NullReferenceException($"{nameof(this.bodyObj)} is null in {this.GetType().Name} for syntax {this.errorSyntax.ToString()}");
+                throw new InvalidOperationException($"{nameof(this.bodyType)} is null in {this.GetType().Name} for syntax {this.errorSyntax.ToString()}");
             }
-            if (this.referencedBodyObj == null)
+            if (this.referencedBodyType == null)
             {
-                throw new NullReferenceException($"{nameof(this.referencedBodyObj)} is null in {this.GetType().Name} for syntax {this.errorSyntax.ToString()}");
+                throw new InvalidOperationException($"{nameof(this.referencedBodyType)} is null in {this.GetType().Name} for syntax {this.errorSyntax.ToString()}");
             }
             if (this.accessedSymbol == null)
             {
-                throw new NullReferenceException($"{nameof(this.accessedSymbol)} is null in {this.GetType().Name} for syntax {this.errorSyntax.ToString()}");
+                throw new InvalidOperationException($"{nameof(this.accessedSymbol)} is null in {this.GetType().Name} for syntax {this.errorSyntax.ToString()}");
             }
-            var usableKeys = this.referencedBodyObj.Properties.Where(kv => kv.Value.Flags.HasFlag(TypePropertyFlags.DeployTimeConstant)).Select(kv => kv.Key);
+            var usableKeys = this.referencedBodyType.Properties.Where(kv => kv.Value.Flags.HasFlag(TypePropertyFlags.DeployTimeConstant)).Select(kv => kv.Key);
             this.diagnosticWriter.Write(DiagnosticBuilder.ForPosition(this.errorSyntax).RuntimePropertyNotAllowed(this.currentProperty, usableKeys, this.accessedSymbol, this.variableVisitorStack?.ToArray().Reverse()));
 
+            ResetState();
+        }
+
+        private void ResetState()
+        {
             this.errorSyntax = null;
-            this.referencedBodyObj = null;
+            this.referencedBodyType = null;
             this.accessedSymbol = null;
             this.variableVisitorStack = null;
         }
 
         #region Helpers
-        public static (DeclaredSymbol?, ObjectType?) ExtractResourceOrModuleSymbolAndBodyObj(SemanticModel model, VariableAccessSyntax syntax)
+        public static (DeclaredSymbol?, ObjectType?) ExtractResourceOrModuleSymbolAndBodyType(SemanticModel model, VariableAccessSyntax syntax)
         {
             var baseSymbol = model.GetSymbolInfo(syntax);
             switch (baseSymbol)
             {
-                case ResourceSymbol:
-                case ModuleSymbol:
+                case ResourceSymbol { IsCollection: false }:
+                case ModuleSymbol { IsCollection: false }:
                     var declaredSymbol = (DeclaredSymbol)baseSymbol;
                     var unwrapped = TypeAssignmentVisitor.UnwrapType(declaredSymbol.Type);
-                    return (declaredSymbol, unwrapped is ObjectType ? (ObjectType)unwrapped : null);
+                    return (declaredSymbol, unwrapped as ObjectType);
+            }
+            return (null, null);
+        }
+
+        public static (DeclaredSymbol?, ObjectType?) ExtractResourceOrModuleCollectionSymbolAndBodyType(SemanticModel model, VariableAccessSyntax syntax)
+        {
+            var baseSymbol = model.GetSymbolInfo(syntax);
+            switch (baseSymbol)
+            {
+                case ResourceSymbol { IsCollection: true }:
+                case ModuleSymbol { IsCollection: true }:
+                    var declaredCollectionSymbol = (DeclaredSymbol)baseSymbol;
+                    return (declaredCollectionSymbol, declaredCollectionSymbol.Type is ArrayType arrayType ? TypeAssignmentVisitor.UnwrapType(arrayType.Item.Type) as ObjectType : null);
             }
             return (null, null);
         }

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -43,6 +43,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             // construct a parallel compilation
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
+
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
 
@@ -176,7 +177,8 @@ namespace Bicep.LangServer.IntegrationTests
                     break;
 
                 case VariableSymbol variable:
-                    hover.Contents.MarkupContent.Value.Should().Contain($"var {variable.Name}: {variable.Type}");
+                    // the hovers with errors don't appear in VS code and only occur in tests
+                    hover.Contents.MarkupContent.Value.Should().Match(value => value.Contains($"var {variable.Name}: {variable.Type}") || value.Contains($"var {variable.Name}: error"));
                     break;
 
                 case ResourceSymbol resource:


### PR DESCRIPTION
We have logic to detect usages of expressions that aren't deploy-time constants (DTCs) when assigned to names of resources or modules. Loops support was missing from that logic. The change also fixes #1661 and #1697. The root cause the exception was missing state cleanup when the visitor was short-circuiting.