### PR TITLE
Use Multicore JIT

### DIFF
--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 using System;
 using System.IO;
+using System.Runtime;
 using Bicep.Cli.CommandLine;
 using Bicep.Cli.CommandLine.Arguments;
 using Bicep.Cli.Logging;
+using Bicep.Core;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
 using Bicep.Core.FileSystem;
@@ -37,6 +39,10 @@ namespace Bicep.Cli
 
         public static int Main(string[] args)
         {
+            string profilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), LanguageConstants.LanguageId);
+            Directory.CreateDirectory(profilePath);
+            ProfileOptimization.SetProfileRoot(profilePath);
+            ProfileOptimization.StartProfile("bicep.profile");
             Console.OutputEncoding = TemplateEmitter.UTF8EncodingWithoutBom;
 
             BicepDeploymentsInterop.Initialize();

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -6,7 +6,6 @@ using System.Runtime;
 using Bicep.Cli.CommandLine;
 using Bicep.Cli.CommandLine.Arguments;
 using Bicep.Cli.Logging;
-using Bicep.Core;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
 using Bicep.Core.FileSystem;
@@ -14,6 +13,7 @@ using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 using Bicep.Decompiler;
 using Microsoft.Extensions.Logging;
@@ -39,8 +39,7 @@ namespace Bicep.Cli
 
         public static int Main(string[] args)
         {
-            string profilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), LanguageConstants.LanguageId);
-            Directory.CreateDirectory(profilePath);
+            string profilePath = MulticoreJIT.GetMulticoreJITPath();
             ProfileOptimization.SetProfileRoot(profilePath);
             ProfileOptimization.StartProfile("bicep.profile");
             Console.OutputEncoding = TemplateEmitter.UTF8EncodingWithoutBom;

--- a/src/Bicep.Core/FileSystem/PathHelper.cs
+++ b/src/Bicep.Core/FileSystem/PathHelper.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
-using System.Linq;
 using System.IO;
 
 namespace Bicep.Core.FileSystem
@@ -12,7 +11,7 @@ namespace Bicep.Core.FileSystem
 
         private const string TemplateOutputExtension = ".json";
 
-        private const string BicepExtension = ".bicep";
+        private const string BicepExtension = LanguageConstants.LanguageFileExtension;
 
         public static StringComparer PathComparer => IsFileSystemCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
 

--- a/src/Bicep.Core/Utils/MulticoreJIT.cs
+++ b/src/Bicep.Core/Utils/MulticoreJIT.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.IO;
+
+namespace Bicep.Core.Utils
+{
+    public static class MulticoreJIT
+    {
+        public static string GetMulticoreJITPath()
+        {
+            string profilePath = Path.Combine(Path.GetTempPath(), LanguageConstants.LanguageFileExtension); // bicep extension as a hidden folder name
+            Directory.CreateDirectory(profilePath);
+            return profilePath;
+        }
+    }
+}

--- a/src/Bicep.LangServer/Program.cs
+++ b/src/Bicep.LangServer/Program.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
+using System.IO;
+using System.Runtime;
 using System.Threading;
 using System.Threading.Tasks;
+using Bicep.Core;
 using Bicep.Core.FileSystem;
 using Bicep.Core.TypeSystem.Az;
 
@@ -13,6 +16,11 @@ namespace Bicep.LanguageServer
         public static async Task Main(string[] args)
             => await RunWithCancellationAsync(async cancellationToken =>
             {
+                string profilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), LanguageConstants.LanguageId);
+                Directory.CreateDirectory(profilePath);
+                ProfileOptimization.SetProfileRoot(profilePath);
+                ProfileOptimization.StartProfile("bicepserver.profile");
+
                 // the server uses JSON-RPC over stdin & stdout to communicate,
                 // so be careful not to use console for logging!
                 var server = new Server(

--- a/src/Bicep.LangServer/Program.cs
+++ b/src/Bicep.LangServer/Program.cs
@@ -5,9 +5,9 @@ using System.IO;
 using System.Runtime;
 using System.Threading;
 using System.Threading.Tasks;
-using Bicep.Core;
 using Bicep.Core.FileSystem;
 using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.Utils;
 
 namespace Bicep.LanguageServer
 {
@@ -16,8 +16,7 @@ namespace Bicep.LanguageServer
         public static async Task Main(string[] args)
             => await RunWithCancellationAsync(async cancellationToken =>
             {
-                string profilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), LanguageConstants.LanguageId);
-                Directory.CreateDirectory(profilePath);
+                string profilePath = MulticoreJIT.GetMulticoreJITPath();
                 ProfileOptimization.SetProfileRoot(profilePath);
                 ProfileOptimization.StartProfile("bicepserver.profile");
 


### PR DESCRIPTION
Fixes #2804

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

* [ ] I have checked that there is not an equivalent example already submitted
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
