### PR TITLE
New Snippet example for Shared Image Gallery

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -587,7 +587,7 @@
     "detail": "Create Image Gallery",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {\n  name: name\n  location: resourceGroup().location\n  properties: {\n    description: description\n  }\n}\n\n```"
+      "value": "```bicep\nresource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {\n  name: 'name'\n  location: resourceGroup().location\n  properties: {\n    description: 'description'\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -596,7 +596,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {\n  name: ${1:name}\n  location: resourceGroup().location\n  properties: {\n    description: ${2:description}\n  }\n}\n"
+      "newText": "resource ${1:sharedImageGallery} 'Microsoft.Compute/galleries@2020-09-30' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  properties: {\n    description: ${3:'description'}\n  }\n}\n"
     }
   },
   {

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.bicep
@@ -1,4 +1,5 @@
-﻿// $1 = 'name'
-// $2 = 'description'
+﻿// $1 = sharedImageGallery
+// $2 = 'name'
+// $3 = 'description'
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.bicep
@@ -1,4 +1,4 @@
-﻿// $1 = 'sharedImageGallery'
-// $2 = 'sharedImageGalleryDescription'
+﻿// $1 = 'name'
+// $2 = 'description'
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.bicep
@@ -1,0 +1,4 @@
+﻿// $1 = 'sharedImageGallery'
+// $2 = 'sharedImageGalleryDescription'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.combined.bicep
@@ -1,7 +1,7 @@
 resource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {
-  name: 'sharedImageGallery'
+  name: 'name'
   location: resourceGroup().location
   properties: {
-    description: 'sharedImageGalleryDescription'
+    description: 'description'
   }
 }

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.combined.bicep
@@ -1,0 +1,7 @@
+resource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {
+  name: 'sharedImageGallery'
+  location: resourceGroup().location
+  properties: {
+    description: 'sharedImageGalleryDescription'
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-shared-image-gallery.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-shared-image-gallery.bicep
@@ -1,0 +1,8 @@
+// Create Image Gallery
+resource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {
+  name: ${1:sharedImageGallery}
+  location: resourceGroup().location
+  properties: {
+    description: ${2:sharedImageGalleryDescription}
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-shared-image-gallery.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-shared-image-gallery.bicep
@@ -1,8 +1,8 @@
 // Create Image Gallery
 resource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {
-  name: ${1:sharedImageGallery}
+  name: ${1:name}
   location: resourceGroup().location
   properties: {
-    description: ${2:sharedImageGalleryDescription}
+    description: ${2:description}
   }
 }

--- a/src/Bicep.LangServer/Snippets/Templates/res-shared-image-gallery.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-shared-image-gallery.bicep
@@ -1,8 +1,8 @@
 // Create Image Gallery
-resource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {
-  name: ${1:name}
+resource ${1:sharedImageGallery} 'Microsoft.Compute/galleries@2020-09-30' = {
+  name: ${2:'name'}
   location: resourceGroup().location
   properties: {
-    description: ${2:description}
+    description: ${3:'description'}
   }
 }


### PR DESCRIPTION
Adding new Code Snippet for Shared Image Gallery Resource.

## Contributing a snippet

* [x] I have only a single resource in my snippet
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"