### PR TITLE
Trigger Build action on baseline update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Update Baselines"]
+    types:
+      - completed
 
 jobs:
   build-bicep:


### PR DESCRIPTION
Using suggested answer under [this SO question](https://stackoverflow.com/questions/62750603/github-actions-trigger-another-action-after-one-action-is-completed)

This should remove the need to close & reopen a PR to retrigger Build, after the Update Baselines action