### PR TITLE
Revert "Bump MSTest.TestAdapter from 2.1.2 to 2.2.1"

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/Bicep.Cli.IntegrationTests.csproj
+++ b/src/Bicep.Cli.IntegrationTests/Bicep.Cli.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
   </ItemGroup>
 

--- a/src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj
+++ b/src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
   </ItemGroup>
 

--- a/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
+++ b/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
+++ b/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
+++ b/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.Decompiler.IntegrationTests/Bicep.Decompiler.IntegrationTests.csproj
+++ b/src/Bicep.Decompiler.IntegrationTests/Bicep.Decompiler.IntegrationTests.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.Decompiler.UnitTests/Bicep.Decompiler.UnitTests.csproj
+++ b/src/Bicep.Decompiler.UnitTests/Bicep.Decompiler.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
+++ b/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.18.3" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">

--- a/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
+++ b/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.1" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.18.3" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">


### PR DESCRIPTION
Reverts Azure/bicep#1673. The original PR was accidentally merged due to auto merge being enabled. The library has an issue with data-driven tests in VS. The MSTest team is working on rolling out the fix (link in the reverted PR).