### PR TITLE
Add GitHub bot rule

### DIFF
--- a/.github/needs-more-info-closer.yml
+++ b/.github/needs-more-info-closer.yml
@@ -1,0 +1,26 @@
+name: Needs More Info Closer
+on:
+  schedule:
+    - cron: 30 5 * * * # 10:30pm PT
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout triage-actions
+        uses: actions/checkout@v2
+        with:
+          repository: "Azure/bicep"
+          path: ./bicep
+          ref: main
+      - name: npm install
+        run: npm install --production --prefix ./bicep/triage-actions
+      - name: Run Needs More Info Closer
+        uses: ./bicep/triage-actions/needs-more-info-closer
+        with:
+          token: ${{secrets.AZCODE_BOT_PAT}}
+          label: needs more info
+          closeDays: 14
+          closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity."
+          readonly: true

--- a/.github/needs_more_info.yml
+++ b/.github/needs_more_info.yml
@@ -1,0 +1,6 @@
+{
+    daysUntilClose: 21,
+    needsMoreInfoLabel: 'needs more info',
+    perform: true,
+    closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity. See also our [issue reporting](https://aka.ms/azcodeissuereporting) guidelines.\n\nHappy Coding!"
+}


### PR DESCRIPTION
This rule will:
- Automatically close any issue marked "needs more info", if there has been no activity in the past 21 days.
