### PR TITLE
Fixed property value context with partially typed identifiers

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -300,6 +300,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -1,23 +1,5 @@
 [
   {
-    "label": "'kind'",
-    "kind": "property",
-    "detail": "kind (Required)",
-    "documentation": {
-      "kind": "markdown",
-      "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \n"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "1_'kind'",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "'kind'"
-    }
-  },
-  {
     "label": "any",
     "kind": "function",
     "detail": "any()",
@@ -302,23 +284,6 @@
     "command": {
       "command": "editor.action.triggerParameterHints"
     }
-  },
-  {
-    "label": "booleanPropertyPartialValue",
-    "kind": "interface",
-    "detail": "booleanPropertyPartialValue",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_booleanPropertyPartialValue",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "asIs",
-    "textEdit": {
-      "range": {},
-      "newText": "booleanPropertyPartialValue"
-    },
-    "commitCharacters": [
-      ":"
-    ]
   },
   {
     "label": "coalesce",
@@ -1253,6 +1218,20 @@
     }
   },
   {
+    "label": "discriminatorKeyValueMissingCompletions3",
+    "kind": "variable",
+    "detail": "discriminatorKeyValueMissingCompletions3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_discriminatorKeyValueMissingCompletions3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "discriminatorKeyValueMissingCompletions3"
+    }
+  },
+  {
     "label": "discriminatorKeyValueMissingCompletions3_for",
     "kind": "variable",
     "detail": "discriminatorKeyValueMissingCompletions3_for",
@@ -1852,6 +1831,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "false",
+    "kind": "keyword",
+    "detail": "false",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "1_false",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "false"
     }
   },
   {
@@ -4730,6 +4723,20 @@
     },
     "command": {
       "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "true",
+    "kind": "keyword",
+    "detail": "true",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "1_true",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "true"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -328,6 +328,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -556,6 +556,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -556,6 +556,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -556,6 +556,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -556,6 +556,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -304,6 +304,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -304,6 +304,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -304,6 +304,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -304,6 +304,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -790,6 +790,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -790,6 +790,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -790,6 +790,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -790,6 +790,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -314,6 +314,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -314,6 +314,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -314,6 +314,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -314,6 +314,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -304,6 +304,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -304,6 +304,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -304,6 +304,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -286,6 +286,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -412,6 +412,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -286,6 +286,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
@@ -300,6 +300,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -300,6 +300,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -300,6 +300,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleStateSomething.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleStateSomething.json
@@ -300,6 +300,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -300,6 +300,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -300,6 +300,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -300,6 +300,23 @@
     }
   },
   {
+    "label": "booleanPropertyPartialValue",
+    "kind": "interface",
+    "detail": "booleanPropertyPartialValue",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_booleanPropertyPartialValue",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "asIs",
+    "textEdit": {
+      "range": {},
+      "newText": "booleanPropertyPartialValue"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "coalesce",
     "kind": "function",
     "detail": "coalesce()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -919,6 +919,16 @@ resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@20
 //#completionTest(56) -> vmProperties
 var sigh = nestedPropertyAccessOnConditional.properties.
 
+/*
+  boolean property value completions
+*/ 
+resource booleanPropertyPartialValue 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+  properties: {
+    // #completionTest(28,29,30) -> boolPropertyValuesPlusSymbols
+    autoUpgradeMinorVersion: t
+  }
+}
+
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
   name: 'selfScope'
   scope: selfScope

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -1200,6 +1200,17 @@ resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@20
 var sigh = nestedPropertyAccessOnConditional.properties.
 //@[56:56) [BCP020 (Error)] Expected a function or property name at this location. ||
 
+/*
+  boolean property value completions
+*/ 
+resource booleanPropertyPartialValue 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+  properties: {
+    // #completionTest(28,29,30) -> boolPropertyValuesPlusSymbols
+    autoUpgradeMinorVersion: t
+//@[29:30) [BCP057 (Error)] The name "t" does not exist in the current context. |t|
+  }
+}
+
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
 //@[19:50) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-12-01" does not have types available. |'My.Rp/mockResource@2020-12-01'|
   name: 'selfScope'

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
@@ -872,6 +872,16 @@ resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@20
 //#completionTest(56) -> vmProperties
 var sigh = nestedPropertyAccessOnConditional.properties.
 
+/*
+  boolean property value completions
+*/
+resource booleanPropertyPartialValue 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+  properties: {
+    // #completionTest(28,29,30) -> boolPropertyValuesPlusSymbols
+    autoUpgradeMinorVersion: t
+  }
+}
+
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
   name: 'selfScope'
   scope: selfScope

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -1132,6 +1132,17 @@ resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@20
 var sigh = nestedPropertyAccessOnConditional.properties.
 //@[4:8) Variable sigh. Type: error. Declaration start char: 0, length: 56
 
+/*
+  boolean property value completions
+*/ 
+resource booleanPropertyPartialValue 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+//@[9:36) Resource booleanPropertyPartialValue. Type: Microsoft.Compute/virtualMachines/extensions@2020-06-01. Declaration start char: 0, length: 222
+  properties: {
+    // #completionTest(28,29,30) -> boolPropertyValuesPlusSymbols
+    autoUpgradeMinorVersion: t
+  }
+}
+
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
 //@[9:18) Resource selfScope. Type: My.Rp/mockResource@2020-12-01. Declaration start char: 0, length: 98
   name: 'selfScope'

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -6269,6 +6269,47 @@ var sigh = nestedPropertyAccessOnConditional.properties.
 //@[56:56)    SkippedTriviaSyntax
 //@[56:60) NewLine |\r\n\r\n|
 
+/*
+  boolean property value completions
+*/ 
+//@[3:5) NewLine |\r\n|
+resource booleanPropertyPartialValue 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+//@[0:222) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:36)  IdentifierSyntax
+//@[9:36)   Identifier |booleanPropertyPartialValue|
+//@[37:94)  StringSyntax
+//@[37:94)   StringComplete |'Microsoft.Compute/virtualMachines/extensions@2020-06-01'|
+//@[95:96)  Assignment |=|
+//@[97:222)  ObjectSyntax
+//@[97:98)   LeftBrace |{|
+//@[98:100)   NewLine |\r\n|
+  properties: {
+//@[2:119)   ObjectPropertySyntax
+//@[2:12)    IdentifierSyntax
+//@[2:12)     Identifier |properties|
+//@[12:13)    Colon |:|
+//@[14:119)    ObjectSyntax
+//@[14:15)     LeftBrace |{|
+//@[15:17)     NewLine |\r\n|
+    // #completionTest(28,29,30) -> boolPropertyValuesPlusSymbols
+//@[65:67)     NewLine |\r\n|
+    autoUpgradeMinorVersion: t
+//@[4:30)     ObjectPropertySyntax
+//@[4:27)      IdentifierSyntax
+//@[4:27)       Identifier |autoUpgradeMinorVersion|
+//@[27:28)      Colon |:|
+//@[29:30)      VariableAccessSyntax
+//@[29:30)       IdentifierSyntax
+//@[29:30)        Identifier |t|
+//@[30:32)     NewLine |\r\n|
+  }
+//@[2:3)     RightBrace |}|
+//@[3:5)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
 //@[0:98) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -4070,6 +4070,36 @@ var sigh = nestedPropertyAccessOnConditional.properties.
 //@[55:56) Dot |.|
 //@[56:60) NewLine |\r\n\r\n|
 
+/*
+  boolean property value completions
+*/ 
+//@[3:5) NewLine |\r\n|
+resource booleanPropertyPartialValue 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+//@[0:8) Identifier |resource|
+//@[9:36) Identifier |booleanPropertyPartialValue|
+//@[37:94) StringComplete |'Microsoft.Compute/virtualMachines/extensions@2020-06-01'|
+//@[95:96) Assignment |=|
+//@[97:98) LeftBrace |{|
+//@[98:100) NewLine |\r\n|
+  properties: {
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:17) NewLine |\r\n|
+    // #completionTest(28,29,30) -> boolPropertyValuesPlusSymbols
+//@[65:67) NewLine |\r\n|
+    autoUpgradeMinorVersion: t
+//@[4:27) Identifier |autoUpgradeMinorVersion|
+//@[27:28) Colon |:|
+//@[29:30) Identifier |t|
+//@[30:32) NewLine |\r\n|
+  }
+//@[2:3) RightBrace |}|
+//@[3:5) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
 //@[0:8) Identifier |resource|
 //@[9:18) Identifier |selfScope|


### PR DESCRIPTION
This fixes #1882. Also rewrote the logic using the `SyntaxMatcher.IsTailMatch()` pattern.