### PR TITLE
Use utf-8 encoding when output to console

### DIFF
--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 using System;
 using System.IO;
-using System.Linq;
 using Bicep.Cli.CommandLine;
 using Bicep.Cli.CommandLine.Arguments;
 using Bicep.Cli.Logging;
@@ -38,6 +37,8 @@ namespace Bicep.Cli
 
         public static int Main(string[] args)
         {
+            Console.OutputEncoding = TemplateEmitter.UTF8EncodingWithoutBom;
+
             BicepDeploymentsInterop.Initialize();
             var program = new Program(AzResourceTypeProvider.CreateWithAzTypes(), Console.Out, Console.Error, ThisAssembly.AssemblyFileVersion);
             return program.Run(args);

--- a/src/Bicep.Core/Emit/TemplateEmitter.cs
+++ b/src/Bicep.Core/Emit/TemplateEmitter.cs
@@ -15,11 +15,6 @@ namespace Bicep.Core.Emit
         private readonly SemanticModel model;
 
         /// <summary>
-        /// The JSON spec requires UTF8 without a BOM, so we use this encoding to write JSON files.
-        /// </summary>
-        private Encoding UTF8EncodingWithoutBom => new UTF8Encoding(false);
-
-        /// <summary>
         /// Assembly File Version to emit into the metadata
         /// </summary>
         private readonly string assemblyFileVersion;
@@ -29,6 +24,11 @@ namespace Bicep.Core.Emit
             this.model = model;
             this.assemblyFileVersion = assemblyFileVersion;
         }
+
+        /// <summary>
+        /// The JSON spec requires UTF8 without a BOM, so we use this encoding to write JSON files.
+        /// </summary>
+        public static Encoding UTF8EncodingWithoutBom { get; } = new UTF8Encoding(false);
 
         /// <summary>
         /// Emits a template to the specified stream if there are no errors. No writes are made to the stream if there are compilation errors.


### PR DESCRIPTION
Fixes #2682.
Fixes https://github.com/Azure/azure-cli/issues/18029.