### PR TITLE
Add `az bicep version` to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Bicep version**
-run `bicep --version` via the Bicep CLI or via VS code by navigating to the extensions tab and searching for Bicep
+run `bicep --version` via the Bicep CLI, `az bicep version` via the AZ CLI or via VS code by navigating to the extensions tab and searching for Bicep
 
 **Describe the bug**
 A clear and concise description of what the bug is vs what you expected to happen


### PR DESCRIPTION
Added `az bicep version` to the bug report template to highlight how to get the version if using bicep through the AZ CLI.