### PR TITLE
fix broken link in no-hardcoded-env-urls.md

### DIFF
--- a/docs/linter-rules/no-hardcoded-env-urls.md
+++ b/docs/linter-rules/no-hardcoded-env-urls.md
@@ -2,7 +2,7 @@
 
 **Code**: no-hardcoded-env-urls
 
-**Description**: Do not hardcode environment URLs in your template. Instead, use the [environment function](https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-deployment?tabs=json#environment) to dynamically get these URLs during deployment. For a list of the URL hosts that are blocked, see the default list of DisallowedHosts in [`bicepconfig.json`](./src/Bicep.Core/Configuration/bicepconfig.json).
+**Description**: Do not hardcode environment URLs in your template. Instead, use the [environment function](https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-deployment?tabs=json#environment) to dynamically get these URLs during deployment. For a list of the URL hosts that are blocked, see the default list of DisallowedHosts in [`bicepconfig.json`](../../src/Bicep.Core/Configuration/bicepconfig.json).
 
 The following example fails this test because the URL is hardcoded.
 


### PR DESCRIPTION
-Found a broken link in no-hardcoded-env-urls.md.

## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)