### PR TITLE
Migrate example: 101/1vm-2nics-2subnets-1vnet

### DIFF
--- a/docs/examples/101/1vm-2nics-2subnets-1vnet/README-MOVED.md
+++ b/docs/examples/101/1vm-2nics-2subnets-1vnet/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/1vm-2nics-2subnets-1vnet/main.bicep
+++ b/docs/examples/101/1vm-2nics-2subnets-1vnet/main.bicep
@@ -201,5 +201,3 @@ resource nsg 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
     ]
   }
 }
-
-output publicIp string = pip.properties.ipAddress

--- a/docs/examples/101/1vm-2nics-2subnets-1vnet/main.bicep
+++ b/docs/examples/101/1vm-2nics-2subnets-1vnet/main.bicep
@@ -1,9 +1,21 @@
-param virtualMachineSize string
+@description('Virtual machine size (has to be at least the size of Standard_A3 to support 2 NICs)')
+param virtualMachineSize string = 'Standard_DS1_v2'
+
+@description('Default Admin username')
 param adminUsername string
 
+@description('Default Admin password')
 @secure()
 param adminPassword string
-param storageAccountType string
+
+@description('Storage Account type for the VM and VM diagnostic storage')
+@allowed([
+  'Standard_LRS'
+  'Premium_LRS'
+])
+param storageAccountType string = 'Standard_LRS'
+
+@description('Location for all resources.')
 param location string = resourceGroup().location
 
 var virtualMachineName = 'VM-MultiNic'
@@ -13,9 +25,9 @@ var virtualNetworkName = 'virtualNetwork'
 var subnet1Name = 'subnet-1'
 var subnet2Name = 'subnet-2'
 var publicIPAddressName = 'publicIp'
-var diagStorageAccountName = concat('diags', uniqueString(resourceGroup().id))
+var diagStorageAccountName = 'diags${uniqueString(resourceGroup().id)}'
 var networkSecurityGroupName = 'NSG'
-var networkSecurityGroupName2 = concat(subnet2Name, '-nsg')
+var networkSecurityGroupName2 = '${subnet2Name}-nsg'
 
 // This is the virtual machine that you're building.
 resource vm 'Microsoft.Compute/virtualMachines@2020-06-01' = {
@@ -37,13 +49,12 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-06-01' = {
       imageReference: {
         publisher: 'MicrosoftWindowsServer'
         offer: 'WindowsServer'
-        sku: '2016-Datacenter'
+        sku: '2019-Datacenter'
         version: 'latest'
       }
       osDisk: {
         createOption: 'FromImage'
       }
-      dataDisks: []
     }
     networkProfile: {
       networkInterfaces: [
@@ -76,14 +87,13 @@ resource diagsAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   sku: {
     name: storageAccountType
   }
-  kind: 'Storage'
+  kind: 'StorageV2'
 }
 
 // Simple Network Security Group for subnet2
 resource nsg2 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
   name: networkSecurityGroupName2
   location: location
-  properties: {}
 }
 
 // This will build a Virtual Network.
@@ -126,7 +136,7 @@ resource nic1 'Microsoft.Network/networkInterfaces@2020-06-01' = {
         name: 'ipconfig1'
         properties: {
           subnet: {
-            id: '${vnet.id}/subnets/${subnet1Name}'
+            id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, subnet1Name)
           }
           privateIPAllocationMethod: 'Dynamic'
           publicIPAddress: {
@@ -151,7 +161,7 @@ resource nic2 'Microsoft.Network/networkInterfaces@2020-06-01' = {
         name: 'ipconfig1'
         properties: {
           subnet: {
-            id: '${vnet.id}/subnets/${subnet2Name}'
+            id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, subnet2Name)
           }
           privateIPAllocationMethod: 'Dynamic'
         }

--- a/docs/examples/101/1vm-2nics-2subnets-1vnet/main.json
+++ b/docs/examples/101/1vm-2nics-2subnets-1vnet/main.json
@@ -1,57 +1,78 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "5482832119940093967"
-    }
-  },
   "parameters": {
     "virtualMachineSize": {
-      "type": "string"
+      "type": "string",
+      "defaultValue": "Standard_DS1_v2",
+      "metadata": {
+        "description": "Virtual machine size (has to be at least the size of Standard_A3 to support 2 NICs)"
+      }
     },
     "adminUsername": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Default Admin username"
+      }
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring",
+      "metadata": {
+        "description": "Default Admin password"
+      }
     },
     "storageAccountType": {
-      "type": "string"
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "metadata": {
+        "description": "Storage Account type for the VM and VM diagnostic storage"
+      },
+      "allowedValues": [
+        "Standard_LRS",
+        "Premium_LRS"
+      ]
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     }
   },
-  "functions": [],
   "variables": {
     "virtualMachineName": "VM-MultiNic",
-    "nic1Name": "nic-1",
-    "nic2Name": "nic-2",
+    "nic1": "nic-1",
+    "nic2": "nic-2",
     "virtualNetworkName": "virtualNetwork",
     "subnet1Name": "subnet-1",
     "subnet2Name": "subnet-2",
     "publicIPAddressName": "publicIp",
-    "diagStorageAccountName": "[concat('diags', uniqueString(resourceGroup().id))]",
+    "subnet1Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]",
+    "subnet2Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet2Name'))]",
+    "diagStorageAccountName": "[concat('diags',uniqueString(resourceGroup().id))]",
     "networkSecurityGroupName": "NSG",
     "networkSecurityGroupName2": "[concat(variables('subnet2Name'), '-nsg')]"
   },
   "resources": [
     {
-      "type": "Microsoft.Compute/virtualMachines",
-      "apiVersion": "2020-06-01",
       "name": "[variables('virtualMachineName')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2019-12-01",
       "location": "[parameters('location')]",
+      "comments": "This is the virtual machine that you're building.",
+      "dependsOn": [
+        "[variables('nic1')]",
+        "[variables('nic2')]",
+        "[variables('diagStorageAccountName')]"
+      ],
       "properties": {
         "osProfile": {
           "computerName": "[variables('virtualMachineName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]",
           "windowsConfiguration": {
-            "provisionVMAgent": true
+            "provisionVmAgent": "true"
           }
         },
         "hardwareProfile": {
@@ -61,13 +82,12 @@
           "imageReference": {
             "publisher": "MicrosoftWindowsServer",
             "offer": "WindowsServer",
-            "sku": "2016-Datacenter",
+            "sku": "2019-Datacenter",
             "version": "latest"
           },
           "osDisk": {
             "createOption": "FromImage"
-          },
-          "dataDisks": []
+          }
         },
         "networkProfile": {
           "networkInterfaces": [
@@ -75,51 +95,50 @@
               "properties": {
                 "primary": true
               },
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1Name'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1'))]"
             },
             {
               "properties": {
                 "primary": false
               },
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2Name'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2'))]"
             }
           ]
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('diagStorageAccountName'))).primaryEndpoints.blob]"
+            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('diagStorageAccountName')), '2019-06-01').primaryEndpoints['blob']]"
           }
         }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Storage/storageAccounts', variables('diagStorageAccountName'))]",
-        "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1Name'))]",
-        "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2Name'))]"
-      ]
+      }
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "apiVersion": "2019-06-01",
       "name": "[variables('diagStorageAccountName')]",
+      "apiVersion": "2019-06-01",
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('storageAccountType')]"
       },
-      "kind": "Storage"
+      "kind": "StorageV2"
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('subnet2Name')]",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2020-05-01",
       "name": "[variables('networkSecurityGroupName2')]",
-      "location": "[parameters('location')]",
-      "properties": {}
+      "location": "[parameters('location')]"
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-06-01",
       "name": "[variables('virtualNetworkName')]",
+      "apiVersion": "2020-05-01",
       "location": "[parameters('location')]",
+      "comments": "This will build a Virtual Network.",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -143,27 +162,30 @@
             }
           }
         ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
-      ]
+      }
     },
     {
+      "name": "[variables('nic1')]",
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2020-06-01",
-      "name": "[variables('nic1Name')]",
+      "apiVersion": "2020-05-01",
       "location": "[parameters('location')]",
+      "comments": "This will be your Primary NIC",
+      "dependsOn": [
+        "[variables('publicIpAddressName')]",
+        "[variables('networkSecurityGroupName')]",
+        "[variables('virtualNetworkName')]"
+      ],
       "properties": {
         "ipConfigurations": [
           {
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnet1Name'))]"
+                "id": "[variables('subnet1Ref')]"
               },
               "privateIPAllocationMethod": "Dynamic",
-              "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+              "publicIpAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIpAddresses', variables('publicIpAddressName'))]"
               }
             }
           }
@@ -171,49 +193,47 @@
         "networkSecurityGroup": {
           "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
         }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
-        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
-      ]
+      }
     },
     {
+      "name": "[variables('nic2')]",
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2020-06-01",
-      "name": "[variables('nic2Name')]",
+      "apiVersion": "2020-05-01",
       "location": "[parameters('location')]",
+      "comments": "This will be your Secondary NIC",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
       "properties": {
         "ipConfigurations": [
           {
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnet2Name'))]"
+                "id": "[variables('subnet2Ref')]"
               },
               "privateIPAllocationMethod": "Dynamic"
             }
           }
         ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
-      ]
+      }
     },
     {
+      "name": "[variables('publicIpAddressName')]",
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2020-06-01",
-      "name": "[variables('publicIPAddressName')]",
+      "apiVersion": "2020-05-01",
       "location": "[parameters('location')]",
+      "comments": "Public IP for your Primary NIC",
       "properties": {
         "publicIPAllocationMethod": "Dynamic"
       }
     },
     {
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2020-06-01",
       "name": "[variables('networkSecurityGroupName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2020-05-01",
       "location": "[parameters('location')]",
+      "comments": "Network Security Group (NSG) for your Primary NIC",
       "properties": {
         "securityRules": [
           {
@@ -232,11 +252,5 @@
         ]
       }
     }
-  ],
-  "outputs": {
-    "publicIp": {
-      "type": "string",
-      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).ipAddress]"
-    }
-  }
+  ]
 }

--- a/docs/examples/101/1vm-2nics-2subnets-1vnet/main.json
+++ b/docs/examples/101/1vm-2nics-2subnets-1vnet/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1727344137687946960"
+      "templateHash": "15882862518723645512"
     }
   },
   "parameters": {
@@ -251,11 +251,5 @@
         ]
       }
     }
-  ],
-  "outputs": {
-    "publicIp": {
-      "type": "string",
-      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).ipAddress]"
-    }
-  }
+  ]
 }

--- a/docs/examples/101/1vm-2nics-2subnets-1vnet/main.json
+++ b/docs/examples/101/1vm-2nics-2subnets-1vnet/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "1727344137687946960"
+    }
+  },
   "parameters": {
     "virtualMachineSize": {
       "type": "string",
@@ -16,7 +23,7 @@
       }
     },
     "adminPassword": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Default Admin password"
       }
@@ -24,13 +31,13 @@
     "storageAccountType": {
       "type": "string",
       "defaultValue": "Standard_LRS",
-      "metadata": {
-        "description": "Storage Account type for the VM and VM diagnostic storage"
-      },
       "allowedValues": [
         "Standard_LRS",
         "Premium_LRS"
-      ]
+      ],
+      "metadata": {
+        "description": "Storage Account type for the VM and VM diagnostic storage"
+      }
     },
     "location": {
       "type": "string",
@@ -40,39 +47,32 @@
       }
     }
   },
+  "functions": [],
   "variables": {
     "virtualMachineName": "VM-MultiNic",
-    "nic1": "nic-1",
-    "nic2": "nic-2",
+    "nic1Name": "nic-1",
+    "nic2Name": "nic-2",
     "virtualNetworkName": "virtualNetwork",
     "subnet1Name": "subnet-1",
     "subnet2Name": "subnet-2",
     "publicIPAddressName": "publicIp",
-    "subnet1Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]",
-    "subnet2Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet2Name'))]",
-    "diagStorageAccountName": "[concat('diags',uniqueString(resourceGroup().id))]",
+    "diagStorageAccountName": "[format('diags{0}', uniqueString(resourceGroup().id))]",
     "networkSecurityGroupName": "NSG",
-    "networkSecurityGroupName2": "[concat(variables('subnet2Name'), '-nsg')]"
+    "networkSecurityGroupName2": "[format('{0}-nsg', variables('subnet2Name'))]"
   },
   "resources": [
     {
-      "name": "[variables('virtualMachineName')]",
       "type": "Microsoft.Compute/virtualMachines",
-      "apiVersion": "2019-12-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('virtualMachineName')]",
       "location": "[parameters('location')]",
-      "comments": "This is the virtual machine that you're building.",
-      "dependsOn": [
-        "[variables('nic1')]",
-        "[variables('nic2')]",
-        "[variables('diagStorageAccountName')]"
-      ],
       "properties": {
         "osProfile": {
           "computerName": "[variables('virtualMachineName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]",
           "windowsConfiguration": {
-            "provisionVmAgent": "true"
+            "provisionVMAgent": true
           }
         },
         "hardwareProfile": {
@@ -95,28 +95,33 @@
               "properties": {
                 "primary": true
               },
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1Name'))]"
             },
             {
               "properties": {
                 "primary": false
               },
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2Name'))]"
             }
           ]
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('diagStorageAccountName')), '2019-06-01').primaryEndpoints['blob']]"
+            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('diagStorageAccountName'))).primaryEndpoints.blob]"
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('diagStorageAccountName'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1Name'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2Name'))]"
+      ]
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('diagStorageAccountName')]",
       "apiVersion": "2019-06-01",
+      "name": "[variables('diagStorageAccountName')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('storageAccountType')]"
@@ -124,21 +129,16 @@
       "kind": "StorageV2"
     },
     {
-      "comments": "Simple Network Security Group for subnet [variables('subnet2Name')]",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
       "name": "[variables('networkSecurityGroupName2')]",
       "location": "[parameters('location')]"
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-06-01",
       "name": "[variables('virtualNetworkName')]",
-      "apiVersion": "2020-05-01",
       "location": "[parameters('location')]",
-      "comments": "This will build a Virtual Network.",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
-      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -162,30 +162,27 @@
             }
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
+      ]
     },
     {
-      "name": "[variables('nic1')]",
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('nic1Name')]",
       "location": "[parameters('location')]",
-      "comments": "This will be your Primary NIC",
-      "dependsOn": [
-        "[variables('publicIpAddressName')]",
-        "[variables('networkSecurityGroupName')]",
-        "[variables('virtualNetworkName')]"
-      ],
       "properties": {
         "ipConfigurations": [
           {
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[variables('subnet1Ref')]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]"
               },
               "privateIPAllocationMethod": "Dynamic",
-              "publicIpAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIpAddresses', variables('publicIpAddressName'))]"
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               }
             }
           }
@@ -193,47 +190,49 @@
         "networkSecurityGroup": {
           "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+      ]
     },
     {
-      "name": "[variables('nic2')]",
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('nic2Name')]",
       "location": "[parameters('location')]",
-      "comments": "This will be your Secondary NIC",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-      ],
       "properties": {
         "ipConfigurations": [
           {
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[variables('subnet2Ref')]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet2Name'))]"
               },
               "privateIPAllocationMethod": "Dynamic"
             }
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+      ]
     },
     {
-      "name": "[variables('publicIpAddressName')]",
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('publicIPAddressName')]",
       "location": "[parameters('location')]",
-      "comments": "Public IP for your Primary NIC",
       "properties": {
         "publicIPAllocationMethod": "Dynamic"
       }
     },
     {
-      "name": "[variables('networkSecurityGroupName')]",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('networkSecurityGroupName')]",
       "location": "[parameters('location')]",
-      "comments": "Network Security Group (NSG) for your Primary NIC",
       "properties": {
         "securityRules": [
           {
@@ -252,5 +251,11 @@
         ]
       }
     }
-  ]
+  ],
+  "outputs": {
+    "publicIp": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).ipAddress]"
+    }
+  }
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11118