### PR TITLE
Fixed msbuild nuget description

### DIFF
--- a/src/Bicep.MSBuild/Bicep.MSBuild.csproj
+++ b/src/Bicep.MSBuild/Bicep.MSBuild.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Azure.Bicep.MSBuild</RootNamespace>
     <EnableNuget>true</EnableNuget>
     <PackageTags>CLI;compiler</PackageTags>
+    <Description>Bicep MSBuild task</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We were generating packages with a placeholder before. The CLI nuget that is generated via the .nuspec file does not have this issue.