### PR TITLE
log analytics 301 example

### DIFF
--- a/docs/examples/301/log-analytics-with-datasources-solutions/main.bicep
+++ b/docs/examples/301/log-analytics-with-datasources-solutions/main.bicep
@@ -1,0 +1,102 @@
+@description('Location of the workspace')
+param location string = resourceGroup().location
+@description('Name of the workspace')
+param name string
+@allowed([
+  'PerGB2018'
+  'Free'
+  'Standalone'
+  'PerNode'
+  'Standard'
+  'Premium'
+])
+@description('Sku of the workspace')
+param sku string
+@description('The workspace data retention in days, between 30 and 730')
+@minValue(7)
+@maxValue(730)
+param retentionInDays int
+@description('Solutions to add to workspace')
+param solutions array = []
+@description('Name of automation account to link to workspace')
+param automationAccountName string = ''
+@description('Datasources to add to workspace')
+param dataSources array = []
+@description('Enable lock to prevent accidental deletion')
+param enableDeleteLock bool = false
+@description('Enable diagnostic logs')
+param enableDiagnostics bool = false
+@description('Storage account name. Only required if enableDiagnostics is set to true.')
+param diagnosticStorageAccountName string = ''
+@description('Storage account resourceop. Only required if enableDiagnostics is set to true.')
+param diagnosticStorageAccountResourceGroup string = ''
+
+var lockName = concat(logAnalyticsWorkspace.name, '-lck')
+var diagnosticsName = concat(logAnalyticsWorkspace.name, '-dgs')
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-08-01' = {
+  name: name
+  location: location
+  properties: {
+    sku: {
+      name: sku
+    }
+    retentionInDays: retentionInDays
+  }
+}
+
+resource logAnalyticsSolutions 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = [for solution in solutions: {
+  name: concat(solution.name, '(', logAnalyticsWorkspace.name, ')')
+  location: location
+  properties: {
+    workspaceResourceId: logAnalyticsWorkspace.id
+  }
+  plan: {
+    name: concat(solution.name, '(', logAnalyticsWorkspace.name, ')')
+    product: solution.product
+    publisher: solution.publisher
+    promotionCode: solution.promotionCode
+  }
+}]
+
+resource logAnalyticsAutomation 'Microsoft.OperationalInsights/workspaces/linkedServices@2020-08-01' = if (!empty(automationAccountName)) {
+  name: concat(logAnalyticsWorkspace.name, '/Automation')
+  properties: {
+    resourceId: resourceId('Microsoft.Automation/automationAccounts', automationAccountName)
+  }
+}
+
+resource logAnalyticsDataSource 'Microsoft.OperationalInsights/workspaces/dataSources@2020-08-01' = [for dataSource in dataSources: {
+  name: concat(logAnalyticsWorkspace.name, '/', dataSource.name)
+  kind: dataSource.kind
+  properties: dataSource.properties
+}]
+
+resource lock 'Microsoft.Authorization/locks@2016-09-01' = if (enableDeleteLock) {
+  name: lockName
+  scope: logAnalyticsWorkspace
+  properties: {
+    level: 'CanNotDelete'
+  }
+}
+
+resource diagnostics 'Microsoft.Insights/diagnosticSettings@2017-05-01-preview' = if (enableDiagnostics) {
+  name: diagnosticsName
+  scope: logAnalyticsWorkspace
+  properties: {
+    workspaceId: logAnalyticsWorkspace.id
+    storageAccountId: resourceId(diagnosticStorageAccountResourceGroup, 'Microsoft.Storage/storageAccounts', diagnosticStorageAccountName)
+    logs: [
+      {
+        category: 'Audit'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}

--- a/docs/examples/301/log-analytics-with-datasources-solutions/readme.md
+++ b/docs/examples/301/log-analytics-with-datasources-solutions/readme.md
@@ -1,0 +1,156 @@
+# Log Analytics
+This module will deploy a Log Analytics Workspace with solutions, data sources and linked to an automation account.
+
+## Usage
+
+### Example 1 - Log Analytics Workspace with solutions and data sources
+``` bicep
+param deploymentName string = concat('logAnalytics', utcNow())
+
+module logAnalytics './main.bicep' = {
+  name: deploymentName
+  params: {
+    name: 'myLogAnalyticsWorkspace'
+    sku: 'PerGB2018'
+    retentionInDays: 30
+    solutions: [
+      {
+        name: 'AzureActivity'
+        product: 'OMSGallery/AzureActivity'
+        publisher: 'Microsoft'
+        promotionCode: ''
+      }
+    ]
+    dataSources: [
+      {
+        name: 'Application'
+        kind: 'WindowsEvent'
+        properties: {
+          eventLogName: 'Application'
+          eventTypes: [
+            {
+              eventType: 'Error'
+            }
+            {
+              eventType: 'Warning'
+            }
+          ]
+        }
+      }
+      {
+        name: 'LogicalDisk1'
+        kind: 'WindowsPerformanceCounter'
+        properties: {
+          objectName: 'LogicalDisk'
+          instanceName: '*'
+          intervalSeconds: 360
+          counterName: 'Avg Disk sec/Read'
+        }
+      }
+    ]
+  }
+}
+```
+
+### Example 2 - Log Analytics Workspace with solutions, data sources and linked to an automation account
+``` bicep
+param deploymentName string = concat('logAnalytics', utcNow())
+
+module logAnalytics './main.bicep' = {
+  name: deploymentName
+  params: {
+    name: 'myLogAnalyticsWorkspace'
+    sku: 'PerGB2018'
+    retentionInDays: 30
+    automationAccountName: 'myAutomationAccount'
+    solutions: [
+      {
+        name: 'AzureActivity'
+        product: 'OMSGallery/AzureActivity'
+        publisher: 'Microsoft'
+        promotionCode: ''
+      }
+    ]
+    dataSources: [
+      {
+        name: 'Application'
+        kind: 'WindowsEvent'
+        properties: {
+          eventLogName: 'Application'
+          eventTypes: [
+            {
+              eventType: 'Error'
+            }
+            {
+              eventType: 'Warning'
+            }
+          ]
+        }
+      }
+      {
+        name: 'LogicalDisk1'
+        kind: 'WindowsPerformanceCounter'
+        properties: {
+          objectName: 'LogicalDisk'
+          instanceName: '*'
+          intervalSeconds: 360
+          counterName: 'Avg Disk sec/Read'
+        }
+      }
+    ]
+  }
+}
+```
+
+### Example 3 - Log Analytics Workspace with solutions, data sources, delete lock and diagnostic logs enabled
+``` bicep
+param deploymentName string = concat('logAnalytics', utcNow())
+
+module logAnalytics './main.bicep' = {
+  name: deploymentName
+  params: {
+    name: 'myLogAnalyticsWorkspace'
+    sku: 'PerGB2018'
+    retentionInDays: 30
+    enableDeleteLock: true
+    enableDiagnostics: true
+    diagnosticStorageAccountName: 'myStorageAccount'
+    diagnosticStorageAccountResourceGroup: 'myStorageAccountResourceGroup'    
+    solutions: [
+      {
+        name: 'AzureActivity'
+        product: 'OMSGallery/AzureActivity'
+        publisher: 'Microsoft'
+        promotionCode: ''
+      }
+    ]
+    dataSources: [
+      {
+        name: 'Application'
+        kind: 'WindowsEvent'
+        properties: {
+          eventLogName: 'Application'
+          eventTypes: [
+            {
+              eventType: 'Error'
+            }
+            {
+              eventType: 'Warning'
+            }
+          ]
+        }
+      }
+      {
+        name: 'LogicalDisk1'
+        kind: 'WindowsPerformanceCounter'
+        properties: {
+          objectName: 'LogicalDisk'
+          instanceName: '*'
+          intervalSeconds: 360
+          counterName: 'Avg Disk sec/Read'
+        }
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

* [x] I have checked that there is not an equivalent example already submitted
* [x] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [x] I have checked that all tests are passing by running `dotnet test`
* [x] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
