### PR TITLE
Suggesting addition of Shared Image Gallery and Azure Image Builder modules for WVD Backplane Example

### DIFF
--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.bicep
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.bicep
@@ -28,6 +28,17 @@ param storageaccountkind string = 'FileStorage'
 param storgeaccountglobalRedundancy string = 'Premium_LRS'
 param fileshareFolderName string = 'profilecontainers'
 
+//Define Shared Image Gallery and Azure Image Parameters
+param sigName string = 'BicepWVDSIG'
+param imageDefinitionName string = 'BicepAIBWVDImage'
+param imagePublisher string = 'MicrosoftWindowsDesktop'
+param imageOffer string = 'windows-10'
+param imageSKU string = '20h2-ent'
+
+//Define Azure Image Builder Parameters
+//Set below to true to start the Image Definition build using AIB once deployment completes
+param InvokeRunImageBuildThroughDeploymentScript bool = false
+
 //Create Resource Groups
 resource rgwvd 'Microsoft.Resources/resourceGroups@2020-06-01' = {
   name: '${resourceGroupPrefrix}BACKPLANE'
@@ -43,6 +54,10 @@ resource rgfs 'Microsoft.Resources/resourceGroups@2020-06-01' = {
 }
 resource rdmon 'Microsoft.Resources/resourceGroups@2020-06-01' = {
   name: '${resourceGroupPrefrix}MONITOR'
+  location: 'westeurope'
+}
+resource rgsig 'Microsoft.Resources/resourceGroups@2020-06-01'  = {
+  name: '${resourceGroupPrefrix}SIG'
   location: 'westeurope'
 }
 
@@ -105,4 +120,34 @@ module pep './wvd-fileservices-privateendpoint-module.bicep' = {
     vnetId: wvdnetwork.outputs.vnetId
     subnetId: wvdnetwork.outputs.subnetId
   }
+}
+
+//Create WVD Shared Image Gallery and Image Definition
+module wvdsig './wvd-sig-module.bicep' = {
+  name: 'wvdsig'
+  scope: rgsig
+  params: {
+    sigName: sigName
+    sigLocation: rgsig.location
+    imagePublisher: imagePublisher
+    imageDefinitionName: imageDefinitionName
+    imageOffer: imageOffer
+    imageSKU: imageSKU
+
+       }
+}
+
+//Create AIB Image and optionally build and add version to SIG Definition
+module wvdaib './wvd-image-builder-module.bicep' = {
+  name: 'wvdimagebuilder${wvdsig.name}'
+  scope: rgsig
+  params: {
+    siglocation: rgsig.location
+    imagePublisher: imagePublisher
+    imageOffer: imageOffer
+    imageSKU: imageSKU
+    galleryImageId: wvdsig.outputs.wvdidoutput
+    InvokeRunImageBuildThroughDeploymentScript: InvokeRunImageBuildThroughDeploymentScript
+
+     }
 }

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.bicep
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.bicep
@@ -56,7 +56,7 @@ resource rdmon 'Microsoft.Resources/resourceGroups@2020-06-01' = {
   name: '${resourceGroupPrefrix}MONITOR'
   location: 'westeurope'
 }
-resource rgsig 'Microsoft.Resources/resourceGroups@2020-06-01'  = {
+resource rgsig 'Microsoft.Resources/resourceGroups@2020-06-01' = {
   name: '${resourceGroupPrefrix}SIG'
   location: 'westeurope'
 }
@@ -133,8 +133,7 @@ module wvdsig './wvd-sig-module.bicep' = {
     imageDefinitionName: imageDefinitionName
     imageOffer: imageOffer
     imageSKU: imageSKU
-
-       }
+  }
 }
 
 //Create AIB Image and optionally build and add version to SIG Definition
@@ -148,6 +147,5 @@ module wvdaib './wvd-image-builder-module.bicep' = {
     imageSKU: imageSKU
     galleryImageId: wvdsig.outputs.wvdidoutput
     InvokeRunImageBuildThroughDeploymentScript: InvokeRunImageBuildThroughDeploymentScript
-
-     }
+  }
 }

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16399487494121524783"
+      "templateHash": "11359296141017610569"
     }
   },
   "parameters": {
@@ -96,6 +96,30 @@
     "fileshareFolderName": {
       "type": "string",
       "defaultValue": "profilecontainers"
+    },
+    "sigName": {
+      "type": "string",
+      "defaultValue": "BicepWVDSIG"
+    },
+    "imageDefinitionName": {
+      "type": "string",
+      "defaultValue": "BicepAIBWVDImage"
+    },
+    "imagePublisher": {
+      "type": "string",
+      "defaultValue": "MicrosoftWindowsDesktop"
+    },
+    "imageOffer": {
+      "type": "string",
+      "defaultValue": "windows-10"
+    },
+    "imageSKU": {
+      "type": "string",
+      "defaultValue": "20h2-ent"
+    },
+    "InvokeRunImageBuildThroughDeploymentScript": {
+      "type": "bool",
+      "defaultValue": false
     }
   },
   "functions": [],
@@ -122,6 +146,12 @@
       "type": "Microsoft.Resources/resourceGroups",
       "apiVersion": "2020-06-01",
       "name": "[format('{0}MONITOR', parameters('resourceGroupPrefrix'))]",
+      "location": "westeurope"
+    },
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}SIG', parameters('resourceGroupPrefrix'))]",
       "location": "westeurope"
     },
     {
@@ -818,6 +848,419 @@
         "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}NETWORK', parameters('resourceGroupPrefrix')))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}FILESERVICES', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'wvdFileServices')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}NETWORK', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'wvdnetwork')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "wvdsig",
+      "resourceGroup": "[format('{0}SIG', parameters('resourceGroupPrefrix'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "sigName": {
+            "value": "[parameters('sigName')]"
+          },
+          "sigLocation": {
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}SIG', parameters('resourceGroupPrefrix'))), '2020-06-01', 'full').location]"
+          },
+          "imagePublisher": {
+            "value": "[parameters('imagePublisher')]"
+          },
+          "imageDefinitionName": {
+            "value": "[parameters('imageDefinitionName')]"
+          },
+          "imageOffer": {
+            "value": "[parameters('imageOffer')]"
+          },
+          "imageSKU": {
+            "value": "[parameters('imageSKU')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "13198127151453916452"
+            }
+          },
+          "parameters": {
+            "sigName": {
+              "type": "string"
+            },
+            "sigLocation": {
+              "type": "string"
+            },
+            "imagePublisher": {
+              "type": "string"
+            },
+            "imageDefinitionName": {
+              "type": "string"
+            },
+            "imageOffer": {
+              "type": "string"
+            },
+            "imageSKU": {
+              "type": "string"
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Compute/galleries",
+              "apiVersion": "2020-09-30",
+              "name": "[parameters('sigName')]",
+              "location": "[parameters('sigLocation')]"
+            },
+            {
+              "type": "Microsoft.Compute/galleries/images",
+              "apiVersion": "2019-07-01",
+              "name": "[format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName'))]",
+              "location": "[parameters('sigLocation')]",
+              "properties": {
+                "osType": "Windows",
+                "osState": "Generalized",
+                "identifier": {
+                  "publisher": "[parameters('imagePublisher')]",
+                  "offer": "[parameters('imageOffer')]",
+                  "sku": "[parameters('imageSKU')]"
+                },
+                "recommended": {
+                  "vCPUs": {
+                    "min": 2,
+                    "max": 32
+                  },
+                  "memory": {
+                    "min": 4,
+                    "max": 64
+                  }
+                },
+                "hyperVGeneration": "V2"
+              },
+              "tags": {},
+              "dependsOn": [
+                "[resourceId('Microsoft.Compute/galleries', parameters('sigName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "wvdidoutput": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Compute/galleries/images', split(format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName')), '/')[0], split(format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName')), '/')[1])]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}SIG', parameters('resourceGroupPrefrix')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "[format('wvdimagebuilder{0}', 'wvdsig')]",
+      "resourceGroup": "[format('{0}SIG', parameters('resourceGroupPrefrix'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "siglocation": {
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}SIG', parameters('resourceGroupPrefrix'))), '2020-06-01', 'full').location]"
+          },
+          "imagePublisher": {
+            "value": "[parameters('imagePublisher')]"
+          },
+          "imageOffer": {
+            "value": "[parameters('imageOffer')]"
+          },
+          "imageSKU": {
+            "value": "[parameters('imageSKU')]"
+          },
+          "galleryImageId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}SIG', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'wvdsig'), '2019-10-01').outputs.wvdidoutput.value]"
+          },
+          "InvokeRunImageBuildThroughDeploymentScript": {
+            "value": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "17714227319258150588"
+            }
+          },
+          "parameters": {
+            "siglocation": {
+              "type": "string"
+            },
+            "roleNameGalleryImage": {
+              "type": "string",
+              "defaultValue": "[format('{0}{1}', 'BicepSIG', utcNow())]"
+            },
+            "roleNameAIBCustom": {
+              "type": "string",
+              "defaultValue": "[format('{0}{1}', 'BicepAIB', utcNow())]"
+            },
+            "uamiName": {
+              "type": "string",
+              "defaultValue": "[format('{0}{1}', 'AIBUser', utcNow())]"
+            },
+            "uamiId": {
+              "type": "string",
+              "defaultValue": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+            },
+            "imageTemplateName": {
+              "type": "string",
+              "defaultValue": "[format('{0}{1}', 'WVDBicep', utcNow())]"
+            },
+            "outputname": {
+              "type": "string",
+              "defaultValue": "[uniqueString(resourceGroup().name)]"
+            },
+            "galleryImageId": {
+              "type": "string"
+            },
+            "imagePublisher": {
+              "type": "string"
+            },
+            "imageOffer": {
+              "type": "string"
+            },
+            "imageSKU": {
+              "type": "string"
+            },
+            "InvokeRunImageBuildThroughDeploymentScript": {
+              "type": "bool"
+            },
+            "rgname": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().name]"
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+              "apiVersion": "2018-11-30",
+              "name": "[parameters('uamiName')]",
+              "location": "[resourceGroup().location]"
+            },
+            {
+              "type": "Microsoft.Authorization/roleDefinitions",
+              "apiVersion": "2018-01-01-preview",
+              "name": "[guid(parameters('roleNameGalleryImage'))]",
+              "properties": {
+                "roleName": "[parameters('roleNameGalleryImage')]",
+                "description": "Custom role for SIG and AIB",
+                "permissions": [
+                  {
+                    "actions": [
+                      "Microsoft.Compute/galleries/read",
+                      "Microsoft.Compute/galleries/images/read",
+                      "Microsoft.Compute/galleries/images/versions/read",
+                      "Microsoft.Compute/galleries/images/versions/write",
+                      "Microsoft.Compute/images/write",
+                      "Microsoft.Compute/images/read",
+                      "Microsoft.Compute/images/delete"
+                    ]
+                  }
+                ],
+                "assignableScopes": [
+                  "[resourceGroup().id]"
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2020-04-01-preview",
+              "name": "[guid(resourceGroup().id, resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
+              "properties": {
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage')))]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))).principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage')))]",
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.VirtualMachineImages/imageTemplates",
+              "apiVersion": "2020-02-14",
+              "name": "[parameters('imageTemplateName')]",
+              "location": "[parameters('siglocation')]",
+              "tags": {
+                "imagebuilderTemplate": "AzureImageBuilderSIG",
+                "userIdentity": "enabled"
+              },
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]": {}
+                }
+              },
+              "properties": {
+                "buildTimeoutInMinutes": 120,
+                "vmProfile": {
+                  "vmSize": "Standard_D2_v2",
+                  "osDiskSizeGB": 127
+                },
+                "source": {
+                  "type": "PlatformImage",
+                  "publisher": "[parameters('imagePublisher')]",
+                  "offer": "[parameters('imageOffer')]",
+                  "sku": "[parameters('imageSKU')]",
+                  "version": "latest"
+                },
+                "customize": [
+                  {
+                    "type": "PowerShell",
+                    "name": "OptimizeOS",
+                    "runElevated": true,
+                    "runAsSystem": true,
+                    "scriptUri": "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/master/solutions/14_Building_Images_WVD/1_Optimize_OS_for_WVD.ps1"
+                  },
+                  {
+                    "type": "WindowsRestart",
+                    "restartCheckCommand": "write-host 'restarting post Optimizations'",
+                    "restartTimeout": "5m"
+                  },
+                  {
+                    "type": "PowerShell",
+                    "name": "Install Teams",
+                    "runElevated": true,
+                    "runAsSystem": true,
+                    "scriptUri": "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/master/solutions/14_Building_Images_WVD/2_installTeams.ps1"
+                  },
+                  {
+                    "type": "WindowsRestart",
+                    "restartCheckCommand": "write-host 'restarting post Teams Install'",
+                    "restartTimeout": "5m"
+                  },
+                  {
+                    "type": "WindowsUpdate",
+                    "searchCriteria": "IsInstalled=0",
+                    "filters": [
+                      "exclude:$_.Title -like '*Preview*'",
+                      "include:$true"
+                    ],
+                    "updateLimit": 40
+                  }
+                ],
+                "distribute": [
+                  {
+                    "type": "SharedImage",
+                    "galleryImageId": "[parameters('galleryImageId')]",
+                    "runOutputName": "[parameters('outputname')]",
+                    "artifactTags": {
+                      "source": "wvd10",
+                      "baseosimg": "windows10"
+                    },
+                    "replicationRegions": []
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
+              "type": "Microsoft.Authorization/roleDefinitions",
+              "apiVersion": "2018-01-01-preview",
+              "name": "[guid(parameters('roleNameAIBCustom'))]",
+              "properties": {
+                "roleName": "[parameters('roleNameAIBCustom')]",
+                "description": "Custom role for AIB to invoke build of VM Template from deployment",
+                "permissions": [
+                  {
+                    "actions": [
+                      "Microsoft.VirtualMachineImages/imageTemplates/Run/action",
+                      "Microsoft.Storage/storageAccounts/*",
+                      "Microsoft.ContainerInstance/containerGroups/*",
+                      "Microsoft.Resources/deployments/*",
+                      "Microsoft.Resources/deploymentScripts/*"
+                    ]
+                  }
+                ],
+                "assignableScopes": [
+                  "[resourceGroup().id]"
+                ]
+              }
+            },
+            {
+              "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2020-04-01-preview",
+              "name": "[guid(resourceGroup().id, resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
+              "properties": {
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom')))]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))).principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom')))]",
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2020-04-01-preview",
+              "name": "[guid(resourceGroup().id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
+              "properties": {
+                "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))).principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+              ]
+            },
+            {
+              "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
+              "type": "Microsoft.Resources/deploymentScripts",
+              "apiVersion": "2020-10-01",
+              "name": "BuildVMImage",
+              "location": "[resourceGroup().location]",
+              "kind": "AzurePowerShell",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[parameters('uamiId')]": {}
+                }
+              },
+              "properties": {
+                "forceUpdateTag": "1",
+                "azPowerShellVersion": "5.9",
+                "arguments": "",
+                "scriptContent": "[format('Invoke-AzResourceAction -ResourceName {0} -ResourceGroupName {1} -ResourceType Microsoft.VirtualMachineImages/imageTemplates -ApiVersion \"2020-02-14\" -Action Run -Force', parameters('imageTemplateName'), parameters('rgname'))]",
+                "timeout": "PT5M",
+                "cleanupPreference": "Always",
+                "retentionInterval": "P1D"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.VirtualMachineImages/imageTemplates', parameters('imageTemplateName'))]"
+              ]
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}SIG', parameters('resourceGroupPrefrix')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}SIG', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'wvdsig')]"
       ]
     }
   ]

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-image-builder-module.bicep
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-image-builder-module.bicep
@@ -48,7 +48,7 @@ resource gallerydef 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview'
 resource galleryassignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   name: guid(resourceGroup().id, gallerydef.id, managedidentity.id)
   properties: {
-   roleDefinitionId: gallerydef.id
+    roleDefinitionId: gallerydef.id
     principalId: managedidentity.properties.principalId
     principalType: 'ServicePrincipal'
   }
@@ -64,11 +64,11 @@ resource imageTemplateName_resource 'Microsoft.VirtualMachineImages/imageTemplat
     userIdentity: 'enabled'
   }
   identity: {
-   type: 'UserAssigned'
-   userAssignedIdentities: {
-    '${managedidentity.id}' :{}
-   } 
-}
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedidentity.id}': {}
+    }
+  }
   properties: {
     buildTimeoutInMinutes: 120
     vmProfile: {
@@ -121,7 +121,7 @@ resource imageTemplateName_resource 'Microsoft.VirtualMachineImages/imageTemplat
       {
         type: 'SharedImage'
         galleryImageId: galleryImageId
-        runOutputName:  outputname
+        runOutputName: outputname
         artifactTags: {
           source: 'wvd10'
           baseosimg: 'windows10'
@@ -141,7 +141,7 @@ resource aibdef 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' = i
     permissions: [
       {
         actions: [
-          'Microsoft.VirtualMachineImages/imageTemplates/Run/action' 
+          'Microsoft.VirtualMachineImages/imageTemplates/Run/action'
           'Microsoft.Storage/storageAccounts/*'
           'Microsoft.ContainerInstance/containerGroups/*'
           'Microsoft.Resources/deployments/*'
@@ -159,7 +159,7 @@ resource aibdef 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' = i
 resource aibrunnerassignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (InvokeRunImageBuildThroughDeploymentScript) {
   name: guid(resourceGroup().id, aibdef.id, managedidentity.id)
   properties: {
-   roleDefinitionId: aibdef.id
+    roleDefinitionId: aibdef.id
     principalId: managedidentity.properties.principalId
     principalType: 'ServicePrincipal'
   }
@@ -169,7 +169,7 @@ resource aibrunnerassignment 'Microsoft.Authorization/roleAssignments@2020-04-01
 resource miorole 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (InvokeRunImageBuildThroughDeploymentScript) {
   name: guid(resourceGroup().id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830', managedidentity.id)
   properties: {
-   roleDefinitionId: '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830'
+    roleDefinitionId: '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830'
     principalId: managedidentity.properties.principalId
     principalType: 'ServicePrincipal'
   }

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-image-builder-module.bicep
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-image-builder-module.bicep
@@ -1,0 +1,201 @@
+param siglocation string
+param roleNameGalleryImage string = '${'BicepSIG'}${utcNow()}'
+param roleNameAIBCustom string = '${'BicepAIB'}${utcNow()}'
+param uamiName string = '${'AIBUser'}${utcNow()}'
+param uamiId string = resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', uamiName)
+param imageTemplateName string = '${'WVDBicep'}${utcNow()}'
+param outputname string = uniqueString(resourceGroup().name)
+param galleryImageId string
+param imagePublisher string
+param imageOffer string
+param imageSKU string
+param InvokeRunImageBuildThroughDeploymentScript bool
+param rgname string = resourceGroup().name
+
+// Create User-Assigned Managed Identity
+
+resource managedidentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: uamiName
+  location: resourceGroup().location
+}
+
+//Create Role Definition with added VM Run Action for Image Builder to map to SIG Resource Group
+resource gallerydef 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' = {
+  name: guid(roleNameGalleryImage)
+  properties: {
+    roleName: roleNameGalleryImage
+    description: 'Custom role for SIG and AIB'
+    permissions: [
+      {
+        actions: [
+          'Microsoft.Compute/galleries/read'
+          'Microsoft.Compute/galleries/images/read'
+          'Microsoft.Compute/galleries/images/versions/read'
+          'Microsoft.Compute/galleries/images/versions/write'
+          'Microsoft.Compute/images/write'
+          'Microsoft.Compute/images/read'
+          'Microsoft.Compute/images/delete'
+        ]
+      }
+    ]
+    assignableScopes: [
+      resourceGroup().id
+    ]
+  }
+}
+
+// Map Standard SIG Custom Role Assignment to Managed Identity
+resource galleryassignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid(resourceGroup().id, gallerydef.id, managedidentity.id)
+  properties: {
+   roleDefinitionId: gallerydef.id
+    principalId: managedidentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Create Image Template in SIG Resource Group
+
+resource imageTemplateName_resource 'Microsoft.VirtualMachineImages/imageTemplates@2020-02-14' = {
+  name: imageTemplateName
+  location: siglocation
+  tags: {
+    imagebuilderTemplate: 'AzureImageBuilderSIG'
+    userIdentity: 'enabled'
+  }
+  identity: {
+   type: 'UserAssigned'
+   userAssignedIdentities: {
+    '${managedidentity.id}' :{}
+   } 
+}
+  properties: {
+    buildTimeoutInMinutes: 120
+    vmProfile: {
+      vmSize: 'Standard_D2_v2'
+      osDiskSizeGB: 127
+    }
+    source: {
+      type: 'PlatformImage'
+      publisher: imagePublisher
+      offer: imageOffer
+      sku: imageSKU
+      version: 'latest'
+    }
+    customize: [
+      {
+        type: 'PowerShell'
+        name: 'OptimizeOS'
+        runElevated: true
+        runAsSystem: true
+        scriptUri: 'https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/master/solutions/14_Building_Images_WVD/1_Optimize_OS_for_WVD.ps1'
+      }
+      {
+        type: 'WindowsRestart'
+        restartCheckCommand: 'write-host \'restarting post Optimizations\''
+        restartTimeout: '5m'
+      }
+      {
+        type: 'PowerShell'
+        name: 'Install Teams'
+        runElevated: true
+        runAsSystem: true
+        scriptUri: 'https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/master/solutions/14_Building_Images_WVD/2_installTeams.ps1'
+      }
+      {
+        type: 'WindowsRestart'
+        restartCheckCommand: 'write-host \'restarting post Teams Install\''
+        restartTimeout: '5m'
+      }
+      {
+        type: 'WindowsUpdate'
+        searchCriteria: 'IsInstalled=0'
+        filters: [
+          'exclude:$_.Title -like \'*Preview*\''
+          'include:$true'
+        ]
+        updateLimit: 40
+      }
+    ]
+    distribute: [
+      {
+        type: 'SharedImage'
+        galleryImageId: galleryImageId
+        runOutputName:  outputname
+        artifactTags: {
+          source: 'wvd10'
+          baseosimg: 'windows10'
+        }
+        replicationRegions: []
+      }
+    ]
+  }
+}
+
+//Create Role Definition with Image Builder to run Image Build and execute container cli script
+resource aibdef 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' = if (InvokeRunImageBuildThroughDeploymentScript) {
+  name: guid(roleNameAIBCustom)
+  properties: {
+    roleName: roleNameAIBCustom
+    description: 'Custom role for AIB to invoke build of VM Template from deployment'
+    permissions: [
+      {
+        actions: [
+          'Microsoft.VirtualMachineImages/imageTemplates/Run/action' 
+          'Microsoft.Storage/storageAccounts/*'
+          'Microsoft.ContainerInstance/containerGroups/*'
+          'Microsoft.Resources/deployments/*'
+          'Microsoft.Resources/deploymentScripts/*'
+        ]
+      }
+    ]
+    assignableScopes: [
+      resourceGroup().id
+    ]
+  }
+}
+
+// Map AIB Runner Custom Role Assignment to Managed Identity
+resource aibrunnerassignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (InvokeRunImageBuildThroughDeploymentScript) {
+  name: guid(resourceGroup().id, aibdef.id, managedidentity.id)
+  properties: {
+   roleDefinitionId: aibdef.id
+    principalId: managedidentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Map Managed Identity Operator Role to to Managed Identity - Not required if not running Powershell Deployment Script for AIB
+resource miorole 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (InvokeRunImageBuildThroughDeploymentScript) {
+  name: guid(resourceGroup().id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830', managedidentity.id)
+  properties: {
+   roleDefinitionId: '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830'
+    principalId: managedidentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Run Deployment Script to Start build of Virtual Machine Image using AIB
+resource scriptName_BuildVMImage 'Microsoft.Resources/deploymentScripts@2020-10-01' = if (InvokeRunImageBuildThroughDeploymentScript) {
+  name: 'BuildVMImage'
+  location: resourceGroup().location
+  kind: 'AzurePowerShell'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${uamiId}': {}
+    }
+  }
+  properties: {
+    forceUpdateTag: '1'
+    azPowerShellVersion: '5.9'
+    arguments: ''
+    scriptContent: 'Invoke-AzResourceAction -ResourceName ${imageTemplateName} -ResourceGroupName ${rgname} -ResourceType Microsoft.VirtualMachineImages/imageTemplates -ApiVersion "2020-02-14" -Action Run -Force'
+    timeout: 'PT5M'
+    cleanupPreference: 'Always'
+    retentionInterval: 'P1D'
+  }
+  dependsOn: [
+    imageTemplateName_resource
+  ]
+}

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-image-builder-module.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-image-builder-module.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "7828609930759609063"
+    }
+  },
+  "parameters": {
+    "siglocation": {
+      "type": "string"
+    },
+    "roleNameGalleryImage": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', 'BicepSIG', utcNow())]"
+    },
+    "roleNameAIBCustom": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', 'BicepAIB', utcNow())]"
+    },
+    "uamiName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', 'AIBUser', utcNow())]"
+    },
+    "uamiId": {
+      "type": "string",
+      "defaultValue": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+    },
+    "imageTemplateName": {
+      "type": "string",
+      "defaultValue": "[format('{0}{1}', 'WVDBicep', utcNow())]"
+    },
+    "outputname": {
+      "type": "string",
+      "defaultValue": "[uniqueString(resourceGroup().name)]"
+    },
+    "galleryImageId": {
+      "type": "string"
+    },
+    "imagePublisher": {
+      "type": "string"
+    },
+    "imageOffer": {
+      "type": "string"
+    },
+    "imageSKU": {
+      "type": "string"
+    },
+    "InvokeRunImageBuildThroughDeploymentScript": {
+      "type": "bool"
+    },
+    "rgname": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().name]"
+    }
+  },
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2018-11-30",
+      "name": "[parameters('uamiName')]",
+      "location": "[resourceGroup().location]"
+    },
+    {
+      "type": "Microsoft.Authorization/roleDefinitions",
+      "apiVersion": "2018-01-01-preview",
+      "name": "[guid(parameters('roleNameGalleryImage'))]",
+      "properties": {
+        "roleName": "[parameters('roleNameGalleryImage')]",
+        "description": "Custom role for SIG and AIB",
+        "permissions": [
+          {
+            "actions": [
+              "Microsoft.Compute/galleries/read",
+              "Microsoft.Compute/galleries/images/read",
+              "Microsoft.Compute/galleries/images/versions/read",
+              "Microsoft.Compute/galleries/images/versions/write",
+              "Microsoft.Compute/images/write",
+              "Microsoft.Compute/images/read",
+              "Microsoft.Compute/images/delete"
+            ]
+          }
+        ],
+        "assignableScopes": [
+          "[resourceGroup().id]"
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "name": "[guid(resourceGroup().id, resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
+      "properties": {
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage')))]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))).principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage')))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.VirtualMachineImages/imageTemplates",
+      "apiVersion": "2020-02-14",
+      "name": "[parameters('imageTemplateName')]",
+      "location": "[parameters('siglocation')]",
+      "tags": {
+        "imagebuilderTemplate": "AzureImageBuilderSIG",
+        "userIdentity": "enabled"
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]": {}
+        }
+      },
+      "properties": {
+        "buildTimeoutInMinutes": 120,
+        "vmProfile": {
+          "vmSize": "Standard_D2_v2",
+          "osDiskSizeGB": 127
+        },
+        "source": {
+          "type": "PlatformImage",
+          "publisher": "[parameters('imagePublisher')]",
+          "offer": "[parameters('imageOffer')]",
+          "sku": "[parameters('imageSKU')]",
+          "version": "latest"
+        },
+        "customize": [
+          {
+            "type": "PowerShell",
+            "name": "OptimizeOS",
+            "runElevated": true,
+            "runAsSystem": true,
+            "scriptUri": "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/master/solutions/14_Building_Images_WVD/1_Optimize_OS_for_WVD.ps1"
+          },
+          {
+            "type": "WindowsRestart",
+            "restartCheckCommand": "write-host 'restarting post Optimizations'",
+            "restartTimeout": "5m"
+          },
+          {
+            "type": "PowerShell",
+            "name": "Install Teams",
+            "runElevated": true,
+            "runAsSystem": true,
+            "scriptUri": "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/master/solutions/14_Building_Images_WVD/2_installTeams.ps1"
+          },
+          {
+            "type": "WindowsRestart",
+            "restartCheckCommand": "write-host 'restarting post Teams Install'",
+            "restartTimeout": "5m"
+          },
+          {
+            "type": "WindowsUpdate",
+            "searchCriteria": "IsInstalled=0",
+            "filters": [
+              "exclude:$_.Title -like '*Preview*'",
+              "include:$true"
+            ],
+            "updateLimit": 40
+          }
+        ],
+        "distribute": [
+          {
+            "type": "SharedImage",
+            "galleryImageId": "[parameters('galleryImageId')]",
+            "runOutputName": "[parameters('outputname')]",
+            "artifactTags": {
+              "source": "wvd10",
+              "baseosimg": "windows10"
+            },
+            "replicationRegions": []
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+      ]
+    },
+    {
+      "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
+      "type": "Microsoft.Authorization/roleDefinitions",
+      "apiVersion": "2018-01-01-preview",
+      "name": "[guid(parameters('roleNameAIBCustom'))]",
+      "properties": {
+        "roleName": "[parameters('roleNameAIBCustom')]",
+        "description": "Custom role for AIB to invoke build of VM Template from deployment",
+        "permissions": [
+          {
+            "actions": [
+              "Microsoft.VirtualMachineImages/imageTemplates/Run/action",
+              "Microsoft.Storage/storageAccounts/*",
+              "Microsoft.ContainerInstance/containerGroups/*",
+              "Microsoft.Resources/deployments/*",
+              "Microsoft.Resources/deploymentScripts/*"
+            ]
+          }
+        ],
+        "assignableScopes": [
+          "[resourceGroup().id]"
+        ]
+      }
+    },
+    {
+      "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "name": "[guid(resourceGroup().id, resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
+      "properties": {
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom')))]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))).principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom')))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+      ]
+    },
+    {
+      "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "name": "[guid(resourceGroup().id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
+      "properties": {
+        "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))).principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
+      ]
+    },
+    {
+      "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
+      "type": "Microsoft.Resources/deploymentScripts",
+      "apiVersion": "2020-10-01",
+      "name": "BuildVMImage",
+      "location": "[resourceGroup().location]",
+      "kind": "AzurePowerShell",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[parameters('uamiId')]": {}
+        }
+      },
+      "properties": {
+        "forceUpdateTag": "1",
+        "azPowerShellVersion": "5.9",
+        "arguments": "",
+        "scriptContent": "[format('Invoke-AzResourceAction -ResourceName {0} -ResourceGroupName {1} -ResourceType Microsoft.VirtualMachineImages/imageTemplates -ApiVersion \"2020-02-14\" -Action Run -Force', parameters('imageTemplateName'), parameters('rgname'))]",
+        "timeout": "PT5M",
+        "cleanupPreference": "Always",
+        "retentionInterval": "P1D"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.VirtualMachineImages/imageTemplates', parameters('imageTemplateName'))]"
+      ]
+    }
+  ]
+}

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-image-builder-module.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-image-builder-module.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "7828609930759609063"
+      "version": "dev",
+      "templateHash": "17714227319258150588"
     }
   },
   "parameters": {

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-sig-module.bicep
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-sig-module.bicep
@@ -5,7 +5,6 @@ param imageDefinitionName string
 param imageOffer string
 param imageSKU string
 
-
 //Create Shared Image Gallery
 resource wvdsig 'Microsoft.Compute/galleries@2020-09-30' = {
   name: sigName

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-sig-module.bicep
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-sig-module.bicep
@@ -1,0 +1,42 @@
+param sigName string
+param sigLocation string
+param imagePublisher string
+param imageDefinitionName string
+param imageOffer string
+param imageSKU string
+
+
+//Create Shared Image Gallery
+resource wvdsig 'Microsoft.Compute/galleries@2020-09-30' = {
+  name: sigName
+  location: sigLocation
+}
+
+// Create SIG Image Definition
+resource wvdid 'Microsoft.Compute/galleries/images@2019-07-01' = {
+  name: '${wvdsig.name}/${imageDefinitionName}'
+  location: sigLocation
+  properties: {
+    osType: 'Windows'
+    osState: 'Generalized'
+    identifier: {
+      publisher: imagePublisher
+      offer: imageOffer
+      sku: imageSKU
+    }
+    recommended: {
+      vCPUs: {
+        min: 2
+        max: 32
+      }
+      memory: {
+        min: 4
+        max: 64
+      }
+    }
+    hyperVGeneration: 'V2'
+  }
+  tags: {}
+}
+
+output wvdidoutput string = wvdid.id

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-sig-module.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-sig-module.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "5073079281495202193"
+      "version": "dev",
+      "templateHash": "13198127151453916452"
     }
   },
   "parameters": {

--- a/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-sig-module.json
+++ b/docs/examples/201/wvd-backplane-with-network-and-storage-and-monitoring/wvd-sig-module.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "5073079281495202193"
+    }
+  },
+  "parameters": {
+    "sigName": {
+      "type": "string"
+    },
+    "sigLocation": {
+      "type": "string"
+    },
+    "imagePublisher": {
+      "type": "string"
+    },
+    "imageDefinitionName": {
+      "type": "string"
+    },
+    "imageOffer": {
+      "type": "string"
+    },
+    "imageSKU": {
+      "type": "string"
+    }
+  },
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.Compute/galleries",
+      "apiVersion": "2020-09-30",
+      "name": "[parameters('sigName')]",
+      "location": "[parameters('sigLocation')]"
+    },
+    {
+      "type": "Microsoft.Compute/galleries/images",
+      "apiVersion": "2019-07-01",
+      "name": "[format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName'))]",
+      "location": "[parameters('sigLocation')]",
+      "properties": {
+        "osType": "Windows",
+        "osState": "Generalized",
+        "identifier": {
+          "publisher": "[parameters('imagePublisher')]",
+          "offer": "[parameters('imageOffer')]",
+          "sku": "[parameters('imageSKU')]"
+        },
+        "recommended": {
+          "vCPUs": {
+            "min": 2,
+            "max": 32
+          },
+          "memory": {
+            "min": 4,
+            "max": 64
+          }
+        },
+        "hyperVGeneration": "V2"
+      },
+      "tags": {},
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/galleries', parameters('sigName'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "wvdidoutput": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Compute/galleries/images', split(format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName')), '/')[0], split(format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName')), '/')[1])]"
+    }
+  }
+}


### PR DESCRIPTION
## Contributing an example

* [] I have checked that there is not an equivalent example already submitted
* [] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [] I have checked that all tests are passing by running `dotnet test`
* [] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

@fberson  Suggesting the addition of a Shared image gallery and Azure Image Builder module which:
Create a SIG, Image Definition, AIB Role, Managed Identity, Image Template for W10 Multisession.

Optionally, if the AIB parameter is set to true it can then invoke a deploy script in the template to start the build of the Image using AIB at the end.

Some of this is based on the content created by @danielsollondon but formatted for Bicep
https://github.com/danielsollondon/azvmimagebuilder/tree/master/solutions/14_Building_Images_WVD

I have been looking at framing this example in the context of our WVD Enterprise Scale Construction set reference and have some more examples to link it up such as vNet Peering to hub (that is ready to go if interest) and Hostpool VM Creation based on the AIB definition, let me know if you think that is worth adding into a separate 'WVD ESLZ Construction Set' Example:
https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/scenarios/wvd/enterprise-scale-landing-zone

