### PR TITLE
Fixed parameter in loop example

### DIFF
--- a/docs/spec/loops.md
+++ b/docs/spec/loops.md
@@ -154,7 +154,7 @@ In the example below we are implementing the same loop as in the previous exampl
 
 
 ```bicep
-parameter subnetsDefinitions array = [
+param subnetsDefinitions array = [
   {
     name: 'api'
     subnetPrefix: '10.144.0.0/24'


### PR DESCRIPTION
Fixed parameter in the "Generate an array variable using a loop" example.

## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)
