### PR TITLE
fixed CTC regression

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
@@ -980,6 +980,20 @@
     }
   },
   {
+    "label": "nonConstantInDecorator",
+    "kind": "field",
+    "detail": "nonConstantInDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonConstantInDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonConstantInDecorator"
+    }
+  },
+  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/oneTwoThreePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/oneTwoThreePlusSymbols.json
@@ -1022,6 +1022,20 @@
     }
   },
   {
+    "label": "nonConstantInDecorator",
+    "kind": "field",
+    "detail": "nonConstantInDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonConstantInDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonConstantInDecorator"
+    }
+  },
+  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/symbolsPlusParamDefaultFunctions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/symbolsPlusParamDefaultFunctions.json
@@ -980,6 +980,20 @@
     }
   },
   {
+    "label": "nonConstantInDecorator",
+    "kind": "field",
+    "detail": "nonConstantInDecorator",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonConstantInDecorator",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "nonConstantInDecorator"
+    }
+  },
+  {
     "label": "padLeft",
     "kind": "function",
     "detail": "padLeft()",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
@@ -394,6 +394,9 @@ param tooManyArguments1 int = 20
 @sys.
 param tooManyArguments2 string
 
+@description(sys.concat(2))
+@allowed([for thing in []: 's'])
+param nonConstantInDecorator string
 
 // unterminated multi-line comment
 /*    

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
@@ -558,7 +558,14 @@ param tooManyArguments1 int = 20
 //@[5:5) [BCP020 (Error)] Expected a function or property name at this location. ||
 param tooManyArguments2 string
 
+@description(sys.concat(2))
+//@[13:26) [BCP032 (Error)] The value must be a compile-time constant. |sys.concat(2)|
+@allowed([for thing in []: 's'])
+//@[9:31) [BCP032 (Error)] The value must be a compile-time constant. |[for thing in []: 's']|
+//@[10:13) [BCP138 (Error)] For-expressions are not supported in this context. For-expressions may be used as values of resource and module declarations, values of resource and module properties, or values of outputs. |for|
+param nonConstantInDecorator string
 
 // unterminated multi-line comment
 /*    
-//@[0:6) [BCP002 (Error)] The multi-line comment at this location is not terminated. Terminate it with the */ character sequence. |/*    |
+//@[0:7) [BCP002 (Error)] The multi-line comment at this location is not terminated. Terminate it with the */ character sequence. |/*    \n|
+

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
@@ -387,5 +387,10 @@ param tooManyArguments1 int = 20
 @sys.
 param tooManyArguments2 string
 
+@description(sys.concat(2))
+@allowed([for thing in []: 's'])
+param nonConstantInDecorator string
+
 // unterminated multi-line comment
 /*    
+

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
@@ -486,6 +486,12 @@ param tooManyArguments1 int = 20
 param tooManyArguments2 string
 //@[6:23) Parameter tooManyArguments2. Type: string. Declaration start char: 0, length: 253
 
+@description(sys.concat(2))
+@allowed([for thing in []: 's'])
+//@[14:19) Local thing. Type: any. Declaration start char: 14, length: 5
+param nonConstantInDecorator string
+//@[6:28) Parameter nonConstantInDecorator. Type: string. Declaration start char: 0, length: 96
 
 // unterminated multi-line comment
 /*    
+

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
@@ -2504,10 +2504,65 @@ param tooManyArguments2 string
 //@[6:23)   Identifier |tooManyArguments2|
 //@[24:30)  TypeSyntax
 //@[24:30)   Identifier |string|
-//@[30:33) NewLine |\n\n\n|
+//@[30:32) NewLine |\n\n|
 
+@description(sys.concat(2))
+//@[0:96) ParameterDeclarationSyntax
+//@[0:27)  DecoratorSyntax
+//@[0:1)   At |@|
+//@[1:27)   FunctionCallSyntax
+//@[1:12)    IdentifierSyntax
+//@[1:12)     Identifier |description|
+//@[12:13)    LeftParen |(|
+//@[13:26)    FunctionArgumentSyntax
+//@[13:26)     InstanceFunctionCallSyntax
+//@[13:16)      VariableAccessSyntax
+//@[13:16)       IdentifierSyntax
+//@[13:16)        Identifier |sys|
+//@[16:17)      Dot |.|
+//@[17:23)      IdentifierSyntax
+//@[17:23)       Identifier |concat|
+//@[23:24)      LeftParen |(|
+//@[24:25)      FunctionArgumentSyntax
+//@[24:25)       IntegerLiteralSyntax
+//@[24:25)        Integer |2|
+//@[25:26)      RightParen |)|
+//@[26:27)    RightParen |)|
+//@[27:28)  NewLine |\n|
+@allowed([for thing in []: 's'])
+//@[0:32)  DecoratorSyntax
+//@[0:1)   At |@|
+//@[1:32)   FunctionCallSyntax
+//@[1:8)    IdentifierSyntax
+//@[1:8)     Identifier |allowed|
+//@[8:9)    LeftParen |(|
+//@[9:31)    FunctionArgumentSyntax
+//@[9:31)     ForSyntax
+//@[9:10)      LeftSquare |[|
+//@[10:13)      Identifier |for|
+//@[14:19)      LocalVariableSyntax
+//@[14:19)       IdentifierSyntax
+//@[14:19)        Identifier |thing|
+//@[20:22)      Identifier |in|
+//@[23:25)      ArraySyntax
+//@[23:24)       LeftSquare |[|
+//@[24:25)       RightSquare |]|
+//@[25:26)      Colon |:|
+//@[27:30)      StringSyntax
+//@[27:30)       StringComplete |'s'|
+//@[30:31)      RightSquare |]|
+//@[31:32)    RightParen |)|
+//@[32:33)  NewLine |\n|
+param nonConstantInDecorator string
+//@[0:5)  Identifier |param|
+//@[6:28)  IdentifierSyntax
+//@[6:28)   Identifier |nonConstantInDecorator|
+//@[29:35)  TypeSyntax
+//@[29:35)   Identifier |string|
+//@[35:37) NewLine |\n\n|
 
 // unterminated multi-line comment
 //@[34:35) NewLine |\n|
 /*    
-//@[6:6) EndOfFile ||
+
+//@[0:0) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
@@ -1615,10 +1615,43 @@ param tooManyArguments2 string
 //@[0:5) Identifier |param|
 //@[6:23) Identifier |tooManyArguments2|
 //@[24:30) Identifier |string|
-//@[30:33) NewLine |\n\n\n|
+//@[30:32) NewLine |\n\n|
 
+@description(sys.concat(2))
+//@[0:1) At |@|
+//@[1:12) Identifier |description|
+//@[12:13) LeftParen |(|
+//@[13:16) Identifier |sys|
+//@[16:17) Dot |.|
+//@[17:23) Identifier |concat|
+//@[23:24) LeftParen |(|
+//@[24:25) Integer |2|
+//@[25:26) RightParen |)|
+//@[26:27) RightParen |)|
+//@[27:28) NewLine |\n|
+@allowed([for thing in []: 's'])
+//@[0:1) At |@|
+//@[1:8) Identifier |allowed|
+//@[8:9) LeftParen |(|
+//@[9:10) LeftSquare |[|
+//@[10:13) Identifier |for|
+//@[14:19) Identifier |thing|
+//@[20:22) Identifier |in|
+//@[23:24) LeftSquare |[|
+//@[24:25) RightSquare |]|
+//@[25:26) Colon |:|
+//@[27:30) StringComplete |'s'|
+//@[30:31) RightSquare |]|
+//@[31:32) RightParen |)|
+//@[32:33) NewLine |\n|
+param nonConstantInDecorator string
+//@[0:5) Identifier |param|
+//@[6:28) Identifier |nonConstantInDecorator|
+//@[29:35) Identifier |string|
+//@[35:37) NewLine |\n\n|
 
 // unterminated multi-line comment
 //@[34:35) NewLine |\n|
 /*    
-//@[6:6) EndOfFile ||
+
+//@[0:0) EndOfFile ||

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
@@ -456,14 +456,15 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithFlags(FunctionFlags.ParameterDecorator)
                 .WithValidator((_, decoratorSyntax, targetType, typeManager, diagnosticWriter) =>
                  {
-                     // The type checker should already verified that there's only one array argument.
-                     var allowedValuesArray = (ArraySyntax)SingleArgumentSelector(decoratorSyntax);
-
-                     TypeValidator.NarrowTypeAndCollectDiagnostics(
-                        typeManager,
-                        allowedValuesArray,
-                        new TypedArrayType(targetType, TypeSymbolValidationFlags.Default),
-                        diagnosticWriter);
+                     // The type checker should already verified that the one argument is assignable to array
+                     if (SingleArgumentSelector(decoratorSyntax) is ArraySyntax allowedValuesArray)
+                     {
+                         TypeValidator.NarrowTypeAndCollectDiagnostics(
+                            typeManager,
+                            allowedValuesArray,
+                            new TypedArrayType(targetType, TypeSymbolValidationFlags.Default),
+                            diagnosticWriter);
+                     }
                  })
                 .WithEvaluator(MergeToTargetObject("allowedValues", SingleArgumentSelector))
                 .Build();

--- a/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
@@ -41,6 +41,16 @@ namespace Bicep.Core.TypeSystem
             this.AppendError(syntax);
         }
 
+        public override void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
+        {
+            this.AppendError(syntax);
+        }
+
+        public override void VisitForSyntax(ForSyntax syntax)
+        {
+            this.AppendError(syntax);
+        }
+
         public override void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax)
         {
             this.AppendError(syntax);


### PR DESCRIPTION
While working on #1625 I discovered a regression in our compile-time constant (CTC) visitor introduced when we added instance function calls and loops. This fixes that.