### PR TITLE
Migrate example: 101/cosmosdb-private-endpoint

### DIFF
--- a/docs/examples/101/cosmosdb-private-endpoint/README-MOVED.md
+++ b/docs/examples/101/cosmosdb-private-endpoint/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/cosmosdb-private-endpoint/main.bicep
+++ b/docs/examples/101/cosmosdb-private-endpoint/main.bicep
@@ -7,7 +7,6 @@ param accountName string
   'Disabled'
 ])
 param publicNetworkAccess string = 'Enabled'
-
 param privateEndpointName string
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2020-06-01' = {
@@ -23,7 +22,8 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 }
 
 resource subNet 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-  name: '${virtualNetwork.name}/default'
+  parent: virtualNetwork
+  name: 'default'
   properties: {
     addressPrefix: '172.20.0.0/24'
     privateEndpointNetworkPolicies: 'Disabled'

--- a/docs/examples/101/cosmosdb-private-endpoint/main.json
+++ b/docs/examples/101/cosmosdb-private-endpoint/main.json
@@ -5,34 +5,58 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5951786724962393414"
+      "templateHash": "15478641268141097497"
     }
   },
   "parameters": {
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     },
     "virtualNetworkName": {
       "type": "string",
-      "defaultValue": "Vnet"
+      "metadata": {
+        "description": "Virtual network name"
+      }
     },
     "accountName": {
-      "type": "string"
+      "type": "string",
+      "maxLength": 44,
+      "metadata": {
+        "description": "Cosmos DB account name (must be lower-case)"
+      }
     },
     "publicNetworkAccess": {
       "type": "string",
       "defaultValue": "Enabled",
+      "metadata": {
+        "description": "Enable public network traffic to access the account; if set to Disabled, public network traffic will be blocked even before the private endpoint is created"
+      },
       "allowedValues": [
         "Enabled",
         "Disabled"
       ]
     },
     "privateEndpointName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Private endpoint name"
+      }
     }
   },
   "functions": [],
+  "variables": {
+    "locations": [
+      {
+        "locationName": "[parameters('location')]",
+        "failoverPriority": 0,
+        "isZoneRedundant": false
+      }
+    ]
+  },
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",
@@ -61,22 +85,15 @@
     },
     {
       "type": "Microsoft.DocumentDB/databaseAccounts",
-      "apiVersion": "2020-06-01-preview",
+      "apiVersion": "2021-01-15",
       "name": "[parameters('accountName')]",
       "location": "[parameters('location')]",
       "kind": "GlobalDocumentDB",
       "properties": {
-        "createMode": "Default",
         "consistencyPolicy": {
           "defaultConsistencyLevel": "Session"
         },
-        "locations": [
-          {
-            "locationName": "[parameters('location')]",
-            "failoverPriority": 0,
-            "isZoneRedundant": false
-          }
-        ],
+        "locations": "[variables('locations')]",
         "databaseAccountOfferType": "Standard",
         "enableAutomaticFailover": false,
         "enableMultipleWriteLocations": false,

--- a/docs/examples/101/cosmosdb-private-endpoint/main.json
+++ b/docs/examples/101/cosmosdb-private-endpoint/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2061619959511486587"
+      "templateHash": "5951786724962393414"
     }
   },
   "parameters": {
@@ -50,7 +50,7 @@
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/default', parameters('virtualNetworkName'))]",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), 'default')]",
       "properties": {
         "addressPrefix": "172.20.0.0/24",
         "privateEndpointNetworkPolicies": "Disabled"
@@ -90,7 +90,7 @@
       "location": "[parameters('location')]",
       "properties": {
         "subnet": {
-          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/default', parameters('virtualNetworkName')), '/')[0], split(format('{0}/default', parameters('virtualNetworkName')), '/')[1])]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), 'default')]"
         },
         "privateLinkServiceConnections": [
           {
@@ -106,7 +106,7 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('accountName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/default', parameters('virtualNetworkName')), '/')[0], split(format('{0}/default', parameters('virtualNetworkName')), '/')[1])]"
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), 'default')]"
       ]
     }
   ]


### PR DESCRIPTION
Updated bicep.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.documentdb/cosmosdb-private-endpoint
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

https://github.com/Azure/azure-quickstart-templates/pull/11039