### PR TITLE
Disable file watching for the Bicep linter config file

### DIFF
--- a/src/Bicep.Core/Configuration/ConfigHelper.cs
+++ b/src/Bicep.Core/Configuration/ConfigHelper.cs
@@ -50,7 +50,7 @@ namespace Bicep.Core.Configuration
                 // last added json settings take precedent - add local settings last
                 if (DiscoverLocalConfigurationFile(localFolder) is string localConfig)
                 {
-                    configBuilder.AddJsonFile(localConfig, true, true);
+                    configBuilder.AddJsonFile(localConfig, true, false);
                     this.CustomSettingsFileName = localConfig;
                 }
                 else

--- a/src/Bicep.Core/Configuration/ConfigHelper.cs
+++ b/src/Bicep.Core/Configuration/ConfigHelper.cs
@@ -50,7 +50,9 @@ namespace Bicep.Core.Configuration
                 // last added json settings take precedent - add local settings last
                 if (DiscoverLocalConfigurationFile(localFolder) is string localConfig)
                 {
-                    configBuilder.AddJsonFile(localConfig, true, false);
+                    // we must set reloadOnChange to false here - if it set to true, then ConfigurationBuilder will initialize 
+                    // a FileSystem.Watcher instance - which has severe performance impact on non-Windows OSes (https://github.com/dotnet/runtime/issues/42036)
+                    configBuilder.AddJsonFile(localConfig, optional: true, reloadOnChange: false);
                     this.CustomSettingsFileName = localConfig;
                 }
                 else


### PR DESCRIPTION
`ConfigurationBuilder.AddJsonFile()` invokes the file system watcher if the `reloadOnChange` param is set to `true`.

On non-Windows platforms, this is a very expensive call to make, and we re-trigger it every time we invoke semantic analysis in the language server.

Related to https://github.com/dotnet/runtime/issues/42036

Closes #3045