### PR TITLE
Fix param description

### DIFF
--- a/docs/examples/101/container-registry/main.bicep
+++ b/docs/examples/101/container-registry/main.bicep
@@ -7,7 +7,7 @@ param acrName string = 'acr001${uniqueString(resourceGroup().id)}' // must be gl
 @description('Enable admin user that have push / pull permission to the registry.')
 param acrAdminUserEnabled bool = false
 
-@description('Specifies the Azure location where the key vault should be created.')
+@description('Specifies the Azure location where the container registry should be created.')
 param location string = resourceGroup().location
 
 @allowed([

--- a/docs/examples/101/container-registry/main.json
+++ b/docs/examples/101/container-registry/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6017186912658227876"
+      "templateHash": "15396773285907426422"
     }
   },
   "parameters": {
@@ -29,7 +29,7 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
-        "description": "Specifies the Azure location where the key vault should be created."
+        "description": "Specifies the Azure location where the container registry should be created."
       }
     },
     "acrSku": {


### PR DESCRIPTION
## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

* [ ] I have checked that there is not an equivalent example already submitted
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have only a single resource in my snippet
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
