### PR TITLE
Change resource access operator to ::

### DIFF
--- a/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
@@ -62,7 +62,7 @@ resource parent 'My.RP/parentType@2020-01-01' = {
               .OrderBy(n => n.name)
               .Should().BeEquivalentTo(expected);
         }
-        
+
         [TestMethod]
         public void NestedResources_resource_can_contain_property_called_resource()
         {
@@ -129,16 +129,16 @@ resource parent 'My.RP/parentType@2020-01-01' = {
   resource sibling 'childType@2020-01-02' = {
     name: 'sibling'
     properties: {
-      style: parent:child.properties.style
+      style: parent::child.properties.style
       size: parent.properties.size
-      temperatureC: child:grandchild.properties.temperature
-      temperatureF: parent:child:grandchild.properties.temperature
+      temperatureC: child::grandchild.properties.temperature
+      temperatureF: parent::child::grandchild.properties.temperature
     }
   }
 }
 
-output fromChild string = parent:child.properties.style
-output fromGrandchild string = parent:child:grandchild.properties.style
+output fromChild string = parent::child.properties.style
+output fromGrandchild string = parent::child::grandchild.properties.style
 ";
 
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
@@ -196,9 +196,9 @@ resource parent 'My.RP/parentType@2020-01-01' = {
   }
 }
 
-output fromVariable string = notResource:child.properties.style
-output fromChildInvalid string = parent:child2.properties.style
-output fromGrandchildInvalid string = parent:child:cousin.properties.temperature
+output fromVariable string = notResource::child.properties.style
+output fromChildInvalid string = parent::child2.properties.style
+output fromGrandchildInvalid string = parent::child::cousin.properties.temperature
 ";
 
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
@@ -522,7 +522,7 @@ resource parent 'My.RP/parentType@2020-01-01' = {
   }]
 }
 
-output loopy string = parent:child[0].name
+output loopy string = parent::child[0].name
 ";
 
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
@@ -553,7 +553,7 @@ resource parent 'My.RP/parentType@2020-01-01' = {
   }
 }
 
-output hmmmm string = parent:child.properties
+output hmmmm string = parent::child.properties
 ";
 
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));
@@ -569,9 +569,9 @@ output hmmmm string = parent:child.properties
         public void NestedResources_provides_correct_error_for_resource_access_with_broken_body()
         {
             var program = @"
-resource broken 'Microsoft.Network/virtualNetworks@2020-06-01' = 
+resource broken 'Microsoft.Network/virtualNetworks@2020-06-01' =
 
-output foo string = broken:fake
+output foo string = broken::fake
 ";
 
             var compilation = new Compilation(TestResourceTypeProvider.Create(), SyntaxTreeGroupingFactory.CreateFromText(program));

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/Completions/childResources.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/Completions/childResources.json
@@ -1,0 +1,36 @@
+[
+  {
+    "label": "basicChild",
+    "kind": "interface",
+    "detail": "basicChild",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_basicChild",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "basicChild"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "basicSibling",
+    "kind": "interface",
+    "detail": "basicSibling",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_basicSibling",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "basicSibling"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/Completions/grandChildResources.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/Completions/grandChildResources.json
@@ -1,0 +1,19 @@
+[
+  {
+    "label": "basicGrandchild",
+    "kind": "interface",
+    "detail": "basicGrandchild",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_basicGrandchild",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "basicGrandchild"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  }
+]

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.bicep
@@ -24,13 +24,14 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
     name: 'basicSibling'
     properties: {
       size: basicParent.properties.size
-      style: basicChild:basicGrandchild.properties.style
+      style: basicChild::basicGrandchild.properties.style
     }
   }
 }
-
-output referenceBasicChild string = basicParent:basicChild.properties.size
-output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+// #completionTest(50) -> childResources
+output referenceBasicChild string = basicParent::basicChild.properties.size
+// #completionTest(67) -> grandChildResources
+output referenceBasicGrandchild string = basicParent::basicChild::basicGrandchild.properties.style
 
 resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
   name: 'existingParent'
@@ -79,4 +80,4 @@ resource loopParent 'My.Rp/parentType@2020-12-01' = {
   }]
 }
 
-output loopChildOutput string = loopParent:loopChild[0].name
+output loopChildOutput string = loopParent::loopChild[0].name

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.diagnostics.bicep
@@ -28,13 +28,14 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
     name: 'basicSibling'
     properties: {
       size: basicParent.properties.size
-      style: basicChild:basicGrandchild.properties.style
+      style: basicChild::basicGrandchild.properties.style
     }
   }
 }
-
-output referenceBasicChild string = basicParent:basicChild.properties.size
-output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+// #completionTest(50) -> childResources
+output referenceBasicChild string = basicParent::basicChild.properties.size
+// #completionTest(67) -> grandChildResources
+output referenceBasicGrandchild string = basicParent::basicChild::basicGrandchild.properties.style
 
 resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
 //@[24:53) [BCP081 (Warning)] Resource type "My.Rp/parentType@2020-12-01" does not have types available. |'My.Rp/parentType@2020-12-01'|
@@ -91,4 +92,4 @@ resource loopParent 'My.Rp/parentType@2020-12-01' = {
   }]
 }
 
-output loopChildOutput string = loopParent:loopChild[0].name
+output loopChildOutput string = loopParent::loopChild[0].name

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.formatted.bicep
@@ -24,13 +24,14 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
     name: 'basicSibling'
     properties: {
       size: basicParent.properties.size
-      style: basicChild:basicGrandchild.properties.style
+      style: basicChild::basicGrandchild.properties.style
     }
   }
 }
-
-output referenceBasicChild string = basicParent:basicChild.properties.size
-output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+// #completionTest(50) -> childResources
+output referenceBasicChild string = basicParent::basicChild.properties.size
+// #completionTest(67) -> grandChildResources
+output referenceBasicGrandchild string = basicParent::basicChild::basicGrandchild.properties.style
 
 resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
   name: 'existingParent'
@@ -79,4 +80,4 @@ resource loopParent 'My.Rp/parentType@2020-12-01' = {
   }]
 }
 
-output loopChildOutput string = loopParent:loopChild[0].name
+output loopChildOutput string = loopParent::loopChild[0].name

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbols.bicep
@@ -1,5 +1,5 @@
 resource basicParent 'My.Rp/parentType@2020-12-01' = {
-//@[9:20) Resource basicParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 658
+//@[9:20) Resource basicParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 659
   name: 'basicParent'
   properties: {
     size: 'large'
@@ -24,19 +24,20 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
   }
 
   resource basicSibling 'childType' = {
-//@[11:23) Resource basicSibling. Type: My.Rp/parentType/childType@2020-12-01. Declaration start char: 2, length: 187
+//@[11:23) Resource basicSibling. Type: My.Rp/parentType/childType@2020-12-01. Declaration start char: 2, length: 188
     name: 'basicSibling'
     properties: {
       size: basicParent.properties.size
-      style: basicChild:basicGrandchild.properties.style
+      style: basicChild::basicGrandchild.properties.style
     }
   }
 }
-
-output referenceBasicChild string = basicParent:basicChild.properties.size
-//@[7:26) Output referenceBasicChild. Type: string. Declaration start char: 0, length: 74
-output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
-//@[7:31) Output referenceBasicGrandchild. Type: string. Declaration start char: 0, length: 96
+// #completionTest(50) -> childResources
+output referenceBasicChild string = basicParent::basicChild.properties.size
+//@[7:26) Output referenceBasicChild. Type: string. Declaration start char: 0, length: 75
+// #completionTest(67) -> grandChildResources
+output referenceBasicGrandchild string = basicParent::basicChild::basicGrandchild.properties.style
+//@[7:31) Output referenceBasicGrandchild. Type: string. Declaration start char: 0, length: 98
 
 resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
 //@[9:23) Resource existingParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 386
@@ -98,5 +99,5 @@ resource loopParent 'My.Rp/parentType@2020-12-01' = {
   }]
 }
 
-output loopChildOutput string = loopParent:loopChild[0].name
-//@[7:22) Output loopChildOutput. Type: string. Declaration start char: 0, length: 60
+output loopChildOutput string = loopParent::loopChild[0].name
+//@[7:22) Output loopChildOutput. Type: string. Declaration start char: 0, length: 61

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.syntax.bicep
@@ -1,12 +1,12 @@
 resource basicParent 'My.Rp/parentType@2020-12-01' = {
-//@[0:658) ResourceDeclarationSyntax
+//@[0:659) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:20)  IdentifierSyntax
 //@[9:20)   Identifier |basicParent|
 //@[21:50)  StringSyntax
 //@[21:50)   StringComplete |'My.Rp/parentType@2020-12-01'|
 //@[51:52)  Assignment |=|
-//@[53:658)  ObjectSyntax
+//@[53:659)  ObjectSyntax
 //@[53:54)   LeftBrace |{|
 //@[54:55)   NewLine |\n|
   name: 'basicParent'
@@ -165,14 +165,14 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
 //@[3:5)   NewLine |\n\n|
 
   resource basicSibling 'childType' = {
-//@[2:189)   ResourceDeclarationSyntax
+//@[2:190)   ResourceDeclarationSyntax
 //@[2:10)    Identifier |resource|
 //@[11:23)    IdentifierSyntax
 //@[11:23)     Identifier |basicSibling|
 //@[24:35)    StringSyntax
 //@[24:35)     StringComplete |'childType'|
 //@[36:37)    Assignment |=|
-//@[38:189)    ObjectSyntax
+//@[38:190)    ObjectSyntax
 //@[38:39)     LeftBrace |{|
 //@[39:40)     NewLine |\n|
     name: 'basicSibling'
@@ -184,11 +184,11 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
 //@[10:24)       StringComplete |'basicSibling'|
 //@[24:25)     NewLine |\n|
     properties: {
-//@[4:120)     ObjectPropertySyntax
+//@[4:121)     ObjectPropertySyntax
 //@[4:14)      IdentifierSyntax
 //@[4:14)       Identifier |properties|
 //@[14:15)      Colon |:|
-//@[16:120)      ObjectSyntax
+//@[16:121)      ObjectSyntax
 //@[16:17)       LeftBrace |{|
 //@[17:18)       NewLine |\n|
       size: basicParent.properties.size
@@ -208,27 +208,27 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
 //@[35:39)         IdentifierSyntax
 //@[35:39)          Identifier |size|
 //@[39:40)       NewLine |\n|
-      style: basicChild:basicGrandchild.properties.style
-//@[6:56)       ObjectPropertySyntax
+      style: basicChild::basicGrandchild.properties.style
+//@[6:57)       ObjectPropertySyntax
 //@[6:11)        IdentifierSyntax
 //@[6:11)         Identifier |style|
 //@[11:12)        Colon |:|
-//@[13:56)        PropertyAccessSyntax
-//@[13:50)         PropertyAccessSyntax
-//@[13:39)          ResourceAccessSyntax
+//@[13:57)        PropertyAccessSyntax
+//@[13:51)         PropertyAccessSyntax
+//@[13:40)          ResourceAccessSyntax
 //@[13:23)           VariableAccessSyntax
 //@[13:23)            IdentifierSyntax
 //@[13:23)             Identifier |basicChild|
-//@[23:24)           Colon |:|
-//@[24:39)           IdentifierSyntax
-//@[24:39)            Identifier |basicGrandchild|
-//@[39:40)          Dot |.|
-//@[40:50)          IdentifierSyntax
-//@[40:50)           Identifier |properties|
-//@[50:51)         Dot |.|
-//@[51:56)         IdentifierSyntax
-//@[51:56)          Identifier |style|
-//@[56:57)       NewLine |\n|
+//@[23:25)           DoubleColon |::|
+//@[25:40)           IdentifierSyntax
+//@[25:40)            Identifier |basicGrandchild|
+//@[40:41)          Dot |.|
+//@[41:51)          IdentifierSyntax
+//@[41:51)           Identifier |properties|
+//@[51:52)         Dot |.|
+//@[52:57)         IdentifierSyntax
+//@[52:57)          Identifier |style|
+//@[57:58)       NewLine |\n|
     }
 //@[4:5)       RightBrace |}|
 //@[5:6)     NewLine |\n|
@@ -237,60 +237,63 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
 //@[3:4)   NewLine |\n|
 }
 //@[0:1)   RightBrace |}|
-//@[1:3) NewLine |\n\n|
-
-output referenceBasicChild string = basicParent:basicChild.properties.size
-//@[0:74) OutputDeclarationSyntax
+//@[1:2) NewLine |\n|
+// #completionTest(50) -> childResources
+//@[40:41) NewLine |\n|
+output referenceBasicChild string = basicParent::basicChild.properties.size
+//@[0:75) OutputDeclarationSyntax
 //@[0:6)  Identifier |output|
 //@[7:26)  IdentifierSyntax
 //@[7:26)   Identifier |referenceBasicChild|
 //@[27:33)  TypeSyntax
 //@[27:33)   Identifier |string|
 //@[34:35)  Assignment |=|
-//@[36:74)  PropertyAccessSyntax
-//@[36:69)   PropertyAccessSyntax
-//@[36:58)    ResourceAccessSyntax
+//@[36:75)  PropertyAccessSyntax
+//@[36:70)   PropertyAccessSyntax
+//@[36:59)    ResourceAccessSyntax
 //@[36:47)     VariableAccessSyntax
 //@[36:47)      IdentifierSyntax
 //@[36:47)       Identifier |basicParent|
-//@[47:48)     Colon |:|
-//@[48:58)     IdentifierSyntax
-//@[48:58)      Identifier |basicChild|
-//@[58:59)    Dot |.|
-//@[59:69)    IdentifierSyntax
-//@[59:69)     Identifier |properties|
-//@[69:70)   Dot |.|
-//@[70:74)   IdentifierSyntax
-//@[70:74)    Identifier |size|
-//@[74:75) NewLine |\n|
-output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
-//@[0:96) OutputDeclarationSyntax
+//@[47:49)     DoubleColon |::|
+//@[49:59)     IdentifierSyntax
+//@[49:59)      Identifier |basicChild|
+//@[59:60)    Dot |.|
+//@[60:70)    IdentifierSyntax
+//@[60:70)     Identifier |properties|
+//@[70:71)   Dot |.|
+//@[71:75)   IdentifierSyntax
+//@[71:75)    Identifier |size|
+//@[75:76) NewLine |\n|
+// #completionTest(67) -> grandChildResources
+//@[45:46) NewLine |\n|
+output referenceBasicGrandchild string = basicParent::basicChild::basicGrandchild.properties.style
+//@[0:98) OutputDeclarationSyntax
 //@[0:6)  Identifier |output|
 //@[7:31)  IdentifierSyntax
 //@[7:31)   Identifier |referenceBasicGrandchild|
 //@[32:38)  TypeSyntax
 //@[32:38)   Identifier |string|
 //@[39:40)  Assignment |=|
-//@[41:96)  PropertyAccessSyntax
-//@[41:90)   PropertyAccessSyntax
-//@[41:79)    ResourceAccessSyntax
-//@[41:63)     ResourceAccessSyntax
+//@[41:98)  PropertyAccessSyntax
+//@[41:92)   PropertyAccessSyntax
+//@[41:81)    ResourceAccessSyntax
+//@[41:64)     ResourceAccessSyntax
 //@[41:52)      VariableAccessSyntax
 //@[41:52)       IdentifierSyntax
 //@[41:52)        Identifier |basicParent|
-//@[52:53)      Colon |:|
-//@[53:63)      IdentifierSyntax
-//@[53:63)       Identifier |basicChild|
-//@[63:64)     Colon |:|
-//@[64:79)     IdentifierSyntax
-//@[64:79)      Identifier |basicGrandchild|
-//@[79:80)    Dot |.|
-//@[80:90)    IdentifierSyntax
-//@[80:90)     Identifier |properties|
-//@[90:91)   Dot |.|
-//@[91:96)   IdentifierSyntax
-//@[91:96)    Identifier |style|
-//@[96:98) NewLine |\n\n|
+//@[52:54)      DoubleColon |::|
+//@[54:64)      IdentifierSyntax
+//@[54:64)       Identifier |basicChild|
+//@[64:66)     DoubleColon |::|
+//@[66:81)     IdentifierSyntax
+//@[66:81)      Identifier |basicGrandchild|
+//@[81:82)    Dot |.|
+//@[82:92)    IdentifierSyntax
+//@[82:92)     Identifier |properties|
+//@[92:93)   Dot |.|
+//@[93:98)   IdentifierSyntax
+//@[93:98)    Identifier |style|
+//@[98:100) NewLine |\n\n|
 
 resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
 //@[0:386) ResourceDeclarationSyntax
@@ -650,28 +653,28 @@ resource loopParent 'My.Rp/parentType@2020-12-01' = {
 //@[0:1)   RightBrace |}|
 //@[1:3) NewLine |\n\n|
 
-output loopChildOutput string = loopParent:loopChild[0].name
-//@[0:60) OutputDeclarationSyntax
+output loopChildOutput string = loopParent::loopChild[0].name
+//@[0:61) OutputDeclarationSyntax
 //@[0:6)  Identifier |output|
 //@[7:22)  IdentifierSyntax
 //@[7:22)   Identifier |loopChildOutput|
 //@[23:29)  TypeSyntax
 //@[23:29)   Identifier |string|
 //@[30:31)  Assignment |=|
-//@[32:60)  PropertyAccessSyntax
-//@[32:55)   ArrayAccessSyntax
-//@[32:52)    ResourceAccessSyntax
+//@[32:61)  PropertyAccessSyntax
+//@[32:56)   ArrayAccessSyntax
+//@[32:53)    ResourceAccessSyntax
 //@[32:42)     VariableAccessSyntax
 //@[32:42)      IdentifierSyntax
 //@[32:42)       Identifier |loopParent|
-//@[42:43)     Colon |:|
-//@[43:52)     IdentifierSyntax
-//@[43:52)      Identifier |loopChild|
-//@[52:53)    LeftSquare |[|
-//@[53:54)    IntegerLiteralSyntax
-//@[53:54)     Integer |0|
-//@[54:55)    RightSquare |]|
-//@[55:56)   Dot |.|
-//@[56:60)   IdentifierSyntax
-//@[56:60)    Identifier |name|
-//@[60:60) EndOfFile ||
+//@[42:44)     DoubleColon |::|
+//@[44:53)     IdentifierSyntax
+//@[44:53)      Identifier |loopChild|
+//@[53:54)    LeftSquare |[|
+//@[54:55)    IntegerLiteralSyntax
+//@[54:55)     Integer |0|
+//@[55:56)    RightSquare |]|
+//@[56:57)   Dot |.|
+//@[57:61)   IdentifierSyntax
+//@[57:61)    Identifier |name|
+//@[61:61) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.tokens.bicep
@@ -130,17 +130,17 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
 //@[34:35) Dot |.|
 //@[35:39) Identifier |size|
 //@[39:40) NewLine |\n|
-      style: basicChild:basicGrandchild.properties.style
+      style: basicChild::basicGrandchild.properties.style
 //@[6:11) Identifier |style|
 //@[11:12) Colon |:|
 //@[13:23) Identifier |basicChild|
-//@[23:24) Colon |:|
-//@[24:39) Identifier |basicGrandchild|
-//@[39:40) Dot |.|
-//@[40:50) Identifier |properties|
-//@[50:51) Dot |.|
-//@[51:56) Identifier |style|
-//@[56:57) NewLine |\n|
+//@[23:25) DoubleColon |::|
+//@[25:40) Identifier |basicGrandchild|
+//@[40:41) Dot |.|
+//@[41:51) Identifier |properties|
+//@[51:52) Dot |.|
+//@[52:57) Identifier |style|
+//@[57:58) NewLine |\n|
     }
 //@[4:5) RightBrace |}|
 //@[5:6) NewLine |\n|
@@ -149,36 +149,39 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
 //@[3:4) NewLine |\n|
 }
 //@[0:1) RightBrace |}|
-//@[1:3) NewLine |\n\n|
-
-output referenceBasicChild string = basicParent:basicChild.properties.size
+//@[1:2) NewLine |\n|
+// #completionTest(50) -> childResources
+//@[40:41) NewLine |\n|
+output referenceBasicChild string = basicParent::basicChild.properties.size
 //@[0:6) Identifier |output|
 //@[7:26) Identifier |referenceBasicChild|
 //@[27:33) Identifier |string|
 //@[34:35) Assignment |=|
 //@[36:47) Identifier |basicParent|
-//@[47:48) Colon |:|
-//@[48:58) Identifier |basicChild|
-//@[58:59) Dot |.|
-//@[59:69) Identifier |properties|
-//@[69:70) Dot |.|
-//@[70:74) Identifier |size|
-//@[74:75) NewLine |\n|
-output referenceBasicGrandchild string = basicParent:basicChild:basicGrandchild.properties.style
+//@[47:49) DoubleColon |::|
+//@[49:59) Identifier |basicChild|
+//@[59:60) Dot |.|
+//@[60:70) Identifier |properties|
+//@[70:71) Dot |.|
+//@[71:75) Identifier |size|
+//@[75:76) NewLine |\n|
+// #completionTest(67) -> grandChildResources
+//@[45:46) NewLine |\n|
+output referenceBasicGrandchild string = basicParent::basicChild::basicGrandchild.properties.style
 //@[0:6) Identifier |output|
 //@[7:31) Identifier |referenceBasicGrandchild|
 //@[32:38) Identifier |string|
 //@[39:40) Assignment |=|
 //@[41:52) Identifier |basicParent|
-//@[52:53) Colon |:|
-//@[53:63) Identifier |basicChild|
-//@[63:64) Colon |:|
-//@[64:79) Identifier |basicGrandchild|
-//@[79:80) Dot |.|
-//@[80:90) Identifier |properties|
-//@[90:91) Dot |.|
-//@[91:96) Identifier |style|
-//@[96:98) NewLine |\n\n|
+//@[52:54) DoubleColon |::|
+//@[54:64) Identifier |basicChild|
+//@[64:66) DoubleColon |::|
+//@[66:81) Identifier |basicGrandchild|
+//@[81:82) Dot |.|
+//@[82:92) Identifier |properties|
+//@[92:93) Dot |.|
+//@[93:98) Identifier |style|
+//@[98:100) NewLine |\n\n|
 
 resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
 //@[0:8) Identifier |resource|
@@ -411,17 +414,17 @@ resource loopParent 'My.Rp/parentType@2020-12-01' = {
 //@[0:1) RightBrace |}|
 //@[1:3) NewLine |\n\n|
 
-output loopChildOutput string = loopParent:loopChild[0].name
+output loopChildOutput string = loopParent::loopChild[0].name
 //@[0:6) Identifier |output|
 //@[7:22) Identifier |loopChildOutput|
 //@[23:29) Identifier |string|
 //@[30:31) Assignment |=|
 //@[32:42) Identifier |loopParent|
-//@[42:43) Colon |:|
-//@[43:52) Identifier |loopChild|
-//@[52:53) LeftSquare |[|
-//@[53:54) Integer |0|
-//@[54:55) RightSquare |]|
-//@[55:56) Dot |.|
-//@[56:60) Identifier |name|
-//@[60:60) EndOfFile ||
+//@[42:44) DoubleColon |::|
+//@[44:53) Identifier |loopChild|
+//@[53:54) LeftSquare |[|
+//@[54:55) Integer |0|
+//@[55:56) RightSquare |]|
+//@[56:57) Dot |.|
+//@[57:61) Identifier |name|
+//@[61:61) EndOfFile ||

--- a/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
@@ -247,19 +247,18 @@ namespace Bicep.Core.UnitTests.Parsing
         }
 
         [DataTestMethod]
-        [DataRow("a:b","(a:b)")]
-        [DataRow("null:fail", "(null:fail)")]
-        [DataRow("foo():bar","(foo():bar)")]
+        [DataRow("a::b","(a::b)")]
+        [DataRow("null::fail", "(null::fail)")]
+        [DataRow("foo()::bar","(foo()::bar)")]
         public void ResourceAccessShouldParseSuccessfully(string text, string expected)
         {
             RunExpressionTest(text, expected, typeof(ResourceAccessSyntax));
         }
 
-        // There's an ambiguity with the ternary operator that we resolve by letting ternary win when it's in between `?` and `:`
         [DataTestMethod]
-        [DataRow("foo?bar:baz:biz","(foo?bar:(baz:biz))")]
-        [DataRow("foo?(bar:biz.prop1):baz:boo","(foo?(((bar:biz).prop1)):(baz:boo))")]
-        //[DataRow("foo:boo?bar:baz","((foo:boo)?bar:baz)")]
+        [DataRow("foo?bar:baz::biz","(foo?bar:(baz::biz))")]
+        [DataRow("foo?bar::biz.prop1:baz::boo","(foo?((bar::biz).prop1):(baz::boo))")]
+        [DataRow("foo::boo?bar:baz","((foo::boo)?bar:baz)")]
         public void ResourceAccessShouldParseSuccessfullyWithTernaries(string text, string expected)
         {
             RunExpressionTest(text, expected, typeof(TernaryOperationSyntax));
@@ -268,7 +267,7 @@ namespace Bicep.Core.UnitTests.Parsing
         [DataTestMethod]
         [DataRow("a.b.c.foo()", "((a.b).c).foo()")]
         [DataRow("a.b.c.d.e.f.g.foo()", "((((((a.b).c).d).e).f).g).foo()")]
-        [DataRow("a:b:c.d:e:f:g.foo()", "((((((a:b):c).d):e):f):g).foo()")]
+        [DataRow("a::b::c.d::e::f::g.foo()", "((((((a::b)::c).d)::e)::f)::g).foo()")]
         public void InstanceFunctionCallShouldParseSuccessfully(string text, string expected)
         {
             RunExpressionTest(text, expected, typeof(InstanceFunctionCallSyntax));
@@ -284,8 +283,8 @@ namespace Bicep.Core.UnitTests.Parsing
         }
 
         [DataTestMethod]
-        [DataRow("a:b:c + 0","(((a:b):c)+0)")]
-        [DataRow("(a:b[c]):c[d]+q()", "((((((a:b)[c])):c)[d])+q())")]
+        [DataRow("a::b::c + 0","(((a::b)::c)+0)")]
+        [DataRow("(a::b[c])::c[d]+q()", "((((((a::b)[c]))::c)[d])+q())")]
         public void ResourceAccessShouldBeLeftToRightAssociative(string text, string expected)
         {
             // this also asserts that (), [], and . have equal precedence
@@ -300,7 +299,7 @@ namespace Bicep.Core.UnitTests.Parsing
         }
 
         [DataTestMethod]
-        [DataRow("a + b:c * z[12]:a && q[foo()] == c:a", "((a+((b:c)*((z[12]):a)))&&((q[foo()])==(c:a)))")]
+        [DataRow("a + b::c * z[12]::a && q[foo()] == c::a", "((a+((b::c)*((z[12])::a)))&&((q[foo()])==(c::a)))")]
         public void ResourceAccessShouldHaveHighestPrecedence(string text, string expected)
         {
             RunExpressionTest(text, expected, typeof(BinaryOperationSyntax));

--- a/src/Bicep.Core/Parsing/ExpressionFlags.cs
+++ b/src/Bicep.Core/Parsing/ExpressionFlags.cs
@@ -1,15 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using Bicep.Core.Diagnostics;
-using Bicep.Core.Extensions;
-using Bicep.Core.Navigation;
-using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Parsing
 {
@@ -19,12 +10,5 @@ namespace Bicep.Core.Parsing
         None = 0,
         AllowComplexLiterals = 1,
         AllowResourceDeclarations = 2,
-
-        /// <summary>
-        /// Used to indicate that the expression appears directly within a colon-delimited context such as the 
-        /// 'true' part of a ternary operator. This is used to resolve an ambiuity with the ':' operator for
-        /// nested resource access.
-        /// </summary>
-        InsideColonDelimitedContext = 4,
     }
 }

--- a/src/Bicep.Core/Parsing/Lexer.cs
+++ b/src/Bicep.Core/Parsing/Lexer.cs
@@ -205,7 +205,7 @@ namespace Bicep.Core.Parsing
                         {
                             return null;
                         }
-                        
+
                         char charOrHighSurrogate = CodepointToString(codePoint, out char lowSurrogate);
                         buffer.Append(charOrHighSurrogate);
                         if (lowSurrogate != SlidingTextWindow.InvalidCharacter)
@@ -281,7 +281,7 @@ namespace Bicep.Core.Parsing
             {
                 yield return ScanWhitespace();
             }
-            
+
             if (textWindow.Peek() == '/' && textWindow.Peek(1) == '/')
             {
                 yield return ScanSingleLineComment();
@@ -322,7 +322,7 @@ namespace Bicep.Core.Parsing
         private void LexToken()
         {
             textWindow.Reset();
-            
+
             // important to force enum evaluation here via .ToImmutableArray()!
             var leadingTrivia = ScanLeadingTrivia().ToImmutableArray();
 
@@ -330,14 +330,14 @@ namespace Bicep.Core.Parsing
             var tokenType = ScanToken();
             var tokenText = textWindow.GetText();
             var tokenSpan = textWindow.GetSpan();
-            
+
             if (tokenType == TokenType.Unrecognized)
             {
                 if (tokenText == "\"")
                 {
                     AddDiagnostic(b => b.DoubleQuoteToken(tokenText));
-                } 
-                else 
+                }
+                else
                 {
                     AddDiagnostic(b => b.UnrecognizedToken(tokenText));
                 }
@@ -549,7 +549,7 @@ namespace Bicep.Core.Parsing
                 if (nextChar == 'u')
                 {
                     // unicode escape
-                    
+
                     if (textWindow.IsAtEnd())
                     {
                         // string was prematurely terminated
@@ -747,6 +747,15 @@ namespace Bicep.Core.Parsing
                     }
                     return TokenType.Question;
                 case ':':
+                    if (!textWindow.IsAtEnd())
+                    {
+                        switch (textWindow.Peek())
+                        {
+                            case ':':
+                                textWindow.Advance();
+                                return TokenType.DoubleColon;
+                        }
+                    }
                     return TokenType.Colon;
                 case ';':
                     return TokenType.Semicolon;

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -378,7 +378,7 @@ namespace Bicep.Core.Parsing
             if (this.Check(TokenType.Question))
             {
                 var question = this.reader.Read();
-                var trueExpression = this.Expression(WithExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext));
+                var trueExpression = this.Expression(expressionFlags);
                 var colon = this.Expect(TokenType.Colon, b => b.ExpectedCharacter(":"));
                 var falseExpression = this.Expression(expressionFlags);
 
@@ -487,21 +487,11 @@ namespace Bicep.Core.Parsing
                     continue;
                 }
 
-                if (this.Check(TokenType.Colon) && !HasExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext))
+                if (this.Check(TokenType.DoubleColon))
                 {
-                    // colon operator (nested resource lookup)
-                    //
-                    // We want a ternary to bind with higher precedance than a resource-access inside the "true" part
-                    // ex: a ? b : c -> a ? (b) : (c) and NOT a ? (b:c) 
-                    // this implies that a resource-access expression will require parenthesis inside a ternary's "true" part
-                    //
-                    // We can't easily do this the other way because a ternary is right-associative and member/resource access
-                    // are left-associative.
-                    //
-                    // The same is true of a for-expression. A colon is used as the right-delimiter.
-                    var colon = this.reader.Read();
+                    var doubleColon = this.reader.Read();
                     var identifier = this.IdentifierOrSkip(b => b.ExpectedFunctionOrPropertyName());
-                    current = new ResourceAccessSyntax(current, colon, identifier);
+                    current = new ResourceAccessSyntax(current, doubleColon, identifier);
 
                     continue;
                 }
@@ -532,11 +522,11 @@ namespace Bicep.Core.Parsing
                     return this.MultilineString();
 
                 case TokenType.LeftBrace when HasExpressionFlag(expressionFlags, ExpressionFlags.AllowComplexLiterals):
-                    return this.Object(WithoutExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext));
+                    return this.Object(expressionFlags);
 
                 case TokenType.LeftSquare when HasExpressionFlag(expressionFlags, ExpressionFlags.AllowComplexLiterals):
-                    return CheckKeyword(this.reader.PeekAhead(), LanguageConstants.ForKeyword) 
-                        ? this.ForExpression(WithoutExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext), requireObjectLiteral: false) 
+                    return CheckKeyword(this.reader.PeekAhead(), LanguageConstants.ForKeyword)
+                        ? this.ForExpression(expressionFlags, requireObjectLiteral: false)
                         : this.Array();
 
                 case TokenType.LeftBrace:
@@ -544,7 +534,7 @@ namespace Bicep.Core.Parsing
                     throw new ExpectedTokenException(nextToken, b => b.ComplexLiteralsNotAllowed());
 
                 case TokenType.LeftParen:
-                    return this.ParenthesizedExpression(WithoutExpressionFlag(expressionFlags, ExpressionFlags.InsideColonDelimitedContext));
+                    return this.ParenthesizedExpression(expressionFlags);
 
                 case TokenType.Identifier:
                     return this.FunctionCallOrVariableAccess(expressionFlags);
@@ -765,7 +755,7 @@ namespace Bicep.Core.Parsing
         {
             var token = reader.Read();
             var stringValue = Lexer.TryGetMultilineStringValue(token);
-            
+
             if (stringValue is null)
             {
                 return new SkippedTriviaSyntax(token.Span, token.AsEnumerable(), Enumerable.Empty<Diagnostic>());
@@ -927,10 +917,10 @@ namespace Bicep.Core.Parsing
                 TokenType.LeftParen => this.ForVariableBlock(),
                 _ => this.SkipEmpty(b => b.ExpectedLoopItemIdentifierOrVariableBlockStart())
             };
-                
+
             // new LocalVariableSyntax(this.IdentifierWithRecovery(b => b.ExpectedLoopVariableIdentifier(), RecoveryFlags.None, TokenType.Identifier, TokenType.RightSquare, TokenType.NewLine));
             var inKeyword = this.WithRecovery(() => this.ExpectKeyword(LanguageConstants.InKeyword), variableSection.HasParseErrors() ? RecoveryFlags.SuppressDiagnostics : RecoveryFlags.None, TokenType.RightSquare, TokenType.NewLine);
-            var expression = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals | ExpressionFlags.InsideColonDelimitedContext), GetSuppressionFlag(inKeyword), TokenType.Colon, TokenType.RightSquare, TokenType.NewLine);
+            var expression = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), GetSuppressionFlag(inKeyword), TokenType.Colon, TokenType.RightSquare, TokenType.NewLine);
             var colon = this.WithRecovery(() => this.Expect(TokenType.Colon, b => b.ExpectedCharacter(":")), GetSuppressionFlag(expression), TokenType.RightSquare, TokenType.NewLine);
             var body = this.WithRecovery(
                 () => requireObjectLiteral ? this.Object(expressionFlags) : this.Expression(WithExpressionFlag(expressionFlags, ExpressionFlags.AllowComplexLiterals)),
@@ -1076,7 +1066,7 @@ namespace Bicep.Core.Parsing
 
                 // Nested resource declarations may be allowed - but we need lookahead to avoid
                 // treating 'resource' as a reserved property name.
-                if (HasExpressionFlag(expressionFlags, ExpressionFlags.AllowResourceDeclarations) && 
+                if (HasExpressionFlag(expressionFlags, ExpressionFlags.AllowResourceDeclarations) &&
                     CheckKeyword(LanguageConstants.ResourceKeyword) &&
 
                     // You are here: |resource <name> ...
@@ -1112,9 +1102,9 @@ namespace Bicep.Core.Parsing
         {
             var keyword = this.ExpectKeyword(LanguageConstants.IfKeyword);
             var conditionExpression = this.WithRecovery(
-                () => this.ParenthesizedExpression(WithoutExpressionFlag(expressionFlags, ExpressionFlags.AllowResourceDeclarations)), 
-                RecoveryFlags.None, 
-                TokenType.LeftBrace, 
+                () => this.ParenthesizedExpression(WithoutExpressionFlag(expressionFlags, ExpressionFlags.AllowResourceDeclarations)),
+                RecoveryFlags.None,
+                TokenType.LeftBrace,
                 TokenType.NewLine);
             var body = this.WithRecovery(
                 () => this.Object(expressionFlags),

--- a/src/Bicep.Core/Parsing/TokenType.cs
+++ b/src/Bicep.Core/Parsing/TokenType.cs
@@ -47,5 +47,6 @@ namespace Bicep.Core.Parsing
         NewLine,
         EndOfFile,
         DoubleQuestion,
+        DoubleColon,
     }
 }

--- a/src/Bicep.Core/Syntax/ResourceAccessSyntax.cs
+++ b/src/Bicep.Core/Syntax/ResourceAccessSyntax.cs
@@ -7,18 +7,18 @@ namespace Bicep.Core.Syntax
 {
     public class ResourceAccessSyntax : ExpressionSyntax, ISymbolReference
     {
-        public ResourceAccessSyntax(SyntaxBase baseExpression, Token colon, IdentifierSyntax resourceName)
+        public ResourceAccessSyntax(SyntaxBase baseExpression, Token doubleColon, IdentifierSyntax resourceName)
         {
-            AssertTokenType(colon, nameof(colon), TokenType.Colon);
+            AssertTokenType(doubleColon, nameof(doubleColon), TokenType.DoubleColon);
 
             this.BaseExpression = baseExpression;
-            this.Colon = colon;
+            this.DoubleColon = doubleColon;
             this.ResourceName = resourceName;
         }
 
         public SyntaxBase BaseExpression { get; }
 
-        public Token Colon { get; }
+        public Token DoubleColon { get; }
 
         public IdentifierSyntax ResourceName { get; }
 

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -153,7 +153,7 @@ namespace Bicep.Core.Syntax
 
             return new LocalVariableSyntax(name);
         }
-        
+
         void ISyntaxVisitor.VisitLocalVariableSyntax(LocalVariableSyntax syntax) => ReplaceCurrent(syntax, ReplaceLocalVariableSyntax);
 
         protected virtual TargetScopeSyntax ReplaceTargetScopeSyntax(TargetScopeSyntax syntax)
@@ -477,7 +477,7 @@ namespace Bicep.Core.Syntax
         protected virtual ResourceAccessSyntax ReplaceResourceAccessSyntax(ResourceAccessSyntax syntax)
         {
             var hasChanges = Rewrite(syntax.BaseExpression, out var baseExpression);
-            hasChanges |= Rewrite(syntax.Colon, out var colon);
+            hasChanges |= Rewrite(syntax.DoubleColon, out var colon);
             hasChanges |= Rewrite(syntax.ResourceName, out var propertyName);
 
             if (!hasChanges)

--- a/src/Bicep.Core/Syntax/SyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxVisitor.cs
@@ -261,7 +261,7 @@ namespace Bicep.Core.Syntax
         public virtual void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
         {
             this.Visit(syntax.BaseExpression);
-            this.Visit(syntax.Colon);
+            this.Visit(syntax.DoubleColon);
             this.Visit(syntax.ResourceName);
         }
 

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -150,7 +150,7 @@ namespace Bicep.LanguageServer.Completions
         {
             return syntax.TryFindMostSpecificTriviaInclusive(offset, current => true);
         }
-        
+
         private static BicepCompletionContextKind ConvertFlag(bool value, BicepCompletionContextKind flag) => value ? flag : BicepCompletionContextKind.None;
 
         private static BicepCompletionContextKind GetDeclarationTypeFlags(IList<SyntaxBase> matchingNodes, int offset)
@@ -238,7 +238,7 @@ namespace Bicep.LanguageServer.Completions
                         // we're in a declaration if one of the following conditions is met:
                         // 1. the token is EOF
                         // 2. the token is a newline
-                        return token.Type == TokenType.EndOfFile || 
+                        return token.Type == TokenType.EndOfFile ||
                                token.Type == TokenType.NewLine;
 
                     case SkippedTriviaSyntax _ when matchingNodes.Count >= 3:
@@ -250,7 +250,7 @@ namespace Bicep.LanguageServer.Completions
                     case ITopLevelNamedDeclarationSyntax declaration:
                         // we are in a fully or partially parsed declaration
                         // whether we are in a declaration context depends on whether our offset is within the keyword token
-                        // (by using exclusive span containment, the cursor position at the end of a keyword token 
+                        // (by using exclusive span containment, the cursor position at the end of a keyword token
                         // result counts as being outside of the declaration context)
                         return declaration.Keyword.Span.Contains(offset);
                 }
@@ -297,7 +297,7 @@ namespace Bicep.LanguageServer.Completions
                             return true;
 
                         case 4 when matchingNodes[^2] is IdentifierSyntax identifier && matchingNodes[^3] is ObjectPropertySyntax property && ReferenceEquals(property.Key, identifier):
-                            // we are in a partial or full property name 
+                            // we are in a partial or full property name
                             return true;
 
                         case 4 when matchingNodes[^2] is SkippedTriviaSyntax skipped && matchingNodes[^3] is ObjectPropertySyntax property && ReferenceEquals(property.Key, skipped):
@@ -332,10 +332,10 @@ namespace Bicep.LanguageServer.Completions
                         (propertyAccess, identifier, token) => ReferenceEquals(propertyAccess.ResourceName, identifier) && token.Type == TokenType.Identifier) ||
                     SyntaxMatcher.IsTailMatch<ResourceAccessSyntax, Token>(
                         matchingNodes,
-                        (propertyAccess, token) => token.Type == TokenType.Colon && ReferenceEquals(propertyAccess.Colon, token)) ||
+                        (propertyAccess, token) => token.Type == TokenType.DoubleColon && ReferenceEquals(propertyAccess.DoubleColon, token)) ||
                     SyntaxMatcher.IsTailMatch<ResourceAccessSyntax>(
                         matchingNodes,
-                        propertyAccess => offset > propertyAccess.Colon.Span.Position));
+                        propertyAccess => offset > propertyAccess.DoubleColon.Span.Position));
         }
 
         private static bool IsArrayIndexContext(List<SyntaxBase> matchingNodes, (ArrayAccessSyntax? node, int index) arrayAccessInfo)
@@ -360,7 +360,7 @@ namespace Bicep.LanguageServer.Completions
                 // so we cannot possibly be in a position to begin an object property
                 return false;
             }
-            
+
             switch (matchingNodes[^1])
             {
                 case ObjectSyntax _:
@@ -377,7 +377,7 @@ namespace Bicep.LanguageServer.Completions
                             return true;
 
                         case 4 when matchingNodes[^2] is IdentifierSyntax identifier && matchingNodes[^3] is ObjectPropertySyntax property && ReferenceEquals(property.Key, identifier):
-                            // we are in a partial or full property name 
+                            // we are in a partial or full property name
                             return true;
 
                         case 4 when matchingNodes[^2] is SkippedTriviaSyntax skipped && matchingNodes[^3] is ObjectPropertySyntax property && ReferenceEquals(property.Key, skipped):
@@ -551,7 +551,7 @@ namespace Bicep.LanguageServer.Completions
                         case OutputDeclarationSyntax outputDeclaration:
                             return ReferenceEquals(outputDeclaration.Value, variableAccess);
                     }
-                    
+
                     break;
 
                 case Token token when token.Type == TokenType.Assignment && matchingNodes.Count >=2 && offset == token.GetEndPosition():


### PR DESCRIPTION
We want to resolve the parsing ambiguity here by choosing another
operator that doesn't overlap with any other features. `::` is common
for namespacing kinds of things, and is similar to `:` which is what we
originally wanted.

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature
