### PR TITLE
Increased timeout in integration tests

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
@@ -28,7 +28,7 @@ namespace Bicep.LangServer.IntegrationTests
 {
     public static class IntegrationTestHelper
     {
-        private const int DefaultTimeout = 10000;
+        private const int DefaultTimeout = 20000;
 
         public static readonly ISnippetsProvider SnippetsProvider = new SnippetsProvider();
 


### PR DESCRIPTION
The linux-musl official build job runs on a small container that is seeing timeouts occasionally during integration tests. Doubling the timeout for now to avoid failures.