### PR TITLE
Decompiler should place param description first

### DIFF
--- a/src/Bicep.Decompiler.IntegrationTests/Working/101-1vm-2nics-2subnets-1vnet/azuredeploy.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/101-1vm-2nics-2subnets-1vnet/azuredeploy.bicep
@@ -8,11 +8,11 @@ param adminUsername string
 @secure()
 param adminPassword string
 
+@description('Storage Account type for the VM and VM diagnostic storage')
 @allowed([
   'Standard_LRS'
   'Premium_LRS'
 ])
-@description('Storage Account type for the VM and VM diagnostic storage')
 param storageAccountType string = 'Standard_LRS'
 
 @description('Location for all resources.')

--- a/src/Bicep.Decompiler.IntegrationTests/Working/201-vm-copy-index-loops/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/201-vm-copy-index-loops/main.bicep
@@ -1,26 +1,26 @@
 @description('Admin username for VM')
 param adminUsername string
 
+@description('Number of VMs to deploy, limit 398 since there is an 800 resource limit for a single template deployment')
 @minValue(2)
 @maxValue(398)
-@description('Number of VMs to deploy, limit 398 since there is an 800 resource limit for a single template deployment')
 param numberOfInstances int = 4
 
+@description('OS Platform for the VM')
 @allowed([
   'Ubuntu'
   'Windows'
 ])
-@description('OS Platform for the VM')
 param OS string = 'Ubuntu'
 
 @description('Location for all resources.')
 param location string = resourceGroup().location
 
+@description('Type of authentication to use on the Virtual Machine. SSH key is recommended.')
 @allowed([
   'sshPublicKey'
   'password'
 ])
-@description('Type of authentication to use on the Virtual Machine. SSH key is recommended.')
 param authenticationType string = 'sshPublicKey'
 
 @description('SSH Key or password for the Virtual Machine. SSH key is recommended.')

--- a/src/Bicep.Decompiler.IntegrationTests/Working/conditional/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/conditional/main.bicep
@@ -13,27 +13,27 @@ param FlowLogName string = 'FlowLog1'
 @description('Resource ID of the target NSG')
 param existingNSG string
 
-@minValue(0)
-@maxValue(365)
 @metadata({
   description: 'Retention period in days. Default is zero which stands for permanent retention. Can be any Integer from 0 to 365'
   range: 'From 0 to 365.'
 })
+@minValue(0)
+@maxValue(365)
 param RetentionDays int = 0
 
+@description('FlowLogs Version. Correct values are 1 or 2 (default)')
 @allowed([
   '1'
   '2'
 ])
-@description('FlowLogs Version. Correct values are 1 or 2 (default)')
 param FlowLogsversion string = '2'
 
+@description('Storage Account type')
 @allowed([
   'Standard_LRS'
   'Standard_GRS'
   'Standard_ZRS'
 ])
-@description('Storage Account type')
 param storageAccountType string = 'Standard_LRS'
 
 var foo = 'foo'

--- a/src/Bicep.Decompiler.IntegrationTests/Working/cross-scope-tenant/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/cross-scope-tenant/main.bicep
@@ -12,11 +12,11 @@ param subscriptionAlias string
 @description('Display name for the subscription')
 param subscriptionDisplayName string
 
+@description('Workload type for the subscription')
 @allowed([
   'Production'
   'DevTest'
 ])
-@description('Workload type for the subscription')
 param subscriptionWorkload string = 'Production'
 
 resource subscriptionAlias_resource 'Microsoft.Subscription/aliases@2020-09-01' = {

--- a/src/Bicep.Decompiler.IntegrationTests/Working/issue2380/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/issue2380/main.bicep
@@ -12,11 +12,11 @@ param subscriptionAlias string
 @description('Display name for the subscription')
 param subscriptionDisplayName string
 
+@description('Workload type for the subscription')
 @allowed([
   'Production'
   'DevTest'
 ])
-@description('Workload type for the subscription')
 param subscriptionWorkload string = 'Production'
 
 resource subscriptionAlias_resource 'Microsoft.Subscription/aliases@2020-09-01' = {

--- a/src/Bicep.Decompiler.IntegrationTests/Working/keysinproperties/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/keysinproperties/main.bicep
@@ -1,8 +1,8 @@
+@description('Storage account type')
 @allowed([
   'Standard_LRS'
   'Standard_GRS'
 ])
-@description('Storage account type')
 param storageAccountType string = 'Standard_LRS'
 
 @description('Name of file share to be created')

--- a/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/azuredeploy.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/azuredeploy.bicep
@@ -10,24 +10,24 @@ param FlowLogName string = 'FlowLog1'
 @description('Resource ID of the target NSG')
 param existingNSG string
 
+@description('Retention period in days. Default is zero which stands for permanent retention. Can be any Integer from 0 to 365')
 @minValue(0)
 @maxValue(365)
-@description('Retention period in days. Default is zero which stands for permanent retention. Can be any Integer from 0 to 365')
 param RetentionDays int = 0
 
+@description('FlowLogs Version. Correct values are 1 or 2 (default)')
 @allowed([
   '1'
   '2'
 ])
-@description('FlowLogs Version. Correct values are 1 or 2 (default)')
 param FlowLogsversion string = '2'
 
+@description('Storage Account type')
 @allowed([
   'Standard_LRS'
   'Standard_GRS'
   'Standard_ZRS'
 ])
-@description('Storage Account type')
 param storageAccountType string = 'Standard_LRS'
 
 var storageAccountName_var = 'flowlogs${uniqueString(resourceGroup().id)}'

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -460,7 +460,7 @@ namespace Bicep.Decompiler
                             // we might be dealing with an array
                             break;
                         }
-                    
+
                         baseSyntax = TryParseStringExpression(expression);
                         break;
                     }
@@ -622,7 +622,9 @@ namespace Bicep.Decompiler
         {
             var decoratorsAndNewLines = new List<SyntaxBase>();
 
-            foreach (var parameterPropertyName in new[] { "minValue", "maxValue", "minLength", "maxLength", "allowedValues", "metadata" })
+            // Metadata/description should be first so users see what the parameter is for before
+            // seeing informationi such as a long list of allowed values
+            foreach (var parameterPropertyName in new[] { "metadata", "minValue", "maxValue", "minLength", "maxLength", "allowedValues" })
             {
                 if (TryParseJToken(value.Value?[parameterPropertyName]) is SyntaxBase expression)
                 {


### PR DESCRIPTION
Per @bmoore-msft's request, make description first decorator on parameters so users first see what it's about before trying to decode things like long allowed lists.