### PR TITLE
ValidateSnippetCompletionAfterPlaceholderReplacements - ensure 'combined' contains the original file + snippet insertion

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -82,6 +82,7 @@ namespace Bicep.LangServer.IntegrationTests
             File.Exists(bicepFileName).Should().BeTrue($"Snippet placeholder file \"{bicepSourceFileName}\" should be checked in");
 
             var bicepContents = await File.ReadAllTextAsync(bicepFileName);
+            bicepContents = StringUtils.ReplaceNewlines(bicepContents, "\n");
             var cursor = bicepContents.IndexOf("// Insert snippet here");
 
             // Request the expected completion from the server, and ensure it is unique + valid
@@ -107,7 +108,7 @@ namespace Bicep.LangServer.IntegrationTests
                 var compilation = new Compilation(TypeProvider, syntaxTreeGrouping);
                 var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
-                var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(bicepContentsReplaced, Environment.NewLine, diagnostics, diag => OutputHelper.GetDiagLoggingString(bicepContentsReplaced, outputDirectory, diag));
+                var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(bicepContentsReplaced, "\n", diagnostics, diag => OutputHelper.GetDiagLoggingString(bicepContentsReplaced, outputDirectory, diag));
                 File.WriteAllText(combinedFileName + ".actual", sourceTextWithDiags);
 
                 sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -80,13 +80,19 @@ namespace Bicep.LangServer.IntegrationTests
             var bicepFileName = Path.Combine(outputDirectory, "main.bicep");
             var bicepSourceFileName = Path.Combine("src", "Bicep.LangServer.IntegrationTests", pathPrefix, Path.GetRelativePath(outputDirectory, bicepFileName));
             File.Exists(bicepFileName).Should().BeTrue($"Snippet placeholder file \"{bicepSourceFileName}\" should be checked in");
+
             var bicepContents = await File.ReadAllTextAsync(bicepFileName);
+            var cursor = bicepContents.IndexOf("// Insert snippet here");
 
             // Request the expected completion from the server, and ensure it is unique + valid
-            var completionText = await RequestSnippetCompletion(bicepFileName, completionData, bicepContents);
+            var completionText = await RequestSnippetCompletion(bicepFileName, completionData, bicepContents, cursor);
 
             // Replace all the placeholders with values from the placeholder file
             var replacementContents = SnippetCompletionTestHelper.GetSnippetTextAfterPlaceholderReplacements(completionText, bicepContents);
+
+            var bicepContentsReplaced = bicepContents.Substring(0, cursor) +
+                replacementContents +
+                bicepContents.Substring(cursor);
 
             using (new AssertionScope())
             {
@@ -96,12 +102,12 @@ namespace Bicep.LangServer.IntegrationTests
 
                 var combinedFileUri = PathHelper.FilePathToFileUrl(combinedFileName);
                 var syntaxTreeGrouping = SyntaxTreeGroupingFactory.CreateForFiles(new Dictionary<Uri, string> {
-                    [combinedFileUri] = replacementContents,
+                    [combinedFileUri] = bicepContentsReplaced,
                 }, combinedFileUri);
                 var compilation = new Compilation(TypeProvider, syntaxTreeGrouping);
                 var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
-                var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(replacementContents, Environment.NewLine, diagnostics, diag => OutputHelper.GetDiagLoggingString(replacementContents, outputDirectory, diag));
+                var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(bicepContentsReplaced, Environment.NewLine, diagnostics, diag => OutputHelper.GetDiagLoggingString(bicepContentsReplaced, outputDirectory, diag));
                 File.WriteAllText(combinedFileName + ".actual", sourceTextWithDiags);
 
                 sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(
@@ -112,7 +118,7 @@ namespace Bicep.LangServer.IntegrationTests
             }
         }
 
-        private async Task<string> RequestSnippetCompletion(string bicepFileName, CompletionData completionData, string placeholderFile)
+        private async Task<string> RequestSnippetCompletion(string bicepFileName, CompletionData completionData, string placeholderFile, int cursor)
         {
             var documentUri = DocumentUri.FromFileSystemPath(bicepFileName);
             var syntaxTree = SyntaxTree.Create(documentUri.ToUri(), placeholderFile);
@@ -124,7 +130,6 @@ namespace Bicep.LangServer.IntegrationTests
                 null,
                 TypeProvider);
 
-            var cursor = placeholderFile.IndexOf("// Insert snippet here");
             var completions = await client.RequestCompletion(new CompletionParams
             {
                 TextDocument = documentUri,

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/module/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/module/main.combined.bicep
@@ -1,4 +1,9 @@
+// $1 = testModule
+// $2 = 'main.bicep'
+// $3 = 'myModule'
+
 module testModule 'main.bicep' = {
   name: 'myModule'
   
-}
+}// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/output/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/output/main.combined.bicep
@@ -1,1 +1,6 @@
-output testOutput int = 1
+// $0 = 1
+// $1 = testOutput
+// $2 = int
+
+output testOutput int = 1// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults-allowed-values/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults-allowed-values/main.combined.bicep
@@ -1,5 +1,11 @@
+// $1 = testParam
+// $2 = int
+// $3 = 1
+// $4 = 2
+
 @allowed([
   1
 ])
-param testParam int = 2
+param testParam int = 2// Insert snippet here
 //@[6:15) [no-unused-params (Warning)] Parameter "testParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |testParam|
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults/main.combined.bicep
@@ -1,2 +1,7 @@
-param testParam int = 1
+// $1 = testParam
+// $2 = int
+// $3 = 1
+
+param testParam int = 1// Insert snippet here
 //@[6:15) [no-unused-params (Warning)] Parameter "testParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |testParam|
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-secure-string/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-secure-string/main.combined.bicep
@@ -1,3 +1,6 @@
+// $1 = testParam
+
 @secure()
-param testParam string
+param testParam string// Insert snippet here
 //@[6:15) [no-unused-params (Warning)] Parameter "testParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |testParam|
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param/main.combined.bicep
@@ -1,2 +1,6 @@
-param testParam int
+// $1 = testParam
+// $2 = int
+
+param testParam int// Insert snippet here
 //@[6:15) [no-unused-params (Warning)] Parameter "testParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |testParam|
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-aks-cluster/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-aks-cluster/main.combined.bicep
@@ -1,3 +1,12 @@
+// $1 = aksCluster
+// $2 = 'name'
+// $3 = 1.19.7
+// $4 = 'dnsPrefix'
+// $5 = 3
+// $6 = 'Standard_DS2_v2'
+// $7 = 'adminUsername'
+// $8 = 'REQUIRED'
+
 resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -29,4 +38,5 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-api-management-instance/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-api-management-instance/main.combined.bicep
@@ -1,3 +1,11 @@
+// $1 = apiManagementInstance
+// $2 = 'name'
+// $3 = 1
+// $4 = 'Developer'
+// $5 = 'None'
+// $6 = 'publisherEmail@contoso.com'
+// $7 = 'publisherName'
+
 resource apiManagementInstance 'Microsoft.ApiManagement/service@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -11,4 +19,5 @@ resource apiManagementInstance 'Microsoft.ApiManagement/service@2020-12-01' = {
     publisherName: 'publisherName'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-gateway-waf/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-gateway-waf/main.combined.bicep
@@ -1,3 +1,13 @@
+// $1 = applicationGatewayFirewall
+// $2 = 'name'
+// $3 = true
+// $4 = 128
+// $5 = 100
+// $6 = Enabled
+// $7 = Detection
+// $8 = 'ruleSetType'
+// $9 = 'ruleSetVersion'
+
 resource applicationGatewayFirewall 'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@2020-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -19,4 +29,5 @@ resource applicationGatewayFirewall 'Microsoft.Network/ApplicationGatewayWebAppl
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-gateway/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-gateway/main.combined.bicep
@@ -1,3 +1,28 @@
+// $1 = applicationGateway
+// $2 = 'name'
+// $3 = Standard_Small
+// $4 = Standard
+// $5 = 2
+// $6 = 'name'
+// $7 = 'id'
+// $8 = 'name'
+// $9 = 'id'
+// $10 = 'name'
+// $11 = 80
+// $12 = 'name'
+// $13 = 'name'
+// $14 = 80
+// $15 = Http
+// $16 = 'name'
+// $17 = 'id'
+// $18 = 'id'
+// $19 = Http
+// $20 = 'name'
+// $21 = Basic
+// $22 = 'id'
+// $23 = 'id'
+// $24 = 'id'
+
 resource applicationGateway 'Microsoft.Network/applicationGateways@2020-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -84,4 +109,5 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2020-11-01' =
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights-alert-rules/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights-alert-rules/main.combined.bicep
@@ -1,3 +1,14 @@
+// $1 = appInsightsAlertRules
+// $2 = 'name'
+// $3 = 'name'
+// $4 = 'description'
+// $5 = 3
+// $6 = Microsoft.Azure.Management.Insights.Models.LocationThresholdRuleCondition
+// $7 = Microsoft.Azure.Management.Insights.Models.RuleManagementEventDataSource
+// $8 = 'resourceUri'
+// $9 = 'windowSize'
+// $10 = Microsoft.Azure.Management.Insights.Models.RuleEmailAction
+
 resource appInsightsAlertRules 'Microsoft.Insights/alertrules@2016-03-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -20,4 +31,5 @@ resource appInsightsAlertRules 'Microsoft.Insights/alertrules@2016-03-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights-auto-scale-settings/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights-auto-scale-settings/main.combined.bicep
@@ -1,3 +1,20 @@
+// $1 = appInsightsAutoScaleSettings
+// $2 = 'name'
+// $3 = web
+// $4 = appServiceId
+// $5 = 'name'
+// $6 = 'name'
+// $7 = 'minimum'
+// $8 = 'maximum'
+// $9 = 'default'
+// $10 = 'name'
+// $11 = 'metricResourceUri'
+// $12 = 'value'
+// $13 = 'metricName'
+// $14 = 'metricResourceUri'
+// $15 = 'value'
+// $16 = 'metricResourceUri'
+
 resource appInsightsAutoScaleSettings 'Microsoft.Insights/autoscalesettings@2015-04-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -59,4 +76,5 @@ resource appInsightsAutoScaleSettings 'Microsoft.Insights/autoscalesettings@2015
     targetResourceUri: 'metricResourceUri'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights/main.combined.bicep
@@ -1,3 +1,7 @@
+// $1 = appInsightsComponents
+// $2 = 'name'
+// $3 = web
+
 resource appInsightsComponents 'Microsoft.Insights/components@2020-02-02-preview' = {
   name: 'name'
   location: resourceGroup().location
@@ -6,4 +10,5 @@ resource appInsightsComponents 'Microsoft.Insights/components@2020-02-02-preview
     Application_Type: 'web'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-plan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-plan/main.combined.bicep
@@ -1,3 +1,6 @@
+// $1 = appServicePlan
+// $2 = 'name'
+
 resource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -6,4 +9,5 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
     capacity: 1
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-security-group/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-security-group/main.combined.bicep
@@ -1,5 +1,9 @@
+// $1 = applicationSecurityGroup
+// $2 = 'name'
+
 resource applicationSecurityGroup 'Microsoft.Network/applicationSecurityGroups@2020-11-01' = {
   name: 'name'
   location: resourceGroup().location
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-account/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-account/main.combined.bicep
@@ -1,3 +1,7 @@
+// $1 = automationAccount
+// $2 = 'name'
+// $3 = 'Basic'
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -7,4 +11,5 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' 
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-cert/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-cert/main.combined.bicep
@@ -1,3 +1,11 @@
+// $1 = 'name'
+// $2 = automationCertificate
+// $3 = 'name'
+// $4 = 'base64Value'
+// $5 = 'description'
+// $6 = 'thumbprint'
+// $7 = true
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
   name: 'name'
 }
@@ -12,4 +20,5 @@ resource automationCertificate 'Microsoft.Automation/automationAccounts/certific
     isExportable: true
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-cred/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-cred/main.combined.bicep
@@ -1,3 +1,10 @@
+// $1 = 'name'
+// $2 = automationCredential
+// $3 = 'name'
+// $4 = 'userName'
+// $5 = 'password'
+// $6 = 'description'
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
   name: 'name'
 }
@@ -11,4 +18,5 @@ resource automationCredential 'Microsoft.Automation/automationAccounts/credentia
     description: 'description'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-job-schedule/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-job-schedule/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = 'name'
+// $2 = automationJobSchedule
+// $3 = 'name'
+// $4 = 'name'
+// $5 = 'name'
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
   name: 'name'
 }
@@ -14,4 +20,5 @@ resource automationJobSchedule 'Microsoft.Automation/automationAccounts/jobSched
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-module/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-module/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = 'name'
+// $2 = automationAccountVariable
+// $3 = 'name'
+// $4 = 'https://test-content-url.nupkg'
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' = {
   name: 'name'
 }
@@ -10,4 +15,5 @@ resource automationAccountVariable 'Microsoft.Automation/automationAccounts/modu
       uri: 'https://test-content-url.nupkg'
     }
   }
-}
+}// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-runbook/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-runbook/main.combined.bicep
@@ -1,3 +1,13 @@
+// $1 = 'name'
+// $2 = automationRunbook
+// $3 = 'name'
+// $4 = true
+// $5 = true
+// $6 = Script
+// $7 = 'uri'
+// $8 = '1.0.0.0'
+// $9 = 'description'
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
   name: 'name'
 }
@@ -17,4 +27,5 @@ resource automationRunbook 'Microsoft.Automation/automationAccounts/runbooks@201
     description: 'description'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-schedule/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-schedule/main.combined.bicep
@@ -1,3 +1,11 @@
+// $1 = 'name'
+// $2 = automationSchedule
+// $3 = 'name'
+// $4 = 'description'
+// $5 = 'startTime'
+// $6 = 'interval'
+// $7 = OneTime
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
   name: 'name'
 }
@@ -12,4 +20,5 @@ resource automationSchedule 'Microsoft.Automation/automationAccounts/schedules@2
     frequency: 'OneTime'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-variable/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-variable/main.combined.bicep
@@ -1,3 +1,10 @@
+// $1 = 'name'
+// $2 = automationVariable
+// $3 = 'name'
+// $4 = 'value'
+// $5 = 'description'
+// $6 = true
+
 resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
   name: 'name'
 }
@@ -11,4 +18,5 @@ resource automationVariable 'Microsoft.Automation/automationAccounts/variables@2
     isEncrypted: true
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-availability-set/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-availability-set/main.combined.bicep
@@ -1,5 +1,9 @@
+// $1 = availabilitySet
+// $2 = 'name'
+
 resource availabilitySet 'Microsoft.Compute/availabilitySets@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-group/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-group/main.combined.bicep
@@ -1,3 +1,15 @@
+// $1 = containerGroup
+// $2 = 'name'
+// $3 = 'containername'
+// $4 = 'mcr.microsoft.com/azuredocs/aci-helloworld:latest'
+// $5 = 80
+// $6 = 1
+// $7 = 4
+// $8 = 'OnFailure'
+// $9 = 'Linux'
+// $10 = 'TCP'
+// $11 = 80
+
 resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2021-03-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -34,4 +46,5 @@ resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2021-03-01'
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = containerRegistry
+// $2 = 'name'
+// $3 = 'Classic'
+// $4 = true
+
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -8,4 +13,5 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' =
     adminUserEnabled: true
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-account/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-account/main.combined.bicep
@@ -1,3 +1,14 @@
+// $1 = cosmosDbAccount
+// $2 = 'name'
+// $3 = 'GlobalDocumentDB'
+// $4 = 'Eventual'
+// $5 = 1
+// $6 = 5
+// $7 = 'location'
+// $8 = 0
+// $9 = true
+// $10 = 'EnableTable'
+
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-03-15' = {
   name: 'name'
   location: resourceGroup().location
@@ -23,4 +34,5 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-03-15' = {
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-keyspace/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-keyspace/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = cassandraKeyspace
+// $2 = 'accountName/cassandra/databaseName'
+// $3 = 'id'
+// $4 = 'throughput'
+
 resource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {
   name: 'accountName/cassandra/databaseName'
   properties: {
@@ -9,4 +14,5 @@ resource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-table/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-table/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = 'accountName/cassandra/databaseName'
+// $2 = 'id'
+// $3 = cassandraKeyspaceTable
+// $4 = 'name'
+// $5 = 'id'
+
 resource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {
   name: 'accountName/cassandra/databaseName'
   properties: {
@@ -18,4 +24,5 @@ resource cassandraKeyspaceTable 'Microsoft.DocumentDb/databaseAccounts/apis/keys
     options: {}
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-database/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-database/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = gremlinDb
+// $2 = 'accountName/gremlin/databaseName'
+// $3 = 'id'
+// $4 = 'throughput'
+
 resource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
   name: 'accountName/gremlin/databaseName'
   properties: {
@@ -9,4 +14,5 @@ resource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-graph/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-graph/main.combined.bicep
@@ -1,3 +1,19 @@
+// $1 = 'accountName/gremlin/databaseName'
+// $2 = 'id'
+// $3 = 'throughput'
+// $4 = cosmosDBGremlinGraph
+// $5 = 'name'
+// $6 = 'id'
+// $7 = 'paths'
+// $8 = Hash
+// $9 = Consistent
+// $10 = 'path'
+// $11 = Hash
+// $12 = String
+// $13 = -1
+// $14 = 'path'
+// $15 = 'throughput'
+
 resource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
   name: 'accountName/gremlin/databaseName'
   properties: {
@@ -48,4 +64,5 @@ resource cosmosDBGremlinGraph 'Microsoft.DocumentDb/databaseAccounts/apis/databa
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-mongo-database/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-mongo-database/main.combined.bicep
@@ -1,3 +1,7 @@
+// $1 = mongoDb
+// $2 = 'accountName/mongodb/databaseName'
+// $3 = 'id'
+
 resource mongoDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
   name: 'accountName/mongodb/databaseName'
   properties: {
@@ -7,4 +11,5 @@ resource mongoDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-3
     options: {}
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-container/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-container/main.combined.bicep
@@ -1,3 +1,17 @@
+// $1 = 'accountName/sql/databaseName'
+// $2 = 'id'
+// $3 = sqlContainerName
+// $4 = 'name'
+// $5 = 'id'
+// $6 = 'paths'
+// $7 = Hash
+// $8 = Consistent
+// $9 = 'path'
+// $10 = Hash
+// $11 = String
+// $12 = -1
+// $13 = 'path'
+
 resource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
   name: 'accountName/sql/databaseName'
   properties: {
@@ -44,4 +58,5 @@ resource sqlContainerName 'Microsoft.DocumentDb/databaseAccounts/apis/databases/
     options: {}
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-database/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-database/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = sqlDb
+// $2 = 'accountName/sql/databaseName'
+// $3 = 'id'
+// $4 = 'throughput'
+
 resource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
   name: 'accountName/sql/databaseName'
   properties: {
@@ -9,4 +14,5 @@ resource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31'
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-tablestorage-table/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-tablestorage-table/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = cosmosTable
+// $2 = 'accountName/table/databaseName'
+// $3 = 'id'
+// $4 = 'throughput'
+
 resource cosmosTable 'Microsoft.DocumentDB/databaseAccounts/apis/tables@2016-03-31' = {
   name: 'accountName/table/databaseName'
   properties: {
@@ -9,4 +14,5 @@ resource cosmosTable 'Microsoft.DocumentDB/databaseAccounts/apis/tables@2016-03-
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-data-lake/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-data-lake/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = dataLakeStore
+// $2 = 'name'
+// $3 = 'Consumption'
+// $4 = 'Enabled'
+
 resource dataLakeStore 'Microsoft.DataLakeStore/accounts@2016-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -6,4 +11,5 @@ resource dataLakeStore 'Microsoft.DataLakeStore/accounts@2016-11-01' = {
     encryptionState: 'Enabled'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-dns-record/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-dns-record/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = 'name'
+// $2 = dnsRecord
+// $3 = A
+// $4 = 'name'
+// $5 = ARecords
+
 resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -11,4 +17,5 @@ resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
     'ARecords': []
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-dns-zone/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-dns-zone/main.combined.bicep
@@ -1,5 +1,9 @@
+// $1 = dnsZone
+// $2 = 'name'
+
 resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   name: 'name'
   location: 'global'
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-firewall/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-firewall/main.combined.bicep
@@ -1,3 +1,38 @@
+// $1 = firewall
+// $2 = 'name'
+// $3 = 'name'
+// $4 = 100
+// $5 = Allow
+// $6 = 'name'
+// $7 = 'description'
+// $8 = 'sourceAddress'
+// $9 = Http
+// $10 = 80
+// $11 = 'www.microsoft.com'
+// $12 = 'name'
+// $13 = 100
+// $14 = Dnat
+// $15 = 'name'
+// $16 = 'description'
+// $17 = 'sourceAddress'
+// $18 = 'destinationAddress'
+// $19 = '80'
+// $20 = TCP
+// $21 = 'translatedAddress'
+// $22 = '80'
+// $23 = 'name'
+// $24 = 100
+// $25 = Deny
+// $26 = 'name'
+// $27 = 'description'
+// $28 = 'sourceAddress'
+// $29 = 'destinationAddress'
+// $30 = '80'
+// $31 = TCP
+// $32 = 'name'
+// $33 = 'id'
+// $34 = 'id'
+
 resource firewall 'Microsoft.Network/azureFirewalls@2020-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -106,4 +141,5 @@ resource firewall 'Microsoft.Network/azureFirewalls@2020-11-01' = {
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-function/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-function/main.combined.bicep
@@ -1,3 +1,16 @@
+// $1 = azureFunction
+// $2 = 'name'
+// $3 = 'serverFarmName'
+// $4 = storageAccountName1
+// $5 = 'storageAccountID1'
+// $6 = storageAccountName2
+// $7 = 'storageAccountID2'
+// $8 = storageAccountName3
+// $9 = 'storageAccountID3'
+// $10 = 'applicationInsightsName'
+// $11 = dotnet
+
+
 resource azureFunction 'Microsoft.Web/sites@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -38,4 +51,5 @@ resource azureFunction 'Microsoft.Web/sites@2020-12-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-ip-prefix/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-ip-prefix/main.combined.bicep
@@ -1,3 +1,7 @@
+// $1 = publicIPPrefix
+// $2 = 'name'
+// $3 = 28
+
 resource publicIPPrefix 'Microsoft.Network/publicIPPrefixes@2019-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -9,4 +13,5 @@ resource publicIPPrefix 'Microsoft.Network/publicIPPrefixes@2019-11-01' = {
     prefixLength: 28
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-ip/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-ip/main.combined.bicep
@@ -1,3 +1,7 @@
+// $1 = publicIPAddress
+// $2 = 'name'
+// $3 = 'dnsName'
+
 resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2019-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -8,4 +12,5 @@ resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2019-11-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault-secret/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault-secret/main.combined.bicep
@@ -1,7 +1,12 @@
+// $1 = keyVaultSecret
+// $2 = 'keyVaultName/name'
+// $3 = 'value'
+
 resource keyVaultSecret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
   name: 'keyVaultName/name'
   properties: {
     value: 'value'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = keyVault
+// $2 = 'name'
+// $3 = 'tenantId'
+// $4 = 'objectId'
+
 resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -27,4 +32,5 @@ resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-loadbalancer-external/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-loadbalancer-external/main.combined.bicep
@@ -1,3 +1,20 @@
+// $1 = loadBalancerExternal
+// $2 = 'name'
+// $3 = 'name'
+// $4 = 'publicIP'
+// $5 = 'name'
+// $6 = 'name'
+// $7 = Tcp
+// $8 = 50001
+// $9 = 3389
+// $10 = 'name'
+// $11 = Tcp
+// $12 = 80
+// $13 = 80
+// $14 = 'name'
+// $15 = Tcp
+// $16 = 80
+
 resource loadBalancerExternal 'Microsoft.Network/loadBalancers@2020-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -65,4 +82,5 @@ resource loadBalancerExternal 'Microsoft.Network/loadBalancers@2020-11-01' = {
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-loadbalancer-internal/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-loadbalancer-internal/main.combined.bicep
@@ -1,3 +1,18 @@
+// $1 = loadBalancerInternal
+// $2 = 'name'
+// $3 = 'name'
+// $4 = '0.0.0.0'
+// $5 = 'virtualNetwork'
+// $6 = 'subnet'
+// $7 = 'name'
+// $8 = 'name'
+// $9 = Tcp
+// $10 = 80
+// $11 = 80
+// $12 = 'name'
+// $13 = Tcp
+// $14 = 80
+
 resource loadBalancerInternal 'Microsoft.Network/loadBalancers@2020-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -53,4 +68,5 @@ resource loadBalancerInternal 'Microsoft.Network/loadBalancers@2020-11-01' = {
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-solution/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-solution/main.combined.bicep
@@ -1,3 +1,12 @@
+// $1 = logAnalyticsSolution
+// $2 = 'name'
+// $3 = 'logAnalyticsWorkspace'
+// $4 = 'logAnalyticsSolution'
+// $5 = 'name'
+// $6 = 'product'
+// $7 = 'publisher'
+// $8 = 'promotionCode'
+
 resource logAnalyticsSolution 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
   name: 'name'
   location: resourceGroup().location
@@ -14,4 +23,5 @@ resource logAnalyticsSolution 'Microsoft.OperationsManagement/solutions@2015-11-
     promotionCode: 'promotionCode'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-workspace/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-workspace/main.combined.bicep
@@ -1,3 +1,7 @@
+// $1 = logAnalyticsWorkspace
+// $2 = 'name'
+// $3 = 'Free'
+
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -7,4 +11,5 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-logic-app-connector/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-logic-app-connector/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = logicAppConnector
+// $2 = 'name'
+// $3 = 'name'
+// $4 = 'logicAppConnectorApi'
+
 resource logicAppConnector 'Microsoft.Web/connections@2015-08-01-preview' = {
   name: 'name'
   location: resourceGroup().location
@@ -6,4 +11,5 @@ resource logicAppConnector 'Microsoft.Web/connections@2015-08-01-preview' = {
     apiDefinitionUrl: subscriptionResourceId('Microsoft.Web/locations/managedApis', resourceGroup().location, 'logicAppConnectorApi')
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-logic-app/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-logic-app/main.combined.bicep
@@ -1,3 +1,6 @@
+// $1 = logicApp
+// $2 = 'name'
+
 resource logicApp 'Microsoft.Logic/integrationAccounts@2016-06-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -9,4 +12,5 @@ resource logicApp 'Microsoft.Logic/integrationAccounts@2016-06-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-managed-identity/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-managed-identity/main.combined.bicep
@@ -1,5 +1,9 @@
+// $1 = managedIdentity
+// $2 = 'name'
+
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
   name: 'name'
   location: resourceGroup().location
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-media/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-media/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = mediaServices
+// $2 = 'name'
+// $3 = 'mediaServiceStorageAccount'
+// $4 = Primary
+
 resource mediaServices 'Microsoft.Media/mediaServices@2020-05-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -10,4 +15,5 @@ resource mediaServices 'Microsoft.Media/mediaServices@2020-05-01' = {
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-mysql/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-mysql/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = mySQLdb
+// $2 = 'name'
+// $3 = 'administratorLogin'
+// $4 = 'administratorLoginPassword'
+// $5 = 'Default'
+
 resource mySQLdb 'Microsoft.DBforMySQL/servers@2017-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -7,4 +13,5 @@ resource mySQLdb 'Microsoft.DBforMySQL/servers@2017-12-01' = {
     createMode: 'Default'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nic/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nic/main.combined.bicep
@@ -1,3 +1,10 @@
+// $1 = networkInterface
+// $2 = 'name'
+// $3 = 'name'
+// $4 = Dynamic
+// $5 = 'virtualNetwork'
+// $6 = 'subnet'
+
 resource networkInterface 'Microsoft.Network/networkInterfaces@2020-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -15,4 +22,5 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2020-11-01' = {
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nsg/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nsg/main.combined.bicep
@@ -1,3 +1,16 @@
+// $1 = networkSecurityGroup
+// $2 = 'name'
+// $3 = 'nsgRule'
+// $4 = 'description'
+// $5 = 'Tcp'
+// $6 = '5'
+// $7 = '*'
+// $8 = '*'
+// $9 = '*'
+// $10 = 'Allow'
+// $11 = 100
+// $12 = 'Inbound'
+
 resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2019-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -20,4 +33,5 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2019-11-0
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nsgrule/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nsgrule/main.combined.bicep
@@ -1,3 +1,15 @@
+// $1 = networkSecurityGroupSecurityRule
+// $2 = 'networkSecurityGroup/name'
+// $3 = 'description'
+// $4 = 'Tcp'
+// $5 = '1026'
+// $6 = '1067'
+// $7 = '0.11.26.162'
+// $8 = '248.233.26.131'
+// $9 = 'Allow'
+// $10 = 100
+// $11 = 'Inbound'
+
 resource networkSecurityGroupSecurityRule 'Microsoft.Network/networkSecurityGroups/securityRules@2019-11-01' = {
   name: 'networkSecurityGroup/name'
   properties: {
@@ -12,4 +24,5 @@ resource networkSecurityGroupSecurityRule 'Microsoft.Network/networkSecurityGrou
     direction: 'Inbound'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-plan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-plan/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = appServicePlan
+// $2 = 'name'
+// $3 = 'name'
+// $4 = 1
+
 resource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -6,4 +11,5 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
     capacity: 1
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-recovery-service-vault/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-recovery-service-vault/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = recoveryServiceVault
+// $2 = 'name'
+// $3 = 'RS0'
+// $4 = 'Standard'
+
 resource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -6,4 +11,5 @@ resource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {
     tier: 'Standard'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-redis/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-redis/main.combined.bicep
@@ -1,3 +1,6 @@
+// $1 = redisCache
+// $2 = 'name'
+
 resource redisCache 'Microsoft.Cache/Redis@2019-07-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -9,4 +12,5 @@ resource redisCache 'Microsoft.Cache/Redis@2019-07-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-table-route/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-table-route/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = routeTableRoute
+// $2 = 'routeTableName/name'
+// $3 = '0.11.26.162'
+// $4 = 'None'
+// $5 = '248.233.26.131'
+
 resource routeTableRoute 'Microsoft.Network/routeTables/routes@2019-11-01' = {
   name: 'routeTableName/name'
   properties: {
@@ -6,4 +12,5 @@ resource routeTableRoute 'Microsoft.Network/routeTables/routes@2019-11-01' = {
     nextHopIpAddress: '248.233.26.131'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-table/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-table/main.combined.bicep
@@ -1,3 +1,11 @@
+// $1 = routeTable
+// $2 = 'name'
+// $3 = 'name'
+// $4 = 'destinationCIDR'
+// $5 = 'VirtualNetworkGateway'
+// $6 = '0.11.26.162'
+// $7 = true
+
 resource routeTable 'Microsoft.Network/routeTables@2019-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -15,4 +23,5 @@ resource routeTable 'Microsoft.Network/routeTables@2019-11-01' = {
     disableBgpRoutePropagation: true
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.combined.bicep
@@ -1,3 +1,7 @@
+// $1 = sharedImageGallery
+// $2 = 'name'
+// $3 = 'description'
+
 resource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {
   name: 'name'
   location: resourceGroup().location
@@ -5,4 +9,5 @@ resource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {
     description: 'description'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql-db-import/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql-db-import/main.combined.bicep
@@ -1,3 +1,14 @@
+// $1 = 'sqlDatabase/import'
+// $2 = 'location'
+// $3 = sqlDatabaseImport
+// $4 = 'name'
+// $5 = StorageAccessKey
+// $6 = 'storageKey'
+// $7 = 'storageUri'
+// $8 = 'administratorLogin'
+// $9 = 'administratorLoginPassword'
+// $10 = 'operationMode'
+
 resource sqlServerDatabase 'Microsoft.Sql/servers/databases@2014-04-01' = {
   name: 'sqlDatabase/import'
   location: 'location'
@@ -15,4 +26,5 @@ resource sqlDatabaseImport 'Microsoft.Sql/servers/databases/extensions@2014-04-0
     operationMode: 'operationMode'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql-server-firewall-rules/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql-server-firewall-rules/main.combined.bicep
@@ -1,3 +1,11 @@
+// $1 = 'name'
+// $2 = 'administratorLogin'
+// $3 = 'administratorLoginPassword'
+// $4 = sqlServerFirewallRules
+// $5 = 'name'
+// $6 = 'startIpAddress'
+// $7 = 'endIpAddress'
+
 resource sqlServer 'Microsoft.Sql/servers@2020-11-01-preview' = {
   name: 'name'
   location: resourceGroup().location
@@ -15,4 +23,5 @@ resource sqlServerFirewallRules 'Microsoft.Sql/servers/firewallRules@2020-11-01-
     endIpAddress: 'endIpAddress'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql/main.combined.bicep
@@ -1,3 +1,11 @@
+// $1 = 'name'
+// $2 = sqlServerDatabase
+// $3 = 'name'
+// $4 = 'collation'
+// $5 = Basic
+// $6 = 'maxSizeBytes'
+// $7 = Basic
+
 resource sqlServer 'Microsoft.Sql/servers@2014-04-01' ={
   name: 'name'
   location: resourceGroup().location
@@ -14,4 +22,5 @@ resource sqlServerDatabase 'Microsoft.Sql/servers/databases@2014-04-01' = {
     requestedServiceObjectiveName: 'Basic'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-storage/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-storage/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = storageaccount
+// $2 = 'name'
+// $3 = 'StorageV2'
+// $4 = 'Premium_LRS'
+// $5 = 'Premium'
+
 resource storageaccount 'Microsoft.Storage/storageAccounts@2021-02-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -7,4 +13,5 @@ resource storageaccount 'Microsoft.Storage/storageAccounts@2021-02-01' = {
     tier: 'Premium'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-template-spec/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-template-spec/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = templateSpec
+// $2 = 'name'
+// $3 = 'description'
+// $4 = 'displayName'
+
 resource templateSpec 'Microsoft.Resources/templateSpecs@2019-06-01-preview' = {
   name: 'name'
   location: resourceGroup().location
@@ -6,4 +11,5 @@ resource templateSpec 'Microsoft.Resources/templateSpecs@2019-06-01-preview' = {
     displayName: 'displayName'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-traffic-manager/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-traffic-manager/main.combined.bicep
@@ -1,3 +1,18 @@
+// $1 = trafficManagerProfile
+// $2 = 'name'
+// $3 = 'Performance'
+// $4 = 'dnsConfigRelativeName'
+// $5 = 'HTTP'
+// $6 = 80
+// $7 = 'path'
+// $8 = 30
+// $9 = 5
+// $10 = 3
+// $11 = 'targetResourceId'
+// $12 = 'Enabled'
+// $13 = 100
+// $14 = 1
+
 resource trafficManagerProfile 'Microsoft.Network/trafficManagerProfiles@2018-04-01' = {
   name: 'name'
   location: 'global'
@@ -28,4 +43,5 @@ resource trafficManagerProfile 'Microsoft.Network/trafficManagerProfiles@2018-04
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = virtualWan
+// $2 = 'name'
+// $3 = 'Standard'
+// $4 = 'None'
+
 resource virtualWan 'Microsoft.Network/virtualWans@2020-07-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -9,4 +14,5 @@ resource virtualWan 'Microsoft.Network/virtualWans@2020-07-01' = {
     office365LocalBreakoutCategory: 'None'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-dsc/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-dsc/main.combined.bicep
@@ -1,3 +1,10 @@
+// $1 = 'name'
+// $2 = windowsVMDsc
+// $3 = 'name'
+// $4 = 'modulesUrl'
+// $5 = 'sasToken'
+// $6 = 'configurationFunction'
+
 resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -19,4 +26,5 @@ resource windowsVMDsc 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' 
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-script-linux/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-script-linux/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = 'name'
+// $2 = linuxVMExtensions
+// $3 = 'name'
+// $4 = 'fileUris'
+// $5 = customScript.sh
+
 resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -22,4 +28,5 @@ resource linuxVMExtensions 'Microsoft.Compute/virtualMachines/extensions@2019-07
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-script-windows/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-script-windows/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = 'name'
+// $2 = windowsVMExtensions
+// $3 = 'name'
+// $4 = 'fileUris'
+// $5 = customScript.ps1
+
 resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -22,4 +28,5 @@ resource windowsVMExtensions 'Microsoft.Compute/virtualMachines/extensions@2020-
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-ubuntu/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-ubuntu/main.combined.bicep
@@ -1,3 +1,12 @@
+// $1 = ubuntuVM
+// $2 = 'name'
+// $3 = 'computerName'
+// $4 = 'adminUsername'
+// $5 = 'adminPassword'
+// $6 = 'name'
+// $7 = 'id'
+// $8 = 'storageUri'
+
 resource ubuntuVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -38,4 +47,5 @@ resource ubuntuVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows-diagnostics/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows-diagnostics/main.combined.bicep
@@ -1,3 +1,10 @@
+// $1 = windowsVMDiagnostics
+// $2 = 'windowsVM/Diagnostics'
+// $3 = 'storageAccount'
+// $4 = 'storageAccountName'
+// $5 = 'storageAccountKey'
+// $6 = 'storageAccountEndPoint'
+
 resource windowsVMDiagnostics 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {
   name: 'windowsVM/Diagnostics'
   location: resourceGroup().location
@@ -17,4 +24,5 @@ resource windowsVMDiagnostics 'Microsoft.Compute/virtualMachines/extensions@2020
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows/main.combined.bicep
@@ -1,3 +1,12 @@
+// $1 = windowsVM
+// $2 = 'name'
+// $3 = 'computerName'
+// $4 = 'adminUsername'
+// $5 = 'adminPassword'
+// $6 = 'name'
+// $7 = 'id'
+// $8 = 'storageUri'
+
 resource windowsVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -38,4 +47,5 @@ resource windowsVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet-peering/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet-peering/main.combined.bicep
@@ -1,3 +1,11 @@
+// $1 = peering
+// $2 = 'virtualNetwork/name'
+// $3 = true
+// $4 = true
+// $5 = true
+// $6 = true
+// $7 = 'REQUIRED'
+
 resource peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-07-01' = {
   name: 'virtualNetwork/name'
   properties: {
@@ -10,4 +18,5 @@ resource peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = virtualNetwork
+// $2 = 'name'
+// $3 = '0.11.26.162'
+// $4 = '248.233.26.131'
+
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2019-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -23,4 +28,5 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2019-11-01' = {
     ]
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-local-gateway/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-local-gateway/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = localNetworkGateway
+// $2 = 'name'
+// $3 = 'REQUIRED'
+// $4 = '98.139.180.149'
+
 resource localNetworkGateway 'Microsoft.Network/localNetworkGateways@2019-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -10,4 +15,5 @@ resource localNetworkGateway 'Microsoft.Network/localNetworkGateways@2019-11-01'
     gatewayIpAddress: '98.139.180.149'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-vnet-connection/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-vnet-connection/main.combined.bicep
@@ -1,3 +1,11 @@
+// $1 = vpnVnetConnection
+// $2 = 'name'
+// $3 = 'vnetGateway'
+// $4 = 'localGateway'
+// $5 = IPsec
+// $6 = 0
+// $7 = 'sharedkey'
+
 resource vpnVnetConnection 'Microsoft.Network/connections@2020-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -15,4 +23,5 @@ resource vpnVnetConnection 'Microsoft.Network/connections@2020-11-01' = {
     sharedKey: 'sharedkey'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-vnet-gateway/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-vnet-gateway/main.combined.bicep
@@ -1,3 +1,15 @@
+// $1 = virtualNetworkGateway
+// $2 = 'name'
+// $3 = 'name'
+// $4 = 'virtualNetwork'
+// $5 = 'subnet'
+// $6 = 'publicIPAddress'
+// $7 = Basic
+// $8 = Basic
+// $9 = Vpn
+// $10 = PolicyBased
+// $11 = true
+
 resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2020-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -25,4 +37,5 @@ resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2020-11
     enableBgp: true
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-web-app-deploy/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-web-app-deploy/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = 'name'
+// $2 = webApplicationExtension
+// $3 = 'packageUri'
+// $4 = 'connectionString'
+// $5 = 'name'
+
 resource webApplication 'Microsoft.Web/sites@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -15,4 +21,5 @@ resource webApplicationExtension 'Microsoft.Web/sites/extensions@2020-12-01' = {
     }
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-web-app/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-web-app/main.combined.bicep
@@ -1,3 +1,8 @@
+// $1 = webApplication
+// $2 = 'name'
+// $3 = appServicePlan
+// $4 = 'appServicePlan'
+
 resource webApplication 'Microsoft.Web/sites@2018-11-01' = {
   name: 'name'
   location: resourceGroup().location
@@ -7,4 +12,5 @@ resource webApplication 'Microsoft.Web/sites@2018-11-01' = {
   properties: {
     serverFarmId: resourceId('Microsoft.Web/serverfarms', 'appServicePlan')
   }
-}
+}// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-appgroup/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-appgroup/main.combined.bicep
@@ -1,3 +1,9 @@
+// $1 = applicationGroup
+// $2 = 'name'
+// $3 = 'friendlyName'
+// $4 = 'Desktop'
+// $5 = 'REQUIRED'
+
 resource applicationGroup 'Microsoft.DesktopVirtualization/applicationgroups@2019-12-10-preview' = {
   name: 'name'
   location: resourceGroup().location
@@ -7,4 +13,5 @@ resource applicationGroup 'Microsoft.DesktopVirtualization/applicationgroups@201
     hostPoolArmPath: resourceId('Microsoft.DesktopVirtualization/hostpools', 'REQUIRED')
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-hostpool/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-hostpool/main.combined.bicep
@@ -1,3 +1,10 @@
+// $1 = hostPool
+// $2 = 'name'
+// $3 = 'friendlyName'
+// $4 = 'Pooled'
+// $5 = 'BreadthFirst'
+// $6 = 'Desktop'
+
 resource hostPool 'Microsoft.DesktopVirtualization/hostpools@2019-12-10-preview' = {
   name: 'name'
   location: resourceGroup().location
@@ -8,4 +15,5 @@ resource hostPool 'Microsoft.DesktopVirtualization/hostpools@2019-12-10-preview'
     preferredAppGroupType: 'Desktop'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-workspace/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-workspace/main.combined.bicep
@@ -1,3 +1,7 @@
+// $1 = workSpace
+// $2 = 'name'
+// $3 = 'friendlyName'
+
 resource workSpace 'Microsoft.DesktopVirtualization/workspaces@2019-12-10-preview' = {
   name: 'name'
   location: resourceGroup().location
@@ -5,4 +9,5 @@ resource workSpace 'Microsoft.DesktopVirtualization/workspaces@2019-12-10-previe
     friendlyName: 'friendlyName'
   }
 }
+// Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-defaults/main.combined.bicep
@@ -1,6 +1,12 @@
+// $0 = suppressionId: any(1)
+// $1 = testIdentifier
+// $2 = Microsoft.Advisor/recommendations/suppressions@2020-01-01
+// $3 = 'testResource/'
+
 resource testIdentifier 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: 'testResource/'
   properties: {
     suppressionId: any(1)
   }
-}
+}// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-without-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-without-defaults/main.combined.bicep
@@ -1,4 +1,9 @@
+// $1 = nsg
+// $2 = Microsoft.Aad/domainServices/ouContainer@2017-06-01
+// $3 = 'testResource/'
+
 resource nsg 'Microsoft.Aad/domainServices/ouContainer@2017-06-01' = {
   name: 'testResource/'
   
-}
+}// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-defaults/main.combined.bicep
@@ -1,7 +1,13 @@
+// $1 = nsg
+// $2 = Microsoft.Aad/domainServices@2017-06-01
+// $3 = 'testResource'
+// $4 = 'testLocation'
+
 resource nsg 'Microsoft.Aad/domainServices@2017-06-01' = {
   name: 'testResource'
   location: 'testLocation'
   properties: {
     
   }
-}
+}// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-without-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-without-defaults/main.combined.bicep
@@ -1,4 +1,10 @@
+// $1 = nsg
+// $2 = Microsoft.Aad/domainServices@2017-06-01
+// $3 = 'testResource'
+// $4 = 'testLocation'
+
 resource nsg 'Microsoft.Aad/domainServices@2017-06-01' = {
   name: 'testResource'
   
-}
+}// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/var/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/var/main.combined.bicep
@@ -1,2 +1,6 @@
-var test = 1
+// $0 = 1
+// $1 = test
+
+var test = 1// Insert snippet here
 //@[4:8) [no-unused-vars (Warning)] Variable "test" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |test|
+


### PR DESCRIPTION
When reviewing #2942, I noticed the 'combined' files just contain the snippet with placeholders, and not the result of accepting the snippet into the original file.

Retaining the original file context is necessary to unblock cases where the the file contains necessary pre-requisites (e.g. setting `targetScope`).