### PR TITLE
Added VNet Peering snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -672,6 +672,24 @@
     }
   },
   {
+    "label": "res-vnet-peering",
+    "kind": "snippet",
+    "detail": "Virtual Network Peering",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-07-01' = {\n  name: 'virtualNetwork/name'\n  properties: {\n    allowVirtualNetworkAccess: true\n    allowForwardedTraffic: true\n    allowGatewayTransit: true\n    useRemoteGateways: true\n    remoteVirtualNetwork: {\n      id: resourceId('Microsoft.Network/virtualNetworks', 'REQUIRED')\n    }\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-vnet-peering",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:peering} 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-07-01' = {\n  name: ${2:'virtualNetwork/name'}\n  properties: {\n    allowVirtualNetworkAccess: ${3|true,false|}\n    allowForwardedTraffic: ${4|true,false|}\n    allowGatewayTransit: ${5|true,false|}\n    useRemoteGateways: ${6|true,false|}\n    remoteVirtualNetwork: {\n      id: resourceId('Microsoft.Network/virtualNetworks', ${7:'REQUIRED'})\n    }\n  }\n}\n"
+    }
+  },
+  {
     "label": "res-vpn-local-gateway",
     "kind": "snippet",
     "detail": "VPN Local Network Gateway",

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet-peering/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet-peering/main.bicep
@@ -1,0 +1,9 @@
+﻿// $1 = peering
+// $2 = 'virtualNetwork/name'
+// $3 = true
+// $4 = true
+// $5 = true
+// $6 = true
+// $7 = 'REQUIRED'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet-peering/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet-peering/main.combined.bicep
@@ -1,0 +1,13 @@
+resource peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-07-01' = {
+  name: 'virtualNetwork/name'
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: true
+    allowGatewayTransit: true
+    useRemoteGateways: true
+    remoteVirtualNetwork: {
+      id: resourceId('Microsoft.Network/virtualNetworks', 'REQUIRED')
+    }
+  }
+}
+

--- a/src/Bicep.LangServer/Snippets/Templates/res-vnet-peering.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-vnet-peering.bicep
@@ -1,0 +1,13 @@
+// Virtual Network Peering
+resource ${1:peering} 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-07-01' = {
+  name: ${2:'virtualNetwork/name'}
+  properties: {
+    allowVirtualNetworkAccess: ${3|true,false|}
+    allowForwardedTraffic: ${4|true,false|}
+    allowGatewayTransit: ${5|true,false|}
+    useRemoteGateways: ${6|true,false|}
+    remoteVirtualNetwork: {
+      id: resourceId('Microsoft.Network/virtualNetworks', ${7:'REQUIRED'})
+    }
+  }
+}


### PR DESCRIPTION
Added a snippet for Virtual Network Peering.

## Contributing a snippet

* [x] I have only a single resource in my snippet
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"

