### PR TITLE
Remove duplicate 'get' from keyvault snippet

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault/main.combined.bicep
@@ -17,6 +17,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {
           secrets: [
             'list'
             'get'
+            'get'
           ]
         }
       }

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault/main.combined.bicep
@@ -17,7 +17,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {
           secrets: [
             'list'
             'get'
-            'get'
           ]
         }
       }


### PR DESCRIPTION
Removes a duplicate 'get' from the keyvault snippet.

I have read the contributing document. 

I'm OK if you close this PR if the contribution is too small.