### PR TITLE
Minor formatting fixes for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,12 @@ If you have an active branch pushed to your GitHub fork, you can use the "Update
 1. If any baseline changes are detected, the action will create a commit with the diffs, and push it to your branch.
 1. Because of [this limitation](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token), you will need to manually re-run the CI action once the commit has been made:
     1. Under your fork of the repo, navigate to "Actions" -> "Build".
-    1. Press "Run workflow", and select your branch name under the "Use work flow from" dropdown.
+    1. Press "Run workflow", and select your branch name under the "Use workflow from" dropdown.
 
 ### Creating new integration tests dataset
 
 * To Add new integration tests dataset you need to:
-  1. Add a entry to src/Bicep.Core.Samples/DataSets.cs
+  1. Add a entry to `src/Bicep.Core.Samples/DataSets.cs`
      * prefix with Invalid if the expectation is that it doesn't compile.
      * The suffix should match the type of newline the file uses, so just pick one (_LF or _CRLF) - that's just to ensure we have support for both.
      * The name of the entry should match the name of the folder you create (same casing), and there should be a main.bicep file in that folder.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ If you have an active branch pushed to your GitHub fork, you can use the "Update
 ### Creating new integration tests dataset
 
 * To Add new integration tests dataset you need to:
-  1. Add a entry to `src/Bicep.Core.Samples/DataSets.cs`
+  1. Add an entry to `src/Bicep.Core.Samples/DataSets.cs`
      * prefix with Invalid if the expectation is that it doesn't compile.
      * The suffix should match the type of newline the file uses, so just pick one (_LF or _CRLF) - that's just to ensure we have support for both.
      * The name of the entry should match the name of the folder you create (same casing), and there should be a main.bicep file in that folder.


### PR DESCRIPTION
Found two minor things in `CONTRIBUTING.md`.

- Changed work flow to workflow
- Fixed formatting of src/Bicep.Core.Samples/DataSets.cs to `src/Bicep.Core.Samples/DataSets.cs`


## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)
