### PR TITLE
Fixes for nested resource and scope interop issues

### DIFF
--- a/src/Bicep.Core.IntegrationTests/DecoratorTests.cs
+++ b/src/Bicep.Core.IntegrationTests/DecoratorTests.cs
@@ -24,7 +24,7 @@ namespace Bicep.Core.IntegrationTests
 ");
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diagnostics.Should().HaveDiagnostics(new[] {
                     ("BCP147", DiagnosticLevel.Error, "Expected a parameter declaration after the decorator."),
                 });
@@ -101,7 +101,7 @@ param inputb string
 ");
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diagnostics.Should().HaveDiagnostics(new[] {
                     ("BCP152", DiagnosticLevel.Error, "Function \"concat\" cannot be used as a decorator."),
                     ("BCP152", DiagnosticLevel.Error, "Function \"resourceId\" cannot be used as a decorator."),

--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -124,7 +124,7 @@ this
             var (template, _, _) = CompilationHelper.Compile(StringUtils.ReplaceNewlines(inputFile, newlineSequence));
 
             var expected = string.Join(newlineSequence, new [] { "this", "  is", "    a", "      multiline", "        string", "" });
-            template!.SelectToken("$.variables.multiline")!.Should().DeepEqual(expected);
+            template.Should().HaveValueAtPath("$.variables.multiline", expected);
         }
 
         private EmitResult EmitTemplate(SyntaxTreeGrouping syntaxTreeGrouping, string filePath, string assemblyFileVersion)

--- a/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
@@ -11,7 +11,9 @@ using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 
 namespace Bicep.Core.IntegrationTests
 {
@@ -580,6 +582,237 @@ output foo string = broken:fake
                 ("BCP118", DiagnosticLevel.Error, "Expected the \"{\" character, the \"[\" character, or the \"if\" keyword at this location."),
                 ("BCP159", DiagnosticLevel.Error, "The resource \"broken\" does not contain a nested resource named \"fake\". Known nested resources are: \"(none)\"."),
             });
+        }
+
+        [TestMethod]
+        public void Nested_resource_formats_names_and_dependsOn_correctly()
+        {
+            var (template, diags, _) = CompilationHelper.Compile(@"
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+  location: resourceGroup().location
+  name: 'myVnet'
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/20'
+      ]
+    }
+  }
+
+  resource subnet1 'subnets' = {
+    parent: vnet
+    name: 'subnet1'
+    properties: {
+      addressPrefix: '10.0.0.0/24'
+    }
+  }
+  
+  resource subnet2 'subnets' = {
+    parent: vnet
+    name: 'subnet2'
+    properties: {
+      addressPrefix: '10.0.1.0/24'
+    }
+  }
+}
+
+
+
+output subnet1prefix string = vnet:subnet1.properties.addressPrefix
+output subnet1name string = vnet:subnet1.name
+output subnet1type string = vnet:subnet1.type
+output subnet1id string = vnet:subnet1.id
+");
+
+            using (new AssertionScope())
+            {
+                diags.Should().BeEmpty();
+
+                template.Should().HaveValueAtPath("$.resources[0].name", "[format('{0}/{1}', 'myVnet', 'subnet1')]");
+                template.Should().HaveValueAtPath("$.resources[0].dependsOn", new JArray { "[resourceId('Microsoft.Network/virtualNetworks', 'myVnet')]" });
+
+                template.Should().HaveValueAtPath("$.resources[1].name", "[format('{0}/{1}', 'myVnet', 'subnet2')]");
+                template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray { "[resourceId('Microsoft.Network/virtualNetworks', 'myVnet')]" });
+
+                template.Should().HaveValueAtPath("$.resources[2].name", "myVnet");
+                template.Should().NotHaveValueAtPath("$.resources[2].dependsOn");
+
+                template.Should().HaveValueAtPath("$.outputs['subnet1prefix'].value", "[reference(resourceId('Microsoft.Network/virtualNetworks/subnets', 'myVnet', 'subnet1')).addressPrefix]");
+                template.Should().HaveValueAtPath("$.outputs['subnet1name'].value", "subnet1");
+                template.Should().HaveValueAtPath("$.outputs['subnet1type'].value", "Microsoft.Network/virtualNetworks/subnets");
+                template.Should().HaveValueAtPath("$.outputs['subnet1id'].value", "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'myVnet', 'subnet1')]");
+            }
+        }
+
+        [TestMethod]
+        public void Nested_resource_works_with_extension_resources()
+        {
+            var (template, diags, _) = CompilationHelper.Compile(@"
+resource res1 'Microsoft.Rp1/resource1@2020-06-01' = {
+  name: 'res1'
+
+  resource child 'child1' = {
+    name: 'child1'
+  }
+}
+
+resource res2 'Microsoft.Rp2/resource2@2020-06-01' = {
+  scope: res1:child
+  name: 'res2'
+
+  resource child 'child2' = {
+    name: 'child2'
+  }
+}
+
+output res2childprop string = res2:child.properties.someProp
+output res2childname string = res2:child.name
+output res2childtype string = res2:child.type
+output res2childid string = res2:child.id
+");
+
+            using (new AssertionScope())
+            {
+                diags.Where(x => x.Code != "BCP081").Should().BeEmpty();
+
+                // res1
+                template.Should().HaveValueAtPath("$.resources[2].name", "res1");
+                template.Should().NotHaveValueAtPath("$.resources[2].dependsOn");
+
+                // res1::child1
+                template.Should().HaveValueAtPath("$.resources[0].name", "[format('{0}/{1}', 'res1', 'child1')]");
+                template.Should().HaveValueAtPath("$.resources[0].dependsOn", new JArray { "[resourceId('Microsoft.Rp1/resource1', 'res1')]" });
+
+                // res2
+                template.Should().HaveValueAtPath("$.resources[3].name", "res2");
+                template.Should().HaveValueAtPath("$.resources[3].dependsOn", new JArray { "[resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1')]" });
+
+                // res2::child2
+                template.Should().HaveValueAtPath("$.resources[1].name", "[format('{0}/{1}', 'res2', 'child2')]");
+                template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray { "[extensionResourceId(resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), 'Microsoft.Rp2/resource2', 'res2')]" });
+
+                template.Should().HaveValueAtPath("$.outputs['res2childprop'].value", "[reference(extensionResourceId(resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), 'Microsoft.Rp2/resource2/child2', 'res2', 'child2')).someProp]");
+                template.Should().HaveValueAtPath("$.outputs['res2childname'].value", "child2");
+                template.Should().HaveValueAtPath("$.outputs['res2childtype'].value", "Microsoft.Rp2/resource2/child2");
+                template.Should().HaveValueAtPath("$.outputs['res2childid'].value", "[extensionResourceId(resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), 'Microsoft.Rp2/resource2/child2', 'res2', 'child2')]");
+            }
+        }
+
+        [TestMethod]
+        public void Nested_resource_works_with_existing_resources()
+        {
+            var (template, diags, _) = CompilationHelper.Compile(@"
+resource res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
+  name: 'res1'
+
+  resource child 'child1' = {
+    name: 'child1'
+  }
+}
+
+output res1childprop string = res1:child.properties.someProp
+output res1childname string = res1:child.name
+output res1childtype string = res1:child.type
+output res1childid string = res1:child.id
+");
+
+            using (new AssertionScope())
+            {
+                diags.Where(x => x.Code != "BCP081").Should().BeEmpty();
+
+                // res1:child1
+                template.Should().HaveValueAtPath("$.resources[0].name", "[format('{0}/{1}', 'res1', 'child1')]");
+                template.Should().HaveValueAtPath("$.resources[0].dependsOn", new JArray());
+
+                template.Should().NotHaveValueAtPath("$.resources[1]");
+
+                template.Should().HaveValueAtPath("$.outputs['res1childprop'].value", "[reference(resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1')).someProp]");
+                template.Should().HaveValueAtPath("$.outputs['res1childname'].value", "child1");
+                template.Should().HaveValueAtPath("$.outputs['res1childtype'].value", "Microsoft.Rp1/resource1/child1");
+                template.Should().HaveValueAtPath("$.outputs['res1childid'].value", "[resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1')]");
+            }
+        }
+
+        [TestMethod]
+        public void Nested_resource_formats_references_correctly_for_existing_resources()
+        {
+            var (template, diags, _) = CompilationHelper.Compile(@"
+resource res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
+  scope: tenant()
+  name: 'res1'
+
+  resource child 'child1' existing = {
+    name: 'child1'
+  }
+}
+
+output res1childprop string = res1:child.properties.someProp
+output res1childname string = res1:child.name
+output res1childtype string = res1:child.type
+output res1childid string = res1:child.id
+");
+
+            using (new AssertionScope())
+            {
+                diags.Where(x => x.Code != "BCP081").Should().BeEmpty();
+
+                template.Should().NotHaveValueAtPath("$.resources[0]");
+
+                template.Should().HaveValueAtPath("$.outputs['res1childprop'].value", "[reference(tenantResourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), '2020-06-01').someProp]");
+                template.Should().HaveValueAtPath("$.outputs['res1childname'].value", "child1");
+                template.Should().HaveValueAtPath("$.outputs['res1childtype'].value", "Microsoft.Rp1/resource1/child1");
+                template.Should().HaveValueAtPath("$.outputs['res1childid'].value", "[tenantResourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1')]");
+            }
+        }
+
+        [TestMethod]
+        public void Nested_resource_blocks_existing_parents_at_different_scopes()
+        {
+            var (template, diags, _) = CompilationHelper.Compile(@"
+resource res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
+  scope: tenant()
+  name: 'res1'
+
+  resource child 'child1' = {
+    name: 'child1'
+  }
+}
+");
+
+            using (new AssertionScope())
+            {
+                template.Should().NotHaveValue();
+                diags.Where(x => x.Code != "BCP081").Should().HaveDiagnostics(new[] {
+                  ("BCP167", DiagnosticLevel.Error, "Cannot deploy a resource with ancestor under a different scope. Resource \"res1\" has the \"scope\" property set."),
+                });
+            }
+        }
+
+        [TestMethod]
+        public void Nested_resource_blocks_scope_on_child_resources()
+        {
+            var (template, diags, _) = CompilationHelper.Compile(@"
+resource res1 'Microsoft.Rp1/resource1@2020-06-01' = {
+  name: 'res1'
+}
+
+resource res2 'Microsoft.Rp2/resource2@2020-06-01' = {
+  name: 'res2'
+
+  resource child 'child2' = {
+    scope: res1
+    name: 'child2'
+  }
+}
+");
+
+            using (new AssertionScope())
+            {
+                template.Should().NotHaveValue();
+                diags.Where(x => x.Code != "BCP081").Should().HaveDiagnostics(new[] {
+                  ("BCP166", DiagnosticLevel.Error, "The \"scope\" property is unsupported for a resource with a parent resource. This resource has \"res2\" declared as its parent."),
+                });
+            }
         }
     }
 }

--- a/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
@@ -600,7 +600,6 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
   }
 
   resource subnet1 'subnets' = {
-    parent: vnet
     name: 'subnet1'
     properties: {
       addressPrefix: '10.0.0.0/24'
@@ -608,7 +607,6 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
   }
   
   resource subnet2 'subnets' = {
-    parent: vnet
     name: 'subnet2'
     properties: {
       addressPrefix: '10.0.1.0/24'
@@ -783,7 +781,7 @@ resource res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
             {
                 template.Should().NotHaveValue();
                 diags.Where(x => x.Code != "BCP081").Should().HaveDiagnostics(new[] {
-                  ("BCP167", DiagnosticLevel.Error, "Cannot deploy a resource with ancestor under a different scope. Resource \"res1\" has the \"scope\" property set."),
+                  ("BCP165", DiagnosticLevel.Error, "Cannot deploy a resource with ancestor under a different scope. Resource \"res1\" has the \"scope\" property set."),
                 });
             }
         }
@@ -810,9 +808,10 @@ resource res2 'Microsoft.Rp2/resource2@2020-06-01' = {
             {
                 template.Should().NotHaveValue();
                 diags.Where(x => x.Code != "BCP081").Should().HaveDiagnostics(new[] {
-                  ("BCP166", DiagnosticLevel.Error, "The \"scope\" property is unsupported for a resource with a parent resource. This resource has \"res2\" declared as its parent."),
+                  ("BCP164", DiagnosticLevel.Error, "The \"scope\" property is unsupported for a resource with a parent resource. This resource has \"res2\" declared as its parent."),
                 });
             }
         }
+
     }
 }

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -25,7 +25,7 @@ param l
 ");
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diags.Should().HaveDiagnostics(new[] {
                     ("BCP028", DiagnosticLevel.Error, "Identifier \"l\" is declared multiple times. Remove or rename the duplicates."),
                     ("BCP079", DiagnosticLevel.Error, "This expression is referencing its own declaration, which is not allowed."),
@@ -92,12 +92,11 @@ output vnetstate string = vnet.properties.provisioningState
 
             using (new AssertionScope())
             {
-                template!.Should().NotBeNull();
                 diags.Should().BeEmpty();
 
                 // ensure we're generating the correct expression with 'subscriptionResourceId', and using the correct name for the module
-                template!.SelectToken("$.outputs['vnetid'].value")!.Should().DeepEqual("[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'vnet-rg'), 'Microsoft.Resources/deployments', 'network-module'), '2019-10-01').outputs.vnetId.value]");
-                template.SelectToken("$.outputs['vnetstate'].value")!.Should().DeepEqual("[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'vnet-rg'), 'Microsoft.Resources/deployments', 'network-module'), '2019-10-01').outputs.vnetstate.value]");
+                template.Should().HaveValueAtPath("$.outputs['vnetid'].value", "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'vnet-rg'), 'Microsoft.Resources/deployments', 'network-module'), '2019-10-01').outputs.vnetId.value]");
+                template.Should().HaveValueAtPath("$.outputs['vnetstate'].value", "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'vnet-rg'), 'Microsoft.Resources/deployments', 'network-module'), '2019-10-01').outputs.vnetstate.value]");
             }
         }
 
@@ -123,10 +122,9 @@ resource functionAppResource 'Microsoft.Web/sites@2020-06-01' = {
 
             using (new AssertionScope())
             {
-                template!.Should().NotBeNull();
                 diags.Should().BeEmpty();
 
-                template!.SelectToken("$.outputs['config'].value")!.Should().DeepEqual("[list(format('{0}/config/appsettings', resourceId('Microsoft.Web/sites', parameters('functionApp').name)), '2020-06-01')]");
+                template.Should().HaveValueAtPath("$.outputs['config'].value", "[list(format('{0}/config/appsettings', resourceId('Microsoft.Web/sites', parameters('functionApp').name)), '2020-06-01')]");
             }
         }
 
@@ -166,11 +164,10 @@ resource rg 'Microsoft.Resources/resourceGroups@2020-06-01' = {
 
             using (new AssertionScope())
             {
-                template!.Should().NotBeNull();
                 diags.Should().BeEmpty();
 
-                template!.SelectToken("$.resources[?(@.name == 'rg30')].location")!.Should().DeepEqual("[deployment().location]");
-                template.SelectToken("$.resources[?(@.name == 'rg31')].location")!.Should().DeepEqual("[deployment().location]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'rg30')].location", "[deployment().location]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'rg31')].location", "[deployment().location]");
             }
         }
 
@@ -321,14 +318,14 @@ resource routetable 'Microsoft.Network/routeTables@2020-06-01' = {
 output id string = routetable.id
 "));
 
-            template!.Should().NotBeNull();
-
-            // variable 'subnets' should have been inlined
-            template!.SelectToken("$.resources[?(@.name == '[variables(\\'vnetName\\')]')].properties.parameters.subnets.value")!.Type.Should().Be(JTokenType.Array);
-            template.SelectToken("$.resources[?(@.name == '[variables(\\'vnetName\\')]')].properties.parameters.subnets.value[0].name")!.Should().DeepEqual("GatewaySubnet");
-            template.SelectToken("$.resources[?(@.name == '[variables(\\'vnetName\\')]')].properties.parameters.subnets.value[1].name")!.Should().DeepEqual("appsn01");
-            // there should be no definition in the variables list for 'subnets'
-            template.SelectToken("$.variables.subnets")!.Should().BeNull();
+            using (new AssertionScope())
+            {
+                // variable 'subnets' should have been inlined
+                template.Should().HaveValueAtPath("$.resources[?(@.name == '[variables(\\'vnetName\\')]')].properties.parameters.subnets.value[0].name", "GatewaySubnet");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == '[variables(\\'vnetName\\')]')].properties.parameters.subnets.value[1].name", "appsn01");
+                // there should be no definition in the variables list for 'subnets'
+                template.Should().NotHaveValueAtPath("$.variables.subnets");
+            }
         }
 
         [TestMethod]
@@ -356,11 +353,10 @@ param mgName string
 
             using (new AssertionScope())
             {
-                template!.Should().NotBeNull();
                 diags.Should().BeEmpty();
 
                 // deploying a management group module at tenant scope requires an unqualified resource id
-                template!.SelectToken("$.resources[?(@.name == 'allupmgdeploy')].scope")!.Should().DeepEqual("[format('Microsoft.Management/managementGroups/{0}', parameters('allUpMgName'))]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'allupmgdeploy')].scope", "[format('Microsoft.Management/managementGroups/{0}', parameters('allUpMgName'))]");
             }
         }
 
@@ -378,10 +374,9 @@ var issue = true ? {
 
             using (new AssertionScope())
             {
-                template!.Should().NotBeNull();
                 diags.Should().BeEmpty();
 
-                template!.SelectToken("$.variables.issue")!.Should().DeepEqual("[if(true(), createObject('prop1', createObject(variables('propname'), createObject())), createObject())]");
+                template.Should().HaveValueAtPath("$.variables.issue", "[if(true(), createObject('prop1', createObject(variables('propname'), createObject())), createObject())]");
             }
         }
 
@@ -396,13 +391,12 @@ var myBigIntExpression = 2199023255552 * 2
 var myBigIntExpression2 = 2199023255552 * 2199023255552
 ");
 
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.variables.myInt")!.Should().DeepEqual(5);
-                template.SelectToken("$.variables.myBigInt")!.Should().DeepEqual(2199023255552);
-                template.SelectToken("$.variables.myIntExpression")!.Should().DeepEqual("[mul(5, 5)]");
-                template.SelectToken("$.variables.myBigIntExpression2")!.Should().DeepEqual("[mul(json('2199023255552'), json('2199023255552'))]");
+                template.Should().HaveValueAtPath("$.variables.myInt", 5);
+                template.Should().HaveValueAtPath("$.variables.myBigInt", 2199023255552);
+                template.Should().HaveValueAtPath("$.variables.myIntExpression", "[mul(5, 5)]");
+                template.Should().HaveValueAtPath("$.variables.myBigIntExpression2", "[mul(json('2199023255552'), json('2199023255552'))]");
             }
         }
 
@@ -421,11 +415,10 @@ module sub './modules/subscription.bicep' = {
 targetScope = 'subscription'
 "));
 
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.resources[?(@.name == 'subDeploy')].subscriptionId")!.Should().DeepEqual("[subscription().subscriptionId]");
-                template.SelectToken("$.resources[?(@.name == 'subDeploy')].location")!.Should().DeepEqual("[resourceGroup().location]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'subDeploy')].subscriptionId", "[subscription().subscriptionId]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'subDeploy')].location", "[resourceGroup().location]");
             }
         }
 
@@ -444,11 +437,10 @@ module sub './modules/subscription.bicep' = {
 targetScope = 'subscription'
 "));
 
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.resources[?(@.name == 'subDeploy')].subscriptionId")!.Should().DeepEqual("abcd-efgh");
-                template.SelectToken("$.resources[?(@.name == 'subDeploy')].location")!.Should().DeepEqual("[resourceGroup().location]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'subDeploy')].subscriptionId", "abcd-efgh");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'subDeploy')].location", "[resourceGroup().location]");
             }
         }
 
@@ -467,12 +459,11 @@ module sub './modules/resourceGroup.bicep' = {
 targetScope = 'resourceGroup'
 "));
 
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.resources[?(@.name == 'subDeploy')].subscriptionId")!.Should().DeepEqual("abcd-efgh");
-                template.SelectToken("$.resources[?(@.name == 'subDeploy')].resourceGroup")!.Should().DeepEqual("bicep-rg");
-                template.SelectToken("$.resources[?(@.name == 'subDeploy')].location")!.Should().BeNull();
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'subDeploy')].subscriptionId", "abcd-efgh");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'subDeploy')].resourceGroup", "bicep-rg");
+                template.Should().NotHaveValueAtPath("$.resources[?(@.name == 'subDeploy')].location");
             }
         }
 
@@ -490,12 +481,13 @@ resource dep 'Microsoft.Resources/deployments@2020-06-01' = {
   }
 }
 ");
-            template!.Should().NotBeNull();
-            diags.Should().BeEmpty();
+
             using (new AssertionScope())
             {
-                template!.SelectToken("$.resources[?(@.name == 'nestedDeployment')].subscriptionId")!.Should().DeepEqual("abcd-efgh");
-                template.SelectToken("$.resources[?(@.name == 'nestedDeployment')].resourceGroup")!.Should().DeepEqual("bicep-rg");
+                diags.Should().BeEmpty();
+
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'nestedDeployment')].subscriptionId", "abcd-efgh");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'nestedDeployment')].resourceGroup", "bicep-rg");
             }
         }
 
@@ -559,7 +551,7 @@ resource redis 'Microsoft.Cache/Redis@2019-07-01' = {
                 
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diags.Should().HaveDiagnostics(new[] {
                     ("BCP120", DiagnosticLevel.Error, "The property \"scope\" must be evaluable at the start of the deployment, and cannot depend on any values that have not yet been calculated. You are referencing a variable which cannot be calculated in time (\"appResGrp\" -> \"rg\"). Accessible properties of rg are \"name\", \"scope\"."),
                 });
@@ -575,10 +567,10 @@ resource foo 'Microsoft.foo/bar@2020-01-01' existing = {
 }
 output prop1 string = foo.properties.prop1
 ");
-            template!.Should().NotBeNull();
+
             using (new AssertionScope())
             {
-                template!.SelectToken("$.outputs['prop1'].value")!.Should().DeepEqual("[reference(resourceId('Microsoft.foo/bar', 'name'), '2020-01-01').prop1]");
+                template.Should().HaveValueAtPath("$.outputs['prop1'].value", "[reference(resourceId('Microsoft.foo/bar', 'name'), '2020-01-01').prop1]");
             }
         }
 
@@ -608,13 +600,13 @@ param location string
 param name string
 "));
 
-            diags.Should().BeEmpty();
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.resources[?(@.name == 'vnet')].subscriptionId")!.Should().BeNull();
-                template!.SelectToken("$.resources[?(@.name == 'vnet')].resourceGroup")!.Should().DeepEqual("rg");
-                template!.SelectToken("$.resources[?(@.name == 'vnet')].dependsOn[0]")!.Should().DeepEqual("[subscriptionResourceId('Microsoft.Resources/resourceGroups', 'rg')]");
+                diags.Should().BeEmpty();
+
+                template.Should().NotHaveValueAtPath("$.resources[?(@.name == 'vnet')].subscriptionId");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'vnet')].resourceGroup", "rg");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'vnet')].dependsOn[0]", "[subscriptionResourceId('Microsoft.Resources/resourceGroups', 'rg')]");
             }
         }
 
@@ -642,12 +634,12 @@ param location string
 param name string
 "));
 
-            diags.Should().BeEmpty();
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.resources[?(@.name == 'vnet')].subscriptionId")!.Should().DeepEqual("abcdef");
-                template!.SelectToken("$.resources[?(@.name == 'vnet')].resourceGroup")!.Should().DeepEqual("rg");
+                diags.Should().BeEmpty();
+
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'vnet')].subscriptionId", "abcdef");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'vnet')].resourceGroup", "rg");
             }
         }
 
@@ -702,7 +694,7 @@ resource rgReader 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' =
 
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diags.Should().HaveDiagnostics(new[] {
                     ("BCP139", DiagnosticLevel.Error, "The root resource scope must match that of the Bicep file. To deploy a resource to a different root scope, use a module."),
                     ("BCP139", DiagnosticLevel.Error, "The root resource scope must match that of the Bicep file. To deploy a resource to a different root scope, use a module."),
@@ -720,7 +712,7 @@ targetScope = 'blablah'
 
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diags.Should().HaveDiagnostics(new[] {
                     ("BCP033", DiagnosticLevel.Error, "Expected a value of type \"'managementGroup' | 'resourceGroup' | 'subscription' | 'tenant'\" but the provided value is of type \"'blablah'\"."),
                 });
@@ -738,12 +730,12 @@ output myparam string = myparam
 output myvar string = myvar
 ");
 
-            diags.Should().BeEmpty();
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.outputs['myparam'].value")!.Should().DeepEqual("[parameters('myparam')]");
-                template!.SelectToken("$.outputs['myvar'].value")!.Should().DeepEqual("[variables('myvar')]");
+                diags.Should().BeEmpty();
+
+                template.Should().HaveValueAtPath("$.outputs['myparam'].value", "[parameters('myparam')]");
+                template.Should().HaveValueAtPath("$.outputs['myvar'].value", "[variables('myvar')]");
             }
         }
 
@@ -757,7 +749,7 @@ output duplicate string = 'hello'
 
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diags.Should().HaveDiagnostics(new[] {
                     ("BCP145", DiagnosticLevel.Error, "Output \"duplicate\" is declared multiple times. Remove or rename the duplicates."),
                     ("BCP145", DiagnosticLevel.Error, "Output \"duplicate\" is declared multiple times. Remove or rename the duplicates."),
@@ -775,7 +767,7 @@ output output2 string = output1
 
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diags.Should().HaveDiagnostics(new[] {
                     ("BCP058", DiagnosticLevel.Error, "The name \"output1\" is an output. Outputs cannot be referenced in expressions."),
                 });
@@ -792,7 +784,7 @@ output xx = x
 
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diags.Should().HaveDiagnostics(new[] {
                     ("BCP146", DiagnosticLevel.Error, "Expected an output type at this location. Please specify one of the following types: \"array\", \"bool\", \"int\", \"object\", \"string\"."),
                 });
@@ -879,15 +871,18 @@ module stamp_1_secrets './kevault-secrets.bicep' = [for secret in secrets: {
 }]
 "), ("global-resources.bicep", string.Empty));
 
-            template!.Should().BeNull();
+            using (new AssertionScope())
+            {
+                template.Should().NotHaveValue();
 
-            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"rg_global\" does not exist in the current context.");
-            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"rg_global\" does not exist in the current context.");
-            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context.");
-            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context.");
-            diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context.");
-            diags.Should().ContainDiagnostic("BCP052", DiagnosticLevel.Error, "The type \"outputs\" does not contain property \"cosmosDbEndpoint\".");
-            diags.Should().ContainDiagnostic("BCP052", DiagnosticLevel.Error, "The type \"outputs\" does not contain property \"cosmosDbKey\".");
+                diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"rg_global\" does not exist in the current context.");
+                diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"rg_global\" does not exist in the current context.");
+                diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context.");
+                diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context.");
+                diags.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"stamps\" does not exist in the current context.");
+                diags.Should().ContainDiagnostic("BCP052", DiagnosticLevel.Error, "The type \"outputs\" does not contain property \"cosmosDbEndpoint\".");
+                diags.Should().ContainDiagnostic("BCP052", DiagnosticLevel.Error, "The type \"outputs\" does not contain property \"cosmosDbKey\".");
+            }
         }
 
         [TestMethod]
@@ -903,11 +898,11 @@ output fooName string = foo.name
     "),
               ("test.bicep", @""));
 
-            diags.Should().BeEmpty();
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.outputs['fooName'].value")!.Should().DeepEqual("foo");
+                diags.Should().BeEmpty();
+
+                template.Should().HaveValueAtPath("$.outputs['fooName'].value", "foo");
             }
         }
 
@@ -929,12 +924,12 @@ output fooOutput string = foo.outputs.test
 output test string = 'hello'
 "));
 
-            diags.Should().BeEmpty();
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.outputs['fooName'].value")!.Should().DeepEqual("[format('{0}-test', parameters('someParam'))]");
-                template!.SelectToken("$.outputs['fooOutput'].value")!.Should().DeepEqual("[reference(resourceId('Microsoft.Resources/deployments', format('{0}-test', parameters('someParam'))), '2019-10-01').outputs.test.value]");
+                diags.Should().BeEmpty();
+
+                template.Should().HaveValueAtPath("$.outputs['fooName'].value", "[format('{0}-test', parameters('someParam'))]");
+                template.Should().HaveValueAtPath("$.outputs['fooOutput'].value", "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-test', parameters('someParam'))), '2019-10-01').outputs.test.value]");
             }
         }
 
@@ -950,7 +945,7 @@ resource foo 'Microsoft.Compute/virtualMachines@2020-06-01' = {
 
             using (new AssertionScope())
             {
-                template!.Should().BeNull();
+                template.Should().NotHaveValue();
                 diags.Should().HaveDiagnostics(new[] {
                     ("BCP025", DiagnosticLevel.Error, "The property \"name\" is declared multiple times in this object. Remove or rename the duplicate properties."),
                     ("BCP025", DiagnosticLevel.Error, "The property \"name\" is declared multiple times in this object. Remove or rename the duplicate properties."),

--- a/src/Bicep.Core.IntegrationTests/ScopeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScopeTests.cs
@@ -64,13 +64,11 @@ targetScope = '$moduleTargetScope'
 output hello string = 'hello!'
 ".Replace("$moduleTargetScope", moduleTargetScope)));
 
-            template!.Should().NotBeNull();
-
             using (new AssertionScope())
             {
-                template!.SelectToken("$.['$schema']")!.Should().DeepEqual(expectedSchema);
-                template.SelectToken("$.outputs.hello.value")!.Should().DeepEqual(expectedOutput);
-                template.SelectToken("$.resources[?(@.name == 'resourceB')].dependsOn[0]")!.Should().DeepEqual(expectedResourceDependsOn);
+                template.Should().HaveValueAtPath("$.['$schema']", expectedSchema);
+                template.Should().HaveValueAtPath("$.outputs.hello.value", expectedOutput);
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'resourceB')].dependsOn[0]", expectedResourceDependsOn);
             }
         }
 
@@ -110,12 +108,10 @@ param dependency string
 ".Replace("$targetScope", targetScope))
             );
 
-            template!.Should().NotBeNull();
-
             using (new AssertionScope())
             {
-                template!.SelectToken("$.resources[?(@.name == 'resourceB')].dependsOn[0]")!.Should().DeepEqual(expectedResourceDependsOn);
-                template.SelectToken("$.resources[?(@.name == 'myMod')].dependsOn[0]")!.Should().DeepEqual(expectedModuleDependsOn);
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'resourceB')].dependsOn[0]", expectedResourceDependsOn);
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'myMod')].dependsOn[0]", expectedModuleDependsOn);
             }
         }
 
@@ -137,15 +133,13 @@ resource resourceC 'My.Rp/myResource@2020-01-01' = {
   name: 'resourceC'
 }");
 
-            template!.Should().NotBeNull();
-
             using (new AssertionScope())
             {
-                template!.SelectToken("$.resources[?(@.name == 'resourceB')].scope")!.Should().DeepEqual("[format('My.Rp/myResource/{0}', 'resourceA')]");
-                template.SelectToken("$.resources[?(@.name == 'resourceB')].dependsOn[0]")!.Should().DeepEqual("[resourceId('My.Rp/myResource', 'resourceA')]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'resourceB')].scope", "[format('My.Rp/myResource/{0}', 'resourceA')]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'resourceB')].dependsOn[0]", "[resourceId('My.Rp/myResource', 'resourceA')]");
 
-                template.SelectToken("$.resources[?(@.name == 'resourceC')].scope")!.Should().DeepEqual("[extensionResourceId(format('My.Rp/myResource/{0}', 'resourceA'), 'My.Rp/myResource', 'resourceB')]");
-                template.SelectToken("$.resources[?(@.name == 'resourceC')].dependsOn[0]")!.Should().DeepEqual("[extensionResourceId(resourceId('My.Rp/myResource', 'resourceA'), 'My.Rp/myResource', 'resourceB')]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'resourceC')].scope", "[extensionResourceId(format('My.Rp/myResource/{0}', 'resourceA'), 'My.Rp/myResource', 'resourceB')]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'resourceC')].dependsOn[0]", "[extensionResourceId(resourceId('My.Rp/myResource', 'resourceA'), 'My.Rp/myResource', 'resourceB')]");
             }
         }
 
@@ -171,14 +165,12 @@ resource resourceB 'My.Rp/myResource@2020-01-01' = {
 output resourceARef string = resourceA.properties.myProp
 ".Replace("$targetScope", targetScope));
 
-            template!.Should().NotBeNull();
-
             using (new AssertionScope())
             {
-                template!.SelectToken("$.resources[?(@.name == 'resourceB')].scope")!.Should().DeepEqual(expectedScopeExpression);
-                (template.SelectToken("$.resources[?(@.name == 'resourceB')].dependsOn") as IEnumerable<JToken>)!.Should().BeEmpty();
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'resourceB')].scope", expectedScopeExpression);
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'resourceB')].dependsOn", new JArray());
 
-                template.SelectToken("$.outputs['resourceARef'].value")!.Should().DeepEqual(expectedReferenceExpression);
+                template.Should().HaveValueAtPath("$.outputs['resourceARef'].value", expectedReferenceExpression);
             }
         }
 
@@ -205,10 +197,9 @@ resource resourceA 'My.Rp/myResource@2020-01-01' existing = {
 output resourceARef string = resourceA.kind
 "));
 
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.outputs['resourceARef'].value")!.Should().DeepEqual("[reference(resourceId('My.Rp/myResource', 'resourceA'), '2020-01-01', 'full').kind]");
+                template.Should().HaveValueAtPath("$.outputs['resourceARef'].value", "[reference(resourceId('My.Rp/myResource', 'resourceA'), '2020-01-01', 'full').kind]");
             }
 
             // use a valid targetScope without setting the scope property
@@ -222,10 +213,9 @@ resource resourceA 'My.Rp/myResource@2020-01-01' existing = {
 output resourceARef string = resourceA.kind
 "));
 
-            template!.Should().NotBeNull();
             using (new AssertionScope())
             {
-                template!.SelectToken("$.outputs['resourceARef'].value")!.Should().DeepEqual("[reference(resourceId('My.Rp/myResource', 'resourceA'), '2020-01-01', 'full').kind]");
+                template.Should().HaveValueAtPath("$.outputs['resourceARef'].value", "[reference(resourceId('My.Rp/myResource', 'resourceA'), '2020-01-01', 'full').kind]");
             }
         }
 
@@ -323,10 +313,9 @@ resource resourceB 'My.Rp/myResource@2020-01-01' = {
 
             using (new AssertionScope())
             {
-                template!.Should().NotBeNull();
                 diags.Should().BeEmpty();
 
-                template!.SelectToken("$.resources[?(@.name == 'resourceB')].scope")!.Should().DeepEqual("[format('My.Rp/myResource/{0}', 'resourceA')]");
+                template.Should().HaveValueAtPath("$.resources[?(@.name == 'resourceB')].scope", "[format('My.Rp/myResource/{0}', 'resourceA')]");
             }
         }
     }

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
@@ -26,10 +26,10 @@
       "name": "[format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild')]",
       "properties": {
         "size": "[reference(resourceId('My.Rp/parentType', 'basicParent')).size]",
-        "style": "[reference(resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[0], split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[1])).style]"
+        "style": "[reference(resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')).style]"
       },
       "dependsOn": [
-        "[resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[0], split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[1])]",
+        "[resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')]",
         "[resourceId('My.Rp/parentType', 'basicParent')]"
       ]
     },
@@ -51,10 +51,10 @@
       "name": "[format('{0}/{1}', 'basicParent', 'basicSibling')]",
       "properties": {
         "size": "[reference(resourceId('My.Rp/parentType', 'basicParent')).size]",
-        "style": "[reference(resourceId('My.Rp/parentType/childType/grandchildType', split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[0], split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[1], split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[2])).style]"
+        "style": "[reference(resourceId('My.Rp/parentType/childType/grandchildType', 'basicParent', 'basicChild', 'basicGrandchild')).style]"
       },
       "dependsOn": [
-        "[resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[0], split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[1])]",
+        "[resourceId('My.Rp/parentType/childType/grandchildType', 'basicParent', 'basicChild', 'basicGrandchild')]",
         "[resourceId('My.Rp/parentType', 'basicParent')]"
       ]
     },
@@ -64,7 +64,7 @@
       "name": "[format('{0}/{1}/{2}', 'existingParent', 'existingChild', 'existingGrandchild')]",
       "properties": {
         "size": "[reference(resourceId('My.Rp/parentType', 'existingParent'), '2020-12-01').size]",
-        "style": "[reference(resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'existingParent', 'existingChild'), '/')[0], split(format('{0}/{1}', 'existingParent', 'existingChild'), '/')[1]), '2020-12-01').style]"
+        "style": "[reference(resourceId('My.Rp/parentType/childType', 'existingParent', 'existingChild'), '2020-12-01').style]"
       },
       "dependsOn": []
     },
@@ -75,10 +75,10 @@
       "name": "[format('{0}/{1}/{2}', 'conditionParent', 'conditionChild', 'conditionGrandchild')]",
       "properties": {
         "size": "[reference(resourceId('My.Rp/parentType', 'conditionParent')).size]",
-        "style": "[reference(resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'conditionParent', 'conditionChild'), '/')[0], split(format('{0}/{1}', 'conditionParent', 'conditionChild'), '/')[1])).style]"
+        "style": "[reference(resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')).style]"
       },
       "dependsOn": [
-        "[resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'conditionParent', 'conditionChild'), '/')[0], split(format('{0}/{1}', 'conditionParent', 'conditionChild'), '/')[1])]",
+        "[resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')]",
         "[resourceId('My.Rp/parentType', 'conditionParent')]"
       ]
     },
@@ -126,22 +126,22 @@
   "outputs": {
     "referenceBasicChild": {
       "type": "string",
-      "value": "[reference(resourceId('My.Rp/parentType/childType', split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[0], split(format('{0}/{1}', 'basicParent', 'basicChild'), '/')[1])).size]"
+      "value": "[reference(resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')).size]"
     },
     "referenceBasicGrandchild": {
       "type": "string",
-      "value": "[reference(resourceId('My.Rp/parentType/childType/grandchildType', split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[0], split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[1], split(format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild'), '/')[2])).style]"
+      "value": "[reference(resourceId('My.Rp/parentType/childType/grandchildType', 'basicParent', 'basicChild', 'basicGrandchild')).style]"
     },
     "loopChildOutput": {
       "type": "string",
-      "value": "[format('{0}/{1}', 'loopParent', 'loopChild')]"
+      "value": "loopChild"
     }
   },
   "metadata": {
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16251729290247853382"
+      "templateHash": "16343843471735200304"
     }
   }
 }

--- a/src/Bicep.Core.UnitTests/Assertions/JTokenAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/JTokenAssertions.cs
@@ -5,9 +5,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Bicep.Core.UnitTests.Assertions
 {
-    public class JTokenAssertions : ReferenceTypeAssertions<JToken, JTokenAssertions>
+    public class JTokenAssertions : ReferenceTypeAssertions<JToken?, JTokenAssertions>
     {
-        public JTokenAssertions(JToken instance)
+        public JTokenAssertions(JToken? instance)
         {
             Subject = instance;
         }

--- a/src/Bicep.Core.UnitTests/Assertions/JTokenAssertionsExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/JTokenAssertionsExtensions.cs
@@ -13,7 +13,7 @@ namespace Bicep.Core.UnitTests.Assertions
 {
     public static class JTokenAssertionsExtensions
     {
-        public static JTokenAssertions Should(this JToken instance)
+        public static JTokenAssertions Should(this JToken? instance)
         {
             return new JTokenAssertions(instance);
         }
@@ -57,7 +57,46 @@ namespace Bicep.Core.UnitTests.Assertions
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(JToken.DeepEquals(instance.Subject, expected))
-                .FailWith("Expected '{0}' but got '{1}'", expected?.ToString(), instance.Subject?.ToString());
+                .FailWith("Expected {0} but got {1}", expected.ToString(), instance.Subject?.ToString());
+
+            return new AndConstraint<JTokenAssertions>(instance);
+        }
+
+        public static AndConstraint<JTokenAssertions> HaveValueAtPath(this JTokenAssertions instance, string jtokenPath, JToken expected, string because = "", params object[] becauseArgs)
+        {
+            var valueAtPath = instance.Subject?.SelectToken(jtokenPath);
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(valueAtPath is not null)
+                .FailWith("Expected value at path {0} to be {1} but it was null", jtokenPath, expected.ToString());
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(JToken.DeepEquals(valueAtPath, expected))
+                .FailWith("Expected value at path {0} to be {1} but it was {2}", jtokenPath, expected.ToString(), valueAtPath?.ToString());
+
+            return new AndConstraint<JTokenAssertions>(instance);
+        }
+
+        public static AndConstraint<JTokenAssertions> NotHaveValueAtPath(this JTokenAssertions instance, string jtokenPath, string because = "", params object[] becauseArgs)
+        {
+            var valueAtPath = instance.Subject?.SelectToken(jtokenPath);
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(valueAtPath is null)
+                .FailWith("Expected value at path {0} to be null, but it was {1}", jtokenPath, valueAtPath);
+
+            return new AndConstraint<JTokenAssertions>(instance);
+        }
+
+        public static AndConstraint<JTokenAssertions> NotHaveValue(this JTokenAssertions instance, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(instance.Subject is null)
+                .FailWith("Expected value to be null, but it was {0}", instance.Subject?.ToString());
 
             return new AndConstraint<JTokenAssertions>(instance);
         }

--- a/src/Bicep.Core/Diagnostics/Diagnostic.cs
+++ b/src/Bicep.Core/Diagnostics/Diagnostic.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Diagnostics;
 using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Diagnostics
 {
     // roughly equivalent to the 'SyntaxDiagnosticInfo' class in Roslyn
+    [DebuggerDisplay("Level = {" + nameof(Level) +"}, Code = {" + nameof(Code) +"}, Message = {" + nameof(Message) +"}")]
     public class Diagnostic : IPositionable
     {
         public Diagnostic(TextSpan span, DiagnosticLevel level, string code, string message, DiagnosticLabel? label = null)

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -928,6 +928,16 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP163",
                 "Expected a loop index variable identifier at this location.");
+
+            public ErrorDiagnostic ScopeUnsupportedOnChildResource(string parentIdentifier) => new(
+                TextSpan,
+                "BCP164",
+                $"The \"{LanguageConstants.ResourceScopePropertyName}\" property is unsupported for a resource with a parent resource. This resource has \"{parentIdentifier}\" declared as its parent.");
+
+            public ErrorDiagnostic ScopeDisallowedForAncestorResource(string ancestorIdentifier) => new(
+                TextSpan,
+                "BCP165",
+                $"Cannot deploy a resource with ancestor under a different scope. Resource \"{ancestorIdentifier}\" has the \"{LanguageConstants.ResourceScopePropertyName}\" property set.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Azure.Deployments.Core.Extensions;
@@ -187,9 +188,12 @@ namespace Bicep.Core.Emit
                             .GetFullyQualifiedResourceId(resourceSymbol);
                     case "name":
                         // the name is dependent on the name expression which could involve locals in case of a resource collection
+
+                        // Note that we don't want to return the fully-qualified resource name in the case of name property access.
+                        // we should return whatever the user has set as the value of the 'name' property for a predictable user experience.
                         return this
                             .CreateConverterForIndexReplacement(GetResourceNameSyntax(resourceSymbol), indexExpression, propertyAccess)
-                            .GetResourceNameExpression(resourceSymbol);
+                            .ConvertExpression(GetResourceNameSyntax(resourceSymbol));
                     case "type":
                         return new JTokenExpression(typeReference.FullyQualifiedType);
                     case "apiVersion":
@@ -290,7 +294,33 @@ namespace Bicep.Core.Emit
                 new JTokenExpression(propertyAccess.PropertyName.IdentifierName));
         }
 
-        public LanguageExpression GetResourceNameExpression(ResourceSymbol resourceSymbol)
+        public IEnumerable<LanguageExpression> GetResourceNameSegments(ResourceSymbol resourceSymbol, ResourceTypeReference typeReference)
+        {
+            var ancestors = this.context.SemanticModel.ResourceAncestors.GetAncestors(resourceSymbol);
+            if (ancestors.Length > 0)
+            {
+                Debug.Assert(ancestors.Length + 1 == typeReference.Types.Length, "ancestors.Length + 1 == typeReference.Types.Length");
+
+                return ancestors.Concat(resourceSymbol.AsEnumerable())
+                    .Select(x => GetResourceNameSyntax(x))
+                    .Select(x => ConvertExpression(x));
+            }
+
+            var nameSyntax = GetResourceNameSyntax(resourceSymbol);
+            var nameExpression = ConvertExpression(nameSyntax);
+
+            if (typeReference.Types.Length == 1)
+            {
+                return nameExpression.AsEnumerable();
+            }
+
+            return typeReference.Types.Select(
+                (type, i) => AppendProperties(
+                    CreateFunction("split", nameExpression, new JTokenExpression("/")),
+                    new JTokenExpression(i)));
+        }
+
+        public LanguageExpression GetFullyQualifiedResourceName(ResourceSymbol resourceSymbol)
         {
             var nameValueSyntax = GetResourceNameSyntax(resourceSymbol);
 
@@ -341,22 +371,6 @@ namespace Bicep.Core.Emit
         {
             // this condition should have already been validated by the type checker
             return moduleSymbol.SafeGetBodyPropertyValue(LanguageConstants.ResourceNamePropertyName) ?? throw new ArgumentException($"Expected module syntax body to contain property 'name'");
-        }
-
-        public IEnumerable<LanguageExpression> GetResourceNameSegments(ResourceSymbol resourceSymbol, ResourceTypeReference typeReference)
-        {
-            if (typeReference.Types.Length == 1)
-            {
-                return GetResourceNameExpression(resourceSymbol).AsEnumerable();
-            }
-
-            return typeReference.Types.Select(
-                (type, i) => AppendProperties(
-                    CreateFunction(
-                        "split",
-                        GetResourceNameExpression(resourceSymbol),
-                        new JTokenExpression("/")),
-                    new JTokenExpression(i)));
         }
 
         public LanguageExpression GetUnqualifiedResourceId(ResourceSymbol resourceSymbol)
@@ -531,6 +545,9 @@ namespace Bicep.Core.Emit
                     return GetReferenceExpression(resourceSymbol, typeReference, true);
 
                 case ModuleSymbol moduleSymbol:
+                    // referencing a module directly should be blocked at an earlier stage - there is nothing great we can codegen here.
+                    Debug.Fail("Found direct module variable access");
+
                     return GetModuleOutputsReferenceExpression(moduleSymbol);
 
                 case LocalVariableSymbol localVariableSymbol:

--- a/src/Bicep.Core/Emit/ExpressionEmitter.cs
+++ b/src/Bicep.Core/Emit/ExpressionEmitter.cs
@@ -118,9 +118,9 @@ namespace Bicep.Core.Emit
             writer.WriteValue(serialized);
         }
 
-        public LanguageExpression GetResourceNameExpression(ResourceSymbol resourceSymbol)
+        public LanguageExpression GetFullyQualifiedResourceName(ResourceSymbol resourceSymbol)
         {
-            return converter.GetResourceNameExpression(resourceSymbol);
+            return converter.GetFullyQualifiedResourceName(resourceSymbol);
         }
 
         public LanguageExpression GetManagementGroupResourceId(SyntaxBase managementGroupNameProperty, bool fullyQualified)

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -408,7 +408,7 @@ namespace Bicep.Core.Emit
                 emitter.EmitProperty("scope", () => emitter.EmitUnqualifiedResourceId(scopeResource));
             }
 
-            emitter.EmitProperty("name", emitter.GetResourceNameExpression(resourceSymbol));
+            emitter.EmitProperty("name", emitter.GetFullyQualifiedResourceName(resourceSymbol));
 
             emitter.EmitObjectProperties((ObjectSyntax)body, ResourcePropertiesToOmit);
 

--- a/src/Bicep.Core/Semantics/Symbol.cs
+++ b/src/Bicep.Core/Semantics/Symbol.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
+using System.Diagnostics;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Semantics
 {
+    [DebuggerDisplay("Name = {" + nameof(Name) +"}, Kind = {" + nameof(Kind) +"}")]
     public abstract class Symbol
     {
         protected Symbol(string name)


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature

Fixes #1810 

This fixes the following issues:
1. Setting 'scope' should not be permitted on nested child resources
1. It should not be possible to deploy a nested child for an existing resource at a different scope to that of the template
1. Scope not being accounted for when generating resourceIds for extension resources
1. Scope note being accounted for when generating 'existing' resource references
1. Simplify formatting of nested resource reference names (avoid concat + split when we already have a list of names)