### PR TITLE
fixed invalid example

### DIFF
--- a/docs/spec/resource-scopes.md
+++ b/docs/spec/resource-scopes.md
@@ -124,7 +124,8 @@ This feature is limited to the same scoping constraints that exist within ARM De
 
 ## Example Usages
 
-If you have a symbolic reference to a scope, you can use that as a value of the `scope` property. Currently this only works with the `resourceGroup` scope, it does not yet support `subscription` or `managementGroup` scope types.
+If you have a symbolic reference to a scope, you can use that as a value of the `scope` property. 
+⚠️ As of release v0.3 symbolic referencing only works with the `resourceGroup` scope,  not `subscription` or `managementGroup` scope types
 
 ```bicep
 // set the target scope for this file
@@ -134,8 +135,6 @@ targetScope = 'subscription'
 resource myRg 'Microsoft.Resources/resourceGroups@2020-10-01' = {
   name: 'myRg'
   location: 'West US'
-  properties: {
-  }
 }
 
 // deploy a module to that newly-created resource group
@@ -145,4 +144,5 @@ module myMod './path/to/module.bicep' = {
 }
 ```
 
-[arm-scopes]: https://docs.microsoft.com/azure/azure-resource-manager/management/overview#understand-scope
+⮴📖 [resourceGroup properties] https://docs.microsoft.com/en-us/azure/templates/microsoft.resources/resourcegroups?tabs=bicep
+⮴📖 [arm-scopes]: https://docs.microsoft.com/azure/azure-resource-manager/management/overview#understand-scope

--- a/docs/spec/resource-scopes.md
+++ b/docs/spec/resource-scopes.md
@@ -125,7 +125,8 @@ This feature is limited to the same scoping constraints that exist within ARM De
 ## Example Usages
 
 If you have a symbolic reference to a scope, you can use that as a value of the `scope` property. 
-⚠️ As of release v0.3 symbolic referencing only works with the `resourceGroup` scope,  not `subscription` or `managementGroup` scope types
+
+⚠️ As of release v0.3 symbolic referencing only works with the `resourceGroup` scope,  not `subscription` or `managementGroup` scope types (tracked with [#1883](https://github.com/Azure/bicep/issues?q=is%3Aissue+is%3Aopen+mg+scope))
 
 ```bicep
 // set the target scope for this file
@@ -144,5 +145,6 @@ module myMod './path/to/module.bicep' = {
 }
 ```
 
-⮴📖 [resourceGroup properties] https://docs.microsoft.com/en-us/azure/templates/microsoft.resources/resourcegroups?tabs=bicep
-⮴📖 [arm-scopes]: https://docs.microsoft.com/azure/azure-resource-manager/management/overview#understand-scope
+[resourceGroup properties](https://docs.microsoft.com/azure/templates/microsoft.resources/resourcegroups?tabs=bicep)
+
+[arm-scopes]: https://docs.microsoft.com/azure/azure-resource-manager/management/overview#understand-scope

--- a/docs/spec/resource-scopes.md
+++ b/docs/spec/resource-scopes.md
@@ -131,10 +131,11 @@ If you have a symbolic reference to a scope, you can use that as a value of the 
 targetScope = 'subscription'
 
 // deploy a resource group to the subscription scope
-resource myRg 'Microsoft.Resources/resourceGroups@2020-01-01' = {
+resource myRg 'Microsoft.Resources/resourceGroups@2020-10-01' = {
   name: 'myRg'
   location: 'West US'
-  scope: subscription()
+  properties: {
+  }
 }
 
 // deploy a module to that newly-created resource group


### PR DESCRIPTION
current example does not match bicep definition 
'Microsoft.Resources/resourceGroups@2020-01-01' is not valid
in newer version @2020-10-01 the scope: parameter is not valid.

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

* [ ] I have checked that there is not an equivalent example already submitted
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature
