### PR TITLE
curl path download file extension added

### DIFF
--- a/docs/cicd-with-bicep.md
+++ b/docs/cicd-with-bicep.md
@@ -18,6 +18,10 @@ name: bicep build and deploy
 
 on: push
 
+env:
+  # Common variables
+  AZURE_RESOURCE_GROUP: 'myResourceGroupName'
+
 jobs:
   bicep-build-and-deploy:
     name: bicep build and deploy
@@ -28,12 +32,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Install the latest release of the bicep CLI
-      - name: Install bicep CLI
+      # Install the latest release of the bicep CLI binaries
+      - name: Install bicep CLI Binaries
         run: |
-          curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
-          chmod +x ./bicep
-          sudo mv ./bicep /usr/local/bin/bicep
+          curl -Lo bicep.bin https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
+          chmod +x ./bicep.bin
+          sudo mv ./bicep.bin /usr/local/bin/bicep
           bicep --help
            
       # Transpile bicep file into ARM template
@@ -56,7 +60,7 @@ jobs:
         with:
           inlineScript: |
             az account show
-            az deployment group what-if -f ./main.json -p ./parameters.json -g my-rg
+            az deployment group what-if -f ./main.json -p ./parameters.json -g ${{ env.AZURE_RESOURCE_GROUP }}
 
       # You may want a human approval in between the what-if step 
       # and the deploy step to evaluate output before deployment
@@ -67,7 +71,7 @@ jobs:
         with:
           inlineScript: |
             az account show
-            az deployment group create -f ./main.json -g my-rg
+            az deployment group create -f ./main.json -g ${{ env.AZURE_RESOURCE_GROUP }}
 ```
 
 Instead of installing the Bicep CLI manually, you may instead want to use the [community-maintained github action](https://github.com/marketplace/actions/bicep-build) from [@justinyoo](https://github.com/justinyoo) that can run `bicep build` on your behalf.


### PR DESCRIPTION
## Contributing a feature
The latest version of curl confuses between a directory and file without extension when downloading form a URL. So in this PR, have added an extension to the bicep binary download, and rename it back when moving to the folder. This works.

Also added an environment variable for the resource group parameter. The docs did not illustrate this correctly.