### PR TITLE
Negative integer literals are compile-time constants

### DIFF
--- a/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
@@ -616,10 +616,10 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 
 
 
-output subnet1prefix string = vnet:subnet1.properties.addressPrefix
-output subnet1name string = vnet:subnet1.name
-output subnet1type string = vnet:subnet1.type
-output subnet1id string = vnet:subnet1.id
+output subnet1prefix string = vnet::subnet1.properties.addressPrefix
+output subnet1name string = vnet::subnet1.name
+output subnet1type string = vnet::subnet1.type
+output subnet1id string = vnet::subnet1.id
 ");
 
             using (new AssertionScope())
@@ -655,7 +655,7 @@ resource res1 'Microsoft.Rp1/resource1@2020-06-01' = {
 }
 
 resource res2 'Microsoft.Rp2/resource2@2020-06-01' = {
-  scope: res1:child
+  scope: res1::child
   name: 'res2'
 
   resource child 'child2' = {
@@ -663,10 +663,10 @@ resource res2 'Microsoft.Rp2/resource2@2020-06-01' = {
   }
 }
 
-output res2childprop string = res2:child.properties.someProp
-output res2childname string = res2:child.name
-output res2childtype string = res2:child.type
-output res2childid string = res2:child.id
+output res2childprop string = res2::child.properties.someProp
+output res2childname string = res2::child.name
+output res2childtype string = res2::child.type
+output res2childid string = res2::child.id
 ");
 
             using (new AssertionScope())
@@ -708,17 +708,17 @@ resource res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
   }
 }
 
-output res1childprop string = res1:child.properties.someProp
-output res1childname string = res1:child.name
-output res1childtype string = res1:child.type
-output res1childid string = res1:child.id
+output res1childprop string = res1::child.properties.someProp
+output res1childname string = res1::child.name
+output res1childtype string = res1::child.type
+output res1childid string = res1::child.id
 ");
 
             using (new AssertionScope())
             {
                 diags.Where(x => x.Code != "BCP081").Should().BeEmpty();
 
-                // res1:child1
+                // res1::child1
                 template.Should().HaveValueAtPath("$.resources[0].name", "[format('{0}/{1}', 'res1', 'child1')]");
                 template.Should().HaveValueAtPath("$.resources[0].dependsOn", new JArray());
 
@@ -744,10 +744,10 @@ resource res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
   }
 }
 
-output res1childprop string = res1:child.properties.someProp
-output res1childname string = res1:child.name
-output res1childtype string = res1:child.type
-output res1childid string = res1:child.id
+output res1childprop string = res1::child.properties.someProp
+output res1childname string = res1::child.name
+output res1childtype string = res1::child.type
+output res1childid string = res1::child.id
 ");
 
             using (new AssertionScope())

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
@@ -1827,6 +1827,20 @@
     }
   },
   {
+    "label": "unaryMinusOnFunction",
+    "kind": "field",
+    "detail": "unaryMinusOnFunction",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unaryMinusOnFunction",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unaryMinusOnFunction"
+    }
+  },
+  {
     "label": "union",
     "kind": "function",
     "detail": "union()",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/oneTwoThreePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/oneTwoThreePlusSymbols.json
@@ -1869,6 +1869,20 @@
     }
   },
   {
+    "label": "unaryMinusOnFunction",
+    "kind": "field",
+    "detail": "unaryMinusOnFunction",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unaryMinusOnFunction",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unaryMinusOnFunction"
+    }
+  },
+  {
     "label": "union",
     "kind": "function",
     "detail": "union()",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/symbolsPlusParamDefaultFunctions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/symbolsPlusParamDefaultFunctions.json
@@ -1827,6 +1827,20 @@
     }
   },
   {
+    "label": "unaryMinusOnFunction",
+    "kind": "field",
+    "detail": "unaryMinusOnFunction",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_unaryMinusOnFunction",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "unaryMinusOnFunction"
+    }
+  },
+  {
     "label": "union",
     "kind": "function",
     "detail": "union()",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
@@ -402,5 +402,11 @@ param tooManyArguments2 string
 @allowed([for thing in []: 's'])
 param nonConstantInDecorator string
 
+@minValue(-length('s'))
+@metadata({
+  bool: !true
+})
+param unaryMinusOnFunction int
+
 // unterminated multi-line comment
 /*    

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
@@ -598,6 +598,15 @@ param tooManyArguments2 string
 //@[10:13) [BCP138 (Error)] For-expressions are not supported in this context. For-expressions may be used as values of resource and module declarations, values of resource and module properties, or values of outputs. |for|
 param nonConstantInDecorator string
 
+@minValue(-length('s'))
+//@[11:22) [BCP032 (Error)] The value must be a compile-time constant. |length('s')|
+@metadata({
+  bool: !true
+//@[8:13) [BCP032 (Error)] The value must be a compile-time constant. |!true|
+//@[8:13) [BCP032 (Error)] The value must be a compile-time constant. |!true|
+})
+param unaryMinusOnFunction int
+
 // unterminated multi-line comment
 /*    
 //@[0:7) [BCP002 (Error)] The multi-line comment at this location is not terminated. Terminate it with the */ character sequence. |/*    \n|

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
@@ -395,6 +395,12 @@ param tooManyArguments2 string
 @allowed([for thing in []: 's'])
 param nonConstantInDecorator string
 
+@minValue(-length('s'))
+@metadata({
+  bool: !true
+})
+param unaryMinusOnFunction int
+
 // unterminated multi-line comment
 /*    
 

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
@@ -497,6 +497,13 @@ param tooManyArguments2 string
 param nonConstantInDecorator string
 //@[6:28) Parameter nonConstantInDecorator. Type: string. Declaration start char: 0, length: 96
 
+@minValue(-length('s'))
+@metadata({
+  bool: !true
+})
+param unaryMinusOnFunction int
+//@[6:26) Parameter unaryMinusOnFunction. Type: int. Declaration start char: 0, length: 83
+
 // unterminated multi-line comment
 /*    
 

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
@@ -2606,6 +2606,60 @@ param nonConstantInDecorator string
 //@[29:35)   Identifier |string|
 //@[35:37) NewLine |\n\n|
 
+@minValue(-length('s'))
+//@[0:83) ParameterDeclarationSyntax
+//@[0:23)  DecoratorSyntax
+//@[0:1)   At |@|
+//@[1:23)   FunctionCallSyntax
+//@[1:9)    IdentifierSyntax
+//@[1:9)     Identifier |minValue|
+//@[9:10)    LeftParen |(|
+//@[10:22)    FunctionArgumentSyntax
+//@[10:22)     UnaryOperationSyntax
+//@[10:11)      Minus |-|
+//@[11:22)      FunctionCallSyntax
+//@[11:17)       IdentifierSyntax
+//@[11:17)        Identifier |length|
+//@[17:18)       LeftParen |(|
+//@[18:21)       FunctionArgumentSyntax
+//@[18:21)        StringSyntax
+//@[18:21)         StringComplete |'s'|
+//@[21:22)       RightParen |)|
+//@[22:23)    RightParen |)|
+//@[23:24)  NewLine |\n|
+@metadata({
+//@[0:28)  DecoratorSyntax
+//@[0:1)   At |@|
+//@[1:28)   FunctionCallSyntax
+//@[1:9)    IdentifierSyntax
+//@[1:9)     Identifier |metadata|
+//@[9:10)    LeftParen |(|
+//@[10:27)    FunctionArgumentSyntax
+//@[10:27)     ObjectSyntax
+//@[10:11)      LeftBrace |{|
+//@[11:12)      NewLine |\n|
+  bool: !true
+//@[2:13)      ObjectPropertySyntax
+//@[2:6)       IdentifierSyntax
+//@[2:6)        Identifier |bool|
+//@[6:7)       Colon |:|
+//@[8:13)       UnaryOperationSyntax
+//@[8:9)        Exclamation |!|
+//@[9:13)        BooleanLiteralSyntax
+//@[9:13)         TrueKeyword |true|
+//@[13:14)      NewLine |\n|
+})
+//@[0:1)      RightBrace |}|
+//@[1:2)    RightParen |)|
+//@[2:3)  NewLine |\n|
+param unaryMinusOnFunction int
+//@[0:5)  Identifier |param|
+//@[6:26)  IdentifierSyntax
+//@[6:26)   Identifier |unaryMinusOnFunction|
+//@[27:30)  TypeSyntax
+//@[27:30)   Identifier |int|
+//@[30:32) NewLine |\n\n|
+
 // unterminated multi-line comment
 //@[34:35) NewLine |\n|
 /*    

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
@@ -1676,6 +1676,39 @@ param nonConstantInDecorator string
 //@[29:35) Identifier |string|
 //@[35:37) NewLine |\n\n|
 
+@minValue(-length('s'))
+//@[0:1) At |@|
+//@[1:9) Identifier |minValue|
+//@[9:10) LeftParen |(|
+//@[10:11) Minus |-|
+//@[11:17) Identifier |length|
+//@[17:18) LeftParen |(|
+//@[18:21) StringComplete |'s'|
+//@[21:22) RightParen |)|
+//@[22:23) RightParen |)|
+//@[23:24) NewLine |\n|
+@metadata({
+//@[0:1) At |@|
+//@[1:9) Identifier |metadata|
+//@[9:10) LeftParen |(|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+  bool: !true
+//@[2:6) Identifier |bool|
+//@[6:7) Colon |:|
+//@[8:9) Exclamation |!|
+//@[9:13) TrueKeyword |true|
+//@[13:14) NewLine |\n|
+})
+//@[0:1) RightBrace |}|
+//@[1:2) RightParen |)|
+//@[2:3) NewLine |\n|
+param unaryMinusOnFunction int
+//@[0:5) Identifier |param|
+//@[6:26) Identifier |unaryMinusOnFunction|
+//@[27:30) Identifier |int|
+//@[30:32) NewLine |\n\n|
+
 // unterminated multi-line comment
 //@[34:35) NewLine |\n|
 /*    

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -1461,7 +1461,6 @@ resource expressionsInPropertyLoopName 'Microsoft.Network/dnsZones@2018-05-01' =
 
 // resource loop body that isn't an object
 @batchSize(-1)
-//@[11:13) [BCP032 (Error)] The value must be a compile-time constant. |-1|
 resource nonObjectResourceLoopBody 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: 'test']
 //@[95:101) [BCP018 (Error)] Expected the "{" character at this location. |'test'|
 resource nonObjectResourceLoopBody2 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: environment()]

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.bicep
@@ -235,6 +235,17 @@ param decoratedString string
 @minValue(200)
 param decoratedInt int = 123
 
+// negative integer literals are allowed as decorator values
+@minValue(-10)
+@maxValue(-3)
+param negativeValues int
+
+// negative integer literals in modifiers
+param negativeModifiers int {
+  minValue: -100
+  maxValue: -33
+}
+
 @sys.description('A boolean.')
 @metadata({
     description: 'I will be overrode.'

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.diagnostics.bicep
@@ -249,6 +249,18 @@ param decoratedString string
 @minValue(200)
 param decoratedInt int = 123
 
+// negative integer literals are allowed as decorator values
+@minValue(-10)
+@maxValue(-3)
+param negativeValues int
+
+// negative integer literals in modifiers
+param negativeModifiers int {
+//@[28:67) [BCP161 (Info)] Parameter modifiers are deprecated and will be removed in a future release. Use decorators instead (see https://aka.ms/BicepSpecParams for examples). |{\r\n  minValue: -100\r\n  maxValue: -33\r\n}|
+  minValue: -100
+  maxValue: -33
+}
+
 @sys.description('A boolean.')
 @metadata({
     description: 'I will be overrode.'

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.formatted.bicep
@@ -231,6 +231,17 @@ param decoratedString string
 @minValue(200)
 param decoratedInt int = 123
 
+// negative integer literals are allowed as decorator values
+@minValue(-10)
+@maxValue(-3)
+param negativeValues int
+
+// negative integer literals in modifiers
+param negativeModifiers int {
+  minValue: -100
+  maxValue: -33
+}
+
 @sys.description('A boolean.')
 @metadata({
   description: 'I will be overrode.'

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.json
@@ -251,6 +251,16 @@
       "defaultValue": 123,
       "minValue": 200
     },
+    "negativeValues": {
+      "type": "int",
+      "maxValue": -3,
+      "minValue": -10
+    },
+    "negativeModifiers": {
+      "type": "int",
+      "minValue": -100,
+      "maxValue": -33
+    },
     "decoratedBool": {
       "type": "bool",
       "defaultValue": "[not(equals(and(true(), false()), true()))]",
@@ -306,7 +316,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1221792736613608003"
+      "templateHash": "16608949399804011015"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.symbols.bicep
@@ -274,6 +274,19 @@ param decoratedString string
 param decoratedInt int = 123
 //@[6:18) Parameter decoratedInt. Type: int. Declaration start char: 0, length: 44
 
+// negative integer literals are allowed as decorator values
+@minValue(-10)
+@maxValue(-3)
+param negativeValues int
+//@[6:20) Parameter negativeValues. Type: int. Declaration start char: 0, length: 55
+
+// negative integer literals in modifiers
+param negativeModifiers int {
+//@[6:23) Parameter negativeModifiers. Type: int. Declaration start char: 0, length: 67
+  minValue: -100
+  maxValue: -33
+}
+
 @sys.description('A boolean.')
 @metadata({
     description: 'I will be overrode.'

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.syntax.bicep
@@ -1412,6 +1412,81 @@ param decoratedInt int = 123
 //@[25:28)    Integer |123|
 //@[28:32) NewLine |\r\n\r\n|
 
+// negative integer literals are allowed as decorator values
+//@[60:62) NewLine |\r\n|
+@minValue(-10)
+//@[0:55) ParameterDeclarationSyntax
+//@[0:14)  DecoratorSyntax
+//@[0:1)   At |@|
+//@[1:14)   FunctionCallSyntax
+//@[1:9)    IdentifierSyntax
+//@[1:9)     Identifier |minValue|
+//@[9:10)    LeftParen |(|
+//@[10:13)    FunctionArgumentSyntax
+//@[10:13)     UnaryOperationSyntax
+//@[10:11)      Minus |-|
+//@[11:13)      IntegerLiteralSyntax
+//@[11:13)       Integer |10|
+//@[13:14)    RightParen |)|
+//@[14:16)  NewLine |\r\n|
+@maxValue(-3)
+//@[0:13)  DecoratorSyntax
+//@[0:1)   At |@|
+//@[1:13)   FunctionCallSyntax
+//@[1:9)    IdentifierSyntax
+//@[1:9)     Identifier |maxValue|
+//@[9:10)    LeftParen |(|
+//@[10:12)    FunctionArgumentSyntax
+//@[10:12)     UnaryOperationSyntax
+//@[10:11)      Minus |-|
+//@[11:12)      IntegerLiteralSyntax
+//@[11:12)       Integer |3|
+//@[12:13)    RightParen |)|
+//@[13:15)  NewLine |\r\n|
+param negativeValues int
+//@[0:5)  Identifier |param|
+//@[6:20)  IdentifierSyntax
+//@[6:20)   Identifier |negativeValues|
+//@[21:24)  TypeSyntax
+//@[21:24)   Identifier |int|
+//@[24:28) NewLine |\r\n\r\n|
+
+// negative integer literals in modifiers
+//@[41:43) NewLine |\r\n|
+param negativeModifiers int {
+//@[0:67) ParameterDeclarationSyntax
+//@[0:5)  Identifier |param|
+//@[6:23)  IdentifierSyntax
+//@[6:23)   Identifier |negativeModifiers|
+//@[24:27)  TypeSyntax
+//@[24:27)   Identifier |int|
+//@[28:67)  ObjectSyntax
+//@[28:29)   LeftBrace |{|
+//@[29:31)   NewLine |\r\n|
+  minValue: -100
+//@[2:16)   ObjectPropertySyntax
+//@[2:10)    IdentifierSyntax
+//@[2:10)     Identifier |minValue|
+//@[10:11)    Colon |:|
+//@[12:16)    UnaryOperationSyntax
+//@[12:13)     Minus |-|
+//@[13:16)     IntegerLiteralSyntax
+//@[13:16)      Integer |100|
+//@[16:18)   NewLine |\r\n|
+  maxValue: -33
+//@[2:15)   ObjectPropertySyntax
+//@[2:10)    IdentifierSyntax
+//@[2:10)     Identifier |maxValue|
+//@[10:11)    Colon |:|
+//@[12:15)    UnaryOperationSyntax
+//@[12:13)     Minus |-|
+//@[13:15)     IntegerLiteralSyntax
+//@[13:15)      Integer |33|
+//@[15:17)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
 @sys.description('A boolean.')
 //@[0:229) ParameterDeclarationSyntax
 //@[0:30)  DecoratorSyntax

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.tokens.bicep
@@ -930,6 +930,54 @@ param decoratedInt int = 123
 //@[25:28) Integer |123|
 //@[28:32) NewLine |\r\n\r\n|
 
+// negative integer literals are allowed as decorator values
+//@[60:62) NewLine |\r\n|
+@minValue(-10)
+//@[0:1) At |@|
+//@[1:9) Identifier |minValue|
+//@[9:10) LeftParen |(|
+//@[10:11) Minus |-|
+//@[11:13) Integer |10|
+//@[13:14) RightParen |)|
+//@[14:16) NewLine |\r\n|
+@maxValue(-3)
+//@[0:1) At |@|
+//@[1:9) Identifier |maxValue|
+//@[9:10) LeftParen |(|
+//@[10:11) Minus |-|
+//@[11:12) Integer |3|
+//@[12:13) RightParen |)|
+//@[13:15) NewLine |\r\n|
+param negativeValues int
+//@[0:5) Identifier |param|
+//@[6:20) Identifier |negativeValues|
+//@[21:24) Identifier |int|
+//@[24:28) NewLine |\r\n\r\n|
+
+// negative integer literals in modifiers
+//@[41:43) NewLine |\r\n|
+param negativeModifiers int {
+//@[0:5) Identifier |param|
+//@[6:23) Identifier |negativeModifiers|
+//@[24:27) Identifier |int|
+//@[28:29) LeftBrace |{|
+//@[29:31) NewLine |\r\n|
+  minValue: -100
+//@[2:10) Identifier |minValue|
+//@[10:11) Colon |:|
+//@[12:13) Minus |-|
+//@[13:16) Integer |100|
+//@[16:18) NewLine |\r\n|
+  maxValue: -33
+//@[2:10) Identifier |maxValue|
+//@[10:11) Colon |:|
+//@[12:13) Minus |-|
+//@[13:15) Integer |33|
+//@[15:17) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
 @sys.description('A boolean.')
 //@[0:1) At |@|
 //@[1:4) Identifier |sys|

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.bicep
@@ -214,6 +214,17 @@ param decoratedString string
 @minValue(200)
 param decoratedInt int = 123
 
+// negative integer literals are allowed as decorator values
+@minValue(-10)
+@maxValue(-3)
+param negativeValues int
+
+// negative integer literals in modifiers
+param negativeModifiers int {
+  minValue: -100
+  maxValue: -33
+}
+
 @sys.description('A boolean.')
 @metadata({
     description: 'I will be overrode.'

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.diagnostics.bicep
@@ -226,6 +226,18 @@ param decoratedString string
 @minValue(200)
 param decoratedInt int = 123
 
+// negative integer literals are allowed as decorator values
+@minValue(-10)
+@maxValue(-3)
+param negativeValues int
+
+// negative integer literals in modifiers
+param negativeModifiers int {
+//@[28:64) [BCP161 (Info)] Parameter modifiers are deprecated and will be removed in a future release. Use decorators instead (see https://aka.ms/BicepSpecParams for examples). |{\n  minValue: -100\n  maxValue: -33\n}|
+  minValue: -100
+  maxValue: -33
+}
+
 @sys.description('A boolean.')
 @metadata({
     description: 'I will be overrode.'

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.formatted.bicep
@@ -210,6 +210,17 @@ param decoratedString string
 @minValue(200)
 param decoratedInt int = 123
 
+// negative integer literals are allowed as decorator values
+@minValue(-10)
+@maxValue(-3)
+param negativeValues int
+
+// negative integer literals in modifiers
+param negativeModifiers int {
+  minValue: -100
+  maxValue: -33
+}
+
 @sys.description('A boolean.')
 @metadata({
   description: 'I will be overrode.'

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.json
@@ -234,6 +234,16 @@
       "defaultValue": 123,
       "minValue": 200
     },
+    "negativeValues": {
+      "type": "int",
+      "maxValue": -3,
+      "minValue": -10
+    },
+    "negativeModifiers": {
+      "type": "int",
+      "minValue": -100,
+      "maxValue": -33
+    },
     "decoratedBool": {
       "type": "bool",
       "metadata": {
@@ -266,7 +276,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12978647735862993085"
+      "templateHash": "1144572426517152891"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.symbols.bicep
@@ -251,6 +251,19 @@ param decoratedString string
 param decoratedInt int = 123
 //@[6:18) Parameter decoratedInt. Type: int. Declaration start char: 0, length: 43
 
+// negative integer literals are allowed as decorator values
+@minValue(-10)
+@maxValue(-3)
+param negativeValues int
+//@[6:20) Parameter negativeValues. Type: int. Declaration start char: 0, length: 53
+
+// negative integer literals in modifiers
+param negativeModifiers int {
+//@[6:23) Parameter negativeModifiers. Type: int. Declaration start char: 0, length: 64
+  minValue: -100
+  maxValue: -33
+}
+
 @sys.description('A boolean.')
 @metadata({
     description: 'I will be overrode.'

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.syntax.bicep
@@ -1339,6 +1339,81 @@ param decoratedInt int = 123
 //@[25:28)    Integer |123|
 //@[28:30) NewLine |\n\n|
 
+// negative integer literals are allowed as decorator values
+//@[60:61) NewLine |\n|
+@minValue(-10)
+//@[0:53) ParameterDeclarationSyntax
+//@[0:14)  DecoratorSyntax
+//@[0:1)   At |@|
+//@[1:14)   FunctionCallSyntax
+//@[1:9)    IdentifierSyntax
+//@[1:9)     Identifier |minValue|
+//@[9:10)    LeftParen |(|
+//@[10:13)    FunctionArgumentSyntax
+//@[10:13)     UnaryOperationSyntax
+//@[10:11)      Minus |-|
+//@[11:13)      IntegerLiteralSyntax
+//@[11:13)       Integer |10|
+//@[13:14)    RightParen |)|
+//@[14:15)  NewLine |\n|
+@maxValue(-3)
+//@[0:13)  DecoratorSyntax
+//@[0:1)   At |@|
+//@[1:13)   FunctionCallSyntax
+//@[1:9)    IdentifierSyntax
+//@[1:9)     Identifier |maxValue|
+//@[9:10)    LeftParen |(|
+//@[10:12)    FunctionArgumentSyntax
+//@[10:12)     UnaryOperationSyntax
+//@[10:11)      Minus |-|
+//@[11:12)      IntegerLiteralSyntax
+//@[11:12)       Integer |3|
+//@[12:13)    RightParen |)|
+//@[13:14)  NewLine |\n|
+param negativeValues int
+//@[0:5)  Identifier |param|
+//@[6:20)  IdentifierSyntax
+//@[6:20)   Identifier |negativeValues|
+//@[21:24)  TypeSyntax
+//@[21:24)   Identifier |int|
+//@[24:26) NewLine |\n\n|
+
+// negative integer literals in modifiers
+//@[41:42) NewLine |\n|
+param negativeModifiers int {
+//@[0:64) ParameterDeclarationSyntax
+//@[0:5)  Identifier |param|
+//@[6:23)  IdentifierSyntax
+//@[6:23)   Identifier |negativeModifiers|
+//@[24:27)  TypeSyntax
+//@[24:27)   Identifier |int|
+//@[28:64)  ObjectSyntax
+//@[28:29)   LeftBrace |{|
+//@[29:30)   NewLine |\n|
+  minValue: -100
+//@[2:16)   ObjectPropertySyntax
+//@[2:10)    IdentifierSyntax
+//@[2:10)     Identifier |minValue|
+//@[10:11)    Colon |:|
+//@[12:16)    UnaryOperationSyntax
+//@[12:13)     Minus |-|
+//@[13:16)     IntegerLiteralSyntax
+//@[13:16)      Integer |100|
+//@[16:17)   NewLine |\n|
+  maxValue: -33
+//@[2:15)   ObjectPropertySyntax
+//@[2:10)    IdentifierSyntax
+//@[2:10)     Identifier |maxValue|
+//@[10:11)    Colon |:|
+//@[12:15)    UnaryOperationSyntax
+//@[12:13)     Minus |-|
+//@[13:15)     IntegerLiteralSyntax
+//@[13:15)      Integer |33|
+//@[15:16)   NewLine |\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
 @sys.description('A boolean.')
 //@[0:193) ParameterDeclarationSyntax
 //@[0:30)  DecoratorSyntax

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.tokens.bicep
@@ -880,6 +880,54 @@ param decoratedInt int = 123
 //@[25:28) Integer |123|
 //@[28:30) NewLine |\n\n|
 
+// negative integer literals are allowed as decorator values
+//@[60:61) NewLine |\n|
+@minValue(-10)
+//@[0:1) At |@|
+//@[1:9) Identifier |minValue|
+//@[9:10) LeftParen |(|
+//@[10:11) Minus |-|
+//@[11:13) Integer |10|
+//@[13:14) RightParen |)|
+//@[14:15) NewLine |\n|
+@maxValue(-3)
+//@[0:1) At |@|
+//@[1:9) Identifier |maxValue|
+//@[9:10) LeftParen |(|
+//@[10:11) Minus |-|
+//@[11:12) Integer |3|
+//@[12:13) RightParen |)|
+//@[13:14) NewLine |\n|
+param negativeValues int
+//@[0:5) Identifier |param|
+//@[6:20) Identifier |negativeValues|
+//@[21:24) Identifier |int|
+//@[24:26) NewLine |\n\n|
+
+// negative integer literals in modifiers
+//@[41:42) NewLine |\n|
+param negativeModifiers int {
+//@[0:5) Identifier |param|
+//@[6:23) Identifier |negativeModifiers|
+//@[24:27) Identifier |int|
+//@[28:29) LeftBrace |{|
+//@[29:30) NewLine |\n|
+  minValue: -100
+//@[2:10) Identifier |minValue|
+//@[10:11) Colon |:|
+//@[12:13) Minus |-|
+//@[13:16) Integer |100|
+//@[16:17) NewLine |\n|
+  maxValue: -33
+//@[2:10) Identifier |maxValue|
+//@[10:11) Colon |:|
+//@[12:13) Minus |-|
+//@[13:15) Integer |33|
+//@[15:16) NewLine |\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\n\n|
+
 @sys.description('A boolean.')
 //@[0:1) At |@|
 //@[1:4) Identifier |sys|

--- a/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorCompileTimeConstantTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorCompileTimeConstantTests.cs
@@ -72,6 +72,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
             yield return CreateTextRow("!true");
             yield return CreateTextRow("!x");
             yield return CreateTextRow("-x");
+            yield return CreateTextRow("!true");
 
             // ternary
             yield return CreateTextRow("true?true:true");
@@ -103,6 +104,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
             yield return CreateRow("false", TestSyntaxFactory.CreateBool(false));
             yield return CreateRow("string", TestSyntaxFactory.CreateString("hello"));
             yield return CreateRow("int", TestSyntaxFactory.CreateInt(42));
+            yield return CreateRow("negative int", TestSyntaxFactory.CreateUnaryMinus(TestSyntaxFactory.CreateInt(42)));
 
             yield return CreateRow("empty object", TestSyntaxFactory.CreateObject(new ObjectPropertySyntax[0]));
 

--- a/src/Bicep.Core.UnitTests/Utils/TestSyntaxFactory.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestSyntaxFactory.cs
@@ -40,6 +40,8 @@ namespace Bicep.Core.UnitTests.Utils
 
         public static ObjectPropertySyntax CreateProperty(IdentifierSyntax name, SyntaxBase value) => new ObjectPropertySyntax(name, CreateToken(TokenType.Colon), value);
 
+        public static UnaryOperationSyntax CreateUnaryMinus(SyntaxBase operand) => new(CreateToken(TokenType.Minus), operand);
+
         public static Token CreateToken(TokenType type, string text = "") => new Token(type, new TextSpan(0, 0), text, ImmutableArray.Create<SyntaxTrivia>(), ImmutableArray.Create<SyntaxTrivia>());
 
         private static IEnumerable<SyntaxBase> CreateChildrenWithNewLines(IEnumerable<SyntaxBase> children)

--- a/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
@@ -22,6 +22,7 @@ namespace Bicep.Core.TypeSystem
         /*
          * Overrides below correspond to nodes whose presence guarantees that
          * the expression is not a compile-time constant (assuming constant folding is not performed)
+         * the only exception is the UnaryOperatorSyntax (see comment within)
          *
          * When the visitor logs an error, it should not visit child nodes as that could lead to redundant errors.
          */
@@ -68,6 +69,15 @@ namespace Bicep.Core.TypeSystem
 
         public override void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax)
         {
+            if(syntax.Operator == UnaryOperator.Minus)
+            {
+                // the unary minus operator is allowed in compile time constants
+                // to support negative integer literals
+                base.VisitUnaryOperationSyntax(syntax);
+
+                return;
+            }
+
             this.AppendError(syntax);
         }
 


### PR DESCRIPTION
Negative integer literals are now considered compile-time constants. This fixes #1748. 

Also fixes the logic merge issue in `main`.