### PR TITLE
upgraded to omnisharp 19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,15 @@ jobs:
         run: dotnet pack --configuration ${{ matrix.configuration }}
       
       - name: Test
-        run: dotnet test --configuration ${{ matrix.configuration }} --collect:"XPlat Code Coverage" --settings ./.github/workflows/codecov.runsettings
+        run: dotnet test --configuration ${{ matrix.configuration }} --logger trx --blame --collect:"XPlat Code Coverage" --settings ./.github/workflows/codecov.runsettings --results-directory ./TestResults/
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: Bicep.TestResults.${{ matrix.rid }}
+          path: ./TestResults/**/*.trx
+          if-no-files-found: error
 
       - name: Publish Language Server
         if: ${{ matrix.publishLanguageServer == 'true' }}

--- a/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
+++ b/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.2" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -30,7 +30,7 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task RequestingCodeActionWithFixableDiagnosticsShouldProduceQuickFixes(DataSet dataSet)
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
 
             // construct a parallel compilation
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -51,7 +51,7 @@ namespace Bicep.LangServer.IntegrationTests
             const string expectedSetName = "declarations";
             var uri = DocumentUri.From($"/{this.TestContext.TestName}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(string.Empty, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, string.Empty, uri);
 
             var actual = await GetActualCompletions(client, uri, new Position(0, 0));
             var actualLocation = FileHelper.SaveResultFile(this.TestContext, $"{this.TestContext.TestName}_{expectedSetName}", actual.ToString(Formatting.Indented));
@@ -64,7 +64,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var expected = JToken.Parse(expectedStr);
 
-            actual.Should().EqualWithJsonDiffOutput(TestContext, expected, GetGlobalCompletionSetPath(expectedSetName), actualLocation);
+            actual.Should().EqualWithJsonDiffOutput(this.TestContext, expected, GetGlobalCompletionSetPath(expectedSetName), actualLocation);
         }
 
         // TODO: Handle varying linter expectations for data-driven test
@@ -75,7 +75,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             string pathPrefix = $"Completions/SnippetTemplates/{completionData.Prefix}";
 
-            var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(TestContext, typeof(CompletionTests).Assembly, pathPrefix);
+            var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(this.TestContext, typeof(CompletionTests).Assembly, pathPrefix);
 
             var bicepFileName = Path.Combine(outputDirectory, "main.bicep");
             var bicepSourceFileName = Path.Combine("src", "Bicep.LangServer.IntegrationTests", pathPrefix, Path.GetRelativePath(outputDirectory, bicepFileName));
@@ -115,6 +115,7 @@ namespace Bicep.LangServer.IntegrationTests
             var syntaxTree = SyntaxTree.Create(documentUri.ToUri(), placeholderFile);
 
             var client = await IntegrationTestHelper.StartServerWithTextAsync(
+                this.TestContext,
                 placeholderFile,
                 documentUri,
                 null,
@@ -133,10 +134,10 @@ namespace Bicep.LangServer.IntegrationTests
             var completion = matchingSnippets.First();
 
             completion.TextEdit.Should().NotBeNull();
-            completion.TextEdit!.Range.Should().Be(new TextSpan(cursor, 0).ToRange(syntaxTree.LineStarts));
-            completion.TextEdit.NewText.Should().NotBeNullOrWhiteSpace();
+            completion.TextEdit!.TextEdit!.Range.Should().Be(new TextSpan(cursor, 0).ToRange(syntaxTree.LineStarts));
+            completion.TextEdit.TextEdit.NewText.Should().NotBeNullOrWhiteSpace();
 
-            return completion.TextEdit.NewText;
+            return completion.TextEdit.TextEdit.NewText;
         }
 
         private static IEnumerable<object[]> GetSnippetCompletionData()
@@ -169,7 +170,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var uri = DocumentUri.FromFileSystemPath(entryPoint);
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri, resourceTypeProvider: TypeProvider, fileResolver: new FileResolver());
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri, resourceTypeProvider: TypeProvider, fileResolver: new FileResolver());
 
             var intermediate = new List<(Position position, JToken actual)>();
 
@@ -194,7 +195,7 @@ hel|lo
 '''|
 ";
 
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
@@ -204,7 +205,7 @@ hel|lo
 var interpolatedString = 'abc${|true}def${|}ghi${res|}xyz'
 ";
 
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsNonEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsNonEmpty);
         }
 
         [TestMethod]
@@ -215,7 +216,7 @@ var test = |// comment here
 var test2 = |/* block comment */|
 ";
 
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsNonEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsNonEmpty);
         }
 
         [TestMethod]
@@ -231,7 +232,7 @@ resource testRes 'Test.Rp/readWriteTests@2020-01-01' = {|
 output baz object = {|
 ";
 
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
@@ -242,7 +243,7 @@ var test = /|/ comment here|
 var test2 = /|* block c|omment *|/
 ";
 
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
@@ -251,7 +252,7 @@ var test2 = /|* block c|omment *|/
             string text = "resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' existing = ";
 
             var syntaxTree = SyntaxTree.Create(new Uri("file:///main.bicep"), text);
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(text, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, text, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
 
             var completions = await client.RequestCompletion(new CompletionParams
             {
@@ -292,7 +293,7 @@ var test2 = /|* block c|omment *|/
             string text = @"resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = ";
 
             var syntaxTree = SyntaxTree.Create(new Uri("file:///main.bicep"), text);
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(text, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, text, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
 
             var completions = await client.RequestCompletion(new CompletionParams
             {
@@ -336,7 +337,7 @@ var test2 = /|* block c|omment *|/
         {
             string text = @"resource deploymentScripts 'Microsoft.Resources/deploymentScripts@2020-10-01'=";
             var syntaxTree = SyntaxTree.Create(new Uri("file:///main.bicep"), text);
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(text, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, text, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
 
             var completions = await client.RequestCompletion(new CompletionParams
             {
@@ -354,7 +355,7 @@ var test2 = /|* block c|omment *|/
                     c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
                     c.Label.Should().Be("required-properties-AzureCLI");
                     c.Detail.Should().Be("Required properties");
-                    c.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
+                    c.TextEdit?.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
 	name: $1
 	location: $2
 	kind: 'AzureCLI'
@@ -370,7 +371,7 @@ var test2 = /|* block c|omment *|/
 
                     c.Label.Should().Be("required-properties-AzurePowerShell");
                     c.Detail.Should().Be("Required properties");
-                    c.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
+                    c.TextEdit?.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
 	name: $1
 	location: $2
 	kind: 'AzurePowerShell'
@@ -414,7 +415,7 @@ output string test = testRes.|
 output string test2 = testRes.properties.|
 ";
 
-            await RunCompletionScenarioTest(fileWithCursors, completions =>
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, completions =>
                 completions.Should().SatisfyRespectively(
                     x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
@@ -458,7 +459,7 @@ resource testRes5 'Test.Rp/readWriteTests@2020-01-01' |= {
                 item.Documentation.Should().BeNull();
                 item.Kind.Should().Be(CompletionItemKind.Keyword);
                 item.Preselect.Should().BeFalse();
-                item.TextEdit!.NewText.Should().Be("existing");
+                item.TextEdit!.TextEdit!.NewText.Should().Be("existing");
 
                 // do not add = to the list of commit chars
                 // it makes it difficult to type = without the "existing" keyword :)
@@ -466,7 +467,7 @@ resource testRes5 'Test.Rp/readWriteTests@2020-01-01' |= {
             }
 
 
-            await RunCompletionScenarioTest(fileWithCursors, completions =>
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, completions =>
                 completions.Should().SatisfyRespectively(
                     x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
                     x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
@@ -491,10 +492,10 @@ resource testRes2 'Test.Rp/readWriteTests@2020-01-01' = {
             {
                 list.Where(i => i.Kind == CompletionItemKind.Property)
                     .Should()
-                    .OnlyContain(x => string.Equals(x.TextEdit!.NewText, x.Label + ':'));
+                    .OnlyContain(x => string.Equals(x.TextEdit!.TextEdit!.NewText, x.Label + ':'));
             }
 
-            await RunCompletionScenarioTest(fileWithCursors, completions =>
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, completions =>
                 completions.Should().SatisfyRespectively(
                     l => AssertPropertyNameCompletionsWithColons(l!),
                     l => AssertPropertyNameCompletionsWithColons(l!)));
@@ -507,7 +508,7 @@ resource testRes2 'Test.Rp/readWriteTests@2020-01-01' = {
             {
                 list.Where(i => i.Kind == CompletionItemKind.Property)
                     .Should()
-                    .OnlyContain(x => string.Equals(x.TextEdit!.NewText, x.Label));
+                    .OnlyContain(x => string.Equals(x.TextEdit!.TextEdit!.NewText, x.Label));
             }
 
             var fileWithCursors = @"
@@ -520,10 +521,10 @@ resource testRes3 'Test.Rp/readWriteTests@2020-01-01' = {
 }
 ";
 
-            await RunCompletionScenarioTest( fileWithCursors, completions =>
-                completions.Should().SatisfyRespectively(
-                    l => AssertPropertyNameCompletionsWithoutColons(l!),
-                    l => AssertPropertyNameCompletionsWithoutColons(l!)));
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, completions =>
+               completions.Should().SatisfyRespectively(
+                   l => AssertPropertyNameCompletionsWithoutColons(l!),
+                   l => AssertPropertyNameCompletionsWithoutColons(l!)));
         }
 
         [TestMethod]
@@ -537,7 +538,7 @@ resource myRes 'Test.Rp/readWriteTests@2020-01-01' = {|
   }
 |}
 ";
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
@@ -560,7 +561,7 @@ resource myRes 'Test.Rp/readWriteTests@2020-01-01' = {
                 }
             }
 
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsContainResourceLabel);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsContainResourceLabel);
         }
 
         [TestMethod]
@@ -573,7 +574,7 @@ resource myRes 'Test.Rp/readWriteTests@2020-01-01' = {
   name: 'myRes'
 }
 ";
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
@@ -591,7 +592,7 @@ var obj6 = { |
   prop  | : false
  |  }
 ";
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
@@ -610,7 +611,7 @@ var arr6 = [ |
   |  true
 | ]
 ";
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
@@ -621,7 +622,7 @@ var unary = |! | true
 var binary = -1 | |+| | 2
 var ternary = true | |?| | 'yes' | |:| | 'no'
 ";
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
@@ -632,14 +633,14 @@ var booleanExp = !|tr|ue| && |fal|se|
 var integerExp = |12|345| + |543|21|
 var nullLit = |n|ull|
 ";
-            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, AssertAllCompletionsEmpty);
         }
 
-        private static async Task RunCompletionScenarioTest(string fileWithCursors, Action<IEnumerable<CompletionList?>> assertAction)
+        private static async Task RunCompletionScenarioTest(TestContext testContext, string fileWithCursors, Action<IEnumerable<CompletionList?>> assertAction)
         {
             var (file, cursors) = ParserHelper.GetFileWithCursors(fileWithCursors);
             var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(testContext, file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
             var completions = await RequestCompletions(client, syntaxTree, cursors);
 
             assertAction(completions);
@@ -702,7 +703,7 @@ var nullLit = |n|ull|
                 _ => GetGlobalCompletionSetPath(setName)
             };
 
-            actual.Should().EqualWithJsonDiffOutput(TestContext, expected, expectedLocation, actualLocation, "because ");
+            actual.Should().EqualWithJsonDiffOutput(this.TestContext, expected, expectedLocation, actualLocation, "because ");
         }
 
         private static string GetGlobalCompletionSetPath(string setName) => Path.Combine("src", "Bicep.Core.Samples", "Files", DataSet.TestCompletionsDirectory, GetFullSetName(setName));
@@ -722,7 +723,65 @@ var nullLit = |n|ull|
         private static async Task<JToken> GetActualCompletions(ILanguageClient client, DocumentUri uri, Position position)
         {
             // local function
-            string NormalizeLineEndings(string value) => value.Replace("\r", string.Empty);
+            string? NormalizeLineEndings(string? value) => value is null
+                ? null
+                : value.Replace("\r", string.Empty);
+
+            StringOrMarkupContent? NormalizeDocumentation(StringOrMarkupContent? value) =>
+                value?.MarkupContent?.Value is null
+                    ? null
+                    : new(value.MarkupContent with
+                    {
+                        Value = NormalizeLineEndings(value.MarkupContent.Value)!
+                    });
+
+            TextEditOrInsertReplaceEdit? NormalizeTextEdit(TextEditOrInsertReplaceEdit? value) =>
+                value is null
+                    ? null
+                    : new TextEditOrInsertReplaceEdit(value.TextEdit! with
+                    {
+                        NewText = NormalizeLineEndings(value.TextEdit.NewText)!,
+
+                        // ranges in these text edits will vary by completion trigger position
+                        // if we try to assert on these, we will have an explosion of assert files
+                        // let's ignore it for now until we come up with a better solution
+                        Range = new Range()
+                    });
+
+            TextEditContainer? NormalizeAdditionalTextEdits(TextEditContainer? value) =>
+                value is null
+                    ? null
+                    : new TextEditContainer(value.Select(edit => edit with
+                    {
+                        Range = new Range()
+                    }));
+
+            // OmniSharp sometimes will add a $$__handler_id__$$ property to the Data dictionary of a completion
+            // (likely is needed to somehow help with routing of the ResolveCompletion requests)
+            // the value is different every time you run the language server
+            // to make our test asserts work, we will remove it and set the Data property null if nothing else remains in the object
+            JToken? NormalizeData(JToken? value)
+            {
+                // LSP protocol dictates that the Data property is of "any" type, so we need to check
+                if (value is JObject @object)
+                {
+                    const string omnisharpHandlerIdPropertyName = "$$__handler_id__$$";
+
+                    if (@object.Property(omnisharpHandlerIdPropertyName) != null)
+                    {
+                        @object.Remove(omnisharpHandlerIdPropertyName);
+
+                        if (!@object.HasValues)
+                        {
+                            return null;
+                        }
+
+                        return @object;
+                    }
+                }
+
+                return value;
+            }
 
             var completions = await client.RequestCompletion(new CompletionParams
             {
@@ -730,67 +789,18 @@ var nullLit = |n|ull|
                 Position = position
             });
 
-            // normalize line endings so assertions match on all OSs
-            foreach (var completion in completions)
+            // normalize the completions to remove OS-specific mismatches (line endings) as well as any randomness
+            var normalized = completions.Select(completion => completion with
             {
-                if (completion.InsertText != null)
-                {
-                    completion.InsertText = NormalizeLineEndings(completion.InsertText);
-                }
+                InsertText = NormalizeLineEndings(completion.InsertText),
+                Detail = NormalizeLineEndings(completion.Detail),
+                Documentation = NormalizeDocumentation(completion.Documentation),
+                TextEdit = NormalizeTextEdit(completion.TextEdit),
+                AdditionalTextEdits = NormalizeAdditionalTextEdits(completion.AdditionalTextEdits),
+                Data = NormalizeData(completion.Data)
+            });
 
-                if (completion.Detail != null)
-                {
-                    completion.Detail = NormalizeLineEndings(completion.Detail);
-                }
-
-                if (completion.Documentation?.MarkupContent?.Value != null)
-                {
-                    completion.Documentation.MarkupContent.Value = NormalizeLineEndings(completion.Documentation.MarkupContent.Value);
-                }
-
-                if (completion.TextEdit != null)
-                {
-                    completion.TextEdit.NewText = NormalizeLineEndings(completion.TextEdit.NewText);
-
-                    // ranges in these text edits will vary by completion trigger position
-                    // if we try to assert on these, we will have an explosion of assert files
-                    // let's ignore it for now until we come up with a better solution
-                    completion.TextEdit.Range = new Range();
-                }
-
-                // can't do != null because the container overloads the != operator 😠
-                if (!(completion.AdditionalTextEdits is null))
-                {
-                    foreach (var additionalEdit in completion.AdditionalTextEdits)
-                    {
-                        additionalEdit.Range = new Range();
-                    }
-                }
-            }
-
-            // OmniSharp sometimes will add a $$__handler_id__$$ property to the Data dictionary of a completion
-            // (likely is needed to somehow help with routing of the ResolveCompletion requests)
-            // the value is different every time you run the language server
-            // to make our test asserts work, we will remove it and set the Data property null if nothing else remains in the object
-            foreach (var completion in completions)
-            {
-                const string omnisharpHandlerIdPropertyName = "$$__handler_id__$$";
-
-                // LSP protocol dictates that the Data property is of "any" type, so we need to check
-                if (completion.Data is JObject @object && @object.Property(omnisharpHandlerIdPropertyName) != null)
-                {
-                    @object.Remove(omnisharpHandlerIdPropertyName);
-
-                    if (!@object.HasValues)
-                    {
-                        completion.Data = null;
-                    }
-                }
-            }
-
-            //var serialized = JToken.FromObject(completions.OrderBy(c => c.Label, StringComparer.Ordinal));
-
-            return JToken.FromObject(completions.OrderBy(c => c.Label, StringComparer.Ordinal), DataSetSerialization.CreateSerializer());
+            return JToken.FromObject(normalized.OrderBy(c => c.Label, StringComparer.Ordinal), DataSetSerialization.CreateSerializer());
         }
 
         private static (JToken content, ExpectedCompletionsScope scope)? ResolveExpectedCompletions(DataSet dataSet, string setName)

--- a/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
@@ -16,6 +16,7 @@ using Bicep.LanguageServer.Utils;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OmniSharp.Extensions.LanguageServer.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -36,7 +37,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
@@ -78,7 +79,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
@@ -111,7 +112,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;

--- a/src/Bicep.LangServer.IntegrationTests/DeploymentGraphTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DeploymentGraphTests.cs
@@ -23,6 +23,9 @@ namespace Bicep.LangServer.IntegrationTests
     [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class DeploymentGraphTests
     {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
         [TestMethod]
         public async Task RequestDeploymentGraphShouldReturnDeploymentGraph()
         {
@@ -30,6 +33,7 @@ namespace Bicep.LangServer.IntegrationTests
             var fileSystemDict = new Dictionary<Uri, string>();
 
             var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(
+                this.TestContext,
                 options => options.OnPublishDiagnostics(diagnosticsParams => diagnosticsListener.AddMessage(diagnosticsParams)),
                 BuiltInTestTypes.Create(),
                 new InMemoryFileResolver(fileSystemDict));

--- a/src/Bicep.LangServer.IntegrationTests/DocumentFormattingTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DocumentFormattingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
@@ -16,13 +16,16 @@ namespace Bicep.LangServer.IntegrationTests
     [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class DocumentFormattingTests
     {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
         [TestMethod]
         public async Task RequestDocumentFormattingShouldReturnFullRangeTextEdit()
         {
             var documentUri = DocumentUri.From("/template.bicep");
             var diagnosticsReceived = new TaskCompletionSource<PublishDiagnosticsParams>();
 
-            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(options => 
+            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(this.TestContext, options => 
             {
                 options.OnPublishDiagnostics(diagnostics => {
                     diagnosticsReceived.SetResult(diagnostics);

--- a/src/Bicep.LangServer.IntegrationTests/DocumentSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DocumentSymbolTests.cs
@@ -17,13 +17,16 @@ namespace Bicep.LangServer.IntegrationTests
     [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class DocumentSymbolTests
     {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
         [TestMethod]
         public async Task RequestDocumentSymbol_should_return_full_symbol_list()
         {
             var documentUri = DocumentUri.From("/template.bicep");
             var diagsReceived = new TaskCompletionSource<PublishDiagnosticsParams>();
 
-            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(options => 
+            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(this.TestContext, options => 
             {
                 options.OnPublishDiagnostics(diags => {
                     diagsReceived.SetResult(diags);

--- a/src/Bicep.LangServer.IntegrationTests/FileWatcherTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/FileWatcherTests.cs
@@ -27,6 +27,9 @@ namespace Bicep.LangServer.IntegrationTests
     [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class FileWatcherTests
     {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
         private static void SendDidChangeWatchedFiles(ILanguageClient client, params (DocumentUri documentUri, FileChangeType changeType)[] changes)
         {
             var fileChanges = new Container<FileEvent>(changes.Select(x => new FileEvent
@@ -47,6 +50,7 @@ namespace Bicep.LangServer.IntegrationTests
             var fileSystemDict = new Dictionary<Uri, string>();
             var diagsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
             var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(
+                this.TestContext,
                 options => 
                 {
                     options.OnPublishDiagnostics(diags => diagsListener.AddMessage(diags));
@@ -124,6 +128,7 @@ param requiredInput string
             var fileSystemDict = new Dictionary<Uri, string>();
             var diagsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
             var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(
+                this.TestContext,
                 options => 
                 {
                     options.OnPublishDiagnostics(diags => diagsListener.AddMessage(diags));
@@ -190,6 +195,7 @@ param requiredIpnut string
             var fileSystemDict = new Dictionary<Uri, string>();
             var diagsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
             var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(
+                this.TestContext,
                 options => 
                 {
                     options.OnPublishDiagnostics(diags => diagsListener.AddMessage(diags));

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
@@ -28,7 +28,7 @@ namespace Bicep.LangServer.IntegrationTests
 {
     public static class IntegrationTestHelper
     {
-        private const int DefaultTimeout = 20000;
+        private const int DefaultTimeout = 10000;
 
         public static readonly ISnippetsProvider SnippetsProvider = new SnippetsProvider();
 

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/TextDocumentParamHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/TextDocumentParamHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -23,7 +23,7 @@ namespace Bicep.LangServer.IntegrationTests.Helpers
         public static DidChangeTextDocumentParams CreateDidChangeTextDocumentParams(DocumentUri documentUri, string text, int version) =>
             new DidChangeTextDocumentParams
             {
-                TextDocument = new VersionedTextDocumentIdentifier
+                TextDocument = new OptionalVersionedTextDocumentIdentifier
                 {
                     Version = version,
                     Uri = documentUri

--- a/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
@@ -37,7 +37,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
@@ -85,7 +85,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
 

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -44,7 +44,7 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task HoveringOverSymbolReferencesAndDeclarationsShouldProduceHovers(DataSet dataSet)
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri, resourceTypeProvider: AzResourceTypeProvider.CreateWithAzTypes());
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri, resourceTypeProvider: AzResourceTypeProvider.CreateWithAzTypes());
 
             // construct a parallel compilation
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
@@ -133,7 +133,7 @@ namespace Bicep.LangServer.IntegrationTests
                 node is not Token;
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
 
             // construct a parallel compilation
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
@@ -190,7 +190,7 @@ output string test = testRes.prop|erties.rea|donly
 ");
 
             var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
             var hovers = await RequestHovers(client, syntaxTree, cursors);
 
             hovers.Should().SatisfyRespectively(
@@ -221,7 +221,7 @@ output string test = testRes[3].prop|erties.rea|donly
 ");
 
             var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
             var hovers = await RequestHovers(client, syntaxTree, cursors);
 
             hovers.Should().SatisfyRespectively(
@@ -252,7 +252,7 @@ output string test = testRes.prop|erties.rea|donly
 ");
 
             var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
             var hovers = await RequestHovers(client, syntaxTree, cursors);
 
             hovers.Should().SatisfyRespectively(
@@ -275,7 +275,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
 ");
 
             var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
             var hovers = await RequestHovers(client, syntaxTree, cursors);
 
             hovers.Should().SatisfyRespectively(

--- a/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
@@ -42,7 +42,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
@@ -89,7 +89,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
@@ -144,7 +144,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
 
@@ -195,7 +195,7 @@ var dep2 = az.deploy|ment()
 ");
 
             var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
             var references = await RequestReferences(client, syntaxTree, cursors);
             
             references.Should().SatisfyRespectively(

--- a/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
@@ -35,7 +35,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
@@ -84,7 +84,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var symbolTable = compilation.ReconstructSymbolTable();
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
@@ -115,7 +115,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var uri = DocumentUri.From($"/{dataSet.Name}");
 
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(dataSet.Bicep, uri);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(this.TestContext, dataSet.Bicep, uri);
             var compilation = dataSet.CopyFilesAndCreateCompilation(TestContext, out _);
             var lineStarts = compilation.SyntaxTreeGrouping.EntryPoint.LineStarts;
 

--- a/src/Bicep.LangServer.IntegrationTests/TextDocumentSyncTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TextDocumentSyncTests.cs
@@ -17,6 +17,9 @@ namespace Bicep.LangServer.IntegrationTests
     [TestClass]
     public class TextDocumentSyncTests
     {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
         [TestMethod]
         [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
         public async Task DidOpenTextDocument_should_trigger_PublishDiagnostics()
@@ -24,7 +27,7 @@ namespace Bicep.LangServer.IntegrationTests
             var documentUri = DocumentUri.From("/template.bicep");
             var diagsReceived = new TaskCompletionSource<PublishDiagnosticsParams>();
 
-            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(options => 
+            var client = await IntegrationTestHelper.StartServerWithClientConnectionAsync(this.TestContext, options => 
             {
                 options.OnPublishDiagnostics(diags => {
                     diagsReceived.SetResult(diags);

--- a/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
+++ b/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.2" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -18,6 +18,7 @@ using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 
 namespace Bicep.LangServer.UnitTests
 {
@@ -385,6 +386,14 @@ namespace Bicep.LangServer.UnitTests
             server
                 .Setup(m => m.TextDocument)
                 .Returns(document.Object);
+
+            var window = Repository.Create<IWindowLanguageServer>();
+            window
+                .Setup(m => m.SendNotification(It.IsAny<LogMessageParams>()));
+
+            server
+                .Setup(m => m.Window)
+                .Returns(window.Object);
 
             return server;
         }

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -51,7 +51,7 @@ namespace Bicep.LangServer.UnitTests
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
                     c.InsertText.Should().BeNull();
                     c.Detail.Should().Be("Module keyword");
-                    c.TextEdit!.NewText.Should().Be("module");
+                    c.TextEdit!.TextEdit!.NewText.Should().Be("module");
                 },
                 c =>
                 {
@@ -60,7 +60,7 @@ namespace Bicep.LangServer.UnitTests
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
                     c.InsertText.Should().BeNull();
                     c.Detail.Should().Be("Output keyword");
-                    c.TextEdit!.NewText.Should().Be("output");
+                    c.TextEdit!.TextEdit!.NewText.Should().Be("output");
                 },
                 c =>
                 {
@@ -69,7 +69,7 @@ namespace Bicep.LangServer.UnitTests
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
                     c.InsertText.Should().BeNull();
                     c.Detail.Should().Be("Parameter keyword");
-                    c.TextEdit!.NewText.Should().Be("param");
+                    c.TextEdit!.TextEdit!.NewText.Should().Be("param");
                 },
                 c =>
                 {
@@ -78,7 +78,7 @@ namespace Bicep.LangServer.UnitTests
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
                     c.InsertText.Should().BeNull();
                     c.Detail.Should().Be("Resource keyword");
-                    c.TextEdit!.NewText.Should().Be("resource");
+                    c.TextEdit!.TextEdit!.NewText.Should().Be("resource");
                 },
                 c =>
                 {
@@ -87,7 +87,7 @@ namespace Bicep.LangServer.UnitTests
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
                     c.InsertText.Should().BeNull();
                     c.Detail.Should().Be("Target Scope keyword");
-                    c.TextEdit!.NewText.Should().Be("targetScope");
+                    c.TextEdit!.TextEdit!.NewText.Should().Be("targetScope");
                 },
                 c =>
                 {
@@ -96,7 +96,7 @@ namespace Bicep.LangServer.UnitTests
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
                     c.InsertText.Should().BeNull();
                     c.Detail.Should().Be("Variable keyword");
-                    c.TextEdit!.NewText.Should().Be("var");
+                    c.TextEdit!.TextEdit!.NewText.Should().Be("var");
                 });
         }
 
@@ -131,7 +131,7 @@ output o int = 42
             resourceCompletion.Label.Should().Be(expectedResource);
             resourceCompletion.Kind.Should().Be(CompletionItemKind.Interface);
             resourceCompletion.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-            resourceCompletion.TextEdit!.NewText.Should().Be(expectedResource);
+            resourceCompletion.TextEdit!.TextEdit!.NewText.Should().Be(expectedResource);
             resourceCompletion.CommitCharacters.Should().BeEquivalentTo(new[]{ ":", });
             resourceCompletion.Detail.Should().Be(expectedResource);
 
@@ -140,7 +140,7 @@ output o int = 42
             paramCompletion.Label.Should().Be(expectedParam);
             paramCompletion.Kind.Should().Be(CompletionItemKind.Field);
             paramCompletion.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-            paramCompletion.TextEdit!.NewText.Should().Be(expectedParam);
+            paramCompletion.TextEdit!.TextEdit!.NewText.Should().Be(expectedParam);
             paramCompletion.CommitCharacters.Should().BeNull();
             paramCompletion.Detail.Should().Be(expectedParam);
         }
@@ -229,7 +229,7 @@ output length int =
             variableCompletion.Label.Should().Be(expectedVariable);
             variableCompletion.Kind.Should().Be(CompletionItemKind.Variable);
             variableCompletion.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-            variableCompletion.TextEdit!.NewText.Should().Be(expectedVariable);
+            variableCompletion.TextEdit!.TextEdit!.NewText.Should().Be(expectedVariable);
             variableCompletion.CommitCharacters.Should().BeNull();
             variableCompletion.Detail.Should().Be(expectedVariable);
 
@@ -238,7 +238,7 @@ output length int =
             resourceCompletion.Label.Should().Be(expectedResource);
             resourceCompletion.Kind.Should().Be(CompletionItemKind.Interface);
             resourceCompletion.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-            resourceCompletion.TextEdit!.NewText.Should().Be(expectedResource);
+            resourceCompletion.TextEdit!.TextEdit!.NewText.Should().Be(expectedResource);
             resourceCompletion.CommitCharacters.Should().BeEquivalentTo(new []{ ":", });
             resourceCompletion.Detail.Should().Be(expectedResource);
 
@@ -247,7 +247,7 @@ output length int =
             paramCompletion.Label.Should().Be(expectedParam);
             paramCompletion.Kind.Should().Be(CompletionItemKind.Field);
             paramCompletion.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-            paramCompletion.TextEdit!.NewText.Should().Be(expectedParam);
+            paramCompletion.TextEdit!.TextEdit!.NewText.Should().Be(expectedParam);
             paramCompletion.CommitCharacters.Should().BeNull();
             paramCompletion.Detail.Should().Be(expectedParam);
         }
@@ -289,8 +289,8 @@ output length int =
                     c.Label.Should().Be("secureObject");
                     c.Kind.Should().Be(CompletionItemKind.Snippet);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
-                    c.TextEdit!.NewText.Should().StartWith("object");
-                    c.TextEdit.NewText.Should().Be("object");
+                    c.TextEdit!.TextEdit!.NewText.Should().StartWith("object");
+                    c.TextEdit.TextEdit.NewText.Should().Be("object");
                     c.Detail.Should().Be("Secure object");
                     c.AdditionalTextEdits!.Count().Should().Be(1);
                     c.AdditionalTextEdits!.ElementAt(0).NewText.Should().Be("@secure()\n");
@@ -304,8 +304,8 @@ output length int =
                     c.Label.Should().Be("secureString");
                     c.Kind.Should().Be(CompletionItemKind.Snippet);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
-                    c.TextEdit!.NewText.Should().StartWith("string");
-                    c.TextEdit.NewText.Should().Be("string");
+                    c.TextEdit!.TextEdit!.NewText.Should().StartWith("string");
+                    c.TextEdit.TextEdit.NewText.Should().Be("string");
                     c.Detail.Should().Be("Secure string");
                     c.AdditionalTextEdits!.Count().Should().Be(1);
                     c.AdditionalTextEdits!.ElementAt(0).NewText.Should().Be("@secure()\n");
@@ -336,9 +336,9 @@ output length int =
                     c.Label.Should().Be("secureObject");
                     c.Kind.Should().Be(CompletionItemKind.Snippet);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
-                    c.TextEdit!.NewText.Should().Be("object");
-                    c.TextEdit.Range.Start.Line.Should().Be(0);
-                    c.TextEdit.Range.Start.Character.Should().Be(18);
+                    c.TextEdit!.TextEdit!.NewText.Should().Be("object");
+                    c.TextEdit.TextEdit.Range.Start.Line.Should().Be(0);
+                    c.TextEdit.TextEdit.Range.Start.Character.Should().Be(18);
                     c.Detail.Should().Be("Secure object");
                     c.AdditionalTextEdits!.Count().Should().Be(1);
                     c.AdditionalTextEdits!.ElementAt(0).NewText.Should().Be("@secure()\n");
@@ -352,9 +352,9 @@ output length int =
                     c.Label.Should().Be("secureString");
                     c.Kind.Should().Be(CompletionItemKind.Snippet);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
-                    c.TextEdit!.NewText.Should().Be("string");
-                    c.TextEdit.Range.Start.Line.Should().Be(0);
-                    c.TextEdit.Range.Start.Character.Should().Be(18);
+                    c.TextEdit!.TextEdit!.NewText.Should().Be("string");
+                    c.TextEdit.TextEdit.Range.Start.Line.Should().Be(0);
+                    c.TextEdit.TextEdit.Range.Start.Character.Should().Be(18);
                     c.Detail.Should().Be("Secure string");
                     c.AdditionalTextEdits!.Count().Should().Be(1);
                     c.AdditionalTextEdits!.ElementAt(0).NewText.Should().Be("@secure()\n");
@@ -396,7 +396,7 @@ output length int =
                     c.Label.Should().Be(expected);
                     c.Kind.Should().Be(CompletionItemKind.Class);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-                    c.TextEdit!.NewText.Should().Be(expected);
+                    c.TextEdit!.TextEdit!.NewText.Should().Be(expected);
                     c.Detail.Should().Be(expected);
                 },
                 c =>
@@ -405,7 +405,7 @@ output length int =
                     c.Label.Should().Be(expected);
                     c.Kind.Should().Be(CompletionItemKind.Class);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-                    c.TextEdit!.NewText.Should().Be(expected);
+                    c.TextEdit!.TextEdit!.NewText.Should().Be(expected);
                     c.Detail.Should().Be(expected);
                 },
                 c =>
@@ -414,7 +414,7 @@ output length int =
                     c.Label.Should().Be(expected);
                     c.Kind.Should().Be(CompletionItemKind.Class);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-                    c.TextEdit!.NewText.Should().Be(expected);
+                    c.TextEdit!.TextEdit!.NewText.Should().Be(expected);
                     c.Detail.Should().Be(expected);
                 },
                 c =>
@@ -423,7 +423,7 @@ output length int =
                     c.Label.Should().Be(expected);
                     c.Kind.Should().Be(CompletionItemKind.Class);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-                    c.TextEdit!.NewText.Should().Be(expected);
+                    c.TextEdit!.TextEdit!.NewText.Should().Be(expected);
                     c.Detail.Should().Be(expected);
                 },
                 c =>
@@ -432,7 +432,7 @@ output length int =
                     c.Label.Should().Be(expected);
                     c.Kind.Should().Be(CompletionItemKind.Class);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
-                    c.TextEdit!.NewText.Should().Be(expected);
+                    c.TextEdit!.TextEdit!.NewText.Should().Be(expected);
                     c.Detail.Should().Be(expected);
                 });
         }
@@ -458,7 +458,7 @@ output length int =
                 .OrderBy(s => s);
 
             functionCompletions.Select(c => c.Label).Should().BeEquivalentTo(availableFunctionNames);
-            functionCompletions.Should().OnlyContain(c => c.TextEdit!.NewText.StartsWith(c.Label + '(', StringComparison.Ordinal));
+            functionCompletions.Should().OnlyContain(c => c.TextEdit!.TextEdit!.NewText.StartsWith(c.Label + '(', StringComparison.Ordinal));
             functionCompletions.Should().OnlyContain(c => string.Equals(c.Label + "()", c.Detail));
             functionCompletions.Should().OnlyContain(c => c.InsertTextFormat == InsertTextFormat.Snippet);
         }

--- a/src/Bicep.LangServer.UnitTests/Completions/CompletionItemBuilderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Completions/CompletionItemBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -16,7 +16,7 @@ namespace Bicep.LangServer.UnitTests.Completions
         [TestMethod]
         public void AddingSnippetTextEditToInsertTextShouldThrow()
         {
-            Action fail = () => CompletionItemBuilder.Create(CompletionItemKind.Class)
+            Action fail = () => CompletionItemBuilder.Create(CompletionItemKind.Class, "label")
                 .WithInsertText("t")
                 .WithSnippetEdit(new Range(), "s");
 
@@ -26,7 +26,7 @@ namespace Bicep.LangServer.UnitTests.Completions
         [TestMethod]
         public void AddingPlainTextEditToInsertTextShouldThrow()
         {
-            Action fail = () => CompletionItemBuilder.Create(CompletionItemKind.Class)
+            Action fail = () => CompletionItemBuilder.Create(CompletionItemKind.Class, "label")
                 .WithInsertText("t")
                 .WithPlainTextEdit(new Range(), "t2");
 
@@ -36,7 +36,7 @@ namespace Bicep.LangServer.UnitTests.Completions
         [TestMethod]
         public void AddingInsertTextToTextEditShouldThrow()
         {
-            Action fail = () => CompletionItemBuilder.Create(CompletionItemKind.Class)
+            Action fail = () => CompletionItemBuilder.Create(CompletionItemKind.Class, "label")
                 .WithPlainTextEdit(new Range(), "t")
                 .WithInsertText("t2");
 
@@ -46,7 +46,7 @@ namespace Bicep.LangServer.UnitTests.Completions
         [TestMethod]
         public void AddingSnippetToTextEditShouldThrow()
         {
-            Action fail = () => CompletionItemBuilder.Create(CompletionItemKind.Class)
+            Action fail = () => CompletionItemBuilder.Create(CompletionItemKind.Class, "label")
                 .WithSnippetEdit(new Range(), "s")
                 .WithSnippet("s2");
 

--- a/src/Bicep.LangServer/Bicep.LangServer.csproj
+++ b/src/Bicep.LangServer/Bicep.LangServer.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -15,6 +15,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Bicep.LanguageServer
@@ -149,7 +150,7 @@ namespace Bicep.LanguageServer
 
                 // publish a single fatal error diagnostic to tell the user something horrible has occurred
                 // TODO: Tell user how to create an issue on GitHub.
-                var fatalError = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic
+                var fatalError = new Diagnostic
                 {
                     Range = new Range
                     {
@@ -172,14 +173,18 @@ namespace Bicep.LanguageServer
         // TODO: Remove the lexer part when we stop it from emitting errors
         private IEnumerable<Core.Diagnostics.IDiagnostic> GetDiagnosticsFromContext(CompilationContext context) => context.Compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
-        private void PublishDocumentDiagnostics(DocumentUri uri, int? version, IEnumerable<OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic> diagnostics)
+        private void PublishDocumentDiagnostics(DocumentUri uri, int? version, IEnumerable<Diagnostic> diagnostics)
         {
+            server.Window.LogInfo("Publishing diagnostics...");
+
             server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
             {
                 Uri = uri,
                 Version = version,
-                Diagnostics = new Container<OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic>(diagnostics)
+                Diagnostics = new Container<Diagnostic>(diagnostics)
             });
+
+            server.Window.LogInfo("Published diagnostics.");
         }
     }
 }

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -175,16 +175,12 @@ namespace Bicep.LanguageServer
 
         private void PublishDocumentDiagnostics(DocumentUri uri, int? version, IEnumerable<Diagnostic> diagnostics)
         {
-            server.Window.LogInfo("Publishing diagnostics...");
-
             server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
             {
                 Uri = uri,
                 Version = version,
                 Diagnostics = new Container<Diagnostic>(diagnostics)
             });
-
-            server.Window.LogInfo("Published diagnostics.");
         }
     }
 }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -281,22 +281,24 @@ namespace Bicep.LanguageServer.Completions
             var fileItems = files
                 .Where(file => file != model.SyntaxTree.FileUri)
                 .Where(file => file.Segments.Last().EndsWith(LanguageConstants.LanguageFileExtension))
-                .Select(file => CreateModulePathCompletion(
+                .Select(file => CreateModulePathCompletionBuilder(
                     file.Segments.Last(),
                     (entered.StartsWith("./") ? "./" : "") + cwdUri.MakeRelativeUri(file).ToString(),
                     context.ReplacementRange,
                     CompletionItemKind.File,
-                    file.Segments.Last().EndsWith(LanguageConstants.LanguageId) ? CompletionPriority.High : CompletionPriority.Medium))
+                    file.Segments.Last().EndsWith(LanguageConstants.LanguageId) ? CompletionPriority.High : CompletionPriority.Medium)
+                .Build())
                 .ToList();
 
             var dirItems = dirs
-                .Select(dir => CreateModulePathCompletion(
+                .Select(dir => CreateModulePathCompletionBuilder(
                     dir.Segments.Last(),
                     (entered.StartsWith("./") ? "./" : "") + cwdUri.MakeRelativeUri(dir).ToString(),
                     context.ReplacementRange,
                     CompletionItemKind.Folder,
                     CompletionPriority.Medium)
-                .WithCommand(new Command { Name = EditorCommands.RequestCompletions }))
+                .WithCommand(new Command { Name = EditorCommands.RequestCompletions })
+                .Build())
                 .ToList();
             return fileItems.Concat(dirItems);
         }
@@ -737,23 +739,23 @@ namespace Bicep.LanguageServer.Completions
                     break;
 
                 case StringLiteralType stringLiteral:
-                    yield return CompletionItemBuilder.Create(CompletionItemKind.EnumMember)
-                        .WithLabel(stringLiteral.Name)
+                    yield return CompletionItemBuilder.Create(CompletionItemKind.EnumMember, stringLiteral.Name)
                         .WithPlainTextEdit(replacementRange, stringLiteral.Name)
                         .WithDetail(stringLiteral.Name)
                         .Preselect()
-                        .WithSortText(GetSortText(stringLiteral.Name, CompletionPriority.Medium));
+                        .WithSortText(GetSortText(stringLiteral.Name, CompletionPriority.Medium))
+                        .Build();
 
                     break;
 
                 case ArrayType arrayType:
                     const string arrayLabel = "[]";
-                    yield return CompletionItemBuilder.Create(CompletionItemKind.Value)
-                        .WithLabel(arrayLabel)
+                    yield return CompletionItemBuilder.Create(CompletionItemKind.Value, arrayLabel)
                         .WithSnippetEdit(replacementRange, "[\n\t$0\n]")
                         .WithDetail(arrayLabel)
                         .Preselect()
-                        .WithSortText(GetSortText(arrayLabel, CompletionPriority.High));
+                        .WithSortText(GetSortText(arrayLabel, CompletionPriority.High))
+                        .Build();
 
                     if (loopsAllowed)
                     {
@@ -785,22 +787,22 @@ namespace Bicep.LanguageServer.Completions
         private static CompletionItem CreateObjectBodyCompletion(Range replacementRange)
         {
             const string objectLabel = "{}";
-            return CompletionItemBuilder.Create(CompletionItemKind.Value)
-                .WithLabel(objectLabel)
+            return CompletionItemBuilder.Create(CompletionItemKind.Value, objectLabel)
                 .WithSnippetEdit(replacementRange, "{\n\t$0\n}")
                 .WithDetail(objectLabel)
                 .Preselect()
-                .WithSortText(GetSortText(objectLabel, CompletionPriority.High));
+                .WithSortText(GetSortText(objectLabel, CompletionPriority.High))
+                .Build();
         }
 
         private static CompletionItem CreateResourceOrModuleConditionCompletion(Range replacementRange)
         {
             const string conditionLabel = "if";
-            return CompletionItemBuilder.Create(CompletionItemKind.Snippet)
-                .WithLabel(conditionLabel)
+            return CompletionItemBuilder.Create(CompletionItemKind.Snippet, conditionLabel)
                 .WithSnippetEdit(replacementRange, "if (${1:condition}) {\n\t$0\n}")
                 .WithDetail(conditionLabel)
-                .WithSortText(GetSortText(conditionLabel, CompletionPriority.High));
+                .WithSortText(GetSortText(conditionLabel, CompletionPriority.High))
+                .Build();
         }
 
         private static IEnumerable<CompletionItem> CreateLoopCompletions(Range replacementRange, TypeSymbol arrayItemType, bool filtersAllowed)
@@ -832,30 +834,29 @@ namespace Bicep.LanguageServer.Completions
         {
             var escapedPropertyName = IsPropertyNameEscapingRequired(property) ? StringUtils.EscapeBicepString(property.Name) : property.Name;
             var suffix = includeColon ? ":" : string.Empty;
-            return CompletionItemBuilder.Create(CompletionItemKind.Property)
-                .WithLabel(property.Name)
+            return CompletionItemBuilder.Create(CompletionItemKind.Property, property.Name)
                 // property names that much Bicep keywords or containing non-identifier chars need to be escaped
                 .WithPlainTextEdit(replacementRange, $"{escapedPropertyName}{suffix}")
                 .WithDetail(FormatPropertyDetail(property))
                 .WithDocumentation(FormatPropertyDocumentation(property))
-                .WithSortText(GetSortText(property.Name, priority));
+                .WithSortText(GetSortText(property.Name, priority))
+                .Build();
         }
 
         private static CompletionItem CreatePropertyIndexCompletion(TypeProperty property, Range replacementRange, CompletionPriority priority = CompletionPriority.Medium)
         {
             var escaped = StringUtils.EscapeBicepString(property.Name);
-            return CompletionItemBuilder.Create(CompletionItemKind.Property)
-                .WithLabel(escaped)
+            return CompletionItemBuilder.Create(CompletionItemKind.Property, escaped)
                 .WithPlainTextEdit(replacementRange, escaped)
                 .WithDetail(FormatPropertyDetail(property))
                 .WithDocumentation(FormatPropertyDocumentation(property))
-                .WithSortText(GetSortText(escaped, priority));
+                .WithSortText(GetSortText(escaped, priority))
+                .Build();
         }
 
         private static CompletionItem CreatePropertyAccessCompletion(TypeProperty property, SyntaxTree tree, PropertyAccessSyntax propertyAccess, Range replacementRange, CompletionPriority priority = CompletionPriority.Medium)
         {
-            var item = CompletionItemBuilder.Create(CompletionItemKind.Property)
-                .WithLabel(property.Name)
+            var item = CompletionItemBuilder.Create(CompletionItemKind.Property, property.Name)
                 .WithCommitCharacters(PropertyAccessCommitChars)
                 .WithDetail(FormatPropertyDetail(property))
                 .WithDocumentation(FormatPropertyDocumentation(property))
@@ -882,23 +883,23 @@ namespace Bicep.LanguageServer.Completions
                 item.WithPlainTextEdit(replacementRange, property.Name);
             }
 
-            return item;
+            return item.Build();
         }
 
         private static CompletionItem CreateKeywordCompletion(string keyword, string detail, Range replacementRange, bool preselect = false, CompletionPriority priority = CompletionPriority.Medium) =>
-            CompletionItemBuilder.Create(CompletionItemKind.Keyword)
-                .WithLabel(keyword)
+            CompletionItemBuilder.Create(CompletionItemKind.Keyword, keyword)
                 .WithPlainTextEdit(replacementRange, keyword)
                 .WithDetail(detail)
                 .Preselect(preselect)
-                .WithSortText(GetSortText(keyword, priority));
+                .WithSortText(GetSortText(keyword, priority))
+                .Build();
 
         private static CompletionItem CreateTypeCompletion(TypeSymbol type, Range replacementRange, CompletionPriority priority = CompletionPriority.Medium) =>
-            CompletionItemBuilder.Create(CompletionItemKind.Class)
-                .WithLabel(type.Name)
+            CompletionItemBuilder.Create(CompletionItemKind.Class, type.Name)
                 .WithPlainTextEdit(replacementRange, type.Name)
                 .WithDetail(type.Name)
-                .WithSortText(GetSortText(type.Name, priority));
+                .WithSortText(GetSortText(type.Name, priority))
+                .Build();
 
         private static CompletionItem CreateResourceTypeCompletion(ResourceTypeReference resourceType, int index, Range replacementRange, bool showApiVersion)
         {
@@ -906,24 +907,24 @@ namespace Bicep.LanguageServer.Completions
             if (showApiVersion)
             {
                 var insertText = StringUtils.EscapeBicepString($"{resourceType.FullyQualifiedType}@{resourceType.ApiVersion}");
-                return CompletionItemBuilder.Create(CompletionItemKind.Class)
-                    .WithLabel(resourceType.ApiVersion)
+                return CompletionItemBuilder.Create(CompletionItemKind.Class, resourceType.ApiVersion)
                     .WithFilterText(insertText)
                     .WithPlainTextEdit(replacementRange, insertText)
                     .WithDocumentation($"Namespace: `{resourceType.Namespace}`{MarkdownNewLine}Type: `{resourceType.TypesString}`{MarkdownNewLine}API Version: `{resourceType.ApiVersion}`")
                     // 8 hex digits is probably overkill :)
-                    .WithSortText(index.ToString("x8"));
+                    .WithSortText(index.ToString("x8"))
+                    .Build();
             }
             else
             {
                 var insertText = StringUtils.EscapeBicepString($"{resourceType.FullyQualifiedType}");
-                return CompletionItemBuilder.Create(CompletionItemKind.Class)
-                    .WithLabel(insertText)
+                return CompletionItemBuilder.Create(CompletionItemKind.Class, insertText)
                     .WithSnippetEdit(replacementRange, $"{insertText.Substring(0, insertText.Length - 1)}@$0'")
                     .WithDocumentation($"Namespace: `{resourceType.Namespace}`{MarkdownNewLine}Type: `{resourceType.TypesString}`{MarkdownNewLine}`")
                     .WithCommand(new Command { Name = EditorCommands.RequestCompletions })
                     // 8 hex digits is probably overkill :)
-                    .WithSortText(index.ToString("x8"));
+                    .WithSortText(index.ToString("x8"))
+                    .Build();
             }
         }
 
@@ -933,19 +934,18 @@ namespace Bicep.LanguageServer.Completions
             var insertText = includeApiVersion ?
                 StringUtils.EscapeBicepString($"{resourceType.Types[^1]}@{resourceType.ApiVersion}") :
                 StringUtils.EscapeBicepString($"{resourceType.Types[^1]}");
-            return CompletionItemBuilder.Create(CompletionItemKind.Class)
-                .WithLabel(insertText)
+            return CompletionItemBuilder.Create(CompletionItemKind.Class, insertText)
                 .WithPlainTextEdit(replacementRange, insertText)
                 .WithDocumentation($"Namespace: `{resourceType.Namespace}`{MarkdownNewLine}Type: `{resourceType.TypesString}`{MarkdownNewLine}API Version: `{displayApiVersion}`")
                 // 8 hex digits is probably overkill :)
-                .WithSortText(index.ToString("x8"));
+                .WithSortText(index.ToString("x8"))
+                .Build();
         }
 
-        private static CompletionItem CreateModulePathCompletion(string name, string path, Range replacementRange, CompletionItemKind completionItemKind, CompletionPriority priority)
+        private static CompletionItemBuilder CreateModulePathCompletionBuilder(string name, string path, Range replacementRange, CompletionItemKind completionItemKind, CompletionPriority priority)
         {
             path = StringUtils.EscapeBicepString(path);
-            var item = CompletionItemBuilder.Create(completionItemKind)
-                .WithLabel(name)
+            var item = CompletionItemBuilder.Create(completionItemKind, name)
                 .WithFilterText(path)
                 .WithSortText(GetSortText(name, priority));
             // Folder completions should keep us within the completion string
@@ -957,6 +957,7 @@ namespace Bicep.LanguageServer.Completions
             {
                 item = item.WithPlainTextEdit(replacementRange, path);
             }
+
             return item;
         }
 
@@ -964,25 +965,25 @@ namespace Bicep.LanguageServer.Completions
         /// Creates a completion with a contextual snippet. This will look like a snippet to the user.
         /// </summary>
         private static CompletionItem CreateContextualSnippetCompletion(string label, string detail, string snippet, Range replacementRange, CompletionPriority priority = CompletionPriority.Medium, bool preselect = false) =>
-            CompletionItemBuilder.Create(CompletionItemKind.Snippet)
-                .WithLabel(label)
+            CompletionItemBuilder.Create(CompletionItemKind.Snippet, label)
                 .WithSnippetEdit(replacementRange, snippet)
                 .WithDetail(detail)
                 .WithDocumentation($"```bicep\n{new Snippet(snippet).FormatDocumentation()}\n```")
                 .WithSortText(GetSortText(label, priority))
-                .Preselect(preselect);
+                .Preselect(preselect)
+                .Build();
 
         /// <summary>
         /// Creates a completion with a contextual snippet. This will look like a snippet to the user.
         /// </summary>
         private static CompletionItem CreateContextualSnippetCompletion(string label, string detail, string snippet, Range replacementRange, TextEditContainer additionalTextEdits, CompletionPriority priority = CompletionPriority.Medium) =>
-            CompletionItemBuilder.Create(CompletionItemKind.Snippet)
-                .WithLabel(label)
+            CompletionItemBuilder.Create(CompletionItemKind.Snippet, label)
                 .WithSnippetEdit(replacementRange, snippet)
                 .WithAdditionalEdits(additionalTextEdits)
                 .WithDetail(detail)
                 .WithDocumentation($"```bicep\n{new Snippet(snippet).FormatDocumentation()}\n```")
-                .WithSortText(GetSortText(label, priority));
+                .WithSortText(GetSortText(label, priority))
+                .Build();
 
         private static CompletionItem CreateSymbolCompletion(Symbol symbol, Range replacementRange, string? insertText = null)
         {
@@ -990,8 +991,7 @@ namespace Bicep.LanguageServer.Completions
             var kind = GetCompletionItemKind(symbol);
             var priority = GetCompletionPriority(symbol);
 
-            var completion = CompletionItemBuilder.Create(kind)
-                .WithLabel(insertText)
+            var completion = CompletionItemBuilder.Create(kind, insertText)
                 .WithSortText(GetSortText(insertText, priority));
 
             if (symbol is ResourceSymbol)
@@ -1017,12 +1017,14 @@ namespace Bicep.LanguageServer.Completions
 
                 return completion
                     .WithDetail($"{insertText}()")
-                    .WithSnippetEdit(replacementRange, snippet);
+                    .WithSnippetEdit(replacementRange, snippet)
+                    .Build();
             }
 
             return completion
                 .WithDetail(insertText)
-                .WithPlainTextEdit(replacementRange, insertText);
+                .WithPlainTextEdit(replacementRange, insertText)
+                .Build();
         }
 
         // the priority must be a number in the sort text

--- a/src/Bicep.LangServer/Completions/CompletionItemBuilder.cs
+++ b/src/Bicep.LangServer/Completions/CompletionItemBuilder.cs
@@ -6,128 +6,167 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Bicep.LanguageServer.Completions
 {
-    public static class CompletionItemBuilder
+    public class CompletionItemBuilder
     {
-        public static CompletionItem Create(CompletionItemKind kind) => new CompletionItem {Kind = kind};
+        private readonly CompletionItemKind kind;
+        private readonly string label;
 
-        public static CompletionItem WithAdditionalEdits(this CompletionItem item, TextEditContainer editContainer)
+        private TextEditContainer? additionalTextEdits;
+        private Container<string>? commitCharacters;
+        private string? detail;
+        private StringOrMarkupContent? documentation;
+        private string? filterText;
+        private string? insertText;
+        private InsertTextFormat insertTextFormat;
+        private TextEditOrInsertReplaceEdit? textEdit;
+        private InsertTextMode insertTextMode;
+        
+        private string? sortText;
+        private bool preselect;
+        private Command? command;
+
+        private CompletionItemBuilder(CompletionItemKind kind, string label)
         {
-            item.AdditionalTextEdits = editContainer;
-            return item;
+            this.kind = kind;
+            this.label = label;
         }
 
-        public static CompletionItem WithCommitCharacters(this CompletionItem item, Container<string> commitCharacters)
+        public static CompletionItemBuilder Create(CompletionItemKind kind, string label) => new CompletionItemBuilder(kind, label);
+
+        public CompletionItem Build()
         {
-            item.CommitCharacters = commitCharacters;
-            return item;
+            return new()
+            {
+                Label = this.label,
+                Kind = kind,
+
+                AdditionalTextEdits = this.additionalTextEdits,
+                CommitCharacters = this.commitCharacters,
+                Detail = this.detail,
+                Documentation = this.documentation,
+                FilterText = this.filterText,
+                InsertText = this.insertText,
+                InsertTextFormat = this.insertTextFormat,
+                TextEdit = this.textEdit,
+                InsertTextMode = this.insertTextMode,                
+                SortText = this.sortText,
+                Preselect = this.preselect,
+                Command = this.command
+            };
         }
 
-        public static CompletionItem WithDetail(this CompletionItem item, string detail)
+        public CompletionItemBuilder WithAdditionalEdits(TextEditContainer editContainer)
         {
-            item.Detail = detail;
-            return item;
+            this.additionalTextEdits = editContainer;
+            return this;
         }
 
-        public static CompletionItem WithDocumentation(this CompletionItem item, string markdown)
+        public CompletionItemBuilder WithCommitCharacters(Container<string> commitCharacters)
         {
-            item.Documentation = new StringOrMarkupContent(new MarkupContent
+            this.commitCharacters = commitCharacters;
+            return this;
+        }
+
+        public CompletionItemBuilder WithDetail(string detail)
+        {
+            this.detail = detail;
+            return this;
+        }
+
+        public CompletionItemBuilder WithDocumentation(string markdown)
+        {
+            this.documentation = new StringOrMarkupContent(new MarkupContent
             {
                 Kind = MarkupKind.Markdown,
                 Value = markdown
             });
-            return item;
+            return this;
         }
         
-        public static CompletionItem WithFilterText(this CompletionItem item, string filterText)
+        public CompletionItemBuilder WithFilterText(string filterText)
         {
-            item.FilterText = filterText;
-            return item;
+            this.filterText = filterText;
+            return this;
         }
 
-        public static CompletionItem WithInsertText(this CompletionItem item, string insertText)
+        public CompletionItemBuilder WithInsertText(string insertText)
         {
-            AssertNoTextEdit(item);
+            this.AssertNoTextEdit();
 
-            item.InsertText = insertText;
-            item.InsertTextFormat = InsertTextFormat.PlainText;
-            item.InsertTextMode = InsertTextMode.AdjustIndentation;
+            this.insertText = insertText;
+            this.insertTextFormat = InsertTextFormat.PlainText;
+            this.insertTextMode = InsertTextMode.AdjustIndentation;
 
-            return item;
+            return this;
         }
-
-        public static CompletionItem WithLabel(this CompletionItem item, string label)
-        {
-            item.Label = label;
-            return item;
-        }        
         
-        public static CompletionItem WithPlainTextEdit(this CompletionItem item, Range range, string text)
+        public CompletionItemBuilder WithPlainTextEdit(Range range, string text)
         {
-            AssertNoInsertText(item);
-            SetTextEditInternal(item, range, InsertTextFormat.PlainText, text);
-            return item;
+            this.AssertNoInsertText();
+            this.SetTextEditInternal(range, InsertTextFormat.PlainText, text);
+            return this;
         }
 
-        public static CompletionItem WithSnippet(this CompletionItem item, string snippet)
+        public CompletionItemBuilder WithSnippet(string snippet)
         {
-            AssertNoTextEdit(item);
+            this.AssertNoTextEdit();
 
-            item.InsertText = snippet;
-            item.InsertTextFormat = InsertTextFormat.Snippet;
-            item.InsertTextMode = InsertTextMode.AdjustIndentation;
+            this.insertText = snippet;
+            this.insertTextFormat = InsertTextFormat.Snippet;
+            this.insertTextMode = InsertTextMode.AdjustIndentation;
 
-            return item;
+            return this;
         }
 
-        public static CompletionItem WithSnippetEdit(this CompletionItem item, Range range, string snippet)
+        public CompletionItemBuilder WithSnippetEdit(Range range, string snippet)
         {
-            AssertNoInsertText(item);
-            SetTextEditInternal(item, range, InsertTextFormat.Snippet, snippet);
-            return item;
+            this.AssertNoInsertText();
+            this.SetTextEditInternal(range, InsertTextFormat.Snippet, snippet);
+            return this;
         }
 
-        public static CompletionItem WithSortText(this CompletionItem item, string sortText)
+        public CompletionItemBuilder WithSortText(string sortText)
         {
-            item.SortText = sortText;
-            return item;
+            this.sortText = sortText;
+            return this;
         }
 
-        public static CompletionItem Preselect(this CompletionItem item) => item.Preselect(preselect: true);
+        public CompletionItemBuilder Preselect() => this.Preselect(preselect: true);
 
-        public static CompletionItem Preselect(this CompletionItem item, bool preselect)
+        public CompletionItemBuilder Preselect(bool preselect)
         {
-            item.Preselect = preselect;
-            return item;
+            this.preselect = preselect;
+            return this;
         }
 
-        public static CompletionItem WithCommand(this CompletionItem item, Command command)
+        public CompletionItemBuilder WithCommand(Command command)
         {
-            item.Command = command;
-            return item;
+            this.command = command;
+            return this;
         }
 
-        private static void SetTextEditInternal(CompletionItem item, Range range, InsertTextFormat format, string text)
+        private void SetTextEditInternal(Range range, InsertTextFormat format, string text)
         {
-            item.InsertTextFormat = format;
-            item.TextEdit = new TextEdit
+            this.insertTextFormat = format;
+            this.textEdit = new TextEdit
             {
                 Range = range,
                 NewText = text
             };
-            item.InsertTextMode = InsertTextMode.AdjustIndentation;
+            this.insertTextMode = InsertTextMode.AdjustIndentation;
         }
 
-        private static void AssertNoTextEdit(CompletionItem item)
+        private void AssertNoTextEdit()
         {
-            if (item.TextEdit != null)
+            if (this.textEdit != null)
             {
                 throw new InvalidOperationException("Unable to set the specified insert text because a text edit is already set.");
             }
         }
 
-        private static void AssertNoInsertText(CompletionItem item)
+        private void AssertNoInsertText()
         {
-            if (item.InsertText != null)
+            if (this.insertText != null)
             {
                 throw new InvalidOperationException("Unable to set the text edit because the insert text is already set.");
             }

--- a/src/Bicep.LangServer/Handlers/BicepCodeActionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCodeActionHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +10,7 @@ using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Extensions;
 using Bicep.LanguageServer.Utils;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -20,11 +21,10 @@ namespace Bicep.LanguageServer.Handlers
         private readonly ICompilationManager compilationManager;
 
         public BicepCodeActionHandler(ICompilationManager compilationManager)
-            : base(CreateCodeActionRegistrationOptions())
         {
             this.compilationManager = compilationManager;
         }
-        
+
         public override Task<CommandOrCodeActionContainer> Handle(CodeActionParams request, CancellationToken cancellationToken)
         {
             var compilationContext = this.compilationManager.GetCompilation(request.TextDocument.Uri);
@@ -78,7 +78,7 @@ namespace Bicep.LanguageServer.Handlers
             };
         }
 
-        private static CodeActionRegistrationOptions CreateCodeActionRegistrationOptions() => new CodeActionRegistrationOptions
+        protected override CodeActionRegistrationOptions CreateRegistrationOptions(CodeActionCapability capability, ClientCapabilities clientCapabilities) => new()
         {
             DocumentSelector = DocumentSelectorFactory.Create(),
             CodeActionKinds = new Container<CodeActionKind>(CodeActionKind.QuickFix),

--- a/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
@@ -9,19 +9,19 @@ using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Completions;
 using Bicep.LanguageServer.Utils;
 using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepCompletionHandler : CompletionHandler
+    public class BicepCompletionHandler : CompletionHandlerBase
     {
         private readonly ILogger<BicepCompletionHandler> logger;
         private readonly ICompilationManager compilationManager;
         private readonly ICompletionProvider completionProvider;
 
         public BicepCompletionHandler(ILogger<BicepCompletionHandler> logger, ICompilationManager compilationManager, ICompletionProvider completionProvider)
-            : base(CreateRegistrationOptions())
         {
             this.logger = logger;
             this.compilationManager = compilationManager;
@@ -56,7 +56,7 @@ namespace Bicep.LanguageServer.Handlers
             return Task.FromResult(request);
         }
 
-        private static CompletionRegistrationOptions CreateRegistrationOptions() => new CompletionRegistrationOptions
+        protected override CompletionRegistrationOptions CreateRegistrationOptions(CompletionCapability capability, ClientCapabilities clientCapabilities) => new()
         {
             DocumentSelector = DocumentSelectorFactory.Create(),
             AllCommitCharacters = new Container<string>(),

--- a/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
@@ -2,21 +2,21 @@
 // Licensed under the MIT License.
 using System.Threading;
 using System.Threading.Tasks;
-using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
 using Bicep.LanguageServer.Extensions;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepDefinitionHandler : DefinitionHandler
+    public class BicepDefinitionHandler : DefinitionHandlerBase
     {
         private readonly ISymbolResolver symbolResolver;
 
-        public BicepDefinitionHandler(ISymbolResolver symbolResolver) : base(CreateRegistrationOptions())
+        public BicepDefinitionHandler(ISymbolResolver symbolResolver) : base()
         {
             this.symbolResolver = symbolResolver;
         }
@@ -54,10 +54,9 @@ namespace Bicep.LanguageServer.Handlers
             return Task.FromResult(new LocationOrLocationLinks());
         }
 
-        private static DefinitionRegistrationOptions CreateRegistrationOptions() =>
-            new DefinitionRegistrationOptions
-            {
-                DocumentSelector = DocumentSelectorFactory.Create()
-            };
+        protected override DefinitionRegistrationOptions CreateRegistrationOptions(DefinitionCapability capability, ClientCapabilities clientCapabilities) => new()
+        {
+            DocumentSelector = DocumentSelectorFactory.Create()
+        };
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepDidChangeWatchedFilesHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDidChangeWatchedFilesHandler.cs
@@ -1,40 +1,38 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
-using Bicep.Core.Parsing;
-using Bicep.Core.Syntax;
 using Bicep.LanguageServer.CompilationManager;
 using MediatR;
-using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public sealed class BicepDidChangeWatchedFilesHandler : DidChangeWatchedFilesHandler
+    public sealed class BicepDidChangeWatchedFilesHandler : DidChangeWatchedFilesHandlerBase
     {
         private readonly ICompilationManager compilationManager;
         private readonly IFileResolver fileResolver;
 
         public BicepDidChangeWatchedFilesHandler(ICompilationManager compilationManager, IFileResolver fileResolver)
-            : base(GetDidChangeWatchedFilesRegistrationOptions())
         {
             this.compilationManager = compilationManager;
             this.fileResolver = fileResolver;
         }
 
-        private static DidChangeWatchedFilesRegistrationOptions GetDidChangeWatchedFilesRegistrationOptions()
-            => new DidChangeWatchedFilesRegistrationOptions()
-            {
-                // These file watcher globs should be kept in-sync with those defined in client.ts
-                Watchers = new Container<FileSystemWatcher>(
+        public override Task<Unit> Handle(DidChangeWatchedFilesParams request, CancellationToken cancellationToken)
+        {
+            compilationManager.HandleFileChanges(request.Changes);
+
+            return Unit.Task;
+        }
+
+        protected override DidChangeWatchedFilesRegistrationOptions CreateRegistrationOptions(DidChangeWatchedFilesCapability capability, ClientCapabilities clientCapabilities) => new()
+        {
+            // These file watcher globs should be kept in-sync with those defined in client.ts
+            Watchers = new Container<FileSystemWatcher>(
                     new FileSystemWatcher()
                     {
                         Kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete,
@@ -46,13 +44,6 @@ namespace Bicep.LanguageServer.Handlers
                         GlobPattern = "**/*.bicep"
                     }
                 )
-            };
-
-        public override Task<Unit> Handle(DidChangeWatchedFilesParams request, CancellationToken cancellationToken)
-        {
-            compilationManager.HandleFileChanges(request.Changes);
-
-            return Unit.Task;
-        }
+        };
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepDocumentFormattingHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDocumentFormattingHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,16 +11,16 @@ using Bicep.Core.PrettyPrint.Options;
 using Microsoft.Extensions.Logging;
 using Bicep.Core.Syntax;
 using Bicep.LanguageServer.Extensions;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepDocumentFormattingHandler : DocumentFormattingHandler
+    public class BicepDocumentFormattingHandler : DocumentFormattingHandlerBase
     {
         private readonly ILogger<BicepDocumentSymbolHandler> logger;
         private readonly ICompilationManager compilationManager;
 
         public BicepDocumentFormattingHandler(ILogger<BicepDocumentSymbolHandler> logger, ICompilationManager compilationManager)
-            : base(CreateRegistrationOptions())
         {
             this.logger = logger;
             this.compilationManager = compilationManager;
@@ -58,10 +58,9 @@ namespace Bicep.LanguageServer.Handlers
             }));
         }
 
-        private static DocumentFormattingRegistrationOptions CreateRegistrationOptions() =>
-            new DocumentFormattingRegistrationOptions
-            {
-                DocumentSelector = DocumentSelectorFactory.Create()
-            };
+        protected override DocumentFormattingRegistrationOptions CreateRegistrationOptions(DocumentFormattingCapability capability, ClientCapabilities clientCapabilities) => new()
+        {
+            DocumentSelector = DocumentSelectorFactory.Create()
+        };
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepDocumentHighlightHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDocumentHighlightHandler.cs
@@ -7,16 +7,17 @@ using Bicep.Core.Navigation;
 using Bicep.Core.Syntax;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepDocumentHighlightHandler : DocumentHighlightHandler
+    public class BicepDocumentHighlightHandler : DocumentHighlightHandlerBase
     {
         private readonly ISymbolResolver symbolResolver;
 
-        public BicepDocumentHighlightHandler(ISymbolResolver symbolResolver) : base(CreateRegistrationOptions())
+        public BicepDocumentHighlightHandler(ISymbolResolver symbolResolver) : base()
         {
             this.symbolResolver = symbolResolver;
         }
@@ -44,11 +45,10 @@ namespace Bicep.LanguageServer.Handlers
             return Task.FromResult<DocumentHighlightContainer?>(new DocumentHighlightContainer(highlights));
         }
 
-        private static DocumentHighlightRegistrationOptions CreateRegistrationOptions() =>
-            new DocumentHighlightRegistrationOptions
-            {
-                DocumentSelector = DocumentSelectorFactory.Create()
-            };
+        protected override DocumentHighlightRegistrationOptions CreateRegistrationOptions(DocumentHighlightCapability capability, ClientCapabilities clientCapabilities) => new()
+        {
+            DocumentSelector = DocumentSelectorFactory.Create()
+        };
     }
 }
 

--- a/src/Bicep.LangServer/Handlers/BicepDocumentSymbolHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDocumentSymbolHandler.cs
@@ -10,19 +10,19 @@ using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Extensions;
 using Bicep.LanguageServer.Utils;
 using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using SymbolKind = OmniSharp.Extensions.LanguageServer.Protocol.Models.SymbolKind;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepDocumentSymbolHandler: DocumentSymbolHandler
+    public class BicepDocumentSymbolHandler: DocumentSymbolHandlerBase
     {
         private readonly ILogger<BicepDocumentSymbolHandler> logger;
         private readonly ICompilationManager compilationManager;
 
         public BicepDocumentSymbolHandler(ILogger<BicepDocumentSymbolHandler> logger, ICompilationManager compilationManager)
-            : base(GetSymbolRegistrationOptions())
         {
             this.logger = logger;
             this.compilationManager = compilationManager;
@@ -36,18 +36,10 @@ namespace Bicep.LanguageServer.Handlers
                 // we have not yet compiled this document, which shouldn't really happen
                 this.logger.LogError("Document symbol request arrived before file {Uri} could be compiled.", request.TextDocument.Uri);
 
-                return Task.FromResult(new SymbolInformationOrDocumentSymbolContainer(new SymbolInformationOrDocumentSymbol()));
+                return Task.FromResult(new SymbolInformationOrDocumentSymbolContainer());
             }
 
             return Task.FromResult(new SymbolInformationOrDocumentSymbolContainer(GetSymbols(context)));
-        }
-
-        private static DocumentSymbolRegistrationOptions GetSymbolRegistrationOptions()
-        {
-            return new DocumentSymbolRegistrationOptions
-            {
-                DocumentSelector = DocumentSelectorFactory.Create()
-            };
         }
 
         private IEnumerable<SymbolInformationOrDocumentSymbol> GetSymbols(CompilationContext context)
@@ -115,6 +107,11 @@ namespace Bicep.LanguageServer.Handlers
                     return string.Empty;
             }
         }
+
+        protected override DocumentSymbolRegistrationOptions CreateRegistrationOptions(DocumentSymbolCapability capability, ClientCapabilities clientCapabilities) => new()
+        {
+            DocumentSelector = DocumentSelectorFactory.Create()
+        };
     }
 }
 

--- a/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
@@ -8,16 +8,17 @@ using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepHoverHandler : HoverHandler
+    public class BicepHoverHandler : HoverHandlerBase
     {
         private readonly ISymbolResolver symbolResolver;
 
-        public BicepHoverHandler(ISymbolResolver symbolResolver) : base(CreateRegistrationOptions())
+        public BicepHoverHandler(ISymbolResolver symbolResolver)
         {
             this.symbolResolver = symbolResolver;
         }
@@ -46,12 +47,6 @@ namespace Bicep.LanguageServer.Handlers
                 Range = PositionHelper.GetNameRange(result.Context.LineStarts, result.Origin)
             });
         }
-
-        private static HoverRegistrationOptions CreateRegistrationOptions() =>
-            new HoverRegistrationOptions
-            {
-                DocumentSelector = DocumentSelectorFactory.Create()
-            };
 
         private static string? GetMarkdown(SymbolResolutionResult result)
         {
@@ -136,6 +131,11 @@ namespace Bicep.LanguageServer.Handlers
 
             return buffer.ToString();
         }
+
+        protected override HoverRegistrationOptions CreateRegistrationOptions(HoverCapability capability, ClientCapabilities clientCapabilities) => new()
+        {
+            DocumentSelector = DocumentSelectorFactory.Create()
+        };
     }
 }
 

--- a/src/Bicep.LangServer/Handlers/BicepReferencesHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepReferencesHandler.cs
@@ -8,16 +8,17 @@ using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepReferencesHandler : ReferencesHandler
+    public class BicepReferencesHandler : ReferencesHandlerBase
     {
         private readonly ISymbolResolver symbolResolver;
 
-        public BicepReferencesHandler(ISymbolResolver symbolResolver) : base(CreateRegistrationOptions())
+        public BicepReferencesHandler(ISymbolResolver symbolResolver)
         {
             this.symbolResolver = symbolResolver;
         }
@@ -48,7 +49,7 @@ namespace Bicep.LanguageServer.Handlers
             return Task.FromResult(new LocationContainer(references));
         }
 
-        private static ReferenceRegistrationOptions CreateRegistrationOptions() => new ReferenceRegistrationOptions
+        protected override ReferenceRegistrationOptions CreateRegistrationOptions(ReferenceCapability capability, ClientCapabilities clientCapabilities) => new()
         {
             DocumentSelector = DocumentSelectorFactory.Create()
         };

--- a/src/Bicep.LangServer/Handlers/BicepRenameHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepRenameHandler.cs
@@ -11,16 +11,17 @@ using Bicep.LanguageServer.Extensions;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Utils;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepRenameHandler : RenameHandler
+    public class BicepRenameHandler : RenameHandlerBase
     {
         private readonly ISymbolResolver symbolResolver;
 
-        public BicepRenameHandler(ISymbolResolver symbolResolver) : base(CreateRegistrationOptions())
+        public BicepRenameHandler(ISymbolResolver symbolResolver) : base()
         {
             this.symbolResolver = symbolResolver;
         }
@@ -81,7 +82,7 @@ namespace Bicep.LanguageServer.Handlers
             }
         }
 
-        private static RenameRegistrationOptions CreateRegistrationOptions() => new RenameRegistrationOptions
+        protected override RenameRegistrationOptions CreateRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities) => new()
         {
             DocumentSelector = DocumentSelectorFactory.Create(),
             PrepareProvider = false

--- a/src/Bicep.LangServer/Handlers/BicepSignatureHelpHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepSignatureHelpHandler.cs
@@ -17,19 +17,20 @@ using Bicep.Core.TypeSystem;
 using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Completions;
 using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepSignatureHelpHandler: SignatureHelpHandler
+    public class BicepSignatureHelpHandler: SignatureHelpHandlerBase
     {
         private const string FunctionArgumentStart = "(";
         private const string FunctionArgumentEnd = ")";
 
         private readonly ICompilationManager compilationManager;
 
-        public BicepSignatureHelpHandler(ICompilationManager compilationManager) : base(CreateRegistrationOptions())
+        public BicepSignatureHelpHandler(ICompilationManager compilationManager)
         {
             this.compilationManager = compilationManager;
         }
@@ -72,7 +73,7 @@ namespace Bicep.LanguageServer.Handlers
             var includeReturnType = semanticModel.Binder.GetParent(functionCall) is not DecoratorSyntax;
 
             var signatureHelp = CreateSignatureHelp(functionCall.Arguments, normalizedArgumentTypes, functionSymbol, offset, includeReturnType);
-            TryReuseActiveSignature(request.Context, signatureHelp);
+            signatureHelp = TryReuseActiveSignature(request.Context, signatureHelp);
 
             return Task.FromResult<SignatureHelp?>(signatureHelp);
         }
@@ -91,22 +92,28 @@ namespace Bicep.LanguageServer.Handlers
             return index < 0 ? null : (FunctionCallSyntaxBase)matchingNodes[index];
         }
 
-        private static void TryReuseActiveSignature(SignatureHelpContext? context, SignatureHelp signatureHelp)
+        private static SignatureHelp TryReuseActiveSignature(SignatureHelpContext? context, SignatureHelp signatureHelp)
         {
             if (context?.ActiveSignatureHelp == null ||
                 string.Equals(context.TriggerCharacter, FunctionArgumentStart, StringComparison.Ordinal) ||
                 string.Equals(context.TriggerCharacter, FunctionArgumentEnd, StringComparison.Ordinal))
             {
                 // we don't have a previous active signature or the user typed ( or ), which would indicate a new "session"
-                return;
+                return signatureHelp;
             }
 
             if (CheckIfSignatureHelpSimilar(context.ActiveSignatureHelp, signatureHelp))
             {
                 // the signature help is for the same function so we can reuse the active signature index
                 // this prevents resetting of the active signature when multiple overloads are ambiguous and the user selected a specific one manually
-                signatureHelp.ActiveSignature = context.ActiveSignatureHelp.ActiveSignature;
+                return signatureHelp with
+                {
+                    ActiveSignature = context.ActiveSignatureHelp.ActiveSignature
+                };
             }
+
+            // cannot improve the active signature - return as-is
+            return signatureHelp;
         }
 
         private static bool CheckIfSignatureHelpSimilar(SignatureHelp active, SignatureHelp @new)
@@ -253,7 +260,7 @@ namespace Bicep.LanguageServer.Handlers
             });
         }
 
-        private static SignatureHelpRegistrationOptions CreateRegistrationOptions() => new()
+        protected override SignatureHelpRegistrationOptions CreateRegistrationOptions(SignatureHelpCapability capability, ClientCapabilities clientCapabilities) => new()
         {
             DocumentSelector = DocumentSelectorFactory.Create(),
             /*

--- a/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,20 +9,24 @@ using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Utils;
 using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepTextDocumentSyncHandler : TextDocumentSyncHandler
+    public class BicepTextDocumentSyncHandler : TextDocumentSyncHandlerBase
     {
         private readonly ICompilationManager compilationManager;
+        private readonly ILanguageServerFacade server;
 
-        public BicepTextDocumentSyncHandler(ICompilationManager compilationManager)
-            : base(TextDocumentSyncKind.Full, GetSaveRegistrationOptions())
+        public BicepTextDocumentSyncHandler(ICompilationManager compilationManager, ILanguageServerFacade server)
         {
             this.compilationManager = compilationManager;
+            this.server = server;
         }
 
         public override TextDocumentAttributes GetTextDocumentAttributes(DocumentUri uri)
@@ -41,9 +46,19 @@ namespace Bicep.LanguageServer.Handlers
 
         public override Task<Unit> Handle(DidOpenTextDocumentParams request, CancellationToken cancellationToken)
         {
-            this.compilationManager.UpsertCompilation(request.TextDocument.Uri, request.TextDocument.Version, request.TextDocument.Text);
-            
-            return Unit.Task;
+            this.server.Window.LogInfo($"Received open file request server-side.");
+
+            try
+            {
+                this.compilationManager.UpsertCompilation(request.TextDocument.Uri, request.TextDocument.Version, request.TextDocument.Text);
+
+                return Unit.Task;
+            }
+            catch(Exception exception)
+            {
+                this.server.Window.LogError($"Exception server side: {exception}");
+                throw;
+            }
         }
 
         public override Task<Unit> Handle(DidSaveTextDocumentParams request, CancellationToken cancellationToken)
@@ -58,11 +73,10 @@ namespace Bicep.LanguageServer.Handlers
             return Unit.Task;
         }
 
-        private static TextDocumentSaveRegistrationOptions GetSaveRegistrationOptions()
-            => new TextDocumentSaveRegistrationOptions
-            {
-                DocumentSelector = DocumentSelectorFactory.Create(),
-                IncludeText = true,
-            };
+        protected override TextDocumentSyncRegistrationOptions CreateRegistrationOptions(SynchronizationCapability capability, ClientCapabilities clientCapabilities) => new()
+        {
+            Change = TextDocumentSyncKind.Full,
+            DocumentSelector = DocumentSelectorFactory.Create()
+        };
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
@@ -21,12 +21,10 @@ namespace Bicep.LanguageServer.Handlers
     public class BicepTextDocumentSyncHandler : TextDocumentSyncHandlerBase
     {
         private readonly ICompilationManager compilationManager;
-        private readonly ILanguageServerFacade server;
 
-        public BicepTextDocumentSyncHandler(ICompilationManager compilationManager, ILanguageServerFacade server)
+        public BicepTextDocumentSyncHandler(ICompilationManager compilationManager)
         {
             this.compilationManager = compilationManager;
-            this.server = server;
         }
 
         public override TextDocumentAttributes GetTextDocumentAttributes(DocumentUri uri)
@@ -46,19 +44,9 @@ namespace Bicep.LanguageServer.Handlers
 
         public override Task<Unit> Handle(DidOpenTextDocumentParams request, CancellationToken cancellationToken)
         {
-            this.server.Window.LogInfo($"Received open file request server-side.");
+            this.compilationManager.UpsertCompilation(request.TextDocument.Uri, request.TextDocument.Version, request.TextDocument.Text);
 
-            try
-            {
-                this.compilationManager.UpsertCompilation(request.TextDocument.Uri, request.TextDocument.Version, request.TextDocument.Text);
-
-                return Unit.Task;
-            }
-            catch(Exception exception)
-            {
-                this.server.Window.LogError($"Exception server side: {exception}");
-                throw;
-            }
+            return Unit.Task;
         }
 
         public override Task<Unit> Handle(DidSaveTextDocumentParams request, CancellationToken cancellationToken)

--- a/src/Bicep.LangServer/SemanticTokenVisitor.cs
+++ b/src/Bicep.LangServer/SemanticTokenVisitor.cs
@@ -7,12 +7,11 @@ using Bicep.Core;
 using Bicep.Core.Parsing;
 using Bicep.Core.Syntax;
 using Bicep.LanguageServer.Extensions;
-using OmniSharp.Extensions.LanguageServer.Protocol.Document.Proposals;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer
 {
-    [Obsolete] // proposed LSP feature must be marked 'obsolete' to access
     public class SemanticTokenVisitor : SyntaxVisitor
     {
         private readonly List<(IPositionable positionable, SemanticTokenType tokenType)> tokens;
@@ -114,7 +113,7 @@ namespace Bicep.LanguageServer
             }
             else
             {
-                AddTokenType(syntax.Key, SemanticTokenType.Member);
+                AddTokenType(syntax.Key, SemanticTokenType.Method);
             }
             Visit(syntax.Colon);
             Visit(syntax.Value);

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -16,6 +16,8 @@ using Bicep.LanguageServer.Handlers;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Snippets;
 using Microsoft.Extensions.DependencyInjection;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 using OmniSharp.Extensions.LanguageServer.Server;
 using OmnisharpLanguageServer = OmniSharp.Extensions.LanguageServer.Server.LanguageServer;
 
@@ -47,7 +49,7 @@ namespace Bicep.LanguageServer
         private Server(CreationOptions creationOptions, Action<LanguageServerOptions> onOptionsFunc)
         {
             BicepDeploymentsInterop.Initialize();
-            server = OmniSharp.Extensions.LanguageServer.Server.LanguageServer.PreInit(options =>
+            server = OmnisharpLanguageServer.PreInit(options =>
             {
                 options
                     .WithHandler<BicepTextDocumentSyncHandler>()
@@ -63,9 +65,7 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepCodeActionHandler>()
                     .WithHandler<BicepDidChangeWatchedFilesHandler>()
                     .WithHandler<BicepSignatureHelpHandler>()
-#pragma warning disable 0612 // disable 'obsolete' warning for proposed LSP feature
                     .WithHandler<BicepSemanticTokensHandler>()
-#pragma warning restore 0612
                     .WithServices(services => RegisterServices(creationOptions, services));
 
                 onOptionsFunc(options);
@@ -75,6 +75,8 @@ namespace Bicep.LanguageServer
         public async Task RunAsync(CancellationToken cancellationToken)
         {
             await server.Initialize(cancellationToken);
+
+            server.LogInfo("Bicep language service initialized.");
 
             await server.WaitForExit;
         }

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -76,8 +76,6 @@ namespace Bicep.LanguageServer
         {
             await server.Initialize(cancellationToken);
 
-            server.LogInfo("Bicep language service initialized.");
-
             await server.WaitForExit;
         }
 


### PR DESCRIPTION
Upgraded the language server and test projects to use OmniSharp 19. This brings full support of LSP 3.16, including the semantic token legend, which should allow more control over syntax highlighting via semantic tokens.

OmniSharp release notes: https://github.com/OmniSharp/csharp-language-server-protocol/releases/tag/v0.19.0