### PR TITLE
Fix mispelling of parameter

### DIFF
--- a/docs/examples/bicepconfig.json
+++ b/docs/examples/bicepconfig.json
@@ -43,7 +43,7 @@
         "prefer-interpolation": {
           "level": "warning"
         },
-        "secure-paramenter-default": {
+        "secure-parameter-default": {
           "level": "warning"
         },
         "simplify-interpolation": {

--- a/docs/linter-rules/secure-paramenter-default.md
+++ b/docs/linter-rules/secure-paramenter-default.md
@@ -1,6 +1,6 @@
-# Secure paramenter default
+# Secure parameter default
 
-**Code**: secure-paramenter-default
+**Code**: secure-parameter-default
 
 **Description**: Don't provide a hard-coded default value for a secure parameter in your template, unless it is empty or an expression containing a call to newGuid().
 

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
@@ -662,7 +662,7 @@ param someString string {
 //@[8:8) [BCP020 (Error)] Expected a function or property name at this location. ||
 param someInteger int = 20
 //@[6:17) [no-unused-params (Warning)] Declared parameter must be referenced within the document scope.\n[See : https://aka.ms/bicep/linter/no-unused-params] |someInteger|
-//@[22:26) [secure-paramenter-default (Warning)] Secure parameters can't have hardcoded default. This prevents storage of sensitive data in the Bicep declaration.\n[See : https://aka.ms/bicep/linter/secure-paramenter-default] |= 20|
+//@[22:26) [secure-parameter-default (Warning)] Secure parameters can't have hardcoded default. This prevents storage of sensitive data in the Bicep declaration.\n[See : https://aka.ms/bicep/linter/secure-parameter-default] |= 20|
 
 @allowed([], [], 2)
 //@[8:19) [BCP071 (Error)] Expected 1 argument, but got 3. |([], [], 2)|

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.diagnostics.bicep
@@ -316,7 +316,7 @@ param decoratedBool bool = (true && false) != true
 @secure()
 param decoratedObject object = {
 //@[6:21) [no-unused-params (Warning)] Declared parameter must be referenced within the document scope.\n[See : https://aka.ms/bicep/linter/no-unused-params] |decoratedObject|
-//@[29:265) [secure-paramenter-default (Warning)] Secure parameters can't have hardcoded default. This prevents storage of sensitive data in the Bicep declaration.\n[See : https://aka.ms/bicep/linter/secure-paramenter-default] |= {\r\n  enabled: true\r\n  name: 'this is my object'\r\n  priority: 3\r\n  info: {\r\n    a: 'b'\r\n  }\r\n  empty: {\r\n  }\r\n  array: [\r\n    'string item'\r\n    12\r\n    true\r\n    [\r\n      'inner'\r\n      false\r\n    ]\r\n    {\r\n      a: 'b'\r\n    }\r\n  ]\r\n}|
+//@[29:265) [secure-parameter-default (Warning)] Secure parameters can't have hardcoded default. This prevents storage of sensitive data in the Bicep declaration.\n[See : https://aka.ms/bicep/linter/secure-parameter-default] |= {\r\n  enabled: true\r\n  name: 'this is my object'\r\n  priority: 3\r\n  info: {\r\n    a: 'b'\r\n  }\r\n  empty: {\r\n  }\r\n  array: [\r\n    'string item'\r\n    12\r\n    true\r\n    [\r\n      'inner'\r\n      false\r\n    ]\r\n    {\r\n      a: 'b'\r\n    }\r\n  ]\r\n}|
   enabled: true
   name: 'this is my object'
   priority: 3

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.diagnostics.bicep
@@ -239,7 +239,7 @@ param someParameter string {
 })
 param someParameterWithDecorator string = 'one'
 //@[6:32) [no-unused-params (Warning)] Declared parameter must be referenced within the document scope.\n[See : https://aka.ms/bicep/linter/no-unused-params] |someParameterWithDecorator|
-//@[40:47) [secure-paramenter-default (Warning)] Secure parameters can't have hardcoded default. This prevents storage of sensitive data in the Bicep declaration.\n[See : https://aka.ms/bicep/linter/secure-paramenter-default] |= 'one'|
+//@[40:47) [secure-parameter-default (Warning)] Secure parameters can't have hardcoded default. This prevents storage of sensitive data in the Bicep declaration.\n[See : https://aka.ms/bicep/linter/secure-parameter-default] |= 'one'|
 
 param defaultValueExpression int {
 //@[6:28) [no-unused-params (Warning)] Declared parameter must be referenced within the document scope.\n[See : https://aka.ms/bicep/linter/no-unused-params] |defaultValueExpression|
@@ -300,7 +300,7 @@ param decoratedBool bool
 @secure()
 param decoratedObject object = {
 //@[6:21) [no-unused-params (Warning)] Declared parameter must be referenced within the document scope.\n[See : https://aka.ms/bicep/linter/no-unused-params] |decoratedObject|
-//@[29:55) [secure-paramenter-default (Warning)] Secure parameters can't have hardcoded default. This prevents storage of sensitive data in the Bicep declaration.\n[See : https://aka.ms/bicep/linter/secure-paramenter-default] |= {\n  location: 'westus'\n}|
+//@[29:55) [secure-parameter-default (Warning)] Secure parameters can't have hardcoded default. This prevents storage of sensitive data in the Bicep declaration.\n[See : https://aka.ms/bicep/linter/secure-parameter-default] |= {\n  location: 'westus'\n}|
   location: 'westus'
 }
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecureParameterDefaultRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecureParameterDefaultRule.cs
@@ -12,12 +12,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 {
     public sealed class SecureParameterDefaultRule : LinterRuleBase
     {
-        public new const string Code = "secure-paramenter-default";
+        public new const string Code = "secure-parameter-default";
 
         public SecureParameterDefaultRule() : base(
             code: Code,
             description: CoreResources.SecureParameterDefaultRuleDescription,
-            docUri: "https://aka.ms/bicep/linter/secure-paramenter-default")
+            docUri: "https://aka.ms/bicep/linter/secure-parameter-default")
         { }
 
         override public IEnumerable<IBicepAnalyzerDiagnostic> AnalyzeInternal(SemanticModel model)


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

* [ ] I have checked that there is not an equivalent example already submitted
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
