### PR TITLE
Fix  Bicep playground

### DIFF
--- a/src/playground/src/playground.tsx
+++ b/src/playground/src/playground.tsx
@@ -98,7 +98,7 @@ export const Playground : React.FC = () => {
     <input type="file" ref={uploadInputRef} style={{ display: 'none' }} onChange={e => handleDecompileClick(e.currentTarget.files[0])} accept="application/json" multiple={false} />
     <Navbar bg="dark" variant="dark">
       <Navbar.Brand>Bicep Playground</Navbar.Brand>
-      <Nav className="ml-auto">
+      <Nav className="ms-auto">
         <OverlayTrigger placement="bottom" overlay={createTooltip('Copy a shareable link to clipboard')}>
           <Button size="sm" variant="primary" className="mx-1" onClick={handlCopyClick}>{copied ? 'Copied' : 'Copy Link'}</Button>
         </OverlayTrigger>

--- a/src/playground/webpack.config.ts
+++ b/src/playground/webpack.config.ts
@@ -4,8 +4,9 @@ import MonacoWebpackPlugin from 'monaco-editor-webpack-plugin';
 import { version as buildVersion } from './package.json';
 import path from 'path';
 import exampleIndex from '../../docs/examples/index.json';
+import { Configuration } from 'webpack';
 
-module.exports = {
+const config: Configuration = {
   entry: {
     "main": './src/index.tsx',
   },
@@ -49,10 +50,10 @@ module.exports = {
       languages: ['json']
     }),
   ],
-  devServer: {
-    contentBase: path.join(__dirname, 'dist'),
-    compress: true,
-    open: true,
-    port: 9000
-  }
+  optimization: {
+    // to avoid minimizing files under _framework (Blazor JS files), just turn off minification entirely.
+    minimize: false,
+  },
 };
+
+module.exports = config;


### PR DESCRIPTION
* Playground doesn't load after breaking change in https://github.com/webpack-contrib/copy-webpack-plugin/releases/tag/v6.0.0
* Playground top buttons are not right aligned after breaking change in https://github.com/twbs/bootstrap/releases/tag/v5.0.0