### PR TITLE
Block completions in locations where inserting nodes makes no sense (Part I)

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
@@ -63,10 +63,11 @@ var bad = --33
 //@[4:7)  IdentifierSyntax
 //@[4:7)   Identifier |bad|
 //@[8:9)  Assignment |=|
-//@[10:14)  SkippedTriviaSyntax
+//@[10:14)  UnaryOperationSyntax
 //@[10:11)   Minus |-|
-//@[11:12)   Minus |-|
-//@[12:14)   Integer |33|
+//@[11:14)   SkippedTriviaSyntax
+//@[11:12)    Minus |-|
+//@[12:14)    Integer |33|
 //@[14:15) NewLine |\n|
 var bad = 3 * 4 /
 //@[0:17) VariableDeclarationSyntax
@@ -142,8 +143,9 @@ var bad = (null) ? !
 //@[11:15)     NullKeyword |null|
 //@[15:16)    RightParen |)|
 //@[17:18)   Question |?|
-//@[19:20)   SkippedTriviaSyntax
+//@[19:20)   UnaryOperationSyntax
 //@[19:20)    Exclamation |!|
+//@[20:20)    SkippedTriviaSyntax
 //@[20:20)   SkippedTriviaSyntax
 //@[20:20)   SkippedTriviaSyntax
 //@[20:21) NewLine |\n|
@@ -287,15 +289,16 @@ var not = !!!!!!!true
 //@[4:7)  IdentifierSyntax
 //@[4:7)   Identifier |not|
 //@[8:9)  Assignment |=|
-//@[10:21)  SkippedTriviaSyntax
+//@[10:21)  UnaryOperationSyntax
 //@[10:11)   Exclamation |!|
-//@[11:12)   Exclamation |!|
-//@[12:13)   Exclamation |!|
-//@[13:14)   Exclamation |!|
-//@[14:15)   Exclamation |!|
-//@[15:16)   Exclamation |!|
-//@[16:17)   Exclamation |!|
-//@[17:21)   TrueKeyword |true|
+//@[11:21)   SkippedTriviaSyntax
+//@[11:12)    Exclamation |!|
+//@[12:13)    Exclamation |!|
+//@[13:14)    Exclamation |!|
+//@[14:15)    Exclamation |!|
+//@[15:16)    Exclamation |!|
+//@[16:17)    Exclamation |!|
+//@[17:21)    TrueKeyword |true|
 //@[21:23) NewLine |\n\n|
 
 // unary minus chaining will not be supported (to reserve -- in case we need it)
@@ -306,14 +309,15 @@ var minus = ------12
 //@[4:9)  IdentifierSyntax
 //@[4:9)   Identifier |minus|
 //@[10:11)  Assignment |=|
-//@[12:20)  SkippedTriviaSyntax
+//@[12:20)  UnaryOperationSyntax
 //@[12:13)   Minus |-|
-//@[13:14)   Minus |-|
-//@[14:15)   Minus |-|
-//@[15:16)   Minus |-|
-//@[16:17)   Minus |-|
-//@[17:18)   Minus |-|
-//@[18:20)   Integer |12|
+//@[13:20)   SkippedTriviaSyntax
+//@[13:14)    Minus |-|
+//@[14:15)    Minus |-|
+//@[15:16)    Minus |-|
+//@[16:17)    Minus |-|
+//@[17:18)    Minus |-|
+//@[18:20)    Integer |12|
 //@[20:22) NewLine |\n\n|
 
 // unary minus

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
@@ -406,7 +406,7 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
   name: 'hello-${x}'
   params: {
     // #completionTest(0,1,2) -> moduleAParams
-
+  
   }
 }]
 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
@@ -554,7 +554,7 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
   params: {
 //@[2:8) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "arrayParam", "objParam", "stringParamB". |params|
     // #completionTest(0,1,2) -> moduleAParams
-
+  
   }
 }]
 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
@@ -553,11 +553,11 @@ module wrongModuleParameterInLoop2 'modulea.bicep' = [for (x,i) in emptyArray:{
 module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in emptyArray: if(true) {
 //@[67:68) Local x. Type: any. Declaration start char: 67, length: 1
 //@[69:70) Local i. Type: int. Declaration start char: 69, length: 1
-//@[7:42) Module paramNameCompletionsInFilteredLoops. Type: module[]. Declaration start char: 0, length: 185
+//@[7:42) Module paramNameCompletionsInFilteredLoops. Type: module[]. Declaration start char: 0, length: 187
   name: 'hello-${x}'
   params: {
     // #completionTest(0,1,2) -> moduleAParams
-
+  
   }
 }]
 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
@@ -2958,14 +2958,14 @@ module wrongModuleParameterInLoop2 'modulea.bicep' = [for (x,i) in emptyArray:{
 //@[2:4) NewLine |\n\n|
 
 module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in emptyArray: if(true) {
-//@[0:185) ModuleDeclarationSyntax
+//@[0:187) ModuleDeclarationSyntax
 //@[0:6)  Identifier |module|
 //@[7:42)  IdentifierSyntax
 //@[7:42)   Identifier |paramNameCompletionsInFilteredLoops|
 //@[43:58)  StringSyntax
 //@[43:58)   StringComplete |'modulea.bicep'|
 //@[59:60)  Assignment |=|
-//@[61:185)  ForSyntax
+//@[61:187)  ForSyntax
 //@[61:62)   LeftSquare |[|
 //@[62:65)   Identifier |for|
 //@[66:71)   ForVariableBlockSyntax
@@ -2983,14 +2983,14 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
 //@[75:85)    IdentifierSyntax
 //@[75:85)     Identifier |emptyArray|
 //@[85:86)   Colon |:|
-//@[87:184)   IfConditionSyntax
+//@[87:186)   IfConditionSyntax
 //@[87:89)    Identifier |if|
 //@[89:95)    ParenthesizedExpressionSyntax
 //@[89:90)     LeftParen |(|
 //@[90:94)     BooleanLiteralSyntax
 //@[90:94)      TrueKeyword |true|
 //@[94:95)     RightParen |)|
-//@[96:184)    ObjectSyntax
+//@[96:186)    ObjectSyntax
 //@[96:97)     LeftBrace |{|
 //@[97:98)     NewLine |\n|
   name: 'hello-${x}'
@@ -3006,16 +3006,17 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
 //@[18:20)       StringRightPiece |}'|
 //@[20:21)     NewLine |\n|
   params: {
-//@[2:63)     ObjectPropertySyntax
+//@[2:65)     ObjectPropertySyntax
 //@[2:8)      IdentifierSyntax
 //@[2:8)       Identifier |params|
 //@[8:9)      Colon |:|
-//@[10:63)      ObjectSyntax
+//@[10:65)      ObjectSyntax
 //@[10:11)       LeftBrace |{|
 //@[11:12)       NewLine |\n|
     // #completionTest(0,1,2) -> moduleAParams
-//@[46:48)       NewLine |\n\n|
-
+//@[46:47)       NewLine |\n|
+  
+//@[2:3)       NewLine |\n|
   }
 //@[2:3)       RightBrace |}|
 //@[3:4)     NewLine |\n|

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
@@ -1926,8 +1926,9 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
 //@[10:11) LeftBrace |{|
 //@[11:12) NewLine |\n|
     // #completionTest(0,1,2) -> moduleAParams
-//@[46:48) NewLine |\n\n|
-
+//@[46:47) NewLine |\n|
+  
+//@[2:3) NewLine |\n|
   }
 //@[2:3) RightBrace |}|
 //@[3:4) NewLine |\n|

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
@@ -164,7 +164,7 @@ param wrongMetadataSchemaWithDecorator string
 
 // expression in modifier
 param expressionInModifier string {
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
   minLength: foo()

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
@@ -277,8 +277,8 @@ param wrongMetadataSchemaWithDecorator string
 
 // expression in modifier
 param expressionInModifier string {
-//@[34:179) [BCP161 (Info)] Parameter modifiers are deprecated and will be removed in a future release. Use decorators instead (see https://aka.ms/BicepSpecParams for examples). |{\n  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions\n  default: 2 + 3\n  maxLength: a + 2\n  minLength: foo()\n  allowed: [\n    i\n  ]\n}|
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+//@[34:176) [BCP161 (Info)] Parameter modifiers are deprecated and will be removed in a future release. Use decorators instead (see https://aka.ms/BicepSpecParams for examples). |{\n  // #completionTest(10) -> symbolsPlusParamDefaultFunctions\n  default: 2 + 3\n  maxLength: a + 2\n  minLength: foo()\n  allowed: [\n    i\n  ]\n}|
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
 //@[13:14) [BCP057 (Error)] The name "a" does not exist in the current context. |a|

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
@@ -160,7 +160,7 @@ param wrongMetadataSchemaWithDecorator string
 
 // expression in modifier
 param expressionInModifier string {
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
   minLength: foo()

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
@@ -217,8 +217,8 @@ param wrongMetadataSchemaWithDecorator string
 
 // expression in modifier
 param expressionInModifier string {
-//@[6:26) Parameter expressionInModifier. Type: string. Declaration start char: 0, length: 179
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+//@[6:26) Parameter expressionInModifier. Type: string. Declaration start char: 0, length: 176
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
   minLength: foo()

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
@@ -1062,17 +1062,17 @@ param wrongMetadataSchemaWithDecorator string
 // expression in modifier
 //@[25:26) NewLine |\n|
 param expressionInModifier string {
-//@[0:179) ParameterDeclarationSyntax
+//@[0:176) ParameterDeclarationSyntax
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |expressionInModifier|
 //@[27:33)  TypeSyntax
 //@[27:33)   Identifier |string|
-//@[34:179)  ObjectSyntax
+//@[34:176)  ObjectSyntax
 //@[34:35)   LeftBrace |{|
 //@[35:36)   NewLine |\n|
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
-//@[63:64)   NewLine |\n|
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
+//@[60:61)   NewLine |\n|
   default: 2 + 3
 //@[2:16)   ObjectPropertySyntax
 //@[2:9)    IdentifierSyntax

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
@@ -687,8 +687,8 @@ param expressionInModifier string {
 //@[27:33) Identifier |string|
 //@[34:35) LeftBrace |{|
 //@[35:36) NewLine |\n|
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
-//@[63:64) NewLine |\n|
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
+//@[60:61) NewLine |\n|
   default: 2 + 3
 //@[2:9) Identifier |default|
 //@[9:10) Colon |:|

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
@@ -5395,5 +5395,19 @@
     "commitCharacters": [
       ":"
     ]
+  },
+  {
+    "label": "{}",
+    "kind": "value",
+    "detail": "{}",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "1_{}",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "{\n\t$0\n}"
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
@@ -126,56 +126,6 @@
     ]
   },
   {
-    "label": "resource",
-    "kind": "keyword",
-    "detail": "Resource keyword",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "resource"
-    }
-  },
-  {
-    "label": "resource",
-    "kind": "snippet",
-    "detail": "Nested resource with defaults",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
-    }
-  },
-  {
-    "label": "resource",
-    "kind": "snippet",
-    "detail": "Nested resource without defaults",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
-    }
-  },
-  {
     "label": "sku",
     "kind": "property",
     "detail": "sku (Required)",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -382,11 +382,11 @@ resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for oth
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
   // #completionTest(0, 1, 2) -> topLevelProperties
-
+  
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
   name: 'me'
   // do not remove whitespace before the closing curly
   // #completionTest(0, 1, 2) -> topLevelPropertiesMinusName
@@ -401,6 +401,8 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
     subnets: [
       {
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
+       
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
         properties: {
           delegations: [
             {
@@ -520,7 +522,7 @@ Discriminator value set 1
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -540,7 +542,7 @@ Discriminator value set 1 (conditional)
 resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -560,7 +562,7 @@ Discriminator value set 1 (loop)
 resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -580,7 +582,7 @@ Discriminator value set 1 (filtered loop)
 resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: if(true) {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -601,7 +603,7 @@ Discriminator value set 2
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -623,7 +625,7 @@ Discriminator value set 2 (conditional)
 resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -646,7 +648,7 @@ Discriminator value set 2 (loops)
 resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -669,7 +671,7 @@ Discriminator value set 2 (filtered loops)
 resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: if(true) {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -1167,12 +1169,12 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
   kind: 'StorageV2'
   properties: {
     // #completionTest(17) -> symbolsPlusAccount
-    networkAcls: {
+    networkAcls:  {
       virtualNetworkRules: [for rule in []: {
         // #completionTest(12,15,31) -> symbolsPlusRule
         id: '${account.name}-${account.location}'
         state: [for state in []: {
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
           fake: [for something in []: true]
         }]
       }]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -551,12 +551,12 @@ resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for oth
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
 //@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "kind", "location", "name", "sku". |missingTopLevelProperties|
   // #completionTest(0, 1, 2) -> topLevelProperties
-
+  
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
 //@[9:44) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "kind", "location", "sku". |missingTopLevelPropertiesExceptName|
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
   name: 'me'
   // do not remove whitespace before the closing curly
   // #completionTest(0, 1, 2) -> topLevelPropertiesMinusName
@@ -571,6 +571,8 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
     subnets: [
       {
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
+       
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
         properties: {
           delegations: [
             {
@@ -711,7 +713,7 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne|
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
@@ -736,7 +738,7 @@ resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne_if|
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
@@ -761,7 +763,7 @@ resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[9:35) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne_for|
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
@@ -786,7 +788,7 @@ resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[9:38) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne_for_if|
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
@@ -812,7 +814,7 @@ resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo|
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
@@ -840,7 +842,7 @@ resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo_if|
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
@@ -869,7 +871,7 @@ resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[9:35) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo_for|
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
@@ -898,7 +900,7 @@ resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[9:38) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo_for_if|
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
@@ -1553,13 +1555,13 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
   kind: 'StorageV2'
   properties: {
     // #completionTest(17) -> symbolsPlusAccount
-    networkAcls: {
+    networkAcls:  {
       virtualNetworkRules: [for rule in []: {
         // #completionTest(12,15,31) -> symbolsPlusRule
         id: '${account.name}-${account.location}'
         state: [for state in []: {
 //@[16:19) [BCP142 (Error)] Property value for-expressions cannot be nested. |for|
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
           fake: [for something in []: true]
 //@[17:20) [BCP142 (Error)] Property value for-expressions cannot be nested. |for|
         }]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
@@ -376,7 +376,7 @@ resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
   name: 'me'
   // do not remove whitespace before the closing curly
   // #completionTest(0, 1, 2) -> topLevelPropertiesMinusName
@@ -390,6 +390,8 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
     subnets: [
       {
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
+
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
         properties: {
           delegations: [
             {
@@ -1114,7 +1116,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
         // #completionTest(12,15,31) -> symbolsPlusRule
         id: '${account.name}-${account.location}'
         state: [for state in []: {
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
           fake: [for something in []: true]
         }]
       }]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -472,14 +472,14 @@ resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for oth
 }]
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-//@[9:34) Resource missingTopLevelProperties. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 151
+//@[9:34) Resource missingTopLevelProperties. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 153
   // #completionTest(0, 1, 2) -> topLevelProperties
-
+  
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-//@[9:44) Resource missingTopLevelPropertiesExceptName. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 358
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+//@[9:44) Resource missingTopLevelPropertiesExceptName. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 305
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
   name: 'me'
   // do not remove whitespace before the closing curly
   // #completionTest(0, 1, 2) -> topLevelPropertiesMinusName
@@ -488,13 +488,15 @@ resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@
 
 // #completionTest(24,25,26,49,65,69,70) -> virtualNetworksResourceTypes
 resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-//@[9:23) Resource unfinishedVnet. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 468
+//@[9:23) Resource unfinishedVnet. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 531
   name: 'v'
   location: 'eastus'
   properties: {
     subnets: [
       {
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
+       
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
         properties: {
           delegations: [
             {
@@ -638,10 +640,10 @@ var discriminatorKeyValueMissingCompletions3_for_if = discriminatorKeyValueMissi
 Discriminator value set 1
 */
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:31) Resource discriminatorKeySetOne. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 264
+//@[9:31) Resource discriminatorKeySetOne. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 266
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -662,10 +664,10 @@ var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 Discriminator value set 1 (conditional)
 */
 resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
-//@[9:34) Resource discriminatorKeySetOne_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 276
+//@[9:34) Resource discriminatorKeySetOne_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 278
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -687,10 +689,10 @@ Discriminator value set 1 (loop)
 */
 resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
 //@[95:100) Local thing. Type: any. Declaration start char: 95, length: 5
-//@[9:35) Resource discriminatorKeySetOne_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 288
+//@[9:35) Resource discriminatorKeySetOne_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 290
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -712,10 +714,10 @@ Discriminator value set 1 (filtered loop)
 */
 resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: if(true) {
 //@[98:103) Local thing. Type: any. Declaration start char: 98, length: 5
-//@[9:38) Resource discriminatorKeySetOne_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 300
+//@[9:38) Resource discriminatorKeySetOne_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 302
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -737,10 +739,10 @@ var discriminatorKeySetOneCompletions3_for_if = discriminatorKeySetOne_for_if[1]
 Discriminator value set 2
 */
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:31) Resource discriminatorKeySetTwo. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 270
+//@[9:31) Resource discriminatorKeySetTwo. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 272
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -764,10 +766,10 @@ var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['pro
 Discriminator value set 2 (conditional)
 */
 resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:34) Resource discriminatorKeySetTwo_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 273
+//@[9:34) Resource discriminatorKeySetTwo_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 275
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -793,10 +795,10 @@ Discriminator value set 2 (loops)
 */
 resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
 //@[94:99) Local thing. Type: any. Declaration start char: 94, length: 5
-//@[9:35) Resource discriminatorKeySetTwo_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 293
+//@[9:35) Resource discriminatorKeySetTwo_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 295
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -822,10 +824,10 @@ Discriminator value set 2 (filtered loops)
 */
 resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: if(true) {
 //@[97:102) Local thing. Type: any. Declaration start char: 97, length: 5
-//@[9:38) Resource discriminatorKeySetTwo_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 305
+//@[9:38) Resource discriminatorKeySetTwo_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 307
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -1493,7 +1495,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 // property loops cannot be nested (even more nesting)
 resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
 //@[88:95) Local account. Type: any. Declaration start char: 88, length: 7
-//@[9:33) Resource propertyLoopsCannotNest2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 720
+//@[9:33) Resource propertyLoopsCannotNest2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 687
   name: account.name
   location: account.location
   sku: {
@@ -1502,14 +1504,14 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
   kind: 'StorageV2'
   properties: {
     // #completionTest(17) -> symbolsPlusAccount
-    networkAcls: {
+    networkAcls:  {
       virtualNetworkRules: [for rule in []: {
 //@[32:36) Local rule. Type: any. Declaration start char: 32, length: 4
         // #completionTest(12,15,31) -> symbolsPlusRule
         id: '${account.name}-${account.location}'
         state: [for state in []: {
 //@[20:25) Local state. Type: any. Declaration start char: 20, length: 5
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
           fake: [for something in []: true]
 //@[21:30) Local something. Type: any. Declaration start char: 21, length: 9
         }]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -2912,36 +2912,37 @@ resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for oth
 //@[2:6) NewLine |\r\n\r\n|
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-//@[0:151) ResourceDeclarationSyntax
+//@[0:153) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:34)  IdentifierSyntax
 //@[9:34)   Identifier |missingTopLevelProperties|
 //@[35:89)  StringSyntax
 //@[35:89)   StringComplete |'Microsoft.Storage/storageAccounts@2020-08-01-preview'|
 //@[90:91)  Assignment |=|
-//@[92:151)  ObjectSyntax
+//@[92:153)  ObjectSyntax
 //@[92:93)   LeftBrace |{|
 //@[93:95)   NewLine |\r\n|
   // #completionTest(0, 1, 2) -> topLevelProperties
-//@[51:55)   NewLine |\r\n\r\n|
-
+//@[51:53)   NewLine |\r\n|
+  
+//@[2:4)   NewLine |\r\n|
 }
 //@[0:1)   RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-//@[0:358) ResourceDeclarationSyntax
+//@[0:305) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:44)  IdentifierSyntax
 //@[9:44)   Identifier |missingTopLevelPropertiesExceptName|
 //@[45:99)  StringSyntax
 //@[45:99)   StringComplete |'Microsoft.Storage/storageAccounts@2020-08-01-preview'|
 //@[100:101)  Assignment |=|
-//@[102:358)  ObjectSyntax
+//@[102:305)  ObjectSyntax
 //@[102:103)   LeftBrace |{|
 //@[103:105)   NewLine |\r\n|
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
-//@[114:116)   NewLine |\r\n|
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+//@[61:63)   NewLine |\r\n|
   name: 'me'
 //@[2:12)   ObjectPropertySyntax
 //@[2:6)    IdentifierSyntax
@@ -2963,14 +2964,14 @@ resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@
 // #completionTest(24,25,26,49,65,69,70) -> virtualNetworksResourceTypes
 //@[72:74) NewLine |\r\n|
 resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-//@[0:468) ResourceDeclarationSyntax
+//@[0:531) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:23)  IdentifierSyntax
 //@[9:23)   Identifier |unfinishedVnet|
 //@[24:70)  StringSyntax
 //@[24:70)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
 //@[71:72)  Assignment |=|
-//@[73:468)  ObjectSyntax
+//@[73:531)  ObjectSyntax
 //@[73:74)   LeftBrace |{|
 //@[74:76)   NewLine |\r\n|
   name: 'v'
@@ -2990,28 +2991,32 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 //@[12:20)     StringComplete |'eastus'|
 //@[20:22)   NewLine |\r\n|
   properties: {
-//@[2:354)   ObjectPropertySyntax
+//@[2:417)   ObjectPropertySyntax
 //@[2:12)    IdentifierSyntax
 //@[2:12)     Identifier |properties|
 //@[12:13)    Colon |:|
-//@[14:354)    ObjectSyntax
+//@[14:417)    ObjectSyntax
 //@[14:15)     LeftBrace |{|
 //@[15:17)     NewLine |\r\n|
     subnets: [
-//@[4:332)     ObjectPropertySyntax
+//@[4:395)     ObjectPropertySyntax
 //@[4:11)      IdentifierSyntax
 //@[4:11)       Identifier |subnets|
 //@[11:12)      Colon |:|
-//@[13:332)      ArraySyntax
+//@[13:395)      ArraySyntax
 //@[13:14)       LeftSquare |[|
 //@[14:16)       NewLine |\r\n|
       {
-//@[6:309)       ArrayItemSyntax
-//@[6:309)        ObjectSyntax
+//@[6:372)       ArrayItemSyntax
+//@[6:372)        ObjectSyntax
 //@[6:7)         LeftBrace |{|
 //@[7:9)         NewLine |\r\n|
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
 //@[78:80)         NewLine |\r\n|
+       
+//@[7:9)         NewLine |\r\n|
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
+//@[52:54)         NewLine |\r\n|
         properties: {
 //@[8:211)         ObjectPropertySyntax
 //@[8:18)          IdentifierSyntax
@@ -3606,14 +3611,14 @@ Discriminator value set 1
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[0:264) ResourceDeclarationSyntax
+//@[0:266) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:31)  IdentifierSyntax
 //@[9:31)   Identifier |discriminatorKeySetOne|
 //@[32:82)  StringSyntax
 //@[32:82)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[83:84)  Assignment |=|
-//@[85:264)  ObjectSyntax
+//@[85:266)  ObjectSyntax
 //@[85:86)   LeftBrace |{|
 //@[86:88)   NewLine |\r\n|
   kind: 'AzureCLI'
@@ -3625,8 +3630,9 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[8:18)     StringComplete |'AzureCLI'|
 //@[18:20)   NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)   NewLine |\r\n\r\n|
-
+//@[55:57)   NewLine |\r\n|
+  
+//@[2:4)   NewLine |\r\n|
   properties: {
 //@[2:94)   ObjectPropertySyntax
 //@[2:12)    IdentifierSyntax
@@ -3712,14 +3718,14 @@ Discriminator value set 1 (conditional)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
-//@[0:276) ResourceDeclarationSyntax
+//@[0:278) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:34)  IdentifierSyntax
 //@[9:34)   Identifier |discriminatorKeySetOne_if|
 //@[35:85)  StringSyntax
 //@[35:85)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[86:87)  Assignment |=|
-//@[88:276)  IfConditionSyntax
+//@[88:278)  IfConditionSyntax
 //@[88:90)   Identifier |if|
 //@[90:96)   ParenthesizedExpressionSyntax
 //@[90:91)    LeftParen |(|
@@ -3730,7 +3736,7 @@ resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[94:95)     IntegerLiteralSyntax
 //@[94:95)      Integer |3|
 //@[95:96)    RightParen |)|
-//@[97:276)   ObjectSyntax
+//@[97:278)   ObjectSyntax
 //@[97:98)    LeftBrace |{|
 //@[98:100)    NewLine |\r\n|
   kind: 'AzureCLI'
@@ -3742,8 +3748,9 @@ resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[8:18)      StringComplete |'AzureCLI'|
 //@[18:20)    NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)    NewLine |\r\n\r\n|
-
+//@[55:57)    NewLine |\r\n|
+  
+//@[2:4)    NewLine |\r\n|
   properties: {
 //@[2:94)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
@@ -3829,14 +3836,14 @@ Discriminator value set 1 (loop)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
-//@[0:288) ResourceDeclarationSyntax
+//@[0:290) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:35)  IdentifierSyntax
 //@[9:35)   Identifier |discriminatorKeySetOne_for|
 //@[36:86)  StringSyntax
 //@[36:86)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[87:88)  Assignment |=|
-//@[89:288)  ForSyntax
+//@[89:290)  ForSyntax
 //@[89:90)   LeftSquare |[|
 //@[91:94)   Identifier |for|
 //@[95:100)   LocalVariableSyntax
@@ -3847,7 +3854,7 @@ resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[104:105)    LeftSquare |[|
 //@[105:106)    RightSquare |]|
 //@[106:107)   Colon |:|
-//@[108:287)   ObjectSyntax
+//@[108:289)   ObjectSyntax
 //@[108:109)    LeftBrace |{|
 //@[109:111)    NewLine |\r\n|
   kind: 'AzureCLI'
@@ -3859,8 +3866,9 @@ resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[8:18)      StringComplete |'AzureCLI'|
 //@[18:20)    NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)    NewLine |\r\n\r\n|
-
+//@[55:57)    NewLine |\r\n|
+  
+//@[2:4)    NewLine |\r\n|
   properties: {
 //@[2:94)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
@@ -3968,14 +3976,14 @@ Discriminator value set 1 (filtered loop)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: if(true) {
-//@[0:300) ResourceDeclarationSyntax
+//@[0:302) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:38)  IdentifierSyntax
 //@[9:38)   Identifier |discriminatorKeySetOne_for_if|
 //@[39:89)  StringSyntax
 //@[39:89)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[90:91)  Assignment |=|
-//@[92:300)  ForSyntax
+//@[92:302)  ForSyntax
 //@[92:93)   LeftSquare |[|
 //@[94:97)   Identifier |for|
 //@[98:103)   LocalVariableSyntax
@@ -3986,14 +3994,14 @@ resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[107:108)    LeftSquare |[|
 //@[108:109)    RightSquare |]|
 //@[109:110)   Colon |:|
-//@[111:299)   IfConditionSyntax
+//@[111:301)   IfConditionSyntax
 //@[111:113)    Identifier |if|
 //@[113:119)    ParenthesizedExpressionSyntax
 //@[113:114)     LeftParen |(|
 //@[114:118)     BooleanLiteralSyntax
 //@[114:118)      TrueKeyword |true|
 //@[118:119)     RightParen |)|
-//@[120:299)    ObjectSyntax
+//@[120:301)    ObjectSyntax
 //@[120:121)     LeftBrace |{|
 //@[121:123)     NewLine |\r\n|
   kind: 'AzureCLI'
@@ -4005,8 +4013,9 @@ resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[8:18)       StringComplete |'AzureCLI'|
 //@[18:20)     NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)     NewLine |\r\n\r\n|
-
+//@[55:57)     NewLine |\r\n|
+  
+//@[2:4)     NewLine |\r\n|
   properties: {
 //@[2:94)     ObjectPropertySyntax
 //@[2:12)      IdentifierSyntax
@@ -4115,14 +4124,14 @@ Discriminator value set 2
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[0:270) ResourceDeclarationSyntax
+//@[0:272) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:31)  IdentifierSyntax
 //@[9:31)   Identifier |discriminatorKeySetTwo|
 //@[32:82)  StringSyntax
 //@[32:82)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[83:84)  Assignment |=|
-//@[85:270)  ObjectSyntax
+//@[85:272)  ObjectSyntax
 //@[85:86)   LeftBrace |{|
 //@[86:88)   NewLine |\r\n|
   kind: 'AzurePowerShell'
@@ -4134,8 +4143,9 @@ resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[8:25)     StringComplete |'AzurePowerShell'|
 //@[25:27)   NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)   NewLine |\r\n\r\n|
-
+//@[55:57)   NewLine |\r\n|
+  
+//@[2:4)   NewLine |\r\n|
   properties: {
 //@[2:93)   ObjectPropertySyntax
 //@[2:12)    IdentifierSyntax
@@ -4243,14 +4253,14 @@ Discriminator value set 2 (conditional)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[0:273) ResourceDeclarationSyntax
+//@[0:275) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:34)  IdentifierSyntax
 //@[9:34)   Identifier |discriminatorKeySetTwo_if|
 //@[35:85)  StringSyntax
 //@[35:85)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[86:87)  Assignment |=|
-//@[88:273)  ObjectSyntax
+//@[88:275)  ObjectSyntax
 //@[88:89)   LeftBrace |{|
 //@[89:91)   NewLine |\r\n|
   kind: 'AzurePowerShell'
@@ -4262,8 +4272,9 @@ resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[8:25)     StringComplete |'AzurePowerShell'|
 //@[25:27)   NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)   NewLine |\r\n\r\n|
-
+//@[55:57)   NewLine |\r\n|
+  
+//@[2:4)   NewLine |\r\n|
   properties: {
 //@[2:93)   ObjectPropertySyntax
 //@[2:12)    IdentifierSyntax
@@ -4372,14 +4383,14 @@ Discriminator value set 2 (loops)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
-//@[0:293) ResourceDeclarationSyntax
+//@[0:295) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:35)  IdentifierSyntax
 //@[9:35)   Identifier |discriminatorKeySetTwo_for|
 //@[36:86)  StringSyntax
 //@[36:86)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[87:88)  Assignment |=|
-//@[89:293)  ForSyntax
+//@[89:295)  ForSyntax
 //@[89:90)   LeftSquare |[|
 //@[90:93)   Identifier |for|
 //@[94:99)   LocalVariableSyntax
@@ -4390,7 +4401,7 @@ resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[103:104)    LeftSquare |[|
 //@[104:105)    RightSquare |]|
 //@[105:106)   Colon |:|
-//@[107:292)   ObjectSyntax
+//@[107:294)   ObjectSyntax
 //@[107:108)    LeftBrace |{|
 //@[108:110)    NewLine |\r\n|
   kind: 'AzurePowerShell'
@@ -4402,8 +4413,9 @@ resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[8:25)      StringComplete |'AzurePowerShell'|
 //@[25:27)    NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)    NewLine |\r\n\r\n|
-
+//@[55:57)    NewLine |\r\n|
+  
+//@[2:4)    NewLine |\r\n|
   properties: {
 //@[2:93)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
@@ -4533,14 +4545,14 @@ Discriminator value set 2 (filtered loops)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: if(true) {
-//@[0:305) ResourceDeclarationSyntax
+//@[0:307) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:38)  IdentifierSyntax
 //@[9:38)   Identifier |discriminatorKeySetTwo_for_if|
 //@[39:89)  StringSyntax
 //@[39:89)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[90:91)  Assignment |=|
-//@[92:305)  ForSyntax
+//@[92:307)  ForSyntax
 //@[92:93)   LeftSquare |[|
 //@[93:96)   Identifier |for|
 //@[97:102)   LocalVariableSyntax
@@ -4551,14 +4563,14 @@ resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[106:107)    LeftSquare |[|
 //@[107:108)    RightSquare |]|
 //@[108:109)   Colon |:|
-//@[110:304)   IfConditionSyntax
+//@[110:306)   IfConditionSyntax
 //@[110:112)    Identifier |if|
 //@[112:118)    ParenthesizedExpressionSyntax
 //@[112:113)     LeftParen |(|
 //@[113:117)     BooleanLiteralSyntax
 //@[113:117)      TrueKeyword |true|
 //@[117:118)     RightParen |)|
-//@[119:304)    ObjectSyntax
+//@[119:306)    ObjectSyntax
 //@[119:120)     LeftBrace |{|
 //@[120:122)     NewLine |\r\n|
   kind: 'AzurePowerShell'
@@ -4570,8 +4582,9 @@ resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[8:25)       StringComplete |'AzurePowerShell'|
 //@[25:27)     NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)     NewLine |\r\n\r\n|
-
+//@[55:57)     NewLine |\r\n|
+  
+//@[2:4)     NewLine |\r\n|
   properties: {
 //@[2:93)     ObjectPropertySyntax
 //@[2:12)      IdentifierSyntax
@@ -8498,14 +8511,14 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 // property loops cannot be nested (even more nesting)
 //@[54:56) NewLine |\r\n|
 resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
-//@[0:720) ResourceDeclarationSyntax
+//@[0:687) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:33)  IdentifierSyntax
 //@[9:33)   Identifier |propertyLoopsCannotNest2|
 //@[34:80)  StringSyntax
 //@[34:80)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
 //@[81:82)  Assignment |=|
-//@[83:720)  ForSyntax
+//@[83:687)  ForSyntax
 //@[83:84)   LeftSquare |[|
 //@[84:87)   Identifier |for|
 //@[88:95)   LocalVariableSyntax
@@ -8516,7 +8529,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[99:114)    IdentifierSyntax
 //@[99:114)     Identifier |storageAccounts|
 //@[114:115)   Colon |:|
-//@[116:719)   ObjectSyntax
+//@[116:686)   ObjectSyntax
 //@[116:117)    LeftBrace |{|
 //@[117:119)    NewLine |\r\n|
   name: account.name
@@ -8573,29 +8586,29 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[8:19)      StringComplete |'StorageV2'|
 //@[19:21)    NewLine |\r\n|
   properties: {
-//@[2:483)    ObjectPropertySyntax
+//@[2:450)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
 //@[2:12)      Identifier |properties|
 //@[12:13)     Colon |:|
-//@[14:483)     ObjectSyntax
+//@[14:450)     ObjectSyntax
 //@[14:15)      LeftBrace |{|
 //@[15:17)      NewLine |\r\n|
     // #completionTest(17) -> symbolsPlusAccount
 //@[48:50)      NewLine |\r\n|
-    networkAcls: {
-//@[4:411)      ObjectPropertySyntax
+    networkAcls:  {
+//@[4:378)      ObjectPropertySyntax
 //@[4:15)       IdentifierSyntax
 //@[4:15)        Identifier |networkAcls|
 //@[15:16)       Colon |:|
-//@[17:411)       ObjectSyntax
-//@[17:18)        LeftBrace |{|
-//@[18:20)        NewLine |\r\n|
+//@[18:378)       ObjectSyntax
+//@[18:19)        LeftBrace |{|
+//@[19:21)        NewLine |\r\n|
       virtualNetworkRules: [for rule in []: {
-//@[6:384)        ObjectPropertySyntax
+//@[6:350)        ObjectPropertySyntax
 //@[6:25)         IdentifierSyntax
 //@[6:25)          Identifier |virtualNetworkRules|
 //@[25:26)         Colon |:|
-//@[27:384)         ForSyntax
+//@[27:350)         ForSyntax
 //@[27:28)          LeftSquare |[|
 //@[28:31)          Identifier |for|
 //@[32:36)          LocalVariableSyntax
@@ -8606,7 +8619,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[40:41)           LeftSquare |[|
 //@[41:42)           RightSquare |]|
 //@[42:43)          Colon |:|
-//@[44:383)          ObjectSyntax
+//@[44:349)          ObjectSyntax
 //@[44:45)           LeftBrace |{|
 //@[45:47)           NewLine |\r\n|
         // #completionTest(12,15,31) -> symbolsPlusRule
@@ -8636,11 +8649,11 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[47:49)             StringRightPiece |}'|
 //@[49:51)           NewLine |\r\n|
         state: [for state in []: {
-//@[8:219)           ObjectPropertySyntax
+//@[8:185)           ObjectPropertySyntax
 //@[8:13)            IdentifierSyntax
 //@[8:13)             Identifier |state|
 //@[13:14)            Colon |:|
-//@[15:219)            ForSyntax
+//@[15:185)            ForSyntax
 //@[15:16)             LeftSquare |[|
 //@[16:19)             Identifier |for|
 //@[20:25)             LocalVariableSyntax
@@ -8651,11 +8664,11 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[29:30)              LeftSquare |[|
 //@[30:31)              RightSquare |]|
 //@[31:32)             Colon |:|
-//@[33:218)             ObjectSyntax
+//@[33:184)             ObjectSyntax
 //@[33:34)              LeftBrace |{|
 //@[34:36)              NewLine |\r\n|
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
-//@[126:128)              NewLine |\r\n|
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
+//@[92:94)              NewLine |\r\n|
           fake: [for something in []: true]
 //@[10:43)              ObjectPropertySyntax
 //@[10:14)               IdentifierSyntax

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -1862,8 +1862,9 @@ resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01
 //@[92:93) LeftBrace |{|
 //@[93:95) NewLine |\r\n|
   // #completionTest(0, 1, 2) -> topLevelProperties
-//@[51:55) NewLine |\r\n\r\n|
-
+//@[51:53) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
 }
 //@[0:1) RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
@@ -1875,8 +1876,8 @@ resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@
 //@[100:101) Assignment |=|
 //@[102:103) LeftBrace |{|
 //@[103:105) NewLine |\r\n|
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
-//@[114:116) NewLine |\r\n|
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+//@[61:63) NewLine |\r\n|
   name: 'me'
 //@[2:6) Identifier |name|
 //@[6:7) Colon |:|
@@ -1926,6 +1927,10 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 //@[7:9) NewLine |\r\n|
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
 //@[78:80) NewLine |\r\n|
+       
+//@[7:9) NewLine |\r\n|
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
+//@[52:54) NewLine |\r\n|
         properties: {
 //@[8:18) Identifier |properties|
 //@[18:19) Colon |:|
@@ -2352,8 +2357,9 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[8:18) StringComplete |'AzureCLI'|
 //@[18:20) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2429,8 +2435,9 @@ resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[8:18) StringComplete |'AzureCLI'|
 //@[18:20) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2507,8 +2514,9 @@ resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[8:18) StringComplete |'AzureCLI'|
 //@[18:20) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2602,8 +2610,9 @@ resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[8:18) StringComplete |'AzureCLI'|
 //@[18:20) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2687,8 +2696,9 @@ resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[8:25) StringComplete |'AzurePowerShell'|
 //@[25:27) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2771,8 +2781,9 @@ resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[8:25) StringComplete |'AzurePowerShell'|
 //@[25:27) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2863,8 +2874,9 @@ resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[8:25) StringComplete |'AzurePowerShell'|
 //@[25:27) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2972,8 +2984,9 @@ resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[8:25) StringComplete |'AzurePowerShell'|
 //@[25:27) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -5523,11 +5536,11 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[15:17) NewLine |\r\n|
     // #completionTest(17) -> symbolsPlusAccount
 //@[48:50) NewLine |\r\n|
-    networkAcls: {
+    networkAcls:  {
 //@[4:15) Identifier |networkAcls|
 //@[15:16) Colon |:|
-//@[17:18) LeftBrace |{|
-//@[18:20) NewLine |\r\n|
+//@[18:19) LeftBrace |{|
+//@[19:21) NewLine |\r\n|
       virtualNetworkRules: [for rule in []: {
 //@[6:25) Identifier |virtualNetworkRules|
 //@[25:26) Colon |:|
@@ -5567,8 +5580,8 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[31:32) Colon |:|
 //@[33:34) LeftBrace |{|
 //@[34:36) NewLine |\r\n|
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
-//@[126:128) NewLine |\r\n|
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
+//@[92:94) NewLine |\r\n|
           fake: [for something in []: true]
 //@[10:14) Identifier |fake|
 //@[14:15) Colon |:|

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.bicep
@@ -306,7 +306,9 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
   name: 'vnet-${i}'
   properties: {
     subnets: [for j in range(0, 4): {
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+     
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
   }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
@@ -322,7 +322,9 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
   name: 'vnet-${i}'
   properties: {
     subnets: [for j in range(0, 4): {
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+     
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
   }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.formatted.bicep
@@ -305,7 +305,9 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
   name: 'vnet-${i}'
   properties: {
     subnets: [for j in range(0, 4): {
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
   }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbols.bicep
@@ -351,12 +351,14 @@ resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01
 // basic nested loop
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
 //@[68:69) Local i. Type: int. Declaration start char: 68, length: 1
-//@[9:13) Resource vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 328
+//@[9:13) Resource vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 345
   name: 'vnet-${i}'
   properties: {
     subnets: [for j in range(0, 4): {
 //@[18:19) Local j. Type: int. Declaration start char: 18, length: 1
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+     
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
   }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.syntax.bicep
@@ -2216,14 +2216,14 @@ resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01
 // basic nested loop
 //@[20:22) NewLine |\r\n|
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[0:328) ResourceDeclarationSyntax
+//@[0:345) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:13)  IdentifierSyntax
 //@[9:13)   Identifier |vnet|
 //@[14:60)  StringSyntax
 //@[14:60)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
 //@[61:62)  Assignment |=|
-//@[63:328)  ForSyntax
+//@[63:345)  ForSyntax
 //@[63:64)   LeftSquare |[|
 //@[64:67)   Identifier |for|
 //@[68:69)   LocalVariableSyntax
@@ -2243,7 +2243,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 //@[82:83)      Integer |3|
 //@[83:84)    RightParen |)|
 //@[84:85)   Colon |:|
-//@[86:327)   ObjectSyntax
+//@[86:344)   ObjectSyntax
 //@[86:87)    LeftBrace |{|
 //@[87:89)    NewLine |\r\n|
   name: 'vnet-${i}'
@@ -2259,19 +2259,19 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 //@[17:19)      StringRightPiece |}'|
 //@[19:21)    NewLine |\r\n|
   properties: {
-//@[2:214)    ObjectPropertySyntax
+//@[2:231)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
 //@[2:12)      Identifier |properties|
 //@[12:13)     Colon |:|
-//@[14:214)     ObjectSyntax
+//@[14:231)     ObjectSyntax
 //@[14:15)      LeftBrace |{|
 //@[15:17)      NewLine |\r\n|
     subnets: [for j in range(0, 4): {
-//@[4:192)      ObjectPropertySyntax
+//@[4:209)      ObjectPropertySyntax
 //@[4:11)       IdentifierSyntax
 //@[4:11)        Identifier |subnets|
 //@[11:12)       Colon |:|
-//@[13:192)       ForSyntax
+//@[13:209)       ForSyntax
 //@[13:14)        LeftSquare |[|
 //@[14:17)        Identifier |for|
 //@[18:19)        LocalVariableSyntax
@@ -2291,11 +2291,15 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 //@[32:33)           Integer |4|
 //@[33:34)         RightParen |)|
 //@[34:35)        Colon |:|
-//@[36:191)        ObjectSyntax
+//@[36:208)        ObjectSyntax
 //@[36:37)         LeftBrace |{|
 //@[37:39)         NewLine |\r\n|
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
-//@[113:115)         NewLine |\r\n|
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+//@[62:64)         NewLine |\r\n|
+     
+//@[5:7)         NewLine |\r\n|
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
+//@[59:61)         NewLine |\r\n|
       name: 'subnet-${i}-${j}'
 //@[6:30)         ObjectPropertySyntax
 //@[6:10)          IdentifierSyntax

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.tokens.bicep
@@ -1465,8 +1465,12 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 //@[34:35) Colon |:|
 //@[36:37) LeftBrace |{|
 //@[37:39) NewLine |\r\n|
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
-//@[113:115) NewLine |\r\n|
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+//@[62:64) NewLine |\r\n|
+     
+//@[5:7) NewLine |\r\n|
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
+//@[59:61) NewLine |\r\n|
       name: 'subnet-${i}-${j}'
 //@[6:10) Identifier |name|
 //@[10:11) Colon |:|

--- a/src/Bicep.Core/Extensions/IPositionableExtensions.cs
+++ b/src/Bicep.Core/Extensions/IPositionableExtensions.cs
@@ -8,9 +8,18 @@ namespace Bicep.Core.Extensions
     public static class IPositionableExtensions
     {
         public static TextSpan ToZeroLengthSpan(this IPositionable positionable)
-            => new TextSpan(positionable.Span.Position, 0);
+            => new(positionable.Span.Position, 0);
+
+        public static int GetPosition(this IPositionable positionable)
+            => positionable.Span.Position;
 
         public static int GetEndPosition(this IPositionable positionable)
             => positionable.Span.Position + positionable.Span.Length;
+
+        public static bool IsOverlapping(this IPositionable positionable, int position)
+            => positionable.GetPosition() <= position && position <= positionable.GetEndPosition();
+
+        public static bool IsEnclosing(this IPositionable positionable, int position)
+            => positionable.GetPosition() < position && position < positionable.GetEndPosition();
     }
 }

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -452,7 +452,15 @@ namespace Bicep.Core.Parsing
             {
                 this.reader.Read();
 
-                var expression = this.MemberExpression(expressionFlags);
+                var expression = this.WithRecovery(
+                    () => this.MemberExpression(expressionFlags),
+                    RecoveryFlags.None,
+                    TokenType.StringRightPiece,
+                    TokenType.RightBrace,
+                    TokenType.RightParen,
+                    TokenType.RightSquare,
+                    TokenType.NewLine);
+
                 return new UnaryOperationSyntax(operatorToken, expression);
             }
 

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -540,13 +540,26 @@ resource myRes 'Test.Rp/readWriteTests@2020-01-01' = {|
         }
 
         [TestMethod]
+        public async Task RequestCompletionsInProgram_AtPositionsWhereNodeShouldNotBeInserted_ReturnsEmptyCompletions()
+        {
+            var fileWithCursors = @"
+|  var obj = {} |
+
+|  resource myRes 'Test.Rp/readWriteTests@2020-01-01' = {
+  name: 'myRes'
+}
+";
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+        }
+
+        [TestMethod]
         public async Task RequestCompletionsInObjects_AtPositionsWhereNodeShouldNotBeInserted_ReturnsEmptyCompletions()
         {
             var fileWithCursors = @"
 var obj1 = {|}
 var obj2 = {| }
-var obj3 = { |}
-var obj4 = { | }
+var obj3 = |{ |}
+var obj4 = { | }|
 var obj5 = {|
   | prop: true |
 |}
@@ -563,8 +576,8 @@ var obj6 = { |
             var fileWithCursors = @"
 var arr1 = [|]
 var arr2 = [| ]
-var arr3 = [ |]
-var arr4 = [ | ]
+var arr3 = [ |]|
+var arr4 = |[ | ]
 var arr5 = [|
   | null |
 |]

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -737,9 +737,11 @@ namespace Bicep.LanguageServer.Completions
             }
 
             var lastNodeBeforeOffset = programSyntax.Children.LastOrDefault(node => node.GetEndPosition() <= offset);
+            var firstNodeAfterOffset = programSyntax.Children.FirstOrDefault(node => node.GetPosition() >= offset);
 
-            // Ensure we are not after some node that is not a newline.
-            return lastNodeBeforeOffset is null or Token { Type: TokenType.NewLine };
+            // Ensure we are in between newlines.
+            return lastNodeBeforeOffset is null or Token { Type: TokenType.NewLine } &&
+                firstNodeAfterOffset is null or Token { Type: TokenType.NewLine };
         }
 
         private static bool CanInsertChildNodeAtOffset(ObjectSyntax objectSyntax, int offset)

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -114,12 +114,12 @@ namespace Bicep.LanguageServer.Completions
                        ConvertFlag(IsNestedResourceStartContext(matchingNodes, topLevelDeclarationInfo, objectInfo, offset), BicepCompletionContextKind.NestedResourceDeclarationStart) |
                        GetDeclarationTypeFlags(matchingNodes, offset) |
                        ConvertFlag(IsResourceTypeFollowerContext(matchingNodes, offset), BicepCompletionContextKind.ResourceTypeFollower) |
-                       GetObjectPropertyNameFlags(matchingNodes, objectInfo) |
+                       GetObjectPropertyNameFlags(matchingNodes, objectInfo, offset) |
                        ConvertFlag(IsMemberAccessContext(matchingNodes, propertyAccessInfo, offset), BicepCompletionContextKind.MemberAccess) |
                        ConvertFlag(IsResourceAccessContext(matchingNodes, resourceAccessInfo, offset), BicepCompletionContextKind.ResourceAccess) |
                        ConvertFlag(IsArrayIndexContext(matchingNodes, arrayAccessInfo), BicepCompletionContextKind.ArrayIndex | BicepCompletionContextKind.Expression) |
                        GetPropertyValueFlags(matchingNodes, propertyInfo, offset) |
-                       ConvertFlag(IsArrayItemContext(matchingNodes, arrayInfo), BicepCompletionContextKind.ArrayItem | BicepCompletionContextKind.Expression) |
+                       ConvertFlag(IsArrayItemContext(matchingNodes, arrayInfo, offset), BicepCompletionContextKind.ArrayItem | BicepCompletionContextKind.Expression) |
                        ConvertFlag(IsResourceBodyContext(matchingNodes, offset), BicepCompletionContextKind.ResourceBody) |
                        ConvertFlag(IsModuleBodyContext(matchingNodes, offset), BicepCompletionContextKind.ModuleBody) |
                        ConvertFlag(IsParameterDefaultValueContext(matchingNodes, offset), BicepCompletionContextKind.ParameterDefaultValue | BicepCompletionContextKind.Expression) |
@@ -254,13 +254,13 @@ namespace Bicep.LanguageServer.Completions
 
                 switch (node)
                 {
-                    case ProgramSyntax _:
+                    case ProgramSyntax programSyntax:
                         // the token at current position is inside a program node
                         // we're in a declaration if one of the following conditions is met:
                         // 1. the token is EOF
-                        // 2. the token is a newline
+                        // 2. the token is a newline and we can insert at the offset
                         return token.Type == TokenType.EndOfFile ||
-                               token.Type == TokenType.NewLine;
+                               (token.Type == TokenType.NewLine && CanInsertChildNodeAtOffset(programSyntax, offset));
 
                     case SkippedTriviaSyntax _ when matchingNodes.Count >= 3:
                         // we are in a line that has a partial declaration keyword (for example "resour" or "modu")
@@ -304,25 +304,17 @@ namespace Bicep.LanguageServer.Completions
 
             switch (matchingNodes[^1])
             {
-                case ObjectSyntax _:
+                case ObjectSyntax objectSyntax:
                     // we are somewhere in the trivia portion of the object node (trivia span is not included in the token span)
                     // which is why the last node in the list of matching nodes is not a Token.
-                    return true;
+                    return CanInsertChildNodeAtOffset(objectSyntax, offset);
 
                 case Token token:
                     int nodeCount = matchingNodes.Count - objectInfo.index;
 
-                    switch (nodeCount)
+                    if (nodeCount == 2 && token.Type == TokenType.NewLine && CanInsertChildNodeAtOffset((ObjectSyntax)matchingNodes[^2], offset))
                     {
-                        case 2 when token.Type == TokenType.NewLine:
-                            return true;
-
-                        case 4 when matchingNodes[^2] is IdentifierSyntax identifier && matchingNodes[^3] is ObjectPropertySyntax property && ReferenceEquals(property.Key, identifier):
-                            // we are in a partial or full property name
-                            return true;
-
-                        case 4 when matchingNodes[^2] is SkippedTriviaSyntax skipped && matchingNodes[^3] is ObjectPropertySyntax property && ReferenceEquals(property.Key, skipped):
-                            return true;
+                        return true;
                     }
 
                     break;
@@ -373,7 +365,7 @@ namespace Bicep.LanguageServer.Completions
                         (arrayAccess, @string, token) => token.Type == TokenType.StringComplete && ReferenceEquals(arrayAccess.IndexExpression, @string)));
         }
 
-        private static BicepCompletionContextKind GetObjectPropertyNameFlags(List<SyntaxBase> matchingNodes, (ObjectSyntax? node, int index) objectInfo)
+        private static BicepCompletionContextKind GetObjectPropertyNameFlags(List<SyntaxBase> matchingNodes, (ObjectSyntax? node, int index) objectInfo, int offset)
         {
             if (objectInfo.node == null)
             {
@@ -389,9 +381,11 @@ namespace Bicep.LanguageServer.Completions
             var isObjectProperty =
                 // we are somewhere in the trivia portion of the object node (trivia span is not included in the token span)
                 // which is why the last node in the list of matching nodes is not a Token.
-                SyntaxMatcher.IsTailMatch<ObjectSyntax>(matchingNodes, _ => true) ||
+                SyntaxMatcher.IsTailMatch<ObjectSyntax>(matchingNodes, objectSyntax => CanInsertChildNodeAtOffset(objectSyntax, offset)) ||
 
-                SyntaxMatcher.IsTailMatch<ObjectSyntax, Token>(matchingNodes, (_, token) => token.Type == TokenType.NewLine) ||
+                SyntaxMatcher.IsTailMatch<ObjectSyntax, Token>(
+                    matchingNodes,
+                    (objectSyntax, token) => token.Type == TokenType.NewLine && CanInsertChildNodeAtOffset(objectSyntax, offset)) ||
 
                 // we are in a partial or full property name
                 SyntaxMatcher.IsTailMatch<ObjectSyntax, ObjectPropertySyntax, IdentifierSyntax, Token>(
@@ -446,7 +440,7 @@ namespace Bicep.LanguageServer.Completions
             return BicepCompletionContextKind.None;
         }
 
-        private static bool IsArrayItemContext(List<SyntaxBase> matchingNodes, (ArraySyntax? node, int index) arrayInfo)
+        private static bool IsArrayItemContext(List<SyntaxBase> matchingNodes, (ArraySyntax? node, int index) arrayInfo, int offset)
         {
             if (arrayInfo.node == null)
             {
@@ -457,8 +451,8 @@ namespace Bicep.LanguageServer.Completions
 
             switch (matchingNodes[^1])
             {
-                case ArraySyntax _:
-                    return true;
+                case ArraySyntax arraySyntax:
+                    return CanInsertChildNodeAtOffset(arraySyntax, offset);
 
                 case Token token:
                     int nodeCount = matchingNodes.Count - arrayInfo.index;
@@ -466,7 +460,7 @@ namespace Bicep.LanguageServer.Completions
                     switch (nodeCount)
                     {
                         case 2:
-                            return token.Type == TokenType.NewLine;
+                            return token.Type == TokenType.NewLine && CanInsertChildNodeAtOffset((ArraySyntax)matchingNodes[^2], offset);
 
                         case 5:
                             return token.Type == TokenType.Identifier;
@@ -607,6 +601,27 @@ namespace Bicep.LanguageServer.Completions
         /// <param name="matchingNodes">The matching nodes</param>
         private static bool IsInnerExpressionContext(List<SyntaxBase> matchingNodes, int offset)
         {
+            if (!matchingNodes.OfType<ExpressionSyntax>().Any())
+            {
+                // Fail fast.
+                return false;
+            }
+
+            var isBooleanOrNumberOrNull = SyntaxMatcher.IsTailMatch<Token>(matchingNodes, token => token.Type switch
+            {
+                TokenType.TrueKeyword => true,
+                TokenType.FalseKeyword => true,
+                TokenType.Integer => true,
+                TokenType.NullKeyword => true,
+                _ => false,
+            });
+
+            if (isBooleanOrNumberOrNull)
+            {
+                // Don't provide completions for a boolean, number, or null literal because it may be confusing.
+                return false;
+            }
+
             var isInStringSegment = SyntaxMatcher.IsTailMatch<StringSyntax, Token>(matchingNodes, (_, token) => token.Type switch
             {
                 // The cursor is immediately after the { character: '...${|...}...'.
@@ -626,20 +641,73 @@ namespace Bicep.LanguageServer.Completions
                 return false;
             }
 
-            // var foo = {|
-            // resource res '...' = {|
-            var isImmediatelyAfterOpenBrace = SyntaxMatcher.IsTailMatch<Token>(matchingNodes, token => token.Type switch
-            {
-                TokenType.LeftBrace when IsOffsetImmediatlyAfterNode(offset, token) => true,
-                _ => false,
-            });
+            // It does not make sense to insert expressions at the cursor positions shown in the comments below.
+            return  !(
+                //║{              ║{             ║|{|           ║{            ║{
+                //║  foo: true |  ║ | foo: true  ║  foo: true   ║  foo: true  ║  |
+                //║}              ║}             ║}             ║|}|          ║}
+                SyntaxMatcher.IsTailMatch<ObjectSyntax>(matchingNodes) ||
+                SyntaxMatcher.IsTailMatch<ObjectSyntax, Token>(matchingNodes) ||
 
-            if (isImmediatelyAfterOpenBrace)
-            {
-                return false;
-            }
+                //║[         ║[        ║|[|      ║[
+                //║  true |  ║ | true  ║  true   ║  true
+                //║]         ║]        ║]        ║|]|
+                SyntaxMatcher.IsTailMatch<ArraySyntax>(matchingNodes) ||
+                SyntaxMatcher.IsTailMatch<ArraySyntax, Token>(
+                    matchingNodes,
+                    (arraySyntax, token) => token.Type != TokenType.NewLine || !CanInsertChildNodeAtOffset(arraySyntax, offset)) ||
 
-            return matchingNodes.OfType<ExpressionSyntax>().Any();
+                // var foo = ! | bar
+                SyntaxMatcher.IsTailMatch<UnaryOperationSyntax>(
+                    matchingNodes,
+                    unaryOperation => !unaryOperation.Expression.IsOverlapping(offset)) ||
+
+                // var foo = |!bar
+                // var foo = !| bar
+                SyntaxMatcher.IsTailMatch<UnaryOperationSyntax, Token>(
+                    matchingNodes,
+                    (unaryOperation, operatorToken) =>
+                        operatorToken.GetPosition() == offset ||
+                        (operatorToken.GetEndPosition() == offset && unaryOperation.Expression is not SkippedTriviaSyntax)) ||
+
+                // var foo = 1 | + ...
+                // var foo = 1 + | 2
+                SyntaxMatcher.IsTailMatch<BinaryOperationSyntax>(
+                    matchingNodes,
+                    binaryOperation =>
+                        !binaryOperation.LeftExpression.IsOverlapping(offset) &&
+                        !binaryOperation.RightExpression.IsOverlapping(offset)) ||
+
+                // var foo = 1 |+ ...
+                // var foo = 1 +| 2
+                SyntaxMatcher.IsTailMatch<BinaryOperationSyntax, Token>(
+                    matchingNodes,
+                    (binaryOperation, operatorToken) =>
+                        (operatorToken.GetPosition() == offset && binaryOperation.LeftExpression is not SkippedTriviaSyntax) ||
+                        (operatorToken.GetEndPosition() == offset && binaryOperation.RightExpression is not SkippedTriviaSyntax)) ||
+
+                // var foo = true | ? ...
+                // var foo = true ? | 'yes'
+                // var foo = true ? 'yes' | : ...
+                // var foo = true ? 'yes' : | 'no'
+                SyntaxMatcher.IsTailMatch<TernaryOperationSyntax>(
+                    matchingNodes,
+                    ternaryOperation =>
+                        !ternaryOperation.ConditionExpression.IsOverlapping(offset) &&
+                        !ternaryOperation.TrueExpression.IsOverlapping(offset) &&
+                        !ternaryOperation.FalseExpression.IsOverlapping(offset)) ||
+
+                // var foo = true |? ...
+                // var foo = true ?| 'yes'
+                // var foo = true ? 'yes' |: ...
+                // var foo = true ? 'yes' :| 'no'
+                SyntaxMatcher.IsTailMatch<TernaryOperationSyntax, Token>(
+                    matchingNodes,
+                    (ternaryOperation, operatorToken) =>
+                        (operatorToken.Type == TokenType.Question && operatorToken.GetPosition() == offset && ternaryOperation.ConditionExpression is not SkippedTriviaSyntax) ||
+                        (operatorToken.Type == TokenType.Question && operatorToken.GetEndPosition() == offset && ternaryOperation.TrueExpression is not SkippedTriviaSyntax) ||
+                        (operatorToken.Type == TokenType.Colon && operatorToken.GetPosition() == offset && ternaryOperation.TrueExpression is not SkippedTriviaSyntax) ||
+                        (operatorToken.Type == TokenType.Colon && operatorToken.GetEndPosition() == offset && ternaryOperation.FalseExpression is not SkippedTriviaSyntax)));
         }
         
         static bool IsOffsetImmediatlyAfterNode(int offset, SyntaxBase node) => node.Span.Position + node.Span.Length == offset;
@@ -656,6 +724,62 @@ namespace Bicep.LanguageServer.Completions
             // (non-replaceable tokens include colons, newlines, parens, etc.)
             // produce an insertion edit
             return new TextSpan(offset, 0).ToRange(syntaxTree.LineStarts);
+        }
+
+        private static bool CanInsertChildNodeAtOffset(ProgramSyntax programSyntax, int offset)
+        {
+            var enclosingNode = programSyntax.Children.FirstOrDefault(child => child.IsEnclosing(offset));
+
+            if (enclosingNode is Token { Type: TokenType.NewLine })
+            {
+                // /r/n|/r/n
+                return true;
+            }
+
+            var lastNodeBeforeOffset = programSyntax.Children.LastOrDefault(node => node.GetEndPosition() <= offset);
+
+            // Ensure we are not after some node that is not a newline.
+            return lastNodeBeforeOffset is null or Token { Type: TokenType.NewLine };
+        }
+
+        private static bool CanInsertChildNodeAtOffset(ObjectSyntax objectSyntax, int offset)
+        {
+            var enclosingNode = objectSyntax.Children.FirstOrDefault(child => child.IsEnclosing(offset));
+
+            if (enclosingNode is Token { Type: TokenType.NewLine })
+            {
+                // /r/n|/r/n
+                return true;
+            }
+
+            var nodes = objectSyntax.OpenBrace.AsEnumerable().Concat(objectSyntax.Children).Concat(objectSyntax.CloseBrace);
+            var lastNodeBeforeOffset = nodes.LastOrDefault(node => node.GetEndPosition() <= offset);
+            var firstNodeAfterOffset = nodes.FirstOrDefault(node => node.GetPosition() >= offset);
+
+            // To insert a new child in an object, we must be in between newlines.
+            // This will not be the case once https://github.com/Azure/bicep/issues/146 is implemented.
+            return lastNodeBeforeOffset is Token { Type: TokenType.NewLine } &&
+                firstNodeAfterOffset is Token { Type: TokenType.NewLine };
+        }
+
+        private static bool CanInsertChildNodeAtOffset(ArraySyntax arraySyntax, int offset)
+        {
+            var enclosingNode = arraySyntax.Children.FirstOrDefault(child => child.IsEnclosing(offset));
+
+            if (enclosingNode is Token { Type: TokenType.NewLine })
+            {
+                // /r/n|/r/n
+                return true;
+            }
+
+            var nodes = arraySyntax.OpenBracket.AsEnumerable().Concat(arraySyntax.Children).Concat(arraySyntax.CloseBracket);
+            var lastNodeBeforeOffset = nodes.LastOrDefault(node => node.GetEndPosition() <= offset);
+            var firstNodeAfterOffset = nodes.FirstOrDefault(node => node.GetPosition() >= offset);
+
+            // To insert a new child in an array, we must be in between newlines.
+            // This will not be the case once https://github.com/Azure/bicep/issues/146 is implemented.
+            return lastNodeBeforeOffset is Token { Type: TokenType.NewLine } &&
+                firstNodeAfterOffset is Token { Type: TokenType.NewLine };
         }
 
         private class ActiveScopesVisitor : SymbolVisitor


### PR DESCRIPTION
Fixes https://github.com/Azure/bicep/issues/2597 (Should not provide completions in single-line empty objects).
Fixes https://github.com/Azure/bicep/issues/1319 (VSCode Extension intellisense lists properties when using ternary operator).

In addition to the two issues, the PR also fixes many other edge cases that I found (see `BicepCompletionContext` for details).