### PR TITLE
Fix vscodeext-build task in root

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,7 +40,7 @@
         {
             "label": "vscodeext-build",
             "command": "npm",
-            "args": ["run", "compile", "--loglevel", "silent"],
+            "args": ["run", "build", "--loglevel", "silent"],
             "type": "shell",
             "problemMatcher": "$tsc-watch",
             "options": {


### PR DESCRIPTION
F5 in vscode from root of enlistment stopped working due to recent changes in the extension's package.json.