### PR TITLE
Migrate example: 101/create-rg-lock-role-assignment

### DIFF
--- a/docs/examples/101/create-rg-lock-role-assignment/README-MOVED.md
+++ b/docs/examples/101/create-rg-lock-role-assignment/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/create-rg-lock-role-assignment/applylock.bicep
+++ b/docs/examples/101/create-rg-lock-role-assignment/applylock.bicep
@@ -9,7 +9,7 @@ param roleDefinitionId string
 @description('Unique name for the roleAssignment in the format of a guid')
 param roleAssignmentName string
 
-resource dontDeleteLock 'Microsoft.Authorization/locks@2017-04-01' = {
+resource dontDeleteLock 'Microsoft.Authorization/locks@2016-09-01' = {
   name: 'DontDelete'
   properties: {
     level: 'CanNotDelete'

--- a/docs/examples/101/create-rg-lock-role-assignment/applylock.bicep
+++ b/docs/examples/101/create-rg-lock-role-assignment/applylock.bicep
@@ -1,10 +1,15 @@
 targetScope = 'resourceGroup'
 
+@description('principalId of the user that will be given contributor access to the resourceGroup')
 param principalId string
+
+@description('roleDefinition to apply to the resourceGroup - default is contributor')
 param roleDefinitionId string
+
+@description('Unique name for the roleAssignment in the format of a guid')
 param roleAssignmentName string
 
-resource lockResource 'Microsoft.Authorization/locks@2016-09-01' = {
+resource dontDeleteLock 'Microsoft.Authorization/locks@2017-04-01' = {
   name: 'DontDelete'
   properties: {
     level: 'CanNotDelete'
@@ -12,7 +17,7 @@ resource lockResource 'Microsoft.Authorization/locks@2016-09-01' = {
   }
 }
 
-resource assignmentResource 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   name: guid(roleAssignmentName)
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)

--- a/docs/examples/101/create-rg-lock-role-assignment/applylock.json
+++ b/docs/examples/101/create-rg-lock-role-assignment/applylock.json
@@ -5,18 +5,27 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5867672624469865160"
+      "templateHash": "15567308115178212258"
     }
   },
   "parameters": {
     "principalId": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "principalId of the user that will be given contributor access to the resourceGroup"
+      }
     },
     "roleDefinitionId": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "roleDefinition to apply to the resourceGroup - default is contributor"
+      }
     },
     "roleAssignmentName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Unique name for the roleAssignment in the format of a guid"
+      }
     }
   },
   "functions": [],

--- a/docs/examples/101/create-rg-lock-role-assignment/main.bicep
+++ b/docs/examples/101/create-rg-lock-role-assignment/main.bicep
@@ -25,8 +25,8 @@ resource newRg 'Microsoft.Resources/resourceGroups@2019-10-01' = {
 }
 
 module applyLock './applylock.bicep' = {
-  name: 'applyLock'
   scope: newRg
+  name: 'applyLock'
   params: {
     principalId: principalId
     roleDefinitionId: roleDefinitionId

--- a/docs/examples/101/create-rg-lock-role-assignment/main.bicep
+++ b/docs/examples/101/create-rg-lock-role-assignment/main.bicep
@@ -1,14 +1,26 @@
 targetScope = 'subscription'
 
+@description('Name of the resourceGroup to create')
 param rgName string
+
+@description('Location for the resourceGroup')
 param rgLocation string
+
+@description('principalId of the user that will be given contributor access to the resourceGroup')
 param principalId string
-param roleDefinitionId string = 'b24988ac-6180-42a0-ab88-20f7382dd24c' // default is contributor
+
+@description('roleDefinition to apply to the resourceGroup - default is contributor')
+param roleDefinitionId string = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+
+@description('Unique name for the roleAssignment in the format of a guid')
 param roleAssignmentName string = guid(principalId, roleDefinitionId, rgName)
 
 resource newRg 'Microsoft.Resources/resourceGroups@2019-10-01' = {
   name: rgName
   location: rgLocation
+  tags: {
+    Note: 'subscription level deployment'
+  }
   properties: {}
 }
 

--- a/docs/examples/101/create-rg-lock-role-assignment/main.json
+++ b/docs/examples/101/create-rg-lock-role-assignment/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "16258936803519211079"
+    }
+  },
   "parameters": {
     "rgName": {
       "type": "string",
@@ -35,7 +42,7 @@
       }
     }
   },
-  "variables": { },
+  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",
@@ -52,18 +59,57 @@
       "apiVersion": "2019-10-01",
       "name": "applyLock",
       "resourceGroup": "[parameters('rgName')]",
-      "dependsOn": [
-        "[parameters('rgName')]"
-      ],
       "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
         "mode": "Incremental",
+        "parameters": {
+          "principalId": {
+            "value": "[parameters('principalId')]"
+          },
+          "roleDefinitionId": {
+            "value": "[parameters('roleDefinitionId')]"
+          },
+          "roleAssignmentName": {
+            "value": "[parameters('roleAssignmentName')]"
+          }
+        },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
           "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "15567308115178212258"
+            }
+          },
+          "parameters": {
+            "principalId": {
+              "type": "string",
+              "metadata": {
+                "description": "principalId of the user that will be given contributor access to the resourceGroup"
+              }
+            },
+            "roleDefinitionId": {
+              "type": "string",
+              "metadata": {
+                "description": "roleDefinition to apply to the resourceGroup - default is contributor"
+              }
+            },
+            "roleAssignmentName": {
+              "type": "string",
+              "metadata": {
+                "description": "Unique name for the roleAssignment in the format of a guid"
+              }
+            }
+          },
+          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Authorization/locks",
-              "apiVersion": "2017-04-01",
+              "apiVersion": "2016-09-01",
               "name": "DontDelete",
               "properties": {
                 "level": "CanNotDelete",
@@ -76,13 +122,15 @@
               "name": "[guid(parameters('roleAssignmentName'))]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]",
-                "principalId": "[parameters('principalId')]",
-                "scope": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('rgName'))]"
+                "principalId": "[parameters('principalId')]"
               }
             }
           ]
         }
-      }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('rgName'))]"
+      ]
     }
   ]
 }

--- a/docs/examples/101/create-rg-lock-role-assignment/main.json
+++ b/docs/examples/101/create-rg-lock-role-assignment/main.json
@@ -1,39 +1,50 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "9136367247469226369"
-    }
-  },
   "parameters": {
     "rgName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Name of the resourceGroup to create"
+      }
     },
     "rgLocation": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Location for the resourceGroup"
+      }
     },
     "principalId": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "principalId of the user that will be given contributor access to the resourceGroup"
+      }
     },
     "roleDefinitionId": {
       "type": "string",
-      "defaultValue": "b24988ac-6180-42a0-ab88-20f7382dd24c"
+      "defaultValue": "b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "metadata": {
+        "description": "roleDefinition to apply to the resourceGroup - default is contributor"
+      }
     },
     "roleAssignmentName": {
       "type": "string",
-      "defaultValue": "[guid(parameters('principalId'), parameters('roleDefinitionId'), parameters('rgName'))]"
+      "defaultValue": "[guid(parameters('principalId'), parameters('roleDefinitionId'), parameters('rgName'))]",
+      "metadata": {
+        "description": "Unique name for the roleAssignment in the format of a guid"
+      }
     }
   },
-  "functions": [],
+  "variables": { },
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",
       "apiVersion": "2019-10-01",
       "name": "[parameters('rgName')]",
       "location": "[parameters('rgLocation')]",
+      "tags": {
+        "Note": "subscription level deployment"
+      },
       "properties": {}
     },
     {
@@ -41,48 +52,18 @@
       "apiVersion": "2019-10-01",
       "name": "applyLock",
       "resourceGroup": "[parameters('rgName')]",
+      "dependsOn": [
+        "[parameters('rgName')]"
+      ],
       "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
         "mode": "Incremental",
-        "parameters": {
-          "principalId": {
-            "value": "[parameters('principalId')]"
-          },
-          "roleDefinitionId": {
-            "value": "[parameters('roleDefinitionId')]"
-          },
-          "roleAssignmentName": {
-            "value": "[parameters('roleAssignmentName')]"
-          }
-        },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
           "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "dev",
-              "templateHash": "5867672624469865160"
-            }
-          },
-          "parameters": {
-            "principalId": {
-              "type": "string"
-            },
-            "roleDefinitionId": {
-              "type": "string"
-            },
-            "roleAssignmentName": {
-              "type": "string"
-            }
-          },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Authorization/locks",
-              "apiVersion": "2016-09-01",
+              "apiVersion": "2017-04-01",
               "name": "DontDelete",
               "properties": {
                 "level": "CanNotDelete",
@@ -95,15 +76,13 @@
               "name": "[guid(parameters('roleAssignmentName'))]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]",
-                "principalId": "[parameters('principalId')]"
+                "principalId": "[parameters('principalId')]",
+                "scope": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('rgName'))]"
               }
             }
           ]
         }
-      },
-      "dependsOn": [
-        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', parameters('rgName'))]"
-      ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatessubscription-deployments/create-rg-lock-role-assignment
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11116