### PR TITLE
Fix typos in docs, test names and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ We are very happy to accept community contributions to Bicep, whether those are 
 
 The Bicep solution is comprised of the following main components:
 
-* **Bicep CLI** (`src/Bicep.Cli`): the `bicep` CLI exectuable.
+* **Bicep CLI** (`src/Bicep.Cli`): the `bicep` CLI executable.
 * **Bicep Language Server** (`src/Bicep.LangServer`): the LanguageServer used by the VSCode extension for parsing and providing information about a Bicep file.
 * **Bicep Core** (`src/Bicep.Core`): the library containing the majority of the Bicep compiler code.
 * **Bicep VSCode Extension** (`src/vscode-bicep`): the VSCode extension itself. This is mostly a thin wrapper around the Bicep Language Server.

--- a/docs/decompiling.md
+++ b/docs/decompiling.md
@@ -7,7 +7,7 @@ The Bicep CLI provides the ability to decompile any existing ARM Template to a `
 bicep decompile "path/to/file.json"
 ```
 
-You can use this command to get to a starting point for Bicep authoring. Note that because there is no guaranteed conversion from JSON to Bicep, decompilation may fail, or you may be left with errors/warnings in the generated Bicep file to fix up. See [Limitations](#limiations) for some details of what is not currently possible. Also note that because there is not an exact 1:1 conversion from ARM Template to Bicep, it's possible (and likely) to wind up with different ARM Template code if you go decompile then rebuild(ARM Template --`bicep decompile`--> Bicep --`bicep build`--> ARM Template).
+You can use this command to get to a starting point for Bicep authoring. Note that because there is no guaranteed conversion from JSON to Bicep, decompilation may fail, or you may be left with errors/warnings in the generated Bicep file to fix up. See [Limitations](#current-limitations) for some details of what is not currently possible. Also note that because there is not an exact 1:1 conversion from ARM Template to Bicep, it's possible (and likely) to wind up with different ARM Template code if you go decompile then rebuild(ARM Template --`bicep decompile`--> Bicep --`bicep build`--> ARM Template).
 
 You can also use the "Decompile" button in the [Bicep Playground](https://aka.ms/bicepdemo)
 

--- a/docs/spec/expressions.md
+++ b/docs/spec/expressions.md
@@ -122,7 +122,7 @@ resource myParent 'My.Rp/parentType@2020-01-01' = {
     }
   }
 
-  // 'myChild' can be referened inside the body of 'myParent'
+  // 'myChild' can be referenced inside the body of 'myParent'
   resource mySibling 'childType' = {
     name: 'mySibling'
     properties: {

--- a/docs/spec/resources.md
+++ b/docs/spec/resources.md
@@ -65,7 +65,7 @@ A nested resource must specify a single type segment to declare its type. The fu
 
 Nested resource declarations should specify their `name` property with a single segment. The the example above the nested resource declares its `name` property with the value `myChild`. In ARM-JSON, child resources must declared their `name` property as a `/`-separated string containing multiple segments like: `myParent/myChild` - this is not required with nested resources.
 
-A nested resource declaration must appear at the top level of syntax of the containing resource. Declarations may be nested arbirarily deep, as long as each level is a child type of its containing resource. 
+A nested resource declaration must appear at the top level of syntax of the containing resource. Declarations may be nested arbitrarily deep, as long as each level is a child type of its containing resource. 
 
 The symbolic name of a nested resource is only accessible inside the body of its containing resource. 
 

--- a/src/Bicep.Core.UnitTests/Resource/ResourceTypeReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Resource/ResourceTypeReferenceTests.cs
@@ -50,7 +50,7 @@ namespace Bicep.Core.UnitTests.Resource
         [DataTestMethod]
         [DataRow("Microsoft.Compute/virtualMachines@2019-06-01", "Microsoft.Compute/virtualMachines")]
         [DataRow("Microsoft.Blueprint/blueprints/versions/artifacts@2018-11-01-preview", "Microsoft.Blueprint/blueprints/versions/artifacts")]
-        public void ValidType_FullyQualitifedTypeShouldBeCorrect(string value, string expectedFullyQualifiedType)
+        public void ValidType_FullyQualifiedTypeShouldBeCorrect(string value, string expectedFullyQualifiedType)
         {
             var actual = ResourceTypeReference.TryParse(value);
 

--- a/src/Bicep.Core.UnitTests/Syntax/SyntaxHierarchyTests.cs
+++ b/src/Bicep.Core.UnitTests/Syntax/SyntaxHierarchyTests.cs
@@ -34,7 +34,7 @@ namespace Bicep.Core.UnitTests.Syntax
         }
 
         [TestMethod]
-        public void NonEmtyFile_GetParent_ShouldReturnExpectedNode()
+        public void NonEmptyFile_GetParent_ShouldReturnExpectedNode()
         {
             var hierarchy = new SyntaxHierarchy();
             var program = ParserHelper.Parse("param foo string\r\nvar bar = 42");

--- a/src/Bicep.Core.UnitTests/Text/TextCoordinateConverterTests.cs
+++ b/src/Bicep.Core.UnitTests/Text/TextCoordinateConverterTests.cs
@@ -113,7 +113,7 @@ namespace Bicep.Core.UnitTests.Text
         }
 
         [TestMethod]
-        public void GetPosition_NegtiveOffset_ThrowsArgumentOutOfRangeException()
+        public void GetPosition_NegativeOffset_ThrowsArgumentOutOfRangeException()
         {
             IReadOnlyList<int> lineStarts = new List<int> { 0, 24 }.AsReadOnly();
             Action sut = () => TextCoordinateConverter.GetPosition(lineStarts, -9);

--- a/src/Bicep.Core.UnitTests/Utils/TestSyntaxHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestSyntaxHelper.cs
@@ -19,7 +19,7 @@ namespace Bicep.Core.UnitTests.Utils
             if (instanceFunctionCallSyntax.BaseExpression is VariableAccessSyntax baseVariableSyntax && 
                 semanticModel.Root.ImportedNamespaces.ContainsKey(baseVariableSyntax.Name.IdentifierName))
             {
-                // we only expect to have bound InstanceFunctionCallsSnytax if they accessed on a namespace - e.g. sys.concat(..)
+                // we only expect to have bound InstanceFunctionCallsSyntax if they accessed on a namespace - e.g. sys.concat(..)
                 return true;
             }
 

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -177,7 +177,7 @@ namespace Bicep.Core.IntegrationTests
 
             var (entryPointUri, filesToSave) = TemplateDecompiler.DecompileFileWithModules(TestResourceTypeProvider.Create(), fileResolver, fileUri);
 
-            // this behavior is actaully controlled by newtonsoft's deserializer, but we should assert it anyway to avoid regressions.
+            // this behavior is actually controlled by newtonsoft's deserializer, but we should assert it anyway to avoid regressions.
             filesToSave[entryPointUri].Should().Contain($"var multilineString = 'multi{escapedNewline}        line{escapedNewline}        string'");
         }
 

--- a/src/Bicep.Decompiler.UnitTests/Rewriters/DependsOnRemovalRewriterTests.cs
+++ b/src/Bicep.Decompiler.UnitTests/Rewriters/DependsOnRemovalRewriterTests.cs
@@ -12,7 +12,7 @@ namespace Bicep.Core.IntegrationTests.ArmHelpers
     public class DependsOnRemovalRewriterTests
     {
         [TestMethod]
-        public void Unneccessary_dependsOn_statements_are_removed()
+        public void Unnecessary_dependsOn_statements_are_removed()
         {
             var bicepFile = @"
 resource resA 'My.Rp/resA@2020-01-01' = {

--- a/src/Bicep.Decompiler.UnitTests/Rewriters/ParentChildResourceNameRewriterTests.cs
+++ b/src/Bicep.Decompiler.UnitTests/Rewriters/ParentChildResourceNameRewriterTests.cs
@@ -12,7 +12,7 @@ namespace Bicep.Core.IntegrationTests.ArmHelpers
     public class ParentChildResourceNameRewriterTests
     {
         [TestMethod]
-        public void Parent_snytax_common_variable_reference_can_be_replaced()
+        public void Parent_syntax_common_variable_reference_can_be_replaced()
         {
             var bicepFile = @"
 var parentName = 'resA'
@@ -48,7 +48,7 @@ resource resB 'My.Rp/resA/childB@2020-01-01' = {
         }
 
         [TestMethod]
-        public void Parent_snytax_common_variable_reference_in_string_can_be_replaced()
+        public void Parent_syntax_common_variable_reference_in_string_can_be_replaced()
         {
             var bicepFile = @"
 var parentName = 'resA'
@@ -84,7 +84,7 @@ resource resB 'My.Rp/resA/childB@2020-01-01' = {
         }
 
         [TestMethod]
-        public void Parent_snytax_common_multiple_variable_references_in_string_can_be_replaced()
+        public void Parent_syntax_common_multiple_variable_references_in_string_can_be_replaced()
         {
             var bicepFile = @"
 param parentName string = 'resA'

--- a/src/Bicep.LangServer.IntegrationTests/DocumentFormattingTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DocumentFormattingTests.cs
@@ -37,7 +37,7 @@ param myParam object
 var myVar1 = 1 + mod(1, 2)
 var myVar2 = myParam.foo[1]
 
-resource myResesource 'myRP/provider@2020-11-01' = {
+resource myResource 'myRP/provider@2020-11-01' = {
 /* block
   comment
   */


### PR DESCRIPTION
# Contributing a Pull Request

Found this VSCode extension [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) that can help catch common spelling errors (with Quick Fix support!). I used it to check our docs and tests and fixed the typos it found.