### PR TITLE
Updated "known limitations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ For more detail on taking advantage of new Bicep constructs that replace an equi
 
 * No support for single-line object and arrays (i.e. `['a', 'b', 'c']`) ([#586](https://github.com/Azure/bicep/issues/586)).
 * Bicep is newline sensitive. We are exploring ways we can remove/relax this restriction ([#146](https://github.com/Azure/bicep/issues/146))
+* No support for the concept of apiProfile which is used to map a single apiProfile to a set apiVersion for each resource type. We are looking to bring support for this type of capability, but suspect it will work slightly differently. Discussion is in [#622](https://github.com/Azure/bicep/issues/622)
+* No support for key vault references in modules, even though this is possible with nested deployments in ARM Templates. ([#1028](https://github.com/Azure/bicep/issues/1028))
 
 ## FAQ
 


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

* [ ] I have checked that there is not an equivalent example already submitted
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have only a single resource in my snippet
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
