### PR TITLE
Update AKS cluster snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -155,7 +155,7 @@
     "detail": "Kubernetes Service Cluster",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource aksCluster 'Microsoft.ContainerService/managedClusters@2020-02-01' = {\n  name: 'aksCluster'\n  location: resourceGroup().location\n  properties: {\n    kubernetesVersion: '1.15.7'\n    dnsPrefix: 'dnsprefix'\n    agentPoolProfiles: [\n      {\n        name: 'agentpool'\n        count: 2\n        vmSize: 'Standard_A1'\n        osType: 'Linux'\n      }\n    ]\n    linuxProfile: {\n      adminUsername: 'adminUserName'\n      ssh: {\n        publicKeys: [\n          {\n            keyData: 'keyData'\n          }\n        ]\n      }\n    }\n    servicePrincipalProfile: {\n      clientId: 'servicePrincipalAppId'\n      secret: 'servicePrincipalAppPassword'\n    }\n  }\n}\n```"
+      "value": "```bicep\nresource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {\n  name: 'aksCluster'\n  location: resourceGroup().location\n  identity: {\n    type: 'SystemAssigned'\n  }\n  properties: {\n    kubernetesVersion: '1.19.7'\n    dnsPrefix: 'dnsprefix'\n    enableRBAC: true\n    agentPoolProfiles: [\n      {\n        name: 'agentpool'\n        count: 3\n        vmSize: 'Standard_DS2_v2'\n        osType: 'Linux'\n        mode: 'System'\n      }\n    ]\n    linuxProfile: {\n      adminUsername: 'adminUserName'\n      ssh: {\n        publicKeys: [\n          {\n            keyData: 'keyData'\n          }\n        ]\n      }\n    }\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -164,7 +164,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource aksCluster 'Microsoft.ContainerService/managedClusters@2020-02-01' = {\n  name: '${1:aksCluster}'\n  location: resourceGroup().location\n  properties: {\n    kubernetesVersion: '${2|1.15.7,1.15.5,1.14.8|}'\n    dnsPrefix: '${3:dnsprefix}'\n    agentPoolProfiles: [\n      {\n        name: 'agentpool'\n        count: ${4:2}\n        vmSize: '${5:Standard_A1}'\n        osType: 'Linux'\n      }\n    ]\n    linuxProfile: {\n      adminUsername: '${6:adminUserName}'\n      ssh: {\n        publicKeys: [\n          {\n            keyData: '${7:keyData}'\n          }\n        ]\n      }\n    }\n    servicePrincipalProfile: {\n      clientId: '${8:servicePrincipalAppId}'\n      secret: '${9:servicePrincipalAppPassword}'\n    }\n  }\n}"
+      "newText": "resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {\n  name: '${1:aksCluster}'\n  location: resourceGroup().location\n  identity: {\n    type: 'SystemAssigned'\n  }\n  properties: {\n    kubernetesVersion: '${2|1.19.7,1.19.6,1.18.14,1.18.10,1.17.16,1.17.13|}'\n    dnsPrefix: '${3:dnsprefix}'\n    enableRBAC: true\n    agentPoolProfiles: [\n      {\n        name: 'agentpool'\n        count: ${4:3}\n        vmSize: '${5:Standard_DS2_v2}'\n        osType: 'Linux'\n        mode: 'System'\n      }\n    ]\n    linuxProfile: {\n      adminUsername: '${6:adminUserName}'\n      ssh: {\n        publicKeys: [\n          {\n            keyData: '${7:keyData}'\n          }\n        ]\n      }\n    }\n  }\n}\n"
     }
   },
   {

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-aks-cluster/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-aks-cluster/main.bicep
@@ -1,11 +1,9 @@
 ﻿// $1 = aksCluster
-// $2 = 1.15.7
+// $2 = 1.19.7
 // $3 = testDnsPrefix
-// $4 = 2
-// $5 = Standard_A1
+// $4 = 3
+// $5 = Standard_DS2_v2
 // $6 = testUser
 // $7 = testKeyData
-// $8 = testId
-// $9 = testPassword
 
 // Insert snippet here

--- a/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
@@ -3,7 +3,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
   name: '${1:aksCluster}'
   location: resourceGroup().location
   properties: {
-    kubernetesVersion: '${2|1.15.7,1.15.5,1.14.8|}'
+    kubernetesVersion: '${2|1.19.7,1.19.6,1.18.14,1.18.10,1.17.16,1.17.13|}'
     dnsPrefix: '${3:dnsprefix}'
     agentPoolProfiles: [
       {

--- a/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
@@ -2,6 +2,9 @@
 resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
   name: '${1:aksCluster}'
   location: resourceGroup().location
+  identity: {
+    type: 'SystemAssigned'
+  }
   properties: {
     kubernetesVersion: '${2|1.19.7,1.19.6,1.18.14,1.18.10,1.17.16,1.17.13|}'
     dnsPrefix: '${3:dnsprefix}'
@@ -23,9 +26,6 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
         ]
       }
     }
-    servicePrincipalProfile: {
-      clientId: '${8:servicePrincipalAppId}'
-      secret: '${9:servicePrincipalAppPassword}'
-    }
+    enableRBAC: true
   }
 }

--- a/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
@@ -9,7 +9,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
       {
         name: 'agentpool'
         count: ${4:3}
-        vmSize: '${5:Standard_A1}'
+        vmSize: '${5:Standard_DS2_v2}'
         osType: 'Linux'
       }
     ]

--- a/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
@@ -8,7 +8,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
     agentPoolProfiles: [
       {
         name: 'agentpool'
-        count: ${4:2}
+        count: ${4:3}
         vmSize: '${5:Standard_A1}'
         osType: 'Linux'
       }

--- a/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
@@ -8,12 +8,14 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
   properties: {
     kubernetesVersion: '${2|1.19.7,1.19.6,1.18.14,1.18.10,1.17.16,1.17.13|}'
     dnsPrefix: '${3:dnsprefix}'
+    enableRBAC: true
     agentPoolProfiles: [
       {
         name: 'agentpool'
         count: ${4:3}
         vmSize: '${5:Standard_DS2_v2}'
         osType: 'Linux'
+        mode: 'System'
       }
     ]
     linuxProfile: {
@@ -26,6 +28,5 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
         ]
       }
     }
-    enableRBAC: true
   }
 }

--- a/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep
@@ -1,5 +1,5 @@
 ﻿// Kubernetes Service Cluster
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2020-02-01' = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
   name: '${1:aksCluster}'
   location: resourceGroup().location
   properties: {


### PR DESCRIPTION
Updates for AKS cluster snippet to latest API version, with default placeholders that match portal defaults for Kubernetes version, VM size, and node count.

Reported in tweet here: https://twitter.com/Pixel_Robots/status/1381871280488640513