### PR TITLE
Allowed implicit nulls values during value assignment in non-required non-readonly non-symbolic resource properties

### DIFF
--- a/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
@@ -54,14 +54,14 @@ resource myRes 'My.Rp/myType@2020-01-01' = {
             var customTypes = new [] {
                 TestTypeHelper.CreateCustomResourceType("My.Rp/myType", "2020-01-01", validationFlags,
                     new TypeProperty("readOnlyProp", LanguageConstants.String, TypePropertyFlags.ReadOnly),
-                    new TypeProperty("writeOnlyProp", LanguageConstants.String, TypePropertyFlags.WriteOnly),
+                    new TypeProperty("writeOnlyProp", LanguageConstants.String, TypePropertyFlags.WriteOnly | TypePropertyFlags.AllowImplicitNull),
                     new TypeProperty("requiredProp", LanguageConstants.String, TypePropertyFlags.Required),
                     new TypeProperty("additionalProps", new ObjectType(
                         "additionalProps",
                         validationFlags,
                         new [] {
                             new TypeProperty("propA", LanguageConstants.String, TypePropertyFlags.Required),
-                            new TypeProperty("propB", LanguageConstants.String),
+                            new TypeProperty("propB", LanguageConstants.String, TypePropertyFlags.AllowImplicitNull),
                         },
                         LanguageConstants.Int
                     )),
@@ -70,7 +70,7 @@ resource myRes 'My.Rp/myType@2020-01-01' = {
                         validationFlags, 
                         new [] {
                             new TypeProperty("readOnlyNestedProp", LanguageConstants.String, TypePropertyFlags.ReadOnly),
-                            new TypeProperty("writeOnlyNestedProp", LanguageConstants.String, TypePropertyFlags.WriteOnly),
+                            new TypeProperty("writeOnlyNestedProp", LanguageConstants.String, TypePropertyFlags.WriteOnly | TypePropertyFlags.AllowImplicitNull),
                             new TypeProperty("requiredNestedProp", LanguageConstants.String, TypePropertyFlags.Required),
                         },
                         null
@@ -104,12 +104,12 @@ output incorrectTypeOutput2 int = myRes.properties.nestedObj.readOnlyProp
             model.GetAllDiagnostics().Should().SatisfyRespectively(
                 x => x.Should().HaveCodeAndSeverity("BCP035", expectedDiagnosticLevel).And.HaveMessage("The specified \"object\" declaration is missing the following required properties: \"requiredProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP073", expectedDiagnosticLevel).And.HaveMessage("The property \"readOnlyProp\" is read-only. Expressions cannot be assigned to read-only properties."),
-                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyProp\" expected a value of type \"string\" but the provided value is of type \"int\"."),
+                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyProp\" expected a value of type \"null | string\" but the provided value is of type \"int\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP035", expectedDiagnosticLevel).And.HaveMessage("The specified \"object\" declaration is missing the following required properties: \"propA\"."),
-                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"propB\" expected a value of type \"string\" but the provided value is of type \"int\"."),
+                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"propB\" expected a value of type \"null | string\" but the provided value is of type \"int\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP035", expectedDiagnosticLevel).And.HaveMessage("The specified \"object\" declaration is missing the following required properties: \"requiredNestedProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP073", expectedDiagnosticLevel).And.HaveMessage("The property \"readOnlyNestedProp\" is read-only. Expressions cannot be assigned to read-only properties."),
-                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyNestedProp\" expected a value of type \"string\" but the provided value is of type \"int\"."),
+                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyNestedProp\" expected a value of type \"null | string\" but the provided value is of type \"int\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP077", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyProp\" on type \"properties\" is write-only. Write-only properties cannot be accessed."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"nestedObj\" does not contain property \"writeOnlyProp\". Available properties include \"readOnlyNestedProp\", \"requiredNestedProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"properties\" does not contain property \"missingOutput\". Available properties include \"additionalProps\", \"nestedObj\", \"readOnlyProp\", \"requiredProp\"."),
@@ -126,16 +126,16 @@ output incorrectTypeOutput2 int = myRes.properties.nestedObj.readOnlyProp
         {
             var customTypes = new [] {
                 TestTypeHelper.CreateCustomResourceType("My.Rp/myType", "2020-01-01", validationFlags,
-                    new TypeProperty("stringOrInt", UnionType.Create(LanguageConstants.String, LanguageConstants.Int)),
-                    new TypeProperty("unspecifiedStringOrInt", UnionType.Create(LanguageConstants.String, LanguageConstants.Int)),
-                    new TypeProperty("abcOrDef", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def"))),
-                    new TypeProperty("unspecifiedAbcOrDef", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def")))),
+                    new TypeProperty("stringOrInt", UnionType.Create(LanguageConstants.String, LanguageConstants.Int), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("unspecifiedStringOrInt", UnionType.Create(LanguageConstants.String, LanguageConstants.Int), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("abcOrDef", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def")), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("unspecifiedAbcOrDef", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def")), TypePropertyFlags.AllowImplicitNull)),
                 TestTypeHelper.CreateCustomResourceType("My.Rp/myDependentType", "2020-01-01", validationFlags,
-                    new TypeProperty("stringOnly", LanguageConstants.String),
-                    new TypeProperty("abcOnly", new StringLiteralType("abc")),
-                    new TypeProperty("abcOnlyUnNarrowed", new StringLiteralType("abc")),
-                    new TypeProperty("stringOrIntUnNarrowed", UnionType.Create(LanguageConstants.String, LanguageConstants.Int)),
-                    new TypeProperty("abcOrDefUnNarrowed", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def"), new StringLiteralType("ghi")))),
+                    new TypeProperty("stringOnly", LanguageConstants.String, TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("abcOnly", new StringLiteralType("abc"), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("abcOnlyUnNarrowed", new StringLiteralType("abc"), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("stringOrIntUnNarrowed", UnionType.Create(LanguageConstants.String, LanguageConstants.Int), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("abcOrDefUnNarrowed", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def"), new StringLiteralType("ghi")), TypePropertyFlags.AllowImplicitNull)),
             };
             var program = @"
 resource myRes 'My.Rp/myType@2020-01-01' = {
@@ -160,7 +160,7 @@ resource myDependentRes 'My.Rp/myDependentType@2020-01-01' = {
 
             var model = GetSemanticModelForTest(program, customTypes);
             model.GetAllDiagnostics().Should().SatisfyRespectively(
-                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"abcOnlyUnNarrowed\" expected a value of type \"'abc'\" but the provided value is of type \"'abc' | 'def'\".")
+                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"abcOnlyUnNarrowed\" expected a value of type \"'abc' | null\" but the provided value is of type \"'abc' | 'def'\".")
             );
         }
 

--- a/src/Bicep.Core.Samples/Files/IntermediaryVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/IntermediaryVariables_LF/main.diagnostics.bicep
@@ -15,9 +15,9 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: 'vm'
   location: 'West US'
   properties: vmProperties
-//@[14:26) [BCP036 (Warning)] The property "enabled" expected a value of type "bool" but the provided value in source declaration "vmProperties" is of type "int". |vmProperties|
-//@[14:26) [BCP036 (Warning)] The property "evictionPolicy" expected a value of type "'Deallocate' | 'Delete'" but the provided value in source declaration "vmProperties" is of type "bool". |vmProperties|
-//@[14:26) [BCP036 (Warning)] The property "storageUri" expected a value of type "string" but the provided value in source declaration "vmProperties" is of type "bool". |vmProperties|
+//@[14:26) [BCP036 (Warning)] The property "enabled" expected a value of type "bool | null" but the provided value in source declaration "vmProperties" is of type "int". |vmProperties|
+//@[14:26) [BCP036 (Warning)] The property "evictionPolicy" expected a value of type "'Deallocate' | 'Delete' | null" but the provided value in source declaration "vmProperties" is of type "bool". |vmProperties|
+//@[14:26) [BCP036 (Warning)] The property "storageUri" expected a value of type "null | string" but the provided value in source declaration "vmProperties" is of type "bool". |vmProperties|
 //@[14:26) [BCP037 (Warning)] The property "unknownProp" from source declaration "vmProperties" is not allowed on objects of type "BootDiagnostics". No other properties are allowed. |vmProperties|
 }
 
@@ -34,9 +34,9 @@ resource nic 'Microsoft.Network/networkInterfaces@2020-11-01' = {
   name: 'abc'
   properties: {
     ipConfigurations: ipConfigurations
-//@[22:38) [BCP036 (Warning)] The property "id" expected a value of type "string" but the provided value in source declaration "ipConfigurations" is of type "bool". |ipConfigurations|
+//@[22:38) [BCP036 (Warning)] The property "id" expected a value of type "null | string" but the provided value in source declaration "ipConfigurations" is of type "bool". |ipConfigurations|
 //@[22:38) [BCP037 (Warning)] The property "madeUpProperty" from source declaration "ipConfigurations" is not allowed on objects of type "NetworkInterfaceIPConfigurationPropertiesFormat". Permissible properties include "applicationGatewayBackendAddressPools", "applicationSecurityGroups", "loadBalancerBackendAddressPools", "loadBalancerInboundNatRules", "primary", "privateIPAddress", "privateIPAddressVersion", "privateIPAllocationMethod", "publicIPAddress", "virtualNetworkTaps". |ipConfigurations|
-//@[22:38) [BCP036 (Warning)] The property "subnet" expected a value of type "Subnet" but the provided value in source declaration "ipConfigurations" is of type "'hello'". |ipConfigurations|
+//@[22:38) [BCP036 (Warning)] The property "subnet" expected a value of type "Subnet | null" but the provided value in source declaration "ipConfigurations" is of type "'hello'". |ipConfigurations|
   }
 }
 

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
@@ -42,7 +42,7 @@ resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
   properties: {
     supportsHttpsTrafficOnly: !false
     accessTier: true ? 'Hot' : 'Cold'
-//@[16:37) [BCP036 (Warning)] The property "accessTier" expected a value of type "'Cool' | 'Hot'" but the provided value is of type "'Cold' | 'Hot'". |true ? 'Hot' : 'Cold'|
+//@[16:37) [BCP036 (Warning)] The property "accessTier" expected a value of type "'Cool' | 'Hot' | null" but the provided value is of type "'Cold' | 'Hot'". |true ? 'Hot' : 'Cold'|
     encryption: {
       keySource: 'Microsoft.Storage'
       services: {

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
 using System.Linq;
@@ -61,6 +61,11 @@ namespace Bicep.Core.TypeSystem.Az
             if (input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.DeployTimeConstant))
             {
                 flags |= TypePropertyFlags.DeployTimeConstant;
+            }
+            if(!input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.Required) && !input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.ReadOnly))
+            {
+                // for non-required and non-readonly resource properties, we allow null assignment
+                flags |= TypePropertyFlags.AllowImplicitNull;
             }
 
             return flags;

--- a/src/Bicep.Core/TypeSystem/TypePropertyFlags.cs
+++ b/src/Bicep.Core/TypeSystem/TypePropertyFlags.cs
@@ -51,6 +51,12 @@ namespace Bicep.Core.TypeSystem
         /// The property must be loop-variant. In other words, the value of the property must change
         /// based on the value of the loop item or index variables. This flag has no effect outside of top-level properties.
         /// </summary>
-        LoopVariant = 1 << 7
+        LoopVariant = 1 << 7,
+
+        /// <summary>
+        /// On non-required properties, this allows the property type to be treated as "<x> | null" (where <x> is the current property type)
+        /// for the purposes of type checking the value assigned to the property.
+        /// </summary>
+        AllowImplicitNull = 1 << 8
     }
 }

--- a/src/Bicep.Decompiler.IntegrationTests/Working/101-1vm-2nics-2subnets-1vnet/azuredeploy.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/101-1vm-2nics-2subnets-1vnet/azuredeploy.bicep
@@ -41,7 +41,7 @@ resource virtualMachineName 'Microsoft.Compute/virtualMachines@2019-12-01' = {
       adminPassword: adminPassword
       windowsConfiguration: {
         provisionVMAgent: 'true'
-//@[26:32) [BCP036 (Warning)] The property "provisionVMAgent" expected a value of type "bool" but the provided value is of type "'true'". |'true'|
+//@[26:32) [BCP036 (Warning)] The property "provisionVMAgent" expected a value of type "bool | null" but the provided value is of type "'true'". |'true'|
       }
     }
     hardwareProfile: {

--- a/src/Bicep.Decompiler.IntegrationTests/Working/conditional/nested_deployFlowLogs.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/conditional/nested_deployFlowLogs.bicep
@@ -20,7 +20,7 @@ resource NetworkWatcherName_FlowLogName 'Microsoft.Network/networkWatchers/flowL
     format: {
       type: 'JSON'
       version: FlowLogsversion
-//@[15:30) [BCP036 (Warning)] The property "version" expected a value of type "int" but the provided value is of type "string". |FlowLogsversion|
+//@[15:30) [BCP036 (Warning)] The property "version" expected a value of type "int | null" but the provided value is of type "string". |FlowLogsversion|
     }
   }
 }

--- a/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/nested_deployFlowLogs.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/nested_deployFlowLogs.bicep
@@ -20,7 +20,7 @@ resource NetworkWatcherName_FlowLogName 'Microsoft.Network/networkWatchers/flowL
     format: {
       type: 'JSON'
       version: FlowLogsversion
-//@[15:30) [BCP036 (Warning)] The property "version" expected a value of type "int" but the provided value is of type "string". |FlowLogsversion|
+//@[15:30) [BCP036 (Warning)] The property "version" expected a value of type "int | null" but the provided value is of type "string". |FlowLogsversion|
     }
   }
 }


### PR DESCRIPTION
This fixes #449. This also fixes #1735.

Allowed implicit nulls values during value assignment in non-required non-readonly non-symbolic resource properties. This means that almost all optional properties that make up a resource body will accept a `null` value directly or as part of a union type that arises in ternary expressions. This unblocks certain conditional scenarios but may cause runtime errors with RPs that don't allow `null` values.

The behavior of "symbolic" properties like `dependsOn`, `parent`, or `scope` is not changing in this PR. If there's a need, we can revisit.

The types of properties are not changing when "reading" (aka property access).