### PR TITLE
Added Virtual WAN Snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -650,7 +650,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:virtualWan} 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  properties: {\n    type: '${3|Standard,Basic|}'\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: '${4|Optimize,OptimizeAndAllow,All,None|}'\n  }\n}\n"
+      "newText": "resource ${1:virtualWan} 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  properties: {\n    type: ${3|'Standard','Basic'|}\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: ${4|'Optimize','OptimizeAndAllow','All','None'|}\n  }\n}\n"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -641,7 +641,7 @@
     "detail": "Virtual WAN",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: 'virtualWanName'\n  location: resourceGroup().location\n  properties: {\n    type: 'Standard'\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: 'Optimize'\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualWan 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  properties: {\n    type: 'Standard'\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: 'Optimize'\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -650,7 +650,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: ${1:'virtualWanName'}\n  location: resourceGroup().location\n  properties: {\n    type: '${2|Standard,Basic|}'\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: '${3|Optimize,OptimizeAndAllow,All,None|}'\n  }\n}\n"
+      "newText": "resource ${1:virtualWan} 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  properties: {\n    type: '${3|Standard,Basic|}'\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: '${4|Optimize,OptimizeAndAllow,All,None|}'\n  }\n}\n"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -636,6 +636,24 @@
     }
   },
   {
+    "label": "res-virtual-wan",
+    "kind": "snippet",
+    "detail": "Virtual WAN",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: 'virtualWanName'\n  location: resourceGroup().location\n  properties: {\n    type: 'Standard'\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: 'Optimize'\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-virtual-wan",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {\n  name: ${1:'virtualWanName'}\n  location: resourceGroup().location\n  properties: {\n    type: '${2|Standard,Basic|}'\n    disableVpnEncryption: false\n    allowBranchToBranchTraffic: true\n    allowVnetToVnetTraffic: true\n    office365LocalBreakoutCategory: '${3|Optimize,OptimizeAndAllow,All,None|}'\n  }\n}\n"
+    }
+  },
+  {
     "label": "res-vnet",
     "kind": "snippet",
     "detail": "Virtual Network",

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.bicep
@@ -1,0 +1,5 @@
+﻿// $1 = 'virtualWanName'
+// $2 = Standard
+// $3 = None
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.bicep
@@ -1,6 +1,6 @@
 ﻿// $1 = virtualWan
 // $2 = 'name'
-// $3 = Standard
-// $4 = None
+// $3 = 'Standard'
+// $4 = 'None'
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.bicep
@@ -1,5 +1,6 @@
-﻿// $1 = 'virtualWanName'
-// $2 = Standard
-// $3 = None
+﻿// $1 = virtualWan
+// $2 = 'name'
+// $3 = Standard
+// $4 = None
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
@@ -9,3 +9,4 @@ resource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {
     office365LocalBreakoutCategory: 'None'
   }
 }
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
@@ -9,3 +9,4 @@ resource virtualWan 'Microsoft.Network/virtualWans@2020-07-01' = {
     office365LocalBreakoutCategory: 'None'
   }
 }
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
@@ -1,0 +1,11 @@
+resource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {
+  name: 'virtualWanName'
+  location: resourceGroup().location
+  properties: {
+    type: 'Standard'
+    disableVpnEncryption: false
+    allowBranchToBranchTraffic: true
+    allowVnetToVnetTraffic: true
+    office365LocalBreakoutCategory: 'None'
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
@@ -1,5 +1,5 @@
-resource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {
-  name: 'virtualWanName'
+resource virtualWan 'Microsoft.Network/virtualWans@2020-07-01' = {
+  name: 'name'
   location: resourceGroup().location
   properties: {
     type: 'Standard'
@@ -9,4 +9,3 @@ resource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {
     office365LocalBreakoutCategory: 'None'
   }
 }
-

--- a/src/Bicep.LangServer/Snippets/Templates/res-virtual-wan.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-virtual-wan.bicep
@@ -1,12 +1,12 @@
 // Virtual WAN
-resource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {
-  name: ${1:'virtualWanName'}
+resource ${1:virtualWan} 'Microsoft.Network/virtualWans@2020-07-01' = {
+  name: ${2:'name'}
   location: resourceGroup().location
   properties: {
-    type: '${2|Standard,Basic|}'
+    type: '${3|Standard,Basic|}'
     disableVpnEncryption: false
     allowBranchToBranchTraffic: true
     allowVnetToVnetTraffic: true
-    office365LocalBreakoutCategory: '${3|Optimize,OptimizeAndAllow,All,None|}'
+    office365LocalBreakoutCategory: '${4|Optimize,OptimizeAndAllow,All,None|}'
   }
 }

--- a/src/Bicep.LangServer/Snippets/Templates/res-virtual-wan.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-virtual-wan.bicep
@@ -1,0 +1,12 @@
+// Virtual WAN
+resource vwan 'Microsoft.Network/virtualWans@2020-07-01' = {
+  name: ${1:'virtualWanName'}
+  location: resourceGroup().location
+  properties: {
+    type: '${2|Standard,Basic|}'
+    disableVpnEncryption: false
+    allowBranchToBranchTraffic: true
+    allowVnetToVnetTraffic: true
+    office365LocalBreakoutCategory: '${3|Optimize,OptimizeAndAllow,All,None|}'
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-virtual-wan.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-virtual-wan.bicep
@@ -3,10 +3,10 @@ resource ${1:virtualWan} 'Microsoft.Network/virtualWans@2020-07-01' = {
   name: ${2:'name'}
   location: resourceGroup().location
   properties: {
-    type: '${3|Standard,Basic|}'
+    type: ${3|'Standard','Basic'|}
     disableVpnEncryption: false
     allowBranchToBranchTraffic: true
     allowVnetToVnetTraffic: true
-    office365LocalBreakoutCategory: '${4|Optimize,OptimizeAndAllow,All,None|}'
+    office365LocalBreakoutCategory: ${4|'Optimize','OptimizeAndAllow','All','None'|}
   }
 }


### PR DESCRIPTION
Added a snippet for Azure Virtual WAN resource.

## Contributing a snippet

* [x] I have only a single resource in my snippet
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"
