### PR TITLE
Fixed official VSIX build

### DIFF
--- a/.pipelines/Common.yml
+++ b/.pipelines/Common.yml
@@ -224,7 +224,7 @@ stages:
       displayName: Copy language server for packaging
       inputs:
         sourceFolder: '$(Pipeline.Workspace)/drop_build_bicep_windows/bicep.LangServer/'
-        contents: '*.*'
+        contents: '**'
         targetFolder: '$(Build.SourcesDirectory)/src/vscode-bicep/bicepLanguageServer'
     
     - script: npm run test:unit

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -17,7 +17,6 @@ export async function activate(
     outputChannel,
     async () => {
       const logger = createLogger(context, outputChannel);
-      logger.info("Logger created");
 
       try {
         await launchLanguageServiceWithProgressReport(context, outputChannel);

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -22,6 +22,7 @@ export async function activate(
         await launchLanguageServiceWithProgressReport(context, outputChannel);
       } catch (e) {
         logger.error(e);
+        throw e;
       }
     }
   );

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -16,9 +16,14 @@ export async function activate(
     context,
     outputChannel,
     async () => {
-      createLogger(context, outputChannel);
+      const logger = createLogger(context, outputChannel);
+      logger.info("Logger created");
 
-      await launchLanguageServiceWithProgressReport(context, outputChannel);
+      try {
+        await launchLanguageServiceWithProgressReport(context, outputChannel);
+      } catch (e) {
+        logger.error(e);
+      }
     }
   );
 }

--- a/src/vscode-bicep/src/utils/logger.ts
+++ b/src/vscode-bicep/src/utils/logger.ts
@@ -92,7 +92,7 @@ function isTestEnv() {
 export function createLogger(
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel
-): void {
+): Logger {
   // TODO:
   // - make log level configurable
   // - Default log level should be info
@@ -102,6 +102,8 @@ export function createLogger(
   logger.info("Current log level: debug.");
 
   context.subscriptions.push(winstonLogger);
+
+  return logger;
 }
 
 export function getLogger(): Logger {


### PR DESCRIPTION
The official build was not packaging all the language server files recursively. This PR fixes this and adds some logging on the VS code extension side.