### PR TITLE
Provide completions immediately after '{' in string expressions

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -184,88 +184,69 @@ namespace Bicep.LangServer.IntegrationTests
         [TestMethod]
         public async Task String_segments_do_not_return_completions()
         {
-            var (file, cursors) = ParserHelper.GetFileWithCursors(@"
+            var fileWithCursors = @"
 var completeString = |'he|llo'|
-var interpolatedString = |'abc${|true}|de|f${|false}|gh|i'|
+var interpolatedString = |'abc|${true}|de|f|${false}|gh|i'|
 var multilineString = |'''|
 hel|lo
 '''|
-");
+";
 
-            var syntaxTree = SyntaxTree.Create(new Uri("file:///main.bicep"), file);
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+        }
 
-            foreach (var cursor in cursors)
-            {
-                using (new AssertionScope().WithVisualCursor(syntaxTree, new TextSpan(cursor, 0)))
-                {
-                    var completions = await client.RequestCompletion(new CompletionParams
-                    {
-                        TextDocument = new TextDocumentIdentifier(syntaxTree.FileUri),
-                        Position = TextCoordinateConverter.GetPosition(syntaxTree.LineStarts, cursor),
-                    });
+        [TestMethod]
+        public async Task Completions_are_offered_in_string_expressions()
+        {
+            var fileWithCursors = @"
+var interpolatedString = 'abc${|true}def${|}ghi${res|}xyz'
+";
 
-                    completions.Should().BeEmpty();
-                }
-            }
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsNonEmpty);
         }
 
         [TestMethod]
         public async Task Completions_are_offered_immediately_before_and_after_comments()
         {
-            var (file, cursors) = ParserHelper.GetFileWithCursors(@"
+            var fileWithCursors = @"
 var test = |// comment here
 var test2 = |/* block comment */|
-");
+";
 
-            var syntaxTree = SyntaxTree.Create(new Uri("file:///main.bicep"), file);
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsNonEmpty);
+        }
 
-            foreach (var cursor in cursors)
-            {
-                using (new AssertionScope().WithVisualCursor(syntaxTree, new TextSpan(cursor, 0)))
-                {
-                    var completions = await client.RequestCompletion(new CompletionParams
-                    {
-                        TextDocument = new TextDocumentIdentifier(syntaxTree.FileUri),
-                        Position = TextCoordinateConverter.GetPosition(syntaxTree.LineStarts, cursor),
-                    });
+        [TestMethod]
+        public async Task Completions_are_not_offered_immediately_after_open_paren()
+        {
+            var fileWithCursors = @"
+param foo = {|
 
-                    completions.Should().NotBeEmpty();
-                }
-            }
+var bar = {|
+
+resource testRes 'Test.Rp/readWriteTests@2020-01-01' = {|
+
+output baz object = {|
+";
+
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
         public async Task Completions_are_not_offered_inside_comments()
         {
-            var (file, cursors) = ParserHelper.GetFileWithCursors(@"
+            var fileWithCursors = @"
 var test = /|/ comment here|
 var test2 = /|* block c|omment *|/
-");
+";
 
-            var syntaxTree = SyntaxTree.Create(new Uri("file:///main.bicep"), file);
-            using var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
-
-            foreach (var cursor in cursors)
-            {
-                using (new AssertionScope().WithVisualCursor(syntaxTree, new TextSpan(cursor, 0)))
-                {
-                    var completions = await client.RequestCompletion(new CompletionParams
-                    {
-                        TextDocument = new TextDocumentIdentifier(syntaxTree.FileUri),
-                        Position = TextCoordinateConverter.GetPosition(syntaxTree.LineStarts, cursor),
-                    });
-
-                    completions.Should().BeEmpty();
-                }
-            }
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         [TestMethod]
         public async Task Property_completions_include_descriptions()
         {
-            var (file, cursors) = ParserHelper.GetFileWithCursors(@"
+            var fileWithCursors = @"
 resource testRes 'Test.Rp/readWriteTests@2020-01-01' = {
   name: 'testRes'
   properties: {
@@ -275,33 +256,30 @@ resource testRes 'Test.Rp/readWriteTests@2020-01-01' = {
 
 output string test = testRes.|
 output string test2 = testRes.properties.|
-");
+";
 
-            var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
-            var completions = await RequestCompletions(client, syntaxTree, cursors);
-
-            completions.Should().SatisfyRespectively(
-                x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which is required."),
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which only supports writing.")),
-                x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("apiVersion property"),
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("id property"),
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("name property"),
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("properties property"),
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("type property")),
-                x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which only supports reading."),
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
-                    d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which is required.")));
+            await RunCompletionScenarioTest(fileWithCursors, completions =>
+                completions.Should().SatisfyRespectively(
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which is required."),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which only supports writing.")),
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("apiVersion property"),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("id property"),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("name property"),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("properties property"),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("type property")),
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which only supports reading."),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which is required."))));
         }
 
         [TestMethod]
         public async Task Completions_after_resource_type_should_only_include_existing_keyword()
         {
-            var (file, cursors) = ParserHelper.GetFileWithCursors(@"
+            var fileWithCursors = @"
 resource testRes 'Test.Rp/readWriteTests@2020-01-01' |
 
 resource testRes2 'Test.Rp/readWriteTests@2020-01-01' | = {
@@ -315,7 +293,7 @@ resource testRes4 'Test.Rp/readWriteTests@2020-01-01' e|= {
 
 resource testRes5 'Test.Rp/readWriteTests@2020-01-01' |= {
 }
-");
+";
 
             static void AssertExistingKeywordCompletion(CompletionItem item)
             {
@@ -331,22 +309,20 @@ resource testRes5 'Test.Rp/readWriteTests@2020-01-01' |= {
                 item.CommitCharacters.Should().BeNull();
             }
 
-            var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
-            var completions = await RequestCompletions(client, syntaxTree, cursors);
 
-            completions.Should().SatisfyRespectively(
-                x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
-                x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
-                x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
-                x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
-                x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)));
+            await RunCompletionScenarioTest(fileWithCursors, completions =>
+                completions.Should().SatisfyRespectively(
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d)),
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(d => AssertExistingKeywordCompletion(d))));
         }
 
         [TestMethod]
         public async Task PropertyNameCompletionsShouldIncludeTrailingColonIfColonIsMissing()
         {
-            var (file, cursors) = ParserHelper.GetFileWithCursors(@"
+            var fileWithCursors = @"
 resource testRes 'Test.Rp/readWriteTests@2020-01-01' = {
   |
 }
@@ -354,7 +330,7 @@ resource testRes 'Test.Rp/readWriteTests@2020-01-01' = {
 resource testRes2 'Test.Rp/readWriteTests@2020-01-01' = {
   n|
 }
-");
+";
             static void AssertPropertyNameCompletionsWithColons(CompletionList list)
             {
                 list.Where(i => i.Kind == CompletionItemKind.Property)
@@ -362,18 +338,23 @@ resource testRes2 'Test.Rp/readWriteTests@2020-01-01' = {
                     .OnlyContain(x => string.Equals(x.TextEdit!.NewText, x.Label + ':'));
             }
 
-            var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
-            var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
-            var completions = await RequestCompletions(client, syntaxTree, cursors);
-            completions.Should().SatisfyRespectively(
-                l => AssertPropertyNameCompletionsWithColons(l!),
-                l => AssertPropertyNameCompletionsWithColons(l!));
+            await RunCompletionScenarioTest(fileWithCursors, completions =>
+                completions.Should().SatisfyRespectively(
+                    l => AssertPropertyNameCompletionsWithColons(l!),
+                    l => AssertPropertyNameCompletionsWithColons(l!)));
         }
 
         [TestMethod]
         public async Task PropertyNameCompletionsShouldNotIncludeTrailingColonIfItIsPresent()
         {
-            var (file, cursors) = ParserHelper.GetFileWithCursors(@"
+            static void AssertPropertyNameCompletionsWithoutColons(CompletionList list)
+            {
+                list.Where(i => i.Kind == CompletionItemKind.Property)
+                    .Should()
+                    .OnlyContain(x => string.Equals(x.TextEdit!.NewText, x.Label));
+            }
+
+            var fileWithCursors = @"
 resource testRes2 'Test.Rp/readWriteTests@2020-01-01' = {
   n|:
 }
@@ -381,20 +362,38 @@ resource testRes2 'Test.Rp/readWriteTests@2020-01-01' = {
 resource testRes3 'Test.Rp/readWriteTests@2020-01-01' = {
   n| :
 }
-");
-            static void AssertPropertyNameCompletionsWithColons(CompletionList list)
-            {
-                list.Where(i => i.Kind == CompletionItemKind.Property)
-                    .Should()
-                    .OnlyContain(x => string.Equals(x.TextEdit!.NewText, x.Label));
-            }
+";
 
+            await RunCompletionScenarioTest( fileWithCursors, completions =>
+                completions.Should().SatisfyRespectively(
+                    l => AssertPropertyNameCompletionsWithoutColons(l!),
+                    l => AssertPropertyNameCompletionsWithoutColons(l!)));
+        }
+
+        private static async Task RunCompletionScenarioTest(string fileWithCursors, Action<IEnumerable<CompletionList?>> assertAction)
+        {
+            var (file, cursors) = ParserHelper.GetFileWithCursors(fileWithCursors);
             var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
             var client = await IntegrationTestHelper.StartServerWithTextAsync(file, syntaxTree.FileUri, resourceTypeProvider: BuiltInTestTypes.Create());
             var completions = await RequestCompletions(client, syntaxTree, cursors);
-            completions.Should().SatisfyRespectively(
-                l => AssertPropertyNameCompletionsWithColons(l!),
-                l => AssertPropertyNameCompletionsWithColons(l!));
+
+            assertAction(completions);
+        }
+
+        private static void AssertAllCompletionsNonEmpty(IEnumerable<CompletionList?> completionLists)
+        {
+            foreach (var completionList in completionLists)
+            {
+                completionList.Should().NotBeEmpty();
+            }
+        }
+
+        private static void AssertAllCompletionsEmpty(IEnumerable<CompletionList?> completionLists)
+        {
+            foreach (var completionList in completionLists)
+            {
+                completionList.Should().BeEmpty();
+            }
         }
 
         private void ValidateCompletions(DataSet dataSet, string setName, List<(Position position, JToken actual)> intermediate)

--- a/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -61,7 +61,7 @@ namespace Bicep.LanguageServer.Handlers
             DocumentSelector = DocumentSelectorFactory.Create(),
             AllCommitCharacters = new Container<string>(),
             ResolveProvider = false,
-            TriggerCharacters = new Container<string>(":", " ", ".", "/", "'", "@")
+            TriggerCharacters = new Container<string>(":", " ", ".", "/", "'", "@", "{")
         };
     }
 }

--- a/src/Bicep.LangServer/SemanticTokenVisitor.cs
+++ b/src/Bicep.LangServer/SemanticTokenVisitor.cs
@@ -141,6 +141,13 @@ namespace Bicep.LanguageServer
             base.VisitPropertyAccessSyntax(syntax);
         }
 
+        public override void VisitArrayAccessSyntax(ArrayAccessSyntax syntax)
+        {
+            AddTokenType(syntax.OpenSquare, SemanticTokenType.Operator);
+            AddTokenType(syntax.CloseSquare, SemanticTokenType.Operator);
+            base.VisitArrayAccessSyntax(syntax);
+        }
+
         public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
         {
             AddTokenType(syntax.ResourceName, SemanticTokenType.Property);


### PR DESCRIPTION
Fixes https://github.com/Azure/bicep/issues/2528.