### PR TITLE
fix example to use parent syntax

### DIFF
--- a/docs/examples/101/function-app-create/main.bicep
+++ b/docs/examples/101/function-app-create/main.bicep
@@ -51,7 +51,9 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 
 // Blob Services for Storage Account
 resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2019-06-01' = {
-  name: '${storageAccount.name}/default'
+  parent: storageAccount
+
+  name: 'default'
   properties: {
     cors: {
       corsRules: []
@@ -166,7 +168,9 @@ resource functionApp 'Microsoft.Web/sites@2020-06-01' = {
 
 // Function App Config
 resource functionAppConfig 'Microsoft.Web/sites/config@2020-06-01' = {
-  name: '${functionApp.name}/web'
+  parent: functionApp
+
+  name: 'web'
   properties: {
     numberOfWorkers: -1
     defaultDocuments: [
@@ -188,7 +192,6 @@ resource functionAppConfig 'Microsoft.Web/sites/config@2020-06-01' = {
     logsDirectorySizeLimit: 35
     detailedErrorLoggingEnabled: false
     publishingUsername: '$${functionAppName}'
-    azureStorageAccounts: {}
     scmType: 'None'
     use32BitWorkerProcess: true
     webSocketsEnabled: false
@@ -237,13 +240,15 @@ resource functionAppConfig 'Microsoft.Web/sites/config@2020-06-01' = {
     http20Enabled: true
     minTlsVersion: '1.2'
     ftpsState: 'AllAllowed'
-    PreWarmedInstanceCount: 0
+    preWarmedInstanceCount: 0
   }
 }
 
 // Function App Binding
 resource functionAppBinding 'Microsoft.Web/sites/hostNameBindings@2020-06-01' = {
-  name: '${functionApp.name}/${functionApp.name}.azurewebsites.net'
+  parent: functionApp
+
+  name: '${functionApp.name}.azurewebsites.net'
   properties: {
     siteName: functionApp.name
     hostNameType: 'Verified'

--- a/docs/examples/101/function-app-create/main.json
+++ b/docs/examples/101/function-app-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "754050298982564611"
+      "templateHash": "15435256629397286543"
     }
   },
   "parameters": {
@@ -69,7 +69,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts/blobServices",
       "apiVersion": "2019-06-01",
-      "name": "[format('{0}/default', variables('storageAccountName'))]",
+      "name": "[format('{0}/{1}', variables('storageAccountName'), 'default')]",
       "properties": {
         "cors": {
           "corsRules": []
@@ -192,7 +192,7 @@
     {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/web', variables('functionAppName'))]",
+      "name": "[format('{0}/{1}', variables('functionAppName'), 'web')]",
       "properties": {
         "numberOfWorkers": -1,
         "defaultDocuments": [
@@ -214,7 +214,6 @@
         "logsDirectorySizeLimit": 35,
         "detailedErrorLoggingEnabled": false,
         "publishingUsername": "[format('${0}', variables('functionAppName'))]",
-        "azureStorageAccounts": {},
         "scmType": "None",
         "use32BitWorkerProcess": true,
         "webSocketsEnabled": false,
@@ -263,7 +262,7 @@
         "http20Enabled": true,
         "minTlsVersion": "1.2",
         "ftpsState": "AllAllowed",
-        "PreWarmedInstanceCount": 0
+        "preWarmedInstanceCount": 0
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]"
@@ -272,7 +271,7 @@
     {
       "type": "Microsoft.Web/sites/hostNameBindings",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}.azurewebsites.net', variables('functionAppName'), variables('functionAppName'))]",
+      "name": "[format('{0}/{1}', variables('functionAppName'), format('{0}.azurewebsites.net', variables('functionAppName')))]",
       "properties": {
         "siteName": "[variables('functionAppName')]",
         "hostNameType": "Verified"


### PR DESCRIPTION
Fixes #2514 

## Contributing an example

* [x] I have checked that there is not an equivalent example already submitted
* [x] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [x] I have checked that all tests are passing by running `dotnet test`
* [x] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style