### PR TITLE
"required-properties" for discriminated object types should fill in the discriminator value

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -356,10 +356,10 @@ var test2 = /|* block c|omment *|/
                     c.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
 	name: $1
 	location: $2
-	kind: $3
+	kind: 'AzureCLI'
 	properties: {
-		azCliVersion: $4
-		retentionInterval: $5
+		azCliVersion: $3
+		retentionInterval: $4
 	}
 	$0
 }");
@@ -372,10 +372,10 @@ var test2 = /|* block c|omment *|/
                     c.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
 	name: $1
 	location: $2
-	kind: $3
+	kind: 'AzurePowerShell'
 	properties: {
-		azPowerShellVersion: $4
-		retentionInterval: $5
+		azPowerShellVersion: $3
+		retentionInterval: $4
 	}
 	$0
 }");

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -362,7 +362,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
             var objectTypeA = new ObjectType("objA", TypeSymbolValidationFlags.Default, new[]
             {
                 new TypeProperty("discKey", new StringLiteralType("keyA")),
-                new TypeProperty("name", new StringLiteralType("value"), TypePropertyFlags.Required),
+                new TypeProperty("name", new StringLiteralType("keyA"), TypePropertyFlags.Required),
                 new TypeProperty("location", LanguageConstants.String, TypePropertyFlags.Required),
                 new TypeProperty("id", LanguageConstants.String)
             }, null);
@@ -371,7 +371,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
             {
                 new TypeProperty("discKey", new StringLiteralType("keyB")),
                 new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required),
-                new TypeProperty("kind", new StringLiteralType("value"), TypePropertyFlags.ReadOnly),
+                new TypeProperty("kind", new StringLiteralType("discKey"), TypePropertyFlags.ReadOnly),
                 new TypeProperty("hostPoolType", LanguageConstants.String)
             }, null);
 
@@ -398,7 +398,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     x.Detail.Should().Be("Required properties");
                     x.CompletionPriority.Should().Be(CompletionPriority.Medium);
                     x.Text.Should().BeEquivalentToIgnoringNewlines(@"{
-	name: 'value'
+	name: 'keyA'
 	location: $1
 	$0
 }");

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -362,7 +362,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
             var objectTypeA = new ObjectType("objA", TypeSymbolValidationFlags.Default, new[]
             {
                 new TypeProperty("discKey", new StringLiteralType("keyA")),
-                new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("name", new StringLiteralType("value"), TypePropertyFlags.Required),
                 new TypeProperty("location", LanguageConstants.String, TypePropertyFlags.Required),
                 new TypeProperty("id", LanguageConstants.String)
             }, null);
@@ -371,7 +371,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
             {
                 new TypeProperty("discKey", new StringLiteralType("keyB")),
                 new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required),
-                new TypeProperty("kind", LanguageConstants.String, TypePropertyFlags.ReadOnly),
+                new TypeProperty("kind", new StringLiteralType("value"), TypePropertyFlags.ReadOnly),
                 new TypeProperty("hostPoolType", LanguageConstants.String)
             }, null);
 
@@ -398,8 +398,8 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     x.Detail.Should().Be("Required properties");
                     x.CompletionPriority.Should().Be(CompletionPriority.Medium);
                     x.Text.Should().BeEquivalentToIgnoringNewlines(@"{
-	name: $1
-	location: $2
+	name: 'value'
+	location: $1
 	$0
 }");
                 },

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -338,19 +338,19 @@ namespace Bicep.LanguageServer.Snippets
                 else
                 {
                     string value = ": $" + (index).ToString();
-                    bool incrementIndex = true;
+                    bool shouldIncrementIndent = true;
 
                     if (discrimatedObjectKey is not null &&
                         typeProperty.TypeReference.Type is TypeSymbol typeSymbol &&
                         typeSymbol.Name == discrimatedObjectKey)
                     {
                         value = ": " + discrimatedObjectKey;
-                        incrementIndex = false;
+                        shouldIncrementIndent = false;
                     }
 
                     sb.AppendLine(GetIndentString(indentLevel) + typeProperty.Name + value);
 
-                    if (incrementIndex)
+                    if (shouldIncrementIndent)
                     {
                         index++;
                     }

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -336,8 +336,27 @@ namespace Bicep.LanguageServer.Snippets
                 }
                 else
                 {
-                    sb.AppendLine(GetIndentString(indentLevel) + typeProperty.Name + ": $" + (index).ToString());
-                    index++;
+                    string value = ": $" + (index).ToString();
+                    bool incrementIndex = true;
+                    TypeSymbol typeSymbol = typeProperty.TypeReference.Type;
+
+                    if (typeSymbol.TypeKind == TypeKind.StringLiteral)
+                    {
+                        string typeSymbolName = typeSymbol.Name;
+
+                        if (!string.IsNullOrWhiteSpace(typeSymbolName))
+                        {
+                            value = ": " + typeSymbolName;
+                            incrementIndex = false;
+                        }
+                    }
+
+                    sb.AppendLine(GetIndentString(indentLevel) + typeProperty.Name + value);
+
+                    if (incrementIndex)
+                    {
+                        index++;
+                    }
                 }
 
                 return sb.ToString();


### PR DESCRIPTION
"required-properties" for discriminated object types should fill in the discriminator value

Fixes #2672 

![FixFor5672](https://user-images.githubusercontent.com/30270536/118339885-0f214280-b4cf-11eb-894c-9fbdb7e2f6cc.gif)
