### PR TITLE
Linter should not recommend interpolation for 1 argument concat() call

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/InterpolateNotConcatRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/InterpolateNotConcatRuleTests.cs
@@ -373,8 +373,17 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         )]
         [DataRow(
             @"
-                var a = []
-                var b = concat(a) // array
+                var a1 = []
+                var a2 = []
+                var a3 = []
+                var a3 = []
+                var b = concat(a1, a2, a3, a4) // arrays - no interpolate recommended
+            "
+        )]
+        [DataRow(
+            @"
+                var a = 'text'
+                var b = concat(a) // by definition of rule we require more than 1 argument to concat
             "
         )]
         [DataTestMethod]

--- a/src/Bicep.Core/Analyzers/Linter/Rules/InterpolateNotConcatRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/InterpolateNotConcatRule.cs
@@ -56,14 +56,13 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     var resultType = this.model.GetTypeInfo(syntax);
                     if (resultType is not AnyType && TypeValidator.AreTypesAssignable(resultType, LanguageConstants.String))
                     {
+                        // must have more than 1 argument to use interpolation
+                        if (syntax.Arguments.Length > 1 && CreateFix(syntax) is CodeFix fix)
                         {
-                            if (CreateFix(syntax) is CodeFix fix)
-                            {
-                                this.diagnostics.Add(parent.CreateFixableDiagnosticForSpan(syntax.Span, fix));
+                            this.diagnostics.Add(parent.CreateFixableDiagnosticForSpan(syntax.Span, fix));
 
-                                // Only report on the top-most string-valued concat call
-                                return;
-                            }
+                            // Only report on the top-most string-valued concat call
+                            return;
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #2763

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

