### PR TITLE
Fix IdentifierName issue in snippet templates with placeholder for symbolic name

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
@@ -443,7 +443,6 @@ var partialObject = {
 //@[3:3) [BCP018 (Error)] Expected the ":" character at this location. ||
   b $
 //@[4:5) [BCP018 (Error)] Expected the ":" character at this location. |$|
-//@[4:5) [BCP001 (Error)] The following token is not recognized: "$". |$|
 //@[5:5) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. ||
   a # 22
 //@[2:3) [BCP025 (Error)] The property "a" is declared multiple times in this object. Remove or rename the duplicate properties. |a|

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
@@ -2465,7 +2465,7 @@ var partialObject = {
 //@[2:3)    IdentifierSyntax
 //@[2:3)     Identifier |b|
 //@[4:5)    SkippedTriviaSyntax
-//@[4:5)     Unrecognized |$|
+//@[4:5)     Dollar |$|
 //@[5:5)    SkippedTriviaSyntax
 //@[5:6)   NewLine |\n|
   a # 22

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.tokens.bicep
@@ -1537,7 +1537,7 @@ var partialObject = {
 //@[3:4) NewLine |\n|
   b $
 //@[2:3) Identifier |b|
-//@[4:5) Unrecognized |$|
+//@[4:5) Dollar |$|
 //@[5:6) NewLine |\n|
   a # 22
 //@[2:3) Identifier |a|

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -34,7 +34,6 @@ var 2
 //@[6:6) [BCP018 (Error)] Expected the "=" character at this location. ||
 var $ = 23
 //@[4:5) [BCP015 (Error)] Expected a variable identifier at this location. |$|
-//@[4:5) [BCP001 (Error)] The following token is not recognized: "$". |$|
 var # 33 = 43
 //@[4:5) [BCP015 (Error)] Expected a variable identifier at this location. |#|
 //@[4:5) [BCP001 (Error)] The following token is not recognized: "#". |#|

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
@@ -82,7 +82,7 @@ var $ = 23
 //@[0:3)  Identifier |var|
 //@[4:5)  IdentifierSyntax
 //@[4:5)   SkippedTriviaSyntax
-//@[4:5)    Unrecognized |$|
+//@[4:5)    Dollar |$|
 //@[6:7)  Assignment |=|
 //@[8:10)  IntegerLiteralSyntax
 //@[8:10)   Integer |23|

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
@@ -54,7 +54,7 @@ var 2
 //@[6:7) NewLine |\n|
 var $ = 23
 //@[0:3) Identifier |var|
-//@[4:5) Unrecognized |$|
+//@[4:5) Dollar |$|
 //@[6:7) Assignment |=|
 //@[8:10) Integer |23|
 //@[10:11) NewLine |\n|

--- a/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
 using System.Text;
@@ -341,6 +341,20 @@ namespace Bicep.Core.UnitTests.Parsing
         public void CoalesceShouldParseSuccessfully(string text, string expected)
         {
             RunExpressionTest(text, expected, typeof(BinaryOperationSyntax));
+        }
+
+        [TestMethod]
+        public void ResourceDeclarationSyntaxName_WithSnippetPlaceholderInSymbolicName_ShouldBeValid()
+        {
+            string text = @"resource ${1:dnsZone} 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: ${2:'name'}
+  location: 'global'
+}";
+
+            ProgramSyntax programSyntax = ParserHelper.Parse(text);
+            ResourceDeclarationSyntax? resourceDeclarationSyntax = programSyntax.Children[0] as ResourceDeclarationSyntax;
+
+            Assert.AreEqual("${1:dnsZone}", resourceDeclarationSyntax!.Name.IdentifierName);
         }
 
         private static SyntaxBase RunExpressionTest(string text, string expected, Type expectedRootType)

--- a/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
@@ -350,7 +350,6 @@ namespace Bicep.Core.UnitTests.Parsing
   name: ${2:'name'}
   location: 'global'
 }";
-
             ProgramSyntax programSyntax = ParserHelper.Parse(text);
             ResourceDeclarationSyntax? resourceDeclarationSyntax = programSyntax.Children[0] as ResourceDeclarationSyntax;
 

--- a/src/Bicep.Core/Parsing/Lexer.cs
+++ b/src/Bicep.Core/Parsing/Lexer.cs
@@ -735,6 +735,8 @@ namespace Bicep.Core.Parsing
                     return TokenType.Comma;
                 case '.':
                     return TokenType.Dot;
+                case '$':
+                    return TokenType.Dollar;
                 case '?':
                     if (!textWindow.IsAtEnd())
                     {

--- a/src/Bicep.Core/Parsing/TokenType.cs
+++ b/src/Bicep.Core/Parsing/TokenType.cs
@@ -14,6 +14,7 @@ namespace Bicep.Core.Parsing
         RightSquare,
         Comma,
         Dot,
+        Dollar,
         Question,
         Colon,
         Semicolon,

--- a/src/Bicep.Core/Syntax/IdentifierSyntax.cs
+++ b/src/Bicep.Core/Syntax/IdentifierSyntax.cs
@@ -84,7 +84,6 @@ namespace Bicep.Core.Syntax
                 }
 
                 string text = sb.ToString();
-
                 if (SnippetPlaceholderPattern.IsMatch(text))
                 {
                     return text;

--- a/src/Bicep.Core/Syntax/IdentifierSyntax.cs
+++ b/src/Bicep.Core/Syntax/IdentifierSyntax.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax
@@ -14,6 +17,8 @@ namespace Bicep.Core.Syntax
     [DebuggerDisplay("IdentifierName = {" + nameof(IdentifierName) +"}")]
     public class IdentifierSyntax : SyntaxBase
     {
+        private static readonly Regex SnippetPlaceholderPattern = new Regex(@"\${\d+:\w+}", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+
         public IdentifierSyntax(SyntaxBase child)
         {
             if (child is Token token)
@@ -41,12 +46,52 @@ namespace Bicep.Core.Syntax
                         return identifier.Text;
 
                     case SkippedTriviaSyntax skipped:
-                        return skipped.Elements.Any() ? LanguageConstants.ErrorName : LanguageConstants.MissingName;
+
+                        ImmutableArray<SyntaxBase> elements = skipped.Elements;
+                        if (elements.Any())
+                        {
+                            return GetIdentifierName(elements);
+                        }
+                        return LanguageConstants.MissingName;
+
 
                     default:
                         throw new NotImplementedException($"Unexpected child node type '{this.Child.GetType().Name}'.");
                 }
             }
+        }
+
+        private string GetIdentifierName(ImmutableArray<SyntaxBase> elements)
+        {
+            // Snippet templates have placeholders for symbolic name. If elements contains tokens with types in following
+            // order - [Dollar, LeftBrace, Integer, Colon, Identifier, RightBrace], we'll recognize the pattern and use the text
+            // as identifier name
+            // E.g:
+            // resource ${1:dnsZone} 'Microsoft.Network/dnsZones@2018-05-01' = {
+            //   name: ${ 2:'name'}
+            //   location: 'global'
+            // }
+            // In the above example, the IdentifierName of ResourceDeclarationSyntax would be ${1:dnsZone}
+            if (elements.Count() == 6)
+            {
+                StringBuilder sb = new StringBuilder();
+                foreach (SyntaxBase element in elements)
+                {
+                    if (element is Token token)
+                    {
+                        sb.Append(token.Text);
+                    }
+                }
+
+                string text = sb.ToString();
+
+                if (SnippetPlaceholderPattern.IsMatch(text))
+                {
+                    return text;
+                }
+            }
+
+            return LanguageConstants.ErrorName;
         }
 
         public override void Accept(ISyntaxVisitor visitor) => visitor.VisitIdentifierSyntax(this);


### PR DESCRIPTION
Changes to return placeholder text as IdentifierName instead of ```<error>``` for snippet templates with placeholder text for symbolic name

Snippet templates available here: https://github.com/Azure/bicep/tree/main/src/Bicep.LangServer/Snippets/Templates have placeholder text for symbolic name. We seem to return ```<error>``` as IdentiferName while parsing. We should be returning placeholder text instead. Consider below example:
resource ${1:dnsZone} 'Microsoft.Network/dnsZones@2018-05-01' = {
name: ${2:'name'}
location: 'global'
}

We should return ${1:dnsZone} as IdentifierName in this case