### PR TITLE
Api Management Instance Snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -168,6 +168,24 @@
     }
   },
   {
+    "label": "res-api-management-instance",
+    "kind": "snippet",
+    "detail": "Api Management Instance",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource apiManagementInstance 'Microsoft.ApiManagement/service@2020-12-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  sku:{\n    capacity: 0\n    name: 'Developer'\n  }\n  properties:{\n    virtualNetworkType: 'None'\n    publisherEmail: 'publisherEmail@contoso.com'\n    publisherName: 'publisherName'\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-api-management-instance",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:apiManagementInstance} 'Microsoft.ApiManagement/service@2020-12-01' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  sku:{\n    capacity: ${3|0,1|}\n    name: ${4|'Developer','Consumption'|}\n  }\n  properties:{\n    virtualNetworkType: ${5:'None'}\n    publisherEmail: ${6:'publisherEmail@contoso.com'}\n    publisherName: ${7:'publisherName'}\n  }\n}\n"
+    }
+  },
+  {
     "label": "res-app-plan",
     "kind": "snippet",
     "detail": "Application Service Plan (Server Farm)",

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-api-management-instance/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-api-management-instance/main.bicep
@@ -1,0 +1,9 @@
+﻿// $1 = apiManagementInstance
+// $2 = 'name'
+// $3 = 1
+// $4 = 'Developer'
+// $5 = 'None'
+// $6 = 'publisherEmail@contoso.com'
+// $7 = 'publisherName'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-api-management-instance/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-api-management-instance/main.combined.bicep
@@ -1,0 +1,14 @@
+resource apiManagementInstance 'Microsoft.ApiManagement/service@2020-12-01' = {
+  name: 'name'
+  location: resourceGroup().location
+  sku:{
+    capacity: 1
+    name: 'Developer'
+  }
+  properties:{
+    virtualNetworkType: 'None'
+    publisherEmail: 'publisherEmail@contoso.com'
+    publisherName: 'publisherName'
+  }
+}
+

--- a/src/Bicep.LangServer/Snippets/Templates/res-api-management-instance.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-api-management-instance.bicep
@@ -1,0 +1,14 @@
+// Api Management Instance
+resource ${1:apiManagementInstance} 'Microsoft.ApiManagement/service@2020-12-01' = {
+  name: ${2:'name'}
+  location: resourceGroup().location
+  sku:{
+    capacity: ${3|0,1|}
+    name: ${4|'Developer','Consumption'|}
+  }
+  properties:{
+    virtualNetworkType: ${5:'None'}
+    publisherEmail: ${6:'publisherEmail@contoso.com'}
+    publisherName: ${7:'publisherName'}
+  }
+}


### PR DESCRIPTION
Added a small snippet for an Api Management Instance

## Contributing a snippet

* [ x ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ x ] I have checked that there is not an equivalent snippet already submitted
* [ x ] I have used camelCasing unless I have a justification to use another casing style
* [ x ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ x ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ x ] I have a resource name property equal to "name"