### PR TITLE
Changed 'name' parameter to avoid deployment errors while following the tutorial

### DIFF
--- a/docs/tutorial/01-simple-template.md
+++ b/docs/tutorial/01-simple-template.md
@@ -36,10 +36,10 @@ In most cases, I want to expose the resource name and the resource location via 
 
 ```
 param location string = 'eastus'
-param name string = 'uniquestorage001' // must be globally unique
+param storageAccountName string = 'uniquestorage001' // must be globally unique
 
 resource stg 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-  name: name
+  name: storageAccountName
   location: location
   kind: 'Storage'
   sku: {
@@ -59,7 +59,7 @@ Storage account names must be between 3 and 24 characters, so let's add those re
 ```bicep
 @minLength(3)
 @maxLength(24)
-param name string = 'uniquestorage001' // must be globally unique
+param storageAccountName string = 'uniquestorage001' // must be globally unique
 ```
 
 ## Add variables and outputs
@@ -71,12 +71,12 @@ param location string = 'eastus'
 
 @minLength(3)
 @maxLength(24)
-param name string = 'uniquestorage001' // must be globally unique
+param storageAccountName string = 'uniquestorage001' // must be globally unique
 
 var storageSku = 'Standard_LRS' // declare variable and assign value
 
 resource stg 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-  name: name
+  name: storageAccountName
   location: location
   kind: 'Storage'
   sku: {

--- a/docs/tutorial/02-deploying-a-bicep-file.md
+++ b/docs/tutorial/02-deploying-a-bicep-file.md
@@ -16,24 +16,24 @@ az deployment group create -f ./main.bicep -g my-rg
 New-AzResourceGroupDeployment -TemplateFile ./main.bicep -ResourceGroupName my-rg
 ```
 
->**Note:** make sure you update the default value of the `name` parameter to be globally unique before deploying.
+>**Note:** make sure you update the default value of the `storageAccountName` parameter to be globally unique before deploying.
 
 ## Deploy with parameters
 
-Our Bicep file exposed two parameters that we can be optionally overridden (`location` and `name`) by passing new values at deployment time.
+Our Bicep file exposed two parameters that we can be optionally overridden (`location` and `storageAccountName`) by passing new values at deployment time.
 
 ### Pass parameters on the command line
 
 **Az CLI**:
 
 ```bash
-az deployment group create -f ./main.bicep -g my-rg --parameters location=westus name=uniquelogstorage001
+az deployment group create -f ./main.bicep -g my-rg --parameters location=westus storageAccountName=uniquelogstorage001
 ```
 
 **Azure PowerShell**:
 
 ```powershell
-New-AzResourceGroupDeployment -TemplateFile ./main.bicep -ResourceGroupName my-rg -location westus -name uniquelogstorage001
+New-AzResourceGroupDeployment -TemplateFile ./main.bicep -ResourceGroupName my-rg -location westus -storageAccountName uniquelogstorage001
 ```
 
 ### Use a local parameters JSON file

--- a/docs/tutorial/03-using-expressions.md
+++ b/docs/tutorial/03-using-expressions.md
@@ -18,7 +18,7 @@ var location = resourceGroup().location
 output makeCapital string = toUpper('all lowercase')
 ```
 
-In our `main.bicep` file, instead of forcing users to guess a unique storage account name, let's get rid of our `name` parameter and use the `uniqueString()` and `resourceGroup()` functions to calculate a unique name. We'll also use the `resourceGroup().location` property instead of hardcoding a default location.
+In our `main.bicep` file, instead of forcing users to guess a unique storage account name, let's get rid of our `storageAccountName` parameter and use the `uniqueString()` and `resourceGroup()` functions to calculate a unique name. We'll also use the `resourceGroup().location` property instead of hardcoding a default location.
 
 ```bicep
 param location string = resourceGroup().location

--- a/docs/tutorial/complete-bicep-files/01.bicep
+++ b/docs/tutorial/complete-bicep-files/01.bicep
@@ -2,12 +2,12 @@ param location string = 'eastus'
 
 @minLength(3)
 @maxLength(24)
-param name string = 'uniquestorage001' // must be globally unique
+param storageAccountName string = 'uniquestorage001' // must be globally unique
 
 var storageSku = 'Standard_LRS' // declare variable and assign value
 
 resource stg 'Microsoft.Storage/storageAccounts@2019-06-01' = {
-    name: name
+    name: storageAccountName
     location: location
     kind: 'Storage'
     sku: {

--- a/docs/tutorial/complete-bicep-files/01.json
+++ b/docs/tutorial/complete-bicep-files/01.json
@@ -6,7 +6,7 @@
       "type": "string",
       "defaultValue": "eastus"
     },
-    "name": {
+    "storageAccountName": {
       "type": "string",
       "defaultValue": "uniquestorage001",
       "maxLength": 24,
@@ -21,7 +21,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2019-06-01",
-      "name": "[parameters('name')]",
+      "name": "[parameters('storageAccountName')]",
       "location": "[parameters('location')]",
       "kind": "Storage",
       "sku": {
@@ -32,7 +32,7 @@
   "outputs": {
     "storageId": {
       "type": "string",
-      "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
     }
   },
   "metadata": {


### PR DESCRIPTION
Fixes #1799

**Description:**
- Changed the 'name' parameter to 'storageAccountName' in the tutorial .md files 01 - 03
- Also changed the parameter in the 01.bicep and 01.json files
- Checked if the commands and examples work as expected

The behaviour, described in the mentioned issue is solved after changing the parameter names.
The following PowerShell command deploys the storage account as expected:

```PowerShell
New-AzResourceGroupDeployment -TemplateFile ./main.bicep -ResourceGroupName my-rg -location westus -storageAccountName uniquelogstorage001
```



-----------------------------------
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

* [x] I have checked that there is not an equivalent example already submitted
* [x] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [x] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature
