### PR TITLE
Added empty properties object to res-recovery-service-vault snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -515,7 +515,7 @@
     "detail": "Recovery Service Vault",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {\n  name: 'recoveryServiceVault'\n  location: resourceGroup().location\n  sku: {\n    name: 'RS0'\n    tier: 'Standard'\n  }\n}\n```"
+      "value": "```bicep\nresource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {\n  name: 'recoveryServiceVault'\n  location: resourceGroup().location\n  sku: {\n    name: 'RS0'\n    tier: 'Standard'\n  }\n  properties:{}\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -524,7 +524,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {\n  name: ${1:'recoveryServiceVault'}\n  location: resourceGroup().location\n  sku: {\n    name: '${2|RS0,Standard|}'\n    tier: 'Standard'\n  }\n}"
+      "newText": "resource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {\n  name: ${1:'recoveryServiceVault'}\n  location: resourceGroup().location\n  sku: {\n    name: '${2|RS0,Standard|}'\n    tier: 'Standard'\n  }\n  properties:{}\n}\n"
     }
   },
   {

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-recovery-service-vault/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-recovery-service-vault/main.combined.bicep
@@ -5,5 +5,6 @@ resource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {
     name: 'Standard'
     tier: 'Standard'
   }
-  properties: {}
+  properties:{}
 }
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-recovery-service-vault/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-recovery-service-vault/main.combined.bicep
@@ -5,4 +5,5 @@ resource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {
     name: 'Standard'
     tier: 'Standard'
   }
+  properties: {}
 }

--- a/src/Bicep.LangServer/Snippets/Templates/res-recovery-service-vault.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-recovery-service-vault.bicep
@@ -6,4 +6,5 @@ resource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {
     name: '${2|RS0,Standard|}'
     tier: 'Standard'
   }
+  properties:{}
 }


### PR DESCRIPTION
Added missing `properties` object to Recovery Services Vault (res-recovery-service-vault) snippet as mentioned in #2336. This is needed to be able to deploy the vault. 

Closes #2336