### PR TITLE
added cross scoping for tenant resources

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -4864,6 +4864,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -4828,6 +4828,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -4856,6 +4856,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -5087,6 +5087,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -5087,6 +5087,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -5087,6 +5087,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -5087,6 +5087,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -4835,6 +4835,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -4835,6 +4835,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -4835,6 +4835,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -4835,6 +4835,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -5321,6 +5321,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -5321,6 +5321,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -5321,6 +5321,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -5321,6 +5321,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -4842,6 +4842,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -4842,6 +4842,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -4842,6 +4842,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -4842,6 +4842,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -4835,6 +4835,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -4835,6 +4835,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -4835,6 +4835,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -4835,6 +4835,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -4814,6 +4814,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -4940,6 +4940,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -4831,6 +4831,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
@@ -4845,6 +4845,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -4828,6 +4828,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -4873,6 +4873,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleStateSomething.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleStateSomething.json
@@ -4887,6 +4887,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -4895,6 +4895,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -4859,6 +4859,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -4859,6 +4859,23 @@
     }
   },
   {
+    "label": "tenantLevelResourceBlocked",
+    "kind": "interface",
+    "detail": "tenantLevelResourceBlocked",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_tenantLevelResourceBlocked",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "tenantLevelResourceBlocked"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "tenantResourceId",
     "kind": "function",
     "detail": "tenantResourceId()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -1424,3 +1424,7 @@ resource anyTypeInExistingScopeLoop 'Microsoft.Network/dnsZones/AAAA@2018-05-01'
   parent: any('')
   scope: any(false)
 }]
+
+resource tenantLevelResourceBlocked 'Microsoft.Management/managementGroups@2020-05-01' = {
+  name: 'tenantLevelResourceBlocked'
+}

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -1232,7 +1232,7 @@ resource invalidScope 'My.Rp/mockResource@2020-12-01' = {
 //@[22:53) [BCP081 (Warning)] Resource type "My.Rp/mockResource@2020-12-01" does not have types available. |'My.Rp/mockResource@2020-12-01'|
   name: 'invalidScope'
   scope: notAResource
-//@[9:21) [BCP036 (Error)] The property "scope" expected a value of type "resource" but the provided value is of type "object". |notAResource|
+//@[9:21) [BCP036 (Error)] The property "scope" expected a value of type "resource | tenant" but the provided value is of type "object". |notAResource|
 }
 
 resource invalidScope2 'My.Rp/mockResource@2020-12-01' = {
@@ -1870,4 +1870,9 @@ resource anyTypeInExistingScopeLoop 'Microsoft.Network/dnsZones/AAAA@2018-05-01'
   scope: any(false)
 //@[9:19) [BCP176 (Error)] Values of the "any" type are not allowed here. |any(false)|
 }]
+
+resource tenantLevelResourceBlocked 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[89:131) [BCP135 (Error)] Scope "resourceGroup" is not valid for this resource type. Permitted scopes: "tenant". |{\r\n  name: 'tenantLevelResourceBlocked'\r\n}|
+  name: 'tenantLevelResourceBlocked'
+}
 

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
@@ -1364,3 +1364,7 @@ resource anyTypeInExistingScopeLoop 'Microsoft.Network/dnsZones/AAAA@2018-05-01'
   parent: any('')
   scope: any(false)
 }]
+
+resource tenantLevelResourceBlocked 'Microsoft.Management/managementGroups@2020-05-01' = {
+  name: 'tenantLevelResourceBlocked'
+}

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -1828,3 +1828,8 @@ resource anyTypeInExistingScopeLoop 'Microsoft.Network/dnsZones/AAAA@2018-05-01'
   scope: any(false)
 }]
 
+resource tenantLevelResourceBlocked 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[9:35) Resource tenantLevelResourceBlocked. Type: Microsoft.Management/managementGroups@2020-05-01. Declaration start char: 0, length: 131
+  name: 'tenantLevelResourceBlocked'
+}
+

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -10625,6 +10625,29 @@ resource anyTypeInExistingScopeLoop 'Microsoft.Network/dnsZones/AAAA@2018-05-01'
 }]
 //@[0:1)    RightBrace |}|
 //@[1:2)   RightSquare |]|
-//@[2:4) NewLine |\r\n|
+//@[2:6) NewLine |\r\n\r\n|
+
+resource tenantLevelResourceBlocked 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[0:131) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:35)  IdentifierSyntax
+//@[9:35)   Identifier |tenantLevelResourceBlocked|
+//@[36:86)  StringSyntax
+//@[36:86)   StringComplete |'Microsoft.Management/managementGroups@2020-05-01'|
+//@[87:88)  Assignment |=|
+//@[89:131)  ObjectSyntax
+//@[89:90)   LeftBrace |{|
+//@[90:92)   NewLine |\r\n|
+  name: 'tenantLevelResourceBlocked'
+//@[2:36)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:36)    StringSyntax
+//@[8:36)     StringComplete |'tenantLevelResourceBlocked'|
+//@[36:38)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\r\n|
 
 //@[0:0) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -6865,6 +6865,22 @@ resource anyTypeInExistingScopeLoop 'Microsoft.Network/dnsZones/AAAA@2018-05-01'
 }]
 //@[0:1) RightBrace |}|
 //@[1:2) RightSquare |]|
-//@[2:4) NewLine |\r\n|
+//@[2:6) NewLine |\r\n\r\n|
+
+resource tenantLevelResourceBlocked 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[0:8) Identifier |resource|
+//@[9:35) Identifier |tenantLevelResourceBlocked|
+//@[36:86) StringComplete |'Microsoft.Management/managementGroups@2020-05-01'|
+//@[87:88) Assignment |=|
+//@[89:90) LeftBrace |{|
+//@[90:92) NewLine |\r\n|
+  name: 'tenantLevelResourceBlocked'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:36) StringComplete |'tenantLevelResourceBlocked'|
+//@[36:38) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
 
 //@[0:0) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.bicep
@@ -36,3 +36,19 @@ resource readers 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = 
   ]
 }]
 
+resource single_mg 'Microsoft.Management/managementGroups@2020-05-01' = {
+  scope: tenant()
+  name: 'one-mg'
+}
+
+// Blueprints are read-only at tenant Scope, but it's a convenient example to use to validate this.
+resource tenant_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+  name: 'tenant-blueprint'
+  properties: {}
+  scope: tenant()
+}
+
+resource mg_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+  name: 'mg-blueprint'
+  properties: {}
+}

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.diagnostics.bicep
@@ -36,4 +36,20 @@ resource readers 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = 
   ]
 }]
 
+resource single_mg 'Microsoft.Management/managementGroups@2020-05-01' = {
+  scope: tenant()
+  name: 'one-mg'
+}
+
+// Blueprints are read-only at tenant Scope, but it's a convenient example to use to validate this.
+resource tenant_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+  name: 'tenant-blueprint'
+  properties: {}
+  scope: tenant()
+}
+
+resource mg_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+  name: 'mg-blueprint'
+  properties: {}
+}
 

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.formatted.bicep
@@ -35,3 +35,20 @@ resource readers 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = 
     contributors[0]
   ]
 }]
+
+resource single_mg 'Microsoft.Management/managementGroups@2020-05-01' = {
+  scope: tenant()
+  name: 'one-mg'
+}
+
+// Blueprints are read-only at tenant Scope, but it's a convenient example to use to validate this.
+resource tenant_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+  name: 'tenant-blueprint'
+  properties: {}
+  scope: tenant()
+}
+
+resource mg_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+  name: 'mg-blueprint'
+  properties: {}
+}

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5794550789758205473"
+      "templateHash": "3184915884062952651"
     }
   },
   "parameters": {
@@ -62,6 +62,25 @@
         "[format('Microsoft.Authorization/roleAssignments/{0}', guid('contributor', parameters('contributorPrincipals')[0]))]",
         "[format('Microsoft.Authorization/roleAssignments/{0}', guid('owner', parameters('ownerPrincipalId')))]"
       ]
+    },
+    {
+      "type": "Microsoft.Management/managementGroups",
+      "apiVersion": "2020-05-01",
+      "scope": "/",
+      "name": "one-mg"
+    },
+    {
+      "type": "Microsoft.Blueprint/blueprints",
+      "apiVersion": "2018-11-01-preview",
+      "scope": "/",
+      "name": "tenant-blueprint",
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Blueprint/blueprints",
+      "apiVersion": "2018-11-01-preview",
+      "name": "mg-blueprint",
+      "properties": {}
     }
   ]
 }

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.symbols.bicep
@@ -44,4 +44,23 @@ resource readers 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = 
   ]
 }]
 
+resource single_mg 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[9:18) Resource single_mg. Type: Microsoft.Management/managementGroups@2020-05-01. Declaration start char: 0, length: 113
+  scope: tenant()
+  name: 'one-mg'
+}
+
+// Blueprints are read-only at tenant Scope, but it's a convenient example to use to validate this.
+resource tenant_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+//@[9:25) Resource tenant_blueprint. Type: Microsoft.Blueprint/blueprints@2018-11-01-preview. Declaration start char: 0, length: 149
+  name: 'tenant-blueprint'
+  properties: {}
+  scope: tenant()
+}
+
+resource mg_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+//@[9:21) Resource mg_blueprint. Type: Microsoft.Blueprint/blueprints@2018-11-01-preview. Declaration start char: 0, length: 122
+  name: 'mg-blueprint'
+  properties: {}
+}
 

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.syntax.bicep
@@ -287,5 +287,115 @@ resource readers 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = 
 //@[1:2)   RightSquare |]|
 //@[2:6) NewLine |\r\n\r\n|
 
+resource single_mg 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[0:113) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:18)  IdentifierSyntax
+//@[9:18)   Identifier |single_mg|
+//@[19:69)  StringSyntax
+//@[19:69)   StringComplete |'Microsoft.Management/managementGroups@2020-05-01'|
+//@[70:71)  Assignment |=|
+//@[72:113)  ObjectSyntax
+//@[72:73)   LeftBrace |{|
+//@[73:75)   NewLine |\r\n|
+  scope: tenant()
+//@[2:17)   ObjectPropertySyntax
+//@[2:7)    IdentifierSyntax
+//@[2:7)     Identifier |scope|
+//@[7:8)    Colon |:|
+//@[9:17)    FunctionCallSyntax
+//@[9:15)     IdentifierSyntax
+//@[9:15)      Identifier |tenant|
+//@[15:16)     LeftParen |(|
+//@[16:17)     RightParen |)|
+//@[17:19)   NewLine |\r\n|
+  name: 'one-mg'
+//@[2:16)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:16)    StringSyntax
+//@[8:16)     StringComplete |'one-mg'|
+//@[16:18)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
+// Blueprints are read-only at tenant Scope, but it's a convenient example to use to validate this.
+//@[99:101) NewLine |\r\n|
+resource tenant_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+//@[0:149) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:25)  IdentifierSyntax
+//@[9:25)   Identifier |tenant_blueprint|
+//@[26:77)  StringSyntax
+//@[26:77)   StringComplete |'Microsoft.Blueprint/blueprints@2018-11-01-preview'|
+//@[78:79)  Assignment |=|
+//@[80:149)  ObjectSyntax
+//@[80:81)   LeftBrace |{|
+//@[81:83)   NewLine |\r\n|
+  name: 'tenant-blueprint'
+//@[2:26)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:26)    StringSyntax
+//@[8:26)     StringComplete |'tenant-blueprint'|
+//@[26:28)   NewLine |\r\n|
+  properties: {}
+//@[2:16)   ObjectPropertySyntax
+//@[2:12)    IdentifierSyntax
+//@[2:12)     Identifier |properties|
+//@[12:13)    Colon |:|
+//@[14:16)    ObjectSyntax
+//@[14:15)     LeftBrace |{|
+//@[15:16)     RightBrace |}|
+//@[16:18)   NewLine |\r\n|
+  scope: tenant()
+//@[2:17)   ObjectPropertySyntax
+//@[2:7)    IdentifierSyntax
+//@[2:7)     Identifier |scope|
+//@[7:8)    Colon |:|
+//@[9:17)    FunctionCallSyntax
+//@[9:15)     IdentifierSyntax
+//@[9:15)      Identifier |tenant|
+//@[15:16)     LeftParen |(|
+//@[16:17)     RightParen |)|
+//@[17:19)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
+resource mg_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+//@[0:122) ResourceDeclarationSyntax
+//@[0:8)  Identifier |resource|
+//@[9:21)  IdentifierSyntax
+//@[9:21)   Identifier |mg_blueprint|
+//@[22:73)  StringSyntax
+//@[22:73)   StringComplete |'Microsoft.Blueprint/blueprints@2018-11-01-preview'|
+//@[74:75)  Assignment |=|
+//@[76:122)  ObjectSyntax
+//@[76:77)   LeftBrace |{|
+//@[77:79)   NewLine |\r\n|
+  name: 'mg-blueprint'
+//@[2:22)   ObjectPropertySyntax
+//@[2:6)    IdentifierSyntax
+//@[2:6)     Identifier |name|
+//@[6:7)    Colon |:|
+//@[8:22)    StringSyntax
+//@[8:22)     StringComplete |'mg-blueprint'|
+//@[22:24)   NewLine |\r\n|
+  properties: {}
+//@[2:16)   ObjectPropertySyntax
+//@[2:12)    IdentifierSyntax
+//@[2:12)     Identifier |properties|
+//@[12:13)    Colon |:|
+//@[14:16)    ObjectSyntax
+//@[14:15)     LeftBrace |{|
+//@[15:16)     RightBrace |}|
+//@[16:18)   NewLine |\r\n|
+}
+//@[0:1)   RightBrace |}|
+//@[1:3) NewLine |\r\n|
 
 //@[0:0) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.tokens.bicep
@@ -180,5 +180,80 @@ resource readers 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = 
 //@[1:2) RightSquare |]|
 //@[2:6) NewLine |\r\n\r\n|
 
+resource single_mg 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[0:8) Identifier |resource|
+//@[9:18) Identifier |single_mg|
+//@[19:69) StringComplete |'Microsoft.Management/managementGroups@2020-05-01'|
+//@[70:71) Assignment |=|
+//@[72:73) LeftBrace |{|
+//@[73:75) NewLine |\r\n|
+  scope: tenant()
+//@[2:7) Identifier |scope|
+//@[7:8) Colon |:|
+//@[9:15) Identifier |tenant|
+//@[15:16) LeftParen |(|
+//@[16:17) RightParen |)|
+//@[17:19) NewLine |\r\n|
+  name: 'one-mg'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:16) StringComplete |'one-mg'|
+//@[16:18) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
+// Blueprints are read-only at tenant Scope, but it's a convenient example to use to validate this.
+//@[99:101) NewLine |\r\n|
+resource tenant_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+//@[0:8) Identifier |resource|
+//@[9:25) Identifier |tenant_blueprint|
+//@[26:77) StringComplete |'Microsoft.Blueprint/blueprints@2018-11-01-preview'|
+//@[78:79) Assignment |=|
+//@[80:81) LeftBrace |{|
+//@[81:83) NewLine |\r\n|
+  name: 'tenant-blueprint'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:26) StringComplete |'tenant-blueprint'|
+//@[26:28) NewLine |\r\n|
+  properties: {}
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:16) RightBrace |}|
+//@[16:18) NewLine |\r\n|
+  scope: tenant()
+//@[2:7) Identifier |scope|
+//@[7:8) Colon |:|
+//@[9:15) Identifier |tenant|
+//@[15:16) LeftParen |(|
+//@[16:17) RightParen |)|
+//@[17:19) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:5) NewLine |\r\n\r\n|
+
+resource mg_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+//@[0:8) Identifier |resource|
+//@[9:21) Identifier |mg_blueprint|
+//@[22:73) StringComplete |'Microsoft.Blueprint/blueprints@2018-11-01-preview'|
+//@[74:75) Assignment |=|
+//@[76:77) LeftBrace |{|
+//@[77:79) NewLine |\r\n|
+  name: 'mg-blueprint'
+//@[2:6) Identifier |name|
+//@[6:7) Colon |:|
+//@[8:22) StringComplete |'mg-blueprint'|
+//@[22:24) NewLine |\r\n|
+  properties: {}
+//@[2:12) Identifier |properties|
+//@[12:13) Colon |:|
+//@[14:15) LeftBrace |{|
+//@[15:16) RightBrace |}|
+//@[16:18) NewLine |\r\n|
+}
+//@[0:1) RightBrace |}|
+//@[1:3) NewLine |\r\n|
 
 //@[0:0) EndOfFile ||

--- a/src/Bicep.Core/Emit/ScopeHelper.cs
+++ b/src/Bicep.Core/Emit/ScopeHelper.cs
@@ -18,16 +18,34 @@ namespace Bicep.Core.Emit
     {
         public class ScopeData
         {
+            /// <summary>
+            /// Type of scope requested by the resource.
+            /// </summary>
             public ResourceScope RequestedScope { get; set; }
 
+            /// <summary>
+            /// Expression for the name of the Management Group or null.
+            /// </summary>
             public SyntaxBase? ManagementGroupNameProperty { get; set; }
 
+            /// <summary>
+            /// Expression for the subscription ID or null.
+            /// </summary>
             public SyntaxBase? SubscriptionIdProperty { get; set; }
 
+            /// <summary>
+            /// Expression for the resource group name or null.
+            /// </summary>
             public SyntaxBase? ResourceGroupProperty { get; set; }
 
+            /// <summary>
+            /// The symbol of the resource being extended or null.
+            /// </summary>
             public ResourceSymbol? ResourceScopeSymbol { get; set; }
 
+            /// <summary>
+            /// The expression for the loop index. This is used with loops when indexing into resource collections. 
+            /// </summary>
             public SyntaxBase? IndexExpression { get; set; }
         }
 
@@ -363,6 +381,12 @@ namespace Bicep.Core.Emit
                 !scopeInfo.TryGetValue(rootResourceSymbol, out var scopeData))
             {
                 // invalid scope should have already generated errors
+                return;
+            }
+
+            if(scopeData.RequestedScope == ResourceScope.Tenant)
+            {
+                // tenant resources can be deployed cross-scope
                 return;
             }
 

--- a/src/Bicep.Core/Emit/ScopeHelper.cs
+++ b/src/Bicep.Core/Emit/ScopeHelper.cs
@@ -308,6 +308,20 @@ namespace Bicep.Core.Emit
             }
         }
 
+        public static void EmitResourceScopeProperties(ResourceScope targetScope, ScopeData scopeData, ExpressionEmitter expressionEmitter, SyntaxBase newContext)
+        {
+            if (scopeData.ResourceScopeSymbol is { } scopeResource)
+            {
+                // emit the resource id of the resource being extended
+                expressionEmitter.EmitProperty("scope", () => expressionEmitter.EmitUnqualifiedResourceId(scopeResource, scopeData.IndexExpression, newContext));
+            }
+            else if (scopeData.RequestedScope == ResourceScope.Tenant && targetScope != ResourceScope.Tenant)
+            {
+                // emit the "/" to allow cross-scope deployment of a Tenant resource from another deployment scope
+                expressionEmitter.EmitProperty("scope", "/");
+            }
+        }
+
         public static void EmitModuleScopeProperties(ResourceScope targetScope, ScopeData scopeData, ExpressionEmitter expressionEmitter)
         {
             switch (scopeData.RequestedScope)
@@ -346,6 +360,26 @@ namespace Bicep.Core.Emit
                 default:
                     throw new InvalidOperationException($"Cannot format resourceId for scope {scopeData.RequestedScope}");
             }
+        }
+
+        public static TypeProperty CreateExistingResourceScopeProperty(ResourceScope validScopes, TypePropertyFlags propertyFlags) =>
+            CreateResourceScopePropertyInternal(validScopes, propertyFlags);
+
+        public static TypeProperty? TryCreateNonExistingResourceScopeProperty(ResourceScope validScopes, TypePropertyFlags propertyFlags)
+        {
+            // we only support scope in these cases:
+            // 1. extension resources (or resources where the scope is unknown and thus may be an extension resource)
+            // 2. Tenant resources
+            ResourceScope effectiveScopes = validScopes & (ResourceScope.Resource | ResourceScope.Tenant);
+            return effectiveScopes != 0
+                ? CreateResourceScopePropertyInternal(effectiveScopes, propertyFlags)
+                : null;
+        }
+
+        private static TypeProperty CreateResourceScopePropertyInternal(ResourceScope validScopes, TypePropertyFlags scopePropertyFlags)
+        {
+            var scopeReference = LanguageConstants.CreateResourceScopeReference(validScopes);
+            return new(LanguageConstants.ResourceScopePropertyName, scopeReference, scopePropertyFlags);
         }
 
         private static ResourceSymbol? GetRootResourceSymbol(IReadOnlyDictionary<ResourceSymbol, ScopeData> scopeInfo, ResourceSymbol resourceSymbol)

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -419,16 +419,7 @@ namespace Bicep.Core.Emit
             emitter.EmitProperty("apiVersion", typeReference.ApiVersion);
             if (context.SemanticModel.EmitLimitationInfo.ResourceScopeData.TryGetValue(resourceSymbol, out var scopeData))
             {
-                if (scopeData.ResourceScopeSymbol is { } scopeResource)
-                {
-                    // emit the resource id of the resource being extended
-                    emitter.EmitProperty("scope", () => emitter.EmitUnqualifiedResourceId(scopeResource, scopeData.IndexExpression, body));
-                }
-                else if(scopeData.RequestedScope == ResourceScope.Tenant && context.SemanticModel.TargetScope != ResourceScope.Tenant)
-                {
-                    // emit the "/" to allow cross-scope deployment of a Tenant resource from another deployment scope
-                    emitter.EmitProperty("scope", "/");
-                }
+                ScopeHelper.EmitResourceScopeProperties(context.SemanticModel.TargetScope, scopeData, emitter, body);
             }
 
             emitter.EmitProperty("name", emitter.GetFullyQualifiedResourceName(resourceSymbol));

--- a/src/Bicep.Decompiler.IntegrationTests/Working/cross-scope-tenant/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/cross-scope-tenant/main.bicep
@@ -20,13 +20,13 @@ param subscriptionDisplayName string
 param subscriptionWorkload string = 'Production'
 
 resource subscriptionAlias_resource 'Microsoft.Subscription/aliases@2020-09-01' = {
+  scope: tenant()
   name: subscriptionAlias
   properties: {
     workload: subscriptionWorkload
     displayName: subscriptionDisplayName
     billingScope: tenantResourceId('Microsoft.Billing/billingAccounts/enrollmentAccounts', billingAccount, enrollmentAccount)
   }
-  scope: tenant()
 }
 
 output subscriptionId string = subscriptionAlias_resource.properties.subscriptionId

--- a/src/Bicep.Decompiler.IntegrationTests/Working/cross-scope-tenant/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/cross-scope-tenant/main.bicep
@@ -1,0 +1,32 @@
+targetScope = 'managementGroup'
+
+@description('EnrollmentAccount used for subscription billing')
+param enrollmentAccount string
+
+@description('BillingAccount used for subscription billing')
+param billingAccount string
+
+@description('Alias to assign to the subscription')
+param subscriptionAlias string
+
+@description('Display name for the subscription')
+param subscriptionDisplayName string
+
+@allowed([
+  'Production'
+  'DevTest'
+])
+@description('Workload type for the subscription')
+param subscriptionWorkload string = 'Production'
+
+resource subscriptionAlias_resource 'Microsoft.Subscription/aliases@2020-09-01' = {
+  name: subscriptionAlias
+  properties: {
+    workload: subscriptionWorkload
+    displayName: subscriptionDisplayName
+    billingScope: tenantResourceId('Microsoft.Billing/billingAccounts/enrollmentAccounts', billingAccount, enrollmentAccount)
+  }
+  scope: tenant()
+}
+
+output subscriptionId string = subscriptionAlias_resource.properties.subscriptionId

--- a/src/Bicep.Decompiler.IntegrationTests/Working/cross-scope-tenant/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/cross-scope-tenant/main.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "enrollmentAccount": {
+            "type": "string",
+            "metadata": {
+                "description": "EnrollmentAccount used for subscription billing"
+            }
+        },
+        "billingAccount": {
+            "type": "string",
+            "metadata": {
+                "description": "BillingAccount used for subscription billing"
+            }
+        },
+        "subscriptionAlias": {
+            "type": "string",
+            "metadata": {
+                "description": "Alias to assign to the subscription"
+            }
+        },
+        "subscriptionDisplayName": {
+            "type": "string",
+            "metadata": {
+                "description": "Display name for the subscription"
+            }
+        },
+        "subscriptionWorkload": {
+            "type": "string",
+            "defaultValue": "Production",
+            "allowedValues": [
+                "Production",
+                "DevTest"
+            ],
+            "metadata": {
+                "description": "Workload type for the subscription"
+            }
+        }
+    },
+    "resources": [
+        {
+            "scope": "/",
+            "name": "[parameters('subscriptionAlias')]",
+            "type": "Microsoft.Subscription/aliases",
+            "apiVersion": "2020-09-01",
+            "properties": {
+                "workload": "[parameters('subscriptionWorkload')]",
+                "displayName": "[parameters('subscriptionDisplayName')]",
+                "billingScope": "[tenantResourceId('Microsoft.Billing/billingAccounts/enrollmentAccounts', parameters('billingAccount'), parameters('enrollmentAccount'))]"
+            }
+        }
+    ],
+    "outputs": {
+        "subscriptionId": {
+            "type": "string",
+            "value": "[reference(parameters('subscriptionAlias')).subscriptionId]"
+        }
+    }
+}

--- a/src/Bicep.Decompiler.IntegrationTests/Working/extensionresource/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/extensionresource/main.bicep
@@ -28,12 +28,12 @@ resource siteName 'Microsoft.Web/sites@2020-06-01' = {
 }
 
 resource siteLock 'Microsoft.Authorization/locks@2016-09-01' = {
+  scope: siteName
   name: 'siteLock'
   properties: {
     level: 'CanNotDelete'
     notes: 'Site should not be deleted.'
   }
-  scope: siteName
   dependsOn: [
     siteName
   ]

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -1181,6 +1181,13 @@ namespace Bicep.Decompiler
             }
 
             var scopeExpression = ExpressionHelpers.ParseExpression(scopeProperty.Value.ToString());
+            if(scopeExpression is JTokenExpression value && string.Equals(value.Value.ToString(), "/", StringComparison.OrdinalIgnoreCase))
+            {
+                // tenant scope resources can be deployed from any other scope as long as the "scope" property is set to "/"
+                // the bicep equivalent is "scope: tenant()"
+                return SyntaxFactory.CreateFunctionCall("tenant");
+            }
+
             if (TryLookupResource(scopeExpression) is string resourceName)
             {
                 return SyntaxFactory.CreateIdentifier(resourceName);

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -1269,6 +1269,12 @@ namespace Bicep.Decompiler
             }, StringComparer.OrdinalIgnoreCase);
 
             var topLevelProperties = new List<ObjectPropertySyntax>();
+            var scope = TryGetResourceScopeProperty(resource);
+            if (scope is not null)
+            {
+                topLevelProperties.Add(SyntaxFactory.CreateObjectProperty("scope", scope));
+            }
+
             foreach (var prop in resource.Properties())
             {
                 if (resourcePropsToOmit.Contains(prop.Name))
@@ -1288,12 +1294,6 @@ namespace Bicep.Decompiler
                 }
 
                 topLevelProperties.Add(SyntaxFactory.CreateObjectProperty(prop.Name, valueSyntax));
-            }
-
-            var scope = TryGetResourceScopeProperty(resource);
-            if (scope is not null)
-            {
-                topLevelProperties.Add(SyntaxFactory.CreateObjectProperty("scope", scope));
             }
 
             var dependsOn = ProcessDependsOn(copyResourceLookup, resource);


### PR DESCRIPTION
Tenant resources in the JSON support setting `scope: "/"` to deploy them from any other scope. This is useful because permissions to create tenant-level deployments require the involvement of the AAD tenant admin.

Changes:
- non-extension tenant resources now support the `scope` property to allow the scope to be overridden. The syntax is `scope: tenant()`. This fixes #2020.
- Decompiler now understands `scope: "/"` and generates the `tenant()` function call in the decompiled Bicep. This fixes #2379 and #2382.
