### PR TITLE
fixed wrong task assembly path on classic .net

### DIFF
--- a/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.props
+++ b/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.props
@@ -1,10 +1,6 @@
-<Project TreatAsLocalProperty="TaskRuntimeDirectory;TaskAssembly">
+<Project TreatAsLocalProperty="TaskAssembly">
   <PropertyGroup>
-    <TaskRuntimeDirectory Condition=" $(MSBuildRuntimeType) != 'Core' ">net472</TaskRuntimeDirectory>
-    <TaskRuntimeDirectory Condition=" $(MSBuildRuntimeType) == 'Core' ">netstandard2.0</TaskRuntimeDirectory>
-
-    <TaskAssembly>$(MSBuildThisFileDirectory)..\tasks\$(TaskRuntimeDirectory)\Azure.Bicep.MSBuild.dll</TaskAssembly>
-
+    <TaskAssembly>$(MSBuildThisFileDirectory)..\tasks\netstandard2.0\Azure.Bicep.MSBuild.dll</TaskAssembly>
     <BicepDefaultOutputFileExtension Condition=" $(BicepDefaultOutputFileExtension) == '' ">.json</BicepDefaultOutputFileExtension>
   </PropertyGroup>
 


### PR DESCRIPTION
Originally I was planning to include a net472 and netstandard2.0 version of the MSBuild task assembly. However, a number of issues with multi-framework projects forced me to switch to netstandard2.0. Unfortunately, the .props file was still looking for the assembly in the net472 directory on classic .net msbuild. This should not be fixed.

This was missed because e2e tests only ran on .net 5. With this change, the path will be the same on classic .net and .net core, so the existing e2e will cover the classic .net case from now on.