### PR TITLE
improved union type normalization

### DIFF
--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.symbols.bicep
@@ -301,7 +301,7 @@ var isTrue = sys.max(1, 2) == 3
 var isFalse = !isTrue
 //@[4:11) Variable isFalse. Type: bool. Declaration start char: 0, length: 21
 var someText = isTrue ? sys.concat('a', sys.concat('b', 'c')) : 'someText'
-//@[4:12) Variable someText. Type: 'someText' | string. Declaration start char: 0, length: 74
+//@[4:12) Variable someText. Type: string. Declaration start char: 0, length: 74
 
 // Bicep functions that cannot be converted into ARM functions
 var scopesWithoutArmRepresentation = {

--- a/src/Bicep.Core.UnitTests/TypeSystem/UnionTypeTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/UnionTypeTests.cs
@@ -103,6 +103,33 @@ namespace Bicep.Core.UnitTests.TypeSystem
 
             UnionType.Create(UnionType.Create(UnionType.Create(LanguageConstants.Bool))).Should().BeSameAs(LanguageConstants.Bool);
         }
+
+        [TestMethod]
+        public void UnionsOfStringsAndStringLiteralTypesShouldProduceStringType()
+        {
+            UnionType.Create(LanguageConstants.String, new StringLiteralType("hello"), new StringLiteralType("there")).Should().BeSameAs(LanguageConstants.String);
+
+            UnionType.Create(LanguageConstants.String, new StringLiteralType("hello"), LanguageConstants.Bool, new StringLiteralType("there")).Name.Should().Be("bool | string");
+        }
+
+        [TestMethod]
+        public void UnionsOfUntypedAndTypedArraysShouldProduceUntypedArrayType()
+        {
+            UnionType.Create(LanguageConstants.Array, new TypedArrayType(LanguageConstants.String, TypeSymbolValidationFlags.Default)).Should().BeSameAs(LanguageConstants.Array);
+
+            var actual = UnionType.Create(
+                LanguageConstants.Array,
+                new TypedArrayType(LanguageConstants.Int, TypeSymbolValidationFlags.Default),
+                LanguageConstants.String,
+                new ObjectType("myObj", TypeSymbolValidationFlags.Default, Enumerable.Empty<TypeProperty>(), null));
+            actual.Name.Should().Be("array | myObj | string");
+        }
+
+        [TestMethod]
+        public void UnionsInvolvingAnyTypeShouldProduceAnyType()
+        {
+            UnionType.Create(LanguageConstants.String, LanguageConstants.Int, new TypedArrayType(LanguageConstants.Int, TypeSymbolValidationFlags.Default), LanguageConstants.Any).Should().BeSameAs(LanguageConstants.Any);
+        }
     }
 }
 

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -620,7 +620,7 @@ namespace Bicep.Core.TypeSystem
                 }
 
                 var aggregatedItemType = UnionType.Create(itemTypes);
-                if (aggregatedItemType.TypeKind == TypeKind.Union || aggregatedItemType.TypeKind == TypeKind.Never)
+                if (aggregatedItemType.TypeKind == TypeKind.Union || aggregatedItemType.TypeKind == TypeKind.Never || aggregatedItemType.TypeKind == TypeKind.Any)
                 {
                     // array contains a mix of item types or is empty
                     // assume array of any for now


### PR DESCRIPTION
Made small improvements to the union type normalization logic to simplify redundant union types that appeared in various Bicep issues:
* `<x> | any` now becomes `any`
* `<x> | string | 'foo' | 'bar'` now becomes `<x> | string`
* `<x> | array | string[] | int[]` now becomes `<x> | array`

The intent of this change is not to solve the entire problem of union type normalization.