### PR TITLE
Updated all docs examples with syntax highlighting

### DIFF
--- a/docs/spec/expressions.md
+++ b/docs/spec/expressions.md
@@ -59,7 +59,7 @@ Ternary operators operate on 3 operands. Bicep supports only one such operator.
 | `?` `:` | Conditional expression | `bool` `any` `any` | ` <true type> \| <false type> ` | `[if(<condition>, <true value>, <false value>)]` | Returns a value based on whether the condition is true or false |
 
 Example usage:
-```
+```bicep
 param replicateGlobally bool
 
 resource myStorageAccount `Microsoft.Storage/storageAccounts@2017-10-01` = {
@@ -92,7 +92,7 @@ Enclosing an expression between `(` and `)` allows you to override the default B
 
 ## Property accessors
 Property accessors are used to access properties of an object. They are constructed using the `.` operator. Consider the following:
-```
+```bicep
 var x = {
   y: {
     z: 'Hello`
@@ -109,7 +109,7 @@ Property accessors can be used with any object. This includes parameters and var
 ## Nested resource accessors
 Nested resource accessors are used to access resources that are declared inside another resource. The symbolic name declared by a nested resource can normally only be referenced within the body of the containing resource. To reference a nested resource outside the containing resource, it must be qualified with the containing resource name and the `::` operator. Other resources declared within the same containing resource may used the name without qualification.
 
-```
+```bicep
 resource myParent 'My.Rp/parentType@2020-01-01' = {
   name: 'myParent'
   location: 'West US'
@@ -141,7 +141,7 @@ Since the declaration of `myChild` is contained within `myParent` the access to 
 Array indexers serve two purposes. Most commonly, they are used to access items in an array. However, they can also be used to access properties of objects via expressions or string literals.
 
 Consider the following:
-```
+```bicep
 var index = 1
 
 var myArray = [
@@ -154,7 +154,7 @@ var myArray = [
 Arrays in Bicep are 0-based. In other words, the first item in an array is at index 0. As such, the expression `myArray[0]` will evaluate to `1` and `myArray[2]` will evaluate to `3`. The index of the indexer may itself be another expression. In the above example, `myArray[index]` would evaluate to `2`. Integer indexers are only allowed on expression of array types. Usage of integer indexers on other types is an error.
 
 String-based indexers are also allowed in Bicep. Consider the following:
-```
+```bicep
 param environment string = 'prod'
 
 var environmentSettings = {
@@ -168,7 +168,7 @@ var environmentSettings = {
 ```
 
 Given the above, the expression `environmentSettings['dev']` would evaluate to this object:
-```
+```bicep
 {
   name: 'dev'
 }
@@ -177,7 +177,7 @@ Given the above, the expression `environmentSettings['dev']` would evaluate to t
 Just like with integer indexers, the string indexer can also be an expression. Given the above example, the expression `environmentSettings[environment].name` would evaluate to `'dev'`, `'prod'`, or a runtime error depending on the value of the `environment` parameter. String-based indexers can only be used with expression of object type. Usage on expressions of other types is an error.
 
 In general, expressions are allowed anywhere where a value is specified in Bicep. For example you could use the expressions above in a resource declaration as follows:
-```
+```bicep
 resource site 'microsoft.web/sites@2018-11-01' = {
   name: environmentSettings[environment].name
   location: location

--- a/docs/spec/loops.md
+++ b/docs/spec/loops.md
@@ -46,7 +46,6 @@ resource storageAccountResources 'Microsoft.Storage/storageAccounts@2019-06-01' 
 To write a simple index-based loop you can use the `range()` function so that your iterator conceptually represents the index of the current iteration. This is most similar to ARM Template JSON loops with the `copyIndex()` function. For example, we can modify the above example to be index-based:
 
 ```bicep
-
 resource storageAccountResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for i in range(0,3): {
   name: 'storageName${i}'
   location: resourceGroup().location

--- a/docs/spec/outputs.md
+++ b/docs/spec/outputs.md
@@ -4,31 +4,31 @@ Output declarations will be compiled into template outputs and are used to retur
 There are no constraints on placement of output declarations. They can be mixed with any other valid declarations in any order.
 
 ## String output
-```
+```bicep
 output myEndpoint string = myResource.properties.endpoint
 ```
 
 ## Integer output
 The following declares a hard-coded integer output and sets the value to `42`.
-```
+```bicep
 output myHardcodedOutput int = 42
 ```
 
 ## Object output
 The following declares an object output that returns information about the resourceGroup:
-```
+```bicep
 output myResourceGroup object = resourceGroup()
 ```
 
 ## Boolean output
 The following declares a boolean output value and sets the value using an expression.
-```
+```bicep
 output isInputParamEmpty bool = length(myParam) == 0
 ```
 
 ## Array output
 The following declares an array output and computes the value using a [loop](./loops.md).
-```
+```bicep
 output myLoopyOutput array = [for myItem in myArray: {
   myProperty: myItem.myOtherProperty
 }]

--- a/docs/spec/parameters.md
+++ b/docs/spec/parameters.md
@@ -5,7 +5,7 @@ There are no constraints on placement of parameter declarations. They can be mix
 
 ## Minimal Declaration
 These are smallest possible parameter declarations:
-```
+```bicep
 param myString string
 param myInt int
 param myBool bool
@@ -15,12 +15,12 @@ param myArray array
 
 ## Default value
 Default values can be declared as follows:
-```
+```bicep
 param myParam string = 'my default value'
 ```
 
 You may use [expressions](./expressions.md) with the `default` modifier.  Here is an example of a location parameter whose value defaults to the location of the current resource group if the parameter is not specified during the deployment:
-```
+```bicep
 param myParam string = resourceGroup().location
 ```
 
@@ -29,7 +29,7 @@ A parameter cannot have the same name as a [variable](./variables.md), [resource
 ## Declaration with decorators
 Decorators provide a way to attach constrains and metadata to a parameter. Decorators are placed above the parameter declaration to be decorated. They use the form @expression, where expression must be a function call:
 
-```
+```bicep
 @expression
 param myParam string
 ```
@@ -38,16 +38,17 @@ param myParam string
 If you are familiar with ARM template parameters, you will notice a conspicuous absence of `secureString` and `secureObject` types. In this language, these types are annotated with the `@secure` decorator.
 
 The following declarations will compile into a `secureString` and `secureObject` parameters, respectively.
-```
+```bicep
 @secure()
 param myPassword string
 
 @secure()
 param mySuperSecretObject object
 ```
+
 ### Allowed Values
 You can constrain which values are allowed using the `@allowed` decorator:
-```
+```bicep
 @allowed([
   'one'
   'two'
@@ -59,7 +60,7 @@ The constraint will be evaluated at deployment time of the compiled template.
 
 ### String and array length constraint
 Parameters of type `string` and `array` can have length constraints. The following declares a storage account name parameter of type strings whose length can only be between 3-24 characters (inclusive).
-```
+```bicep
 @minLength(3)
 @maxLength(24)
 param storageAccountName string
@@ -69,7 +70,7 @@ The length constraint is evaluated at compiled template deployment time.
 
 ### Integer value constraint
 Integer parameters can also have a value constraint. These are expressed as follows:
-```
+```bicep
 @minValue(1)
 @maxValue(12)
 param month int
@@ -79,7 +80,7 @@ The value constraint is evaluated at compiled template deployment time.
 
 ### Metadata
 Parameters of any type can have metadata. The following example shows how to attach a metadata object to a parameter:
-```
+```bicep
 @metadata({
   author: 'Example Name'
 })
@@ -88,13 +89,13 @@ param myParam string
 
 ### Description
 Parameters of any type can have a description associated with them. This looks like the following:
-```
+```bicep
 @description('There are many like this, but this object is mine.')
 param myObject object
 ```
 
 The `@metadata` decorator can be used to achieve the same goal, but it is a bit more verbose:
-```
+```bicep
 @metadata({
   description: 'There are many like this, but this object is mine.'
 })
@@ -103,7 +104,7 @@ param myObject object
 
 ### Combined decorators
 If applicable to the parameter type, multiple decorators can be combined together. The following is an example of this:
-```
+```bicep
 @minLength(3)
 @maxLength(24)
 @description('Name of the storage account')

--- a/docs/spec/resources.md
+++ b/docs/spec/resources.md
@@ -3,7 +3,7 @@
 A `resource` declaration defines a resource that will be either created or updated at deployment time along with its intended state. The resource is also assigned to an identifier. You can reference the identifier in [expressions](./expressions.md) that are part of [variables](./variables.md), [outputs](./outputs.md), or other `resource` declarations.
 
 Consider the following declaration that creates or updates a [DNS Zone](https://docs.microsoft.com/en-us/azure/dns/dns-zones-records):
-```
+```bicep
 resource dnsZone 'Microsoft.Network/dnszones@2018-05-01' = {
   name: 'myZone'
   location: 'global'

--- a/docs/spec/variables.md
+++ b/docs/spec/variables.md
@@ -11,14 +11,14 @@ There are no constraints on placement of variable declarations. They can be mixe
 The examples below cover variable declaration using hard-coded and calculated values.
 
 ### String variable
-```
+```bicep
 var myString = 'my string value'
 
 var location = resourceGroup().location
 ```
 
 ### Boolean variables
-```
+```bicep
 var iAmTrue = true
 var iAmFalse = false
 
@@ -26,14 +26,14 @@ var hasItems = length(myArray) >= 0
 ```
 
 ### Numeric variables
-```
+```bicep
 var meaningOfLifeTheUniVerseAndEverything = 42
 
 var lengthOfMyArray = length(myArray)
 ```
 
 ### Object variables
-```
+```bicep
 var myObject = {
   first: 1
   second: 2
@@ -43,7 +43,7 @@ var keys = listKeys(myResource.id, myResource.apiVersion)
 ```
 
 ### Array variables
-```
+```bicep
 var myArray = [
   'item 1'
   'item 2'

--- a/docs/the-any-function.md
+++ b/docs/the-any-function.md
@@ -17,7 +17,7 @@ In the following example, at the time of this writing, the API definition for Az
 
 You can see this example live in the [Bicep playground](https://aka.ms/bicepdemo#eJyNVFtvmzAUfudX+I32IUDSbV2RNi1dtq5S17ISdQ/TVDnGSSzhS3wJjab899kQE0IUtfCAOed8F1vHR0AJKVCaS7jAY4S4YfoeUmxDkrAF+AQMIyuD8/r3TGLFjUT4RnIjzs4jUpwHoqEgGh8Cj0mDXS3d5Ksyg0pVXBYe8C8AQGFkJE6BlgYHW19ecgQ14WxP3bfhK4Ig8ClQiTEiIKQESa74XEeIMw0Jw/KWKQ0ZwnEbqXnUl1EyvBoMR4NkGFoRZ4hZ1ykInU9hmdWghZAdSWirvHzarmxQSC6w1ASrtKYCoMXayJ86AnYZ9/SlwjZzzNQ8hNrj7ULSd9HVAAqIljjs1AkudUeyL9yKaI54afmmX7Own7UUKfiYHIS3nb+/nTVmayI5o5jpJygJnJX4Vfnd7n8/PE6yx295/jy5fv7xkE/7RtawNK5wOLqMEvsO04uL5EN40tfblLJxnrtAX63px6dG87Br4xigJWQLXAC9JArMJacgrO3Z5vkMwg72tL3usa15aSj+6S7Lq8dFXVUG9dLuJF5DGVdVFS81Lfs76HfVnJRvtOMvUq/pXMLOA6WP4rbBhbFaSfS+74JiyuXmlt1c1/nL0w72a79qvo0zIsZFUXd6q33U3F1Tp5v6qKG9nD8CvRHu4DIzKwnyyIIpN8fu4AxbTj/ygj2eq2mDuyPMvDjY1s0xbrQwugZ8/zW53w+yekhF+wsetTuM5quC/Qf9MoIp)
 
-```
+```bicep
 resource wpAci 'microsoft.containerInstance/containerGroups@2019-12-01' = {
   name: 'wordpress-containerinstance'
   location: location
@@ -42,7 +42,7 @@ resource wpAci 'microsoft.containerInstance/containerGroups@2019-12-01' = {
 
 In order to get rid of these warnings, simply wrap the relevant property value(s) in the `any()` function like so:
 
-```
+```bicep
 resource wpAci 'microsoft.containerInstance/containerGroups@2019-12-01' = {
   name: 'wordpress-containerinstance'
   location: location

--- a/docs/tutorial/01-simple-template.md
+++ b/docs/tutorial/01-simple-template.md
@@ -34,7 +34,7 @@ The resource declaration has four components:
 
 In most cases, I want to expose the resource name and the resource location via parameters, so I can add the following:
 
-```
+```bicep
 param location string = 'eastus'
 param storageAccountName string = 'uniquestorage001' // must be globally unique
 
@@ -66,7 +66,7 @@ param storageAccountName string = 'uniquestorage001' // must be globally unique
 
 I can also add `variables` for storing values or complex expressions, and emit `outputs` to be passed to a script or another Bicep file:
 
-```
+```bicep
 param location string = 'eastus'
 
 @minLength(3)

--- a/docs/tutorial/05-loops-conditions-existing.md
+++ b/docs/tutorial/05-loops-conditions-existing.md
@@ -86,7 +86,7 @@ resource blob 'Microsoft.Storage/storageAccounts/blobServices/containers@2019-06
 ```
 
 There's also a [loop index variant](../spec/loops.md#use-the-loop-index) which gives us access to the current item's index in the array:
-```
+```bicep
 resource blob 'Microsoft.Storage/storageAccounts/blobServices/containers@2019-06-01' = [for (name, index) in containerNames: {
   name: '${stg.name}/default/${name}-${index + 1}'
 }]

--- a/docs/tutorial/07-convert-arm-template.md
+++ b/docs/tutorial/07-convert-arm-template.md
@@ -47,7 +47,7 @@ Here's an example ARM Template that deploys a storage account.
 
 Let's decompile the ARM template with `bicep decompile ".\storage.json"` and look at the output `.bicep` file.
 
-```
+```bicep
 param location string = resourceGroup().location
 param namePrefix string = 'contoso'
 param production bool = false
@@ -89,7 +89,7 @@ ARM Template:
 ```
 
 Bicep:
-```
+```bicep
 param name string = 'myName'
 ```
 
@@ -115,7 +115,7 @@ ARM Template:
 
 Bicep:
 
-```
+```bicep
 @allowed([
   'myName'
   'myOtherName'
@@ -139,7 +139,7 @@ ARM Template:
 
 Bicep:
 
-```
+```bicep
 var location = 'eastus'
 ```
 
@@ -160,7 +160,7 @@ ARM Template:
 
 Bicep:
 
-```
+```bicep
 output myOutput string = 'my output value'
 ```
 
@@ -210,7 +210,7 @@ ARM Template:
 
 Bicep:
 
-```
+```bicep
 resource vnet 'Microsoft.Network/virtualNetworks@2018-10-01' = {
   name: 'vnet001'
   location: resourceGroup().location


### PR DESCRIPTION
Updated all examples in docs to use the bicep syntax highlighting.

## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)
