### PR TITLE
Added missing colon to array output loop

### DIFF
--- a/docs/spec/outputs.md
+++ b/docs/spec/outputs.md
@@ -29,7 +29,7 @@ output isInputParamEmpty bool = length(myParam) == 0
 ## Array output
 The following declares an array output and computes the value using a [loop](./loops.md).
 ```
-output myLoopyOutput array = [for myItem in myArray {
+output myLoopyOutput array = [for myItem in myArray: {
   myProperty: myItem.myOtherProperty
 }]
 ```


### PR DESCRIPTION
## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

-Added a missing colon to array output loop example.