### PR TITLE
fix issue #2311 - add location to firewall resource in examples/101/azurefirewall-create-with-zones

### DIFF
--- a/docs/examples/101/azurefirewall-create-with-zones/main.bicep
+++ b/docs/examples/101/azurefirewall-create-with-zones/main.bicep
@@ -44,6 +44,7 @@ resource publicIP 'Microsoft.Network/publicIPAddresses@2020-06-01' = {
 
 resource firewall 'Microsoft.Network/azureFirewalls@2020-06-01' = {
   name: firewallName
+  location: location
   zones: length(availabilityZones) == 0 ? json('null') : availabilityZones
   properties: {
     ipConfigurations: [

--- a/docs/examples/101/azurefirewall-create-with-zones/main.json
+++ b/docs/examples/101/azurefirewall-create-with-zones/main.json
@@ -1,13 +1,6 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "17671454004803647679"
-    }
-  },
   "parameters": {
     "virtualNetworkName": {
       "type": "string",
@@ -84,6 +77,7 @@
       "type": "Microsoft.Network/azureFirewalls",
       "apiVersion": "2020-06-01",
       "name": "[parameters('firewallName')]",
+      "location": "[parameters('location')]",
       "zones": "[if(equals(length(parameters('availabilityZones')), 0), json('null'), parameters('availabilityZones'))]",
       "properties": {
         "ipConfigurations": [
@@ -161,5 +155,12 @@
         "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('virtualNetworkName'), variables('azureFirewallSubnetName')), '/')[0], split(format('{0}/{1}', parameters('virtualNetworkName'), variables('azureFirewallSubnetName')), '/')[1])]"
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.3.126.58533",
+      "templateHash": "11912755341882984212"
+    }
+  }
 }

--- a/docs/examples/101/azurefirewall-create-with-zones/main.json
+++ b/docs/examples/101/azurefirewall-create-with-zones/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "1886342650718303760"
+    }
+  },
   "parameters": {
     "virtualNetworkName": {
       "type": "string",
@@ -155,12 +162,5 @@
         "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('virtualNetworkName'), variables('azureFirewallSubnetName')), '/')[0], split(format('{0}/{1}', parameters('virtualNetworkName'), variables('azureFirewallSubnetName')), '/')[1])]"
       ]
     }
-  ],
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "0.3.126.58533",
-      "templateHash": "11912755341882984212"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
this PR fixed issue #2311 

## Contributing an example

* [X] I have checked that there is not an equivalent example already submitted
* [X] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [X] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

