### PR TITLE
Show resource body completion snippet for DiscriminatedObjectType

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -349,6 +349,75 @@ var test2 = /|* block c|omment *|/
         }
 
         [TestMethod]
+        public async Task VerifyResourceBodyCompletionWithDiscriminatedObjectTypeContainsRequiredPropertiesSnippet()
+        {
+            string text = @"resource deploymentScripts 'Microsoft.Resources/deploymentScripts@2020-10-01'=";
+
+            var syntaxTree = SyntaxTree.Create(new Uri("file:///main.bicep"), text);
+            using var client = await IntegrationTestHelper.StartServerWithTextAsync(text, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
+
+            var completions = await client.RequestCompletion(new CompletionParams
+            {
+                TextDocument = new TextDocumentIdentifier(syntaxTree.FileUri),
+                Position = TextCoordinateConverter.GetPosition(syntaxTree.LineStarts, text.Length),
+            });
+
+            completions.Should().SatisfyRespectively(
+                c =>
+                {
+                    c.Label.Should().Be("{}");
+                },
+                c =>
+                {
+                    c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
+                    c.Label.Should().Be("required-properties-AzureCLI");
+                    c.Detail.Should().Be("Required properties");
+                    c.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
+	name: $1
+	location: $2
+	kind: $3
+	properties: {
+		azCliVersion: $4
+		retentionInterval: $5
+	}
+	$0
+}");
+                },
+                c =>
+                {
+                    c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
+                    c.Label.Should().Be("required-properties-AzurePowerShell");
+                    c.Detail.Should().Be("Required properties");
+                    c.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
+	name: $1
+	location: $2
+	kind: $3
+	properties: {
+		azPowerShellVersion: $4
+		retentionInterval: $5
+	}
+	$0
+}");
+                },
+                c =>
+                {
+                    c.Label.Should().Be("if");
+                },
+                c =>
+                {
+                    c.Label.Should().Be("for");
+                },
+                c =>
+                {
+                    c.Label.Should().Be("for-indexed");
+                },
+                c =>
+                {
+                    c.Label.Should().Be("for-filtered");
+                });
+        }
+
+        [TestMethod]
         public async Task Property_completions_include_descriptions()
         {
             var (file, cursors) = ParserHelper.GetFileWithCursors(@"

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -352,7 +352,6 @@ var test2 = /|* block c|omment *|/
         public async Task VerifyResourceBodyCompletionWithDiscriminatedObjectTypeContainsRequiredPropertiesSnippet()
         {
             string text = @"resource deploymentScripts 'Microsoft.Resources/deploymentScripts@2020-10-01'=";
-
             var syntaxTree = SyntaxTree.Create(new Uri("file:///main.bicep"), text);
             using var client = await IntegrationTestHelper.StartServerWithTextAsync(text, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
 
@@ -385,7 +384,7 @@ var test2 = /|* block c|omment *|/
                 },
                 c =>
                 {
-                    c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
+
                     c.Label.Should().Be("required-properties-AzurePowerShell");
                     c.Detail.Should().Be("Required properties");
                     c.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -318,6 +318,96 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                 });
         }
 
+        [TestMethod]
+        public void GetResourceBodyCompletionSnippets_WithDiscriminatedObjectTypeAndNoRequiredProperties_ShouldReturnEmptySnippet()
+        {
+            SnippetsProvider snippetsProvider = new SnippetsProvider();
+
+            var objectTypeA = new ObjectType("objA", TypeSymbolValidationFlags.Default, new[]
+            {
+                new TypeProperty("discKey", new StringLiteralType("keyA")),
+                new TypeProperty("keyAProp", LanguageConstants.String),
+            }, null);
+
+            var objectTypeB = new ObjectType("objB", TypeSymbolValidationFlags.Default, new[]
+            {
+                new TypeProperty("discKey", new StringLiteralType("keyB")),
+                new TypeProperty("keyBProp", LanguageConstants.String),
+            }, null);
+
+            var discriminatedObjectType = new DiscriminatedObjectType("discObj", TypeSymbolValidationFlags.Default, "discKey", new[] { objectTypeA, objectTypeB });
+
+            TypeSymbol typeSymbol = new ResourceType(
+                    ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
+                    ResourceScope.ResourceGroup,
+                    discriminatedObjectType);
+
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false);
+
+            snippets.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Prefix.Should().Be("{}");
+                    x.Detail.Should().Be("{}");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().Be("{\n\t$0\n}");
+                });
+        }
+
+        [TestMethod]
+        public void GetResourceBodyCompletionSnippets_WithDiscriminatedObjectTypeAndRequiredProperties_ShouldReturnRequiredPropertiesSnippet()
+        {
+            SnippetsProvider snippetsProvider = new SnippetsProvider();
+
+            var objectTypeA = new ObjectType("objA", TypeSymbolValidationFlags.Default, new[]
+            {
+                new TypeProperty("discKey", new StringLiteralType("keyA")),
+                new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("location", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("id", LanguageConstants.String)
+            }, null);
+
+            var objectTypeB = new ObjectType("objB", TypeSymbolValidationFlags.Default, new[]
+            {
+                new TypeProperty("discKey", new StringLiteralType("keyB")),
+                new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("kind", LanguageConstants.String, TypePropertyFlags.ReadOnly),
+                new TypeProperty("hostPoolType", LanguageConstants.String)
+            }, null);
+
+            var discriminatedObjectType = new DiscriminatedObjectType("discObj", TypeSymbolValidationFlags.Default, "discKey", new[] { objectTypeA, objectTypeB });
+
+            TypeSymbol typeSymbol = new ResourceType(
+                    ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
+                    ResourceScope.ResourceGroup,
+                    discriminatedObjectType);
+
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false);
+
+            snippets.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Prefix.Should().Be("{}");
+                    x.Detail.Should().Be("{}");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().Be("{\n\t$0\n}");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("required-properties-keyA");
+                    x.Detail.Should().Be("Required properties");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().Be("{\n\tname: $1\r\n\tlocation: $2\r\n\t$0\n}");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("required-properties-keyB");
+                    x.Detail.Should().Be("Required properties");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().Be("{\n\tname: $1\r\n\t$0\n}");
+                });
+        }
+
         private static ObjectType CreateObjectType(string name, params (string name, ITypeReference type, TypePropertyFlags typePropertyFlags)[] properties)
             => new(
                 name,


### PR DESCRIPTION
We currently show resource body completion snippet when type reference is ObjectType. 

As a part of this PR made changes to show completion snippet for DiscriminatedObjectType.

![FixForIssue2627](https://user-images.githubusercontent.com/30270536/117853889-c737bc80-b23d-11eb-977d-3925263fc0ef.gif)
