### PR TITLE
Small Scope change in Diagnostic Settings (example WVD docs)

### DIFF
--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "dev",
-      "templateHash": "6314278475007582369"
+      "version": "0.3.539.46024",
+      "templateHash": "15677362214793058031"
     }
   },
   "parameters": {
@@ -63,11 +63,11 @@
     },
     "vnetaddressPrefix": {
       "type": "string",
-      "defaultValue": "10.0.0.0/15"
+      "defaultValue": "10.60.0.0/15"
     },
     "subnetPrefix": {
       "type": "string",
-      "defaultValue": "10.0.1.0/24"
+      "defaultValue": "10.60.1.0/24"
     },
     "vnetLocation": {
       "type": "string",
@@ -83,7 +83,7 @@
     },
     "storageaccountName": {
       "type": "string",
-      "defaultValue": "bicepsa"
+      "defaultValue": "bicepsasmb2132"
     },
     "storageaccountkind": {
       "type": "string",
@@ -96,6 +96,14 @@
     "fileshareFolderName": {
       "type": "string",
       "defaultValue": "profilecontainers"
+    },
+    "hubrg": {
+      "type": "string",
+      "defaultValue": "AzDemoSB-Identity-rg"
+    },
+    "hubvnet": {
+      "type": "string",
+      "defaultValue": "Identity-vnet"
     }
   },
   "functions": [],
@@ -184,8 +192,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "dev",
-              "templateHash": "15797586949599757778"
+              "version": "0.3.539.46024",
+              "templateHash": "5384349523331205440"
             }
           },
           "parameters": {
@@ -327,8 +335,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "dev",
-                      "templateHash": "8750382069822554676"
+                      "version": "0.3.539.46024",
+                      "templateHash": "5251152976212156215"
                     }
                   },
                   "parameters": {
@@ -396,8 +404,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "dev",
-                              "templateHash": "6360399044046989416"
+                              "version": "0.3.539.46024",
+                              "templateHash": "5005998212056445527"
                             }
                           },
                           "parameters": {
@@ -527,8 +535,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "dev",
-              "templateHash": "14974550603307173803"
+              "version": "0.3.539.46024",
+              "templateHash": "12530551007580652177"
             }
           },
           "parameters": {
@@ -624,8 +632,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "dev",
-              "templateHash": "10122142263707335383"
+              "version": "0.3.539.46024",
+              "templateHash": "18134788139474416411"
             }
           },
           "parameters": {
@@ -717,8 +725,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "dev",
-              "templateHash": "12847428002032474568"
+              "version": "0.3.539.46024",
+              "templateHash": "6388191910784356263"
             }
           },
           "parameters": {
@@ -817,6 +825,125 @@
       "dependsOn": [
         "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}NETWORK', parameters('resourceGroupPrefrix')))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}FILESERVICES', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'wvdFileServices')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}NETWORK', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'wvdnetwork')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "[format('{0}peerto{1}', 'wvdnetwork', parameters('hubvnet'))]",
+      "resourceGroup": "[format('{0}NETWORK', parameters('resourceGroupPrefrix'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "peeringnamefromwvdvnet": {
+            "value": "[format('{0}/{1}-to-{2}', parameters('vnetName'), parameters('vnetName'), parameters('hubvnet'))]"
+          },
+          "hubVnetID": {
+            "value": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('hubrg')), 'Microsoft.Network/virtualNetworks', parameters('hubvnet'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.3.539.46024",
+              "templateHash": "5852103765110730323"
+            }
+          },
+          "parameters": {
+            "hubVnetID": {
+              "type": "string"
+            },
+            "peeringnamefromwvdvnet": {
+              "type": "string"
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+              "apiVersion": "2020-05-01",
+              "name": "[parameters('peeringnamefromwvdvnet')]",
+              "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": false,
+                "allowGatewayTransit": false,
+                "useRemoteGateways": false,
+                "remoteVirtualNetwork": {
+                  "id": "[parameters('hubVnetID')]"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}NETWORK', parameters('resourceGroupPrefrix')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}NETWORK', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'wvdnetwork')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "[format('{0}peerto{1}', parameters('hubvnet'), 'wvdnetwork')]",
+      "resourceGroup": "[parameters('hubrg')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "peeringnamefromhubvnet": {
+            "value": "[format('{0}/{1}-to-{2}', parameters('hubvnet'), parameters('hubvnet'), parameters('vnetName'))]"
+          },
+          "wvdvnetID": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}NETWORK', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'wvdnetwork'), '2019-10-01').outputs.vnetId.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.3.539.46024",
+              "templateHash": "7169430765622565429"
+            }
+          },
+          "parameters": {
+            "wvdvnetID": {
+              "type": "string"
+            },
+            "peeringnamefromhubvnet": {
+              "type": "string"
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+              "apiVersion": "2020-05-01",
+              "name": "[parameters('peeringnamefromhubvnet')]",
+              "properties": {
+                "allowVirtualNetworkAccess": true,
+                "allowForwardedTraffic": false,
+                "allowGatewayTransit": false,
+                "useRemoteGateways": false,
+                "remoteVirtualNetwork": {
+                  "id": "[parameters('wvdvnetID')]"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}NETWORK', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'wvdnetwork')]"
       ]
     }

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16399487494121524783"
+      "templateHash": "6314278475007582369"
     }
   },
   "parameters": {
@@ -185,7 +185,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3767956074323682348"
+              "templateHash": "15797586949599757778"
             }
           },
           "parameters": {
@@ -328,7 +328,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "9997609816176615400"
+                      "templateHash": "8750382069822554676"
                     }
                   },
                   "parameters": {
@@ -397,7 +397,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "6082030172290952535"
+                              "templateHash": "6360399044046989416"
                             }
                           },
                           "parameters": {
@@ -447,7 +447,7 @@
                             {
                               "type": "microsoft.insights/diagnosticSettings",
                               "apiVersion": "2017-05-01-preview",
-                              "scope": "[format('Microsoft.DesktopVirtualization/hostPools/{0}', parameters('hostpoolName'))]",
+                              "scope": "[format('Microsoft.DesktopVirtualization/workspaces/{0}', parameters('workspaceName'))]",
                               "name": "workspacepool-diag",
                               "properties": {
                                 "workspaceId": "[parameters('logAnalyticsWorkspaceID')]",

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-LogAnalytics.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-LogAnalytics.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9997609816176615400"
+      "templateHash": "8750382069822554676"
     }
   },
   "parameters": {
@@ -74,7 +74,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6082030172290952535"
+              "templateHash": "6360399044046989416"
             }
           },
           "parameters": {
@@ -124,7 +124,7 @@
             {
               "type": "microsoft.insights/diagnosticSettings",
               "apiVersion": "2017-05-01-preview",
-              "scope": "[format('Microsoft.DesktopVirtualization/hostPools/{0}', parameters('hostpoolName'))]",
+              "scope": "[format('Microsoft.DesktopVirtualization/workspaces/{0}', parameters('workspaceName'))]",
               "name": "workspacepool-diag",
               "properties": {
                 "workspaceId": "[parameters('logAnalyticsWorkspaceID')]",

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-backplane-module.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-backplane-module.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3767956074323682348"
+      "templateHash": "15797586949599757778"
     }
   },
   "parameters": {
@@ -148,7 +148,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9997609816176615400"
+              "templateHash": "8750382069822554676"
             }
           },
           "parameters": {
@@ -217,7 +217,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "6082030172290952535"
+                      "templateHash": "6360399044046989416"
                     }
                   },
                   "parameters": {
@@ -267,7 +267,7 @@
                     {
                       "type": "microsoft.insights/diagnosticSettings",
                       "apiVersion": "2017-05-01-preview",
-                      "scope": "[format('Microsoft.DesktopVirtualization/hostPools/{0}', parameters('hostpoolName'))]",
+                      "scope": "[format('Microsoft.DesktopVirtualization/workspaces/{0}', parameters('workspaceName'))]",
                       "name": "workspacepool-diag",
                       "properties": {
                         "workspaceId": "[parameters('logAnalyticsWorkspaceID')]",

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-monitor-diag.bicep
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-monitor-diag.bicep
@@ -44,7 +44,7 @@ resource wvdhpds 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = {
 }
 
 resource wvdwsds 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = {
-  scope: hostPool
+  scope: workspace
 
   name: 'workspacepool-diag'
   properties: {

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-monitor-diag.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-monitor-diag.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6082030172290952535"
+      "templateHash": "6360399044046989416"
     }
   },
   "parameters": {
@@ -55,7 +55,7 @@
     {
       "type": "microsoft.insights/diagnosticSettings",
       "apiVersion": "2017-05-01-preview",
-      "scope": "[format('Microsoft.DesktopVirtualization/hostPools/{0}', parameters('hostpoolName'))]",
+      "scope": "[format('Microsoft.DesktopVirtualization/workspaces/{0}', parameters('workspaceName'))]",
       "name": "workspacepool-diag",
       "properties": {
         "workspaceId": "[parameters('logAnalyticsWorkspaceID')]",

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-peering-from-hub-to-vnet-module.bicep
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-peering-from-hub-to-vnet-module.bicep
@@ -1,0 +1,15 @@
+param wvdvnetID string
+param peeringnamefromhubvnet string
+
+resource hubpeer 'microsoft.network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  name: peeringnamefromhubvnet
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: false
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: wvdvnetID
+    }
+  }
+}

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-peering-from-vnet-to-hub-module.bicep
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-peering-from-vnet-to-hub-module.bicep
@@ -1,0 +1,15 @@
+param hubvnetid string
+param peeringnamefromwvdvnet string
+
+resource wvdpeer 'microsoft.network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  name: peeringnamefromwvdvnet
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: false
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: hubvnetid
+    }
+  }
+}


### PR DESCRIPTION
Changing scope from 'hostPool' to 'workspace' in 'Workspace' diag section to resolve deployment errors stating category 'Feed' does not exist when using scope hostPool.

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

* [ ] I have checked that there is not an equivalent example already submitted
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
