### PR TITLE
removed "parent" property from syntactically nested resources

### DIFF
--- a/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
@@ -538,7 +538,7 @@ output loopy string = parent::child[0].name
             {
                 diags.ExcludingMissingTypes().Should().HaveDiagnostics(new[]
                 {
-                    ("BCP179",DiagnosticLevel.Warning,"The loop item variable \"item\" must be referenced in at least one of the value expressions of the following properties: \"name\", \"parent\", \"scope\"")
+                    ("BCP179",DiagnosticLevel.Warning,"The loop item variable \"item\" must be referenced in at least one of the value expressions of the following properties: \"name\", \"scope\"")
                 });
                 template.Should().NotBeNull();
             }

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -1698,7 +1698,7 @@ resource p2 'Microsoft.Network/dnsZones@2018-05-01' = {
             {
                 ("BCP179", DiagnosticLevel.Warning, "The loop item variable \"thing\" must be referenced in at least one of the value expressions of the following properties: \"name\", \"parent\""),
                 ("BCP170", DiagnosticLevel.Error, "Expected resource name to not contain any \"/\" characters. Child resources with a parent resource reference (via the parent property or via nesting) must not contain a fully-qualified name."),
-                ("BCP179", DiagnosticLevel.Warning, "The loop item variable \"thing2\" must be referenced in at least one of the value expressions of the following properties: \"name\", \"parent\""),
+                ("BCP179", DiagnosticLevel.Warning, "The loop item variable \"thing2\" must be referenced in at least one of the value expressions of the following properties: \"name\""),
                 ("BCP170", DiagnosticLevel.Error, "Expected resource name to not contain any \"/\" characters. Child resources with a parent resource reference (via the parent property or via nesting) must not contain a fully-qualified name.")
             });
             result.Template.Should().BeNull();

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.diagnostics.bicep
@@ -87,7 +87,7 @@ resource loopParent 'My.Rp/parentType@2020-12-01' = {
   name: 'loopParent'
 
   resource loopChild 'childType' = [for item in items: {
-//@[11:20) [BCP179 (Warning)] The loop item variable "item" must be referenced in at least one of the value expressions of the following properties: "name", "parent", "scope" |loopChild|
+//@[11:20) [BCP179 (Warning)] The loop item variable "item" must be referenced in at least one of the value expressions of the following properties: "name", "scope" |loopChild|
 //@[21:32) [BCP081 (Warning)] Resource type "My.Rp/parentType/childType@2020-12-01" does not have types available. |'childType'|
     name: 'loopChild'
   }]

--- a/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
@@ -30,6 +30,7 @@ namespace Bicep.Core.UnitTests.TypeSystem.Az
         [DataRow(ResourceTypeGenerationFlags.None)]
         [DataRow(ResourceTypeGenerationFlags.ExistingResource)]
         [DataRow(ResourceTypeGenerationFlags.PermitLiteralNameProperty)]
+        [DataRow(ResourceTypeGenerationFlags.NestedResource)]
         [DataRow(ResourceTypeGenerationFlags.ExistingResource | ResourceTypeGenerationFlags.PermitLiteralNameProperty)]
         public void AzResourceTypeProvider_can_deserialize_all_types_without_throwing(ResourceTypeGenerationFlags flags)
         {
@@ -78,6 +79,12 @@ namespace Bicep.Core.UnitTests.TypeSystem.Az
                         (!string.Equals(property.Name, LanguageConstants.ResourceScopePropertyName, LanguageConstants.IdentifierComparison) || IsSymbolicProperty(property)));
                     loopVariantProperties.Should().NotBeEmpty();
                     loopVariantProperties.Should().OnlyContain(property => property.Flags.HasFlag(TypePropertyFlags.LoopVariant), $"because all loop variant properties in type '{availableType.FullyQualifiedType}' and api version '{availableType.ApiVersion}' should have the {nameof(TypePropertyFlags.LoopVariant)} flag.");
+
+                    if(flags.HasFlag(ResourceTypeGenerationFlags.NestedResource))
+                    {
+                        // syntactically nested resources should not have the parent property
+                        topLevelProperties.Should().NotContain(property => string.Equals(property.Name, LanguageConstants.ResourceParentPropertyName, LanguageConstants.IdentifierComparison));
+                    }
                 }
             }
         }

--- a/src/Bicep.Core/Syntax/ResourceDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ResourceDeclarationSyntax.cs
@@ -81,7 +81,8 @@ namespace Bicep.Core.Syntax
             ResourceTypeReference? typeReference;
             var hasParentDeclaration = false;
             var nestedParents = binder.GetAllAncestors<ResourceDeclarationSyntax>(this);
-            if (nestedParents.Length == 0)
+            bool isTopLevelResourceDeclaration = nestedParents.Length == 0;
+            if (isTopLevelResourceDeclaration)
             {
                 // This is a top level resource - the type is a fully-qualified type.
                 typeReference = ResourceTypeReference.TryParse(stringContent);
@@ -180,6 +181,12 @@ namespace Bicep.Core.Syntax
             {
                 flags |= ResourceTypeGenerationFlags.ExistingResource;
             }
+
+            if(!isTopLevelResourceDeclaration)
+            {
+                flags |= ResourceTypeGenerationFlags.NestedResource;
+            }
+
             if (typeReference.IsRootType || hasParentDeclaration)
             {
                 flags |= ResourceTypeGenerationFlags.PermitLiteralNameProperty;

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
@@ -209,8 +209,8 @@ namespace Bicep.Core.TypeSystem.Az
                 properties = properties.SetItem(LanguageConstants.ResourceNamePropertyName, UpdateFlags(nameProperty, nameProperty.Flags | TypePropertyFlags.LoopVariant));
             }
 
-            // add the 'parent' property for child resource types
-            if (!typeReference.IsRootType)
+            // add the 'parent' property for child resource types that are not nested inside a parent resource
+            if (!typeReference.IsRootType && !flags.HasFlag(ResourceTypeGenerationFlags.NestedResource))
             {
                 var parentType = LanguageConstants.CreateResourceScopeReference(ResourceScope.Resource);
                 var parentFlags = TypePropertyFlags.WriteOnly | TypePropertyFlags.DeployTimeConstant | TypePropertyFlags.DisallowAny | TypePropertyFlags.LoopVariant;

--- a/src/Bicep.Core/TypeSystem/ResourceTypeGenerationFlags.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceTypeGenerationFlags.cs
@@ -24,6 +24,12 @@ namespace Bicep.Core.TypeSystem
         /// Generating a definition for a resource which permits literal-valued names (e.g. enums, or discriminated objects with 'name' key).
         /// This is used for root-level resources, and nested/parent-property child resources.
         /// </summary>
-        PermitLiteralNameProperty = 1 << 1
+        PermitLiteralNameProperty = 1 << 1,
+
+        /// <summary>
+        /// Generating a definition for a resource that is nested inside another resource declaration. Do not use this flag for resources
+        /// using the "parent" property.
+        /// </summary>
+        NestedResource = 1 << 2
     }
 }

--- a/src/Bicep.Core/TypeSystem/ResourceTypeGenerationFlags.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceTypeGenerationFlags.cs
@@ -27,8 +27,7 @@ namespace Bicep.Core.TypeSystem
         PermitLiteralNameProperty = 1 << 1,
 
         /// <summary>
-        /// Generating a definition for a resource that is nested inside another resource declaration. Do not use this flag for resources
-        /// using the "parent" property.
+        /// Generating a definition for a syntactically nested resource. Do not use this flag for resources that need the "parent" property.
         /// </summary>
         NestedResource = 1 << 2
     }


### PR DESCRIPTION
This fixes #2305. Existing tests already covered this but asserted the wrong behavior.