### PR TITLE
Update type string placeholder in resource snippets 

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -673,7 +673,7 @@
     "detail": "Child Resource with defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
+      "value": "```bicep\nresource Identifier 'Provider/ParentType/ChildType@Version' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -682,7 +682,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider/ParentType/ChildType@Version}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
+      "newText": "resource ${1:Identifier} '${2:Provider/ParentType/ChildType@Version}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
     }
   },
   {
@@ -691,7 +691,7 @@
     "detail": "Child Resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Microsoft.Provider/ParentType/ChildType@Version' = {\n  name: \n  \n}\n```"
+      "value": "```bicep\nresource Identifier 'Provider/ParentType/ChildType@Version' = {\n  name: \n  \n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -700,7 +700,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider/ParentType/ChildType@Version}' = {\n  name: $3\n  $0\n}"
+      "newText": "resource ${1:Identifier} '${2:Provider/ParentType/ChildType@Version}' = {\n  name: $3\n  $0\n}"
     }
   },
   {
@@ -709,7 +709,7 @@
     "detail": "Resource with defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\n  name: \n  location: \n  properties: {\n    \n  }\n}\n```"
+      "value": "```bicep\nresource Identifier 'Provider/Type@Version' = {\n  name: \n  location: \n  properties: {\n    \n  }\n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -718,7 +718,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider/Type@Version}' = {\n  name: $3\n  location: $4\n  properties: {\n    $0\n  }\n}"
+      "newText": "resource ${1:Identifier} '${2:Provider/Type@Version}' = {\n  name: $3\n  location: $4\n  properties: {\n    $0\n  }\n}"
     }
   },
   {
@@ -727,7 +727,7 @@
     "detail": "Resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Microsoft.Provider/Type@Version' = {\n  name: \n  \n}\n```"
+      "value": "```bicep\nresource Identifier 'Provider/Type@Version' = {\n  name: \n  \n}\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -736,7 +736,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider/Type@Version}' = {\n  name: $3\n  $0\n}"
+      "newText": "resource ${1:Identifier} '${2:Provider/Type@Version}' = {\n  name: $3\n  $0\n}"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -682,7 +682,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {\n  name: $6\n  properties: {\n    $0\n  }\n}"
+      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider/ParentType/ChildType@Version}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
     }
   },
   {
@@ -700,7 +700,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {\n  name: $6\n  $0\n}"
+      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider/ParentType/ChildType@Version}' = {\n  name: $3\n  $0\n}"
     }
   },
   {
@@ -718,7 +718,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {\n  name: $5\n  location: $6\n  properties: {\n    $0\n  }\n}"
+      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider/Type@Version}' = {\n  name: $3\n  location: $4\n  properties: {\n    $0\n  }\n}"
     }
   },
   {
@@ -736,7 +736,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {\n  name: $5\n  $0\n}"
+      "newText": "resource ${1:Identifier} 'Microsoft.${2:Provider/Type@Version}' = {\n  name: $3\n  $0\n}"
     }
   },
   {

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-defaults/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-defaults/main.bicep
@@ -1,9 +1,6 @@
 ﻿// $0 = suppressionId: any(1)
 // $1 = testIdentifier
-// $2 = Advisor
-// $3 = recommendations
-// $4 = suppressions
-// $5 = 2020-01-01
-// $6 = 'testResource/'
+// $2 = Advisor/recommendations/suppressions@2020-01-01
+// $3 = 'testResource/'
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-defaults/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-defaults/main.bicep
@@ -1,6 +1,6 @@
 ﻿// $0 = suppressionId: any(1)
 // $1 = testIdentifier
-// $2 = Advisor/recommendations/suppressions@2020-01-01
+// $2 = Microsoft.Advisor/recommendations/suppressions@2020-01-01
 // $3 = 'testResource/'
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-without-defaults/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-without-defaults/main.bicep
@@ -1,8 +1,5 @@
 ﻿// $1 = nsg
-// $2 = Aad
-// $3 = domainServices
-// $4 = ouContainer
-// $5 = 2017-06-01
-// $6 = 'testResource/'
+// $2 = Aad/domainServices/ouContainer@2017-06-01
+// $3 = 'testResource/'
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-without-defaults/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-without-defaults/main.bicep
@@ -1,5 +1,5 @@
 ﻿// $1 = nsg
-// $2 = Aad/domainServices/ouContainer@2017-06-01
+// $2 = Microsoft.Aad/domainServices/ouContainer@2017-06-01
 // $3 = 'testResource/'
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-defaults/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-defaults/main.bicep
@@ -1,5 +1,5 @@
 ﻿// $1 = nsg
-// $2 = Aad/domainServices@2017-06-01
+// $2 = Microsoft.Aad/domainServices@2017-06-01
 // $3 = 'testResource'
 // $4 = 'testLocation'
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-defaults/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-defaults/main.bicep
@@ -1,8 +1,6 @@
 ﻿// $1 = nsg
-// $2 = Aad
-// $3 = domainServices
-// $4 = 2017-06-01
-// $5 = 'testResource'
-// $6 = 'testLocation'
+// $2 = Aad/domainServices@2017-06-01
+// $3 = 'testResource'
+// $4 = 'testLocation'
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-without-defaults/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-without-defaults/main.bicep
@@ -1,5 +1,5 @@
 ﻿// $1 = nsg
-// $2 = Aad/domainServices@2017-06-01
+// $2 = Microsoft.Aad/domainServices@2017-06-01
 // $3 = 'testResource'
 // $4 = 'testLocation'
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-without-defaults/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-without-defaults/main.bicep
@@ -1,8 +1,6 @@
 ﻿// $1 = nsg
-// $2 = Aad
-// $3 = domainServices
-// $4 = 2017-06-01
-// $5 = 'testResource'
-// $6 = 'testLocation'
+// $2 = Aad/domainServices@2017-06-01
+// $3 = 'testResource'
+// $4 = 'testLocation'
 
 // Insert snippet here

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetTests.cs
@@ -161,5 +161,31 @@ namespace Bicep.LangServer.UnitTests.Snippets
             Assert.AreEqual(expectedTextAfterPlaceholderReplacements, snippet.FormatDocumentation());
         }
 
+        [TestMethod]
+        public void SnippetPlaceholderTextWithTypeStringShouldParseCorrectly()
+        {
+            string text = "resource ${1:Identifier} 'Microsoft.${2:Aad/domainServices/ouContainer@2017-06-01}' = { }";
+            var snippet = new Snippet(text);
+
+            snippet.Text.Should().Be(text);
+
+            snippet.Placeholders.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Index.Should().Be(1);
+                    x.Name.Should().Be("Identifier");
+                    x.Span.ToString().Should().Be("[9:24]");
+                },
+                x =>
+                {
+                    x.Index.Should().Be(2);
+                    x.Name.Should().Be("Aad/domainServices/ouContainer@2017-06-01");
+                    x.Span.ToString().Should().Be("[36:82]");
+                });
+
+            string expectedTextAfterPlaceholderReplacements = "resource Identifier 'Microsoft.Aad/domainServices/ouContainer@2017-06-01' = { }";
+
+            Assert.AreEqual(expectedTextAfterPlaceholderReplacements, snippet.FormatDocumentation());
+        }
     }
 }

--- a/src/Bicep.LangServer/Snippets/Snippet.cs
+++ b/src/Bicep.LangServer/Snippets/Snippet.cs
@@ -14,11 +14,11 @@ namespace Bicep.LanguageServer.Snippets
     public sealed class Snippet
     {
         // Below regex is used to detect following snippet syntax:
-        // ${(?<index>\d+):(?<name>\w+|\*|(\w+\/\w+)+@(\w+|(\d{4}-\d{2}-\d{2})))} detects placeholders i.e. tab stops with values e.g ${1:foo}
+        // ${(?<index>\d+):(?<name>[^}]+)} detects placeholders i.e. tab stops with values e.g ${1:foo}
         // $(?<index>\d+) detects tab stops e.g. $1
         // $(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|} detects placeholders with choices e.g. ${1|one,two,three|}
         // See https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax for more information
-        private static readonly Regex PlaceholderPattern = new Regex(@"\$({(?<index>\d+):(?<name>\w+|\*|(\w+\/\w+)+@(\w+|(\d{4}-\d{2}-\d{2})))}|(?<index>\d+)|{(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|})", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+        private static readonly Regex PlaceholderPattern = new Regex(@"\$({(?<index>\d+):(?<name>[^}]+)}|(?<index>\d+)|{(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|})", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
         public Snippet(string text, CompletionPriority completionPriority = CompletionPriority.Medium, string prefix = "", string detail = "")
         {

--- a/src/Bicep.LangServer/Snippets/Snippet.cs
+++ b/src/Bicep.LangServer/Snippets/Snippet.cs
@@ -16,9 +16,9 @@ namespace Bicep.LanguageServer.Snippets
         // Below regex is used to detect following snippet syntax:
         // ${(?<index>\d+):(?<name>[^}]+)} detects placeholders i.e. tab stops with values e.g ${1:foo}
         // $(?<index>\d+) detects tab stops e.g. $1
-        // $(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|} detects placeholders with choices e.g. ${1|one,two,three|}
+        // $(?<index>\d+)\|((?<name>[^,]+)(.*))\|} detects placeholders with choices e.g. ${1|one,two,three|}
         // See https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax for more information
-        private static readonly Regex PlaceholderPattern = new Regex(@"\$({(?<index>\d+):(?<name>[^}]+)}|(?<index>\d+)|{(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|})", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+        private static readonly Regex PlaceholderPattern = new Regex(@"\$({(?<index>\d+):(?<name>[^}]+)}|(?<index>\d+)|{(?<index>\d+)\|((?<name>[^,]+)(.*))\|})", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
         public Snippet(string text, CompletionPriority completionPriority = CompletionPriority.Medium, string prefix = "", string detail = "")
         {

--- a/src/Bicep.LangServer/Snippets/Snippet.cs
+++ b/src/Bicep.LangServer/Snippets/Snippet.cs
@@ -18,7 +18,7 @@ namespace Bicep.LanguageServer.Snippets
         // $(?<index>\d+) detects tab stops e.g. $1
         // $(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|} detects placeholders with choices e.g. ${1|one,two,three|}
         // See https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax for more information
-        private static readonly Regex PlaceholderPattern = new Regex(@"\$({(?<index>\d+):(?<name>(\w+|\*))}|(?<index>\d+)|{(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|})", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+        private static readonly Regex PlaceholderPattern = new Regex(@"\$({(?<index>\d+):(?<name>(\w+|\*|((\w+\/\w+)+@(\w+|(\d+-\d+)+))))}|(?<index>\d+)|{(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|})", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
         public Snippet(string text, CompletionPriority completionPriority = CompletionPriority.Medium, string prefix = "", string detail = "")
         {

--- a/src/Bicep.LangServer/Snippets/Snippet.cs
+++ b/src/Bicep.LangServer/Snippets/Snippet.cs
@@ -14,11 +14,11 @@ namespace Bicep.LanguageServer.Snippets
     public sealed class Snippet
     {
         // Below regex is used to detect following snippet syntax:
-        // ${(?<index>\d+):(?<name>\w+)} detects placeholders i.e. tab stops with values e.g ${1:foo}
+        // ${(?<index>\d+):(?<name>\w+|\*|(\w+\/\w+)+@(\w+|(\d{4}-\d{2}-\d{2})))} detects placeholders i.e. tab stops with values e.g ${1:foo}
         // $(?<index>\d+) detects tab stops e.g. $1
         // $(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|} detects placeholders with choices e.g. ${1|one,two,three|}
         // See https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax for more information
-        private static readonly Regex PlaceholderPattern = new Regex(@"\$({(?<index>\d+):(?<name>(\w+|\*|((\w+\/\w+)+@(\w+|(\d+-\d+)+))))}|(?<index>\d+)|{(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|})", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+        private static readonly Regex PlaceholderPattern = new Regex(@"\$({(?<index>\d+):(?<name>\w+|\*|(\w+\/\w+)+@(\w+|(\d{4}-\d{2}-\d{2})))}|(?<index>\d+)|{(?<index>\d+)\|((?<name>[^,]+)(?<value>.*))\|})", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
         public Snippet(string text, CompletionPriority completionPriority = CompletionPriority.Medium, string prefix = "", string detail = "")
         {

--- a/src/Bicep.LangServer/Snippets/Templates/resource-child-defaults.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/resource-child-defaults.bicep
@@ -1,6 +1,6 @@
 ﻿// Child Resource with defaults
-resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {
-  name: $6
+resource ${1:Identifier} 'Microsoft.${2:Provider/ParentType/ChildType@Version}' = {
+  name: $3
   properties: {
     $0
   }

--- a/src/Bicep.LangServer/Snippets/Templates/resource-child-defaults.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/resource-child-defaults.bicep
@@ -1,5 +1,5 @@
 ﻿// Child Resource with defaults
-resource ${1:Identifier} 'Microsoft.${2:Provider/ParentType/ChildType@Version}' = {
+resource ${1:Identifier} '${2:Provider/ParentType/ChildType@Version}' = {
   name: $3
   properties: {
     $0

--- a/src/Bicep.LangServer/Snippets/Templates/resource-child-without-defaults.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/resource-child-without-defaults.bicep
@@ -1,5 +1,5 @@
 ﻿// Child Resource without defaults
-resource ${1:Identifier} 'Microsoft.${2:Provider/ParentType/ChildType@Version}' = {
+resource ${1:Identifier} '${2:Provider/ParentType/ChildType@Version}' = {
   name: $3
   $0
 }

--- a/src/Bicep.LangServer/Snippets/Templates/resource-child-without-defaults.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/resource-child-without-defaults.bicep
@@ -1,5 +1,5 @@
 ﻿// Child Resource without defaults
-resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:ParentType}/${4:ChildType}@${5:Version}' = {
-  name: $6
+resource ${1:Identifier} 'Microsoft.${2:Provider/ParentType/ChildType@Version}' = {
+  name: $3
   $0
 }

--- a/src/Bicep.LangServer/Snippets/Templates/resource-defaults.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/resource-defaults.bicep
@@ -1,7 +1,7 @@
 ﻿// Resource with defaults
-resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {
-  name: $5
-  location: $6
+resource ${1:Identifier} 'Microsoft.${2:Provider/Type@Version}' = {
+  name: $3
+  location: $4
   properties: {
     $0
   }

--- a/src/Bicep.LangServer/Snippets/Templates/resource-defaults.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/resource-defaults.bicep
@@ -1,5 +1,5 @@
 ﻿// Resource with defaults
-resource ${1:Identifier} 'Microsoft.${2:Provider/Type@Version}' = {
+resource ${1:Identifier} '${2:Provider/Type@Version}' = {
   name: $3
   location: $4
   properties: {

--- a/src/Bicep.LangServer/Snippets/Templates/resource-without-defaults.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/resource-without-defaults.bicep
@@ -1,5 +1,5 @@
 ﻿// Resource without defaults
-resource ${1:Identifier} 'Microsoft.${2:Provider}/${3:Type}@${4:Version}' = {
-  name: $5
+resource ${1:Identifier} 'Microsoft.${2:Provider/Type@Version}' = {
+  name: $3
   $0
 }

--- a/src/Bicep.LangServer/Snippets/Templates/resource-without-defaults.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/resource-without-defaults.bicep
@@ -1,5 +1,5 @@
 ﻿// Resource without defaults
-resource ${1:Identifier} 'Microsoft.${2:Provider/Type@Version}' = {
+resource ${1:Identifier} '${2:Provider/Type@Version}' = {
   name: $3
   $0
 }


### PR DESCRIPTION
Fixes #878 

As part of this change, updated resource snippets to have only one placeholder for type string, instead of having separate placeholders for “Provider”, “Type”, and “Version”.