### PR TITLE
Migrate example: 101/aad-domainservices

### DIFF
--- a/docs/examples/101/aad-domainservices/README-MOVED.md
+++ b/docs/examples/101/aad-domainservices/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/aad-domainservices/main.bicep
+++ b/docs/examples/101/aad-domainservices/main.bicep
@@ -146,9 +146,6 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-11-01' = {
       ]
     }
   }
-  dependsOn: [
-    nsg
-  ]
 }
 
 resource subnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = {

--- a/docs/examples/101/aad-domainservices/main.bicep
+++ b/docs/examples/101/aad-domainservices/main.bicep
@@ -1,16 +1,32 @@
+@description('Domain Name')
 param domainName string
-// Location for all resources.
+
+@description('Location for all resources.')
 param location string = resourceGroup().location
-// Virtual Network Name
+
+@description('SKU of the AD Domain Service.')
+param sku string = 'Enterprise'
+
+@description('Domain Configuration Type.')
+param domainConfigurationType string = 'FullySynced'
+
+@description('Choose the filtered sync type.')
+param filteredSync string = 'Disabled'
+
+@description('Virtual Network Name')
 param domainServicesVnetName string = 'domain-services-vnet'
-// Address Prefix
+
+@description('Address Prefix')
 param domainServicesVnetAddressPrefix string = '10.0.0.0/16'
-// Subnet name
+
+@description('Virtual Network Name')
 param domainServicesSubnetName string = 'domain-services-subnet'
-// Subnet prefix
+
+@description('Subnet prefix')
 param domainServicesSubnetAddressPrefix string = '10.0.0.0/24'
 
 var domainServicesNSGName = '${domainServicesSubnetName}-nsg'
+
 var PSRemotingSlicePIPAddresses = [
   '52.180.179.108'
   '52.180.177.87'
@@ -37,6 +53,7 @@ var RDPIPAddresses = [
   '13.106.174.32/27'
   '13.106.4.96/27'
 ]
+
 var PSRemotingSliceTIPAddresses = [
   '52.180.183.67'
   '52.180.181.39'
@@ -58,7 +75,7 @@ var PSRemotingSliceTIPAddresses = [
   '23.99.93.197'
 ]
 
-resource nsg 'Microsoft.Network/networkSecurityGroups@2018-10-01' = {
+resource nsg 'Microsoft.Network/networkSecurityGroups@2020-11-01' = {
   name: domainServicesNSGName
   location: location
   properties: {
@@ -119,7 +136,7 @@ resource nsg 'Microsoft.Network/networkSecurityGroups@2018-10-01' = {
   }
 }
 
-resource vnet 'Microsoft.Network/virtualNetworks@2018-10-01' = {
+resource vnet 'Microsoft.Network/virtualNetworks@2020-11-01' = {
   name: domainServicesVnetName
   location: location
   properties: {
@@ -129,10 +146,14 @@ resource vnet 'Microsoft.Network/virtualNetworks@2018-10-01' = {
       ]
     }
   }
+  dependsOn: [
+    nsg
+  ]
 }
 
-resource subnet 'Microsoft.Network/virtualNetworks/subnets@2018-10-01' = {
-  name: '${vnet.name}/${domainServicesSubnetName}'
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = {
+  parent: vnet
+  name: domainServicesSubnetName
   properties: {
     addressPrefix: domainServicesSubnetAddressPrefix
     networkSecurityGroup: {
@@ -141,11 +162,19 @@ resource subnet 'Microsoft.Network/virtualNetworks/subnets@2018-10-01' = {
   }
 }
 
-resource domainServices 'Microsoft.AAD/DomainServices@2017-06-01' = {
+resource domainServices 'Microsoft.AAD/DomainServices@2020-01-01' = {
   name: domainName
   location: location
   properties: {
     domainName: domainName
-    subnetId: subnet.id
+    filteredSync: filteredSync
+    domainConfigurationType: domainConfigurationType
+    replicaSets: [
+      {
+        subnetId: subnet.id
+        location: location
+      }
+    ]
+    sku: sku
   }
 }

--- a/docs/examples/101/aad-domainservices/main.json
+++ b/docs/examples/101/aad-domainservices/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16298284814952563352"
+      "templateHash": "7692443432302620124"
     }
   },
   "parameters": {
@@ -196,10 +196,7 @@
             "[parameters('domainServicesVnetAddressPrefix')]"
           ]
         }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]"
-      ]
+      }
     },
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",

--- a/docs/examples/101/aad-domainservices/main.json
+++ b/docs/examples/101/aad-domainservices/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "16298284814952563352"
+    }
+  },
   "parameters": {
     "domainName": {
       "type": "string",
@@ -16,21 +23,21 @@
       }
     },
     "sku": {
-      "type": "String",
+      "type": "string",
       "defaultValue": "Enterprise",
       "metadata": {
         "description": "SKU of the AD Domain Service."
       }
     },
     "domainConfigurationType": {
-      "type": "String",
+      "type": "string",
       "defaultValue": "FullySynced",
       "metadata": {
         "description": "Domain Configuration Type."
       }
     },
     "filteredSync": {
-      "type": "String",
+      "type": "string",
       "defaultValue": "Disabled",
       "metadata": {
         "description": "Choose the filtered sync type."
@@ -65,21 +72,60 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "domainServicesNSGName": "[concat(parameters('domainServicesSubnetName'), '-nsg')]",
-    "nsgRefId": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]",
-    "subnetRefId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]",
+    "domainServicesNSGName": "[format('{0}-nsg', parameters('domainServicesSubnetName'))]",
+    "PSRemotingSlicePIPAddresses": [
+      "52.180.179.108",
+      "52.180.177.87",
+      "13.75.105.168",
+      "52.175.18.134",
+      "52.138.68.41",
+      "52.138.65.157",
+      "104.41.159.212",
+      "104.45.138.161",
+      "52.169.125.119",
+      "52.169.218.0",
+      "52.187.19.1",
+      "52.187.120.237",
+      "13.78.172.246",
+      "52.161.110.169",
+      "52.174.189.149",
+      "40.68.160.142",
+      "40.83.144.56",
+      "13.64.151.161"
+    ],
     "RDPIPAddresses": [
       "207.68.190.32/27",
       "13.106.78.32/27",
       "13.106.174.32/27",
       "13.106.4.96/27"
+    ],
+    "PSRemotingSliceTIPAddresses": [
+      "52.180.183.67",
+      "52.180.181.39",
+      "52.175.28.111",
+      "52.175.16.141",
+      "52.138.70.93",
+      "52.138.64.115",
+      "40.80.146.22",
+      "40.121.211.60",
+      "52.138.143.173",
+      "52.169.87.10",
+      "13.76.171.84",
+      "52.187.169.156",
+      "13.78.174.255",
+      "13.78.191.178",
+      "40.68.163.143",
+      "23.100.14.28",
+      "13.64.188.43",
+      "23.99.93.197"
     ]
   },
   "resources": [
     {
-      "apiVersion": "2020-11-01",
       "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2020-11-01",
       "name": "[variables('domainServicesNSGName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -90,7 +136,7 @@
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "5986",
-              "sourceAddressPrefix": "*",
+              "sourceAddressPrefixes": "[variables('PSRemotingSlicePIPAddresses')]",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 301,
@@ -129,7 +175,7 @@
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "5986",
-              "sourceAddressPrefix": "*",
+              "sourceAddressPrefixes": "[variables('PSRemotingSliceTIPAddresses')]",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 302,
@@ -140,51 +186,56 @@
       }
     },
     {
-      "apiVersion": "2020-11-01",
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-11-01",
       "name": "[parameters('domainServicesVnetName')]",
       "location": "[parameters('location')]",
-      "dependsOn": ["[variables('domainServicesNSGName')]"],
       "properties": {
         "addressSpace": {
-          "addressPrefixes": ["[parameters('domainServicesVnetAddressPrefix')]"]
+          "addressPrefixes": [
+            "[parameters('domainServicesVnetAddressPrefix')]"
+          ]
         }
       },
-      "resources": [
-        {
-          "apiVersion": "2020-11-01",
-          "type": "subnets",
-          "location": "[parameters('location')]",
-          "name": "[parameters('domainServicesSubnetName')]",
-          "dependsOn": ["[parameters('domainServicesVnetName')]"],
-          "properties": {
-            "addressPrefix": "[parameters('domainServicesSubnetAddressPrefix')]",
-            "networkSecurityGroup": {
-              "id": "[variables('nsgRefId')]"
-            }
-          }
-        }
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]"
       ]
     },
     {
-      "type": "Microsoft.AAD/DomainServices",
-      "name": "[parameters('domainName')]",
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-11-01",
+      "name": "[format('{0}/{1}', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('domainServicesSubnetAddressPrefix')]",
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('domainServicesVnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.AAD/domainServices",
       "apiVersion": "2020-01-01",
+      "name": "[parameters('domainName')]",
       "location": "[parameters('location')]",
-      "dependsOn": ["[parameters('domainServicesVnetName')]"],
       "properties": {
         "domainName": "[parameters('domainName')]",
         "filteredSync": "[parameters('filteredSync')]",
         "domainConfigurationType": "[parameters('domainConfigurationType')]",
         "replicaSets": [
-                    {
-                        "subnetId": "[variables('subnetRefId')]",
-                        "location": "[parameters('location')]"
-                    }
-                ],
+          {
+            "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]",
+            "location": "[parameters('location')]"
+          }
+        ],
         "sku": "[parameters('sku')]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]"
+      ]
     }
-  ],
-  "outputs": {}
+  ]
 }

--- a/docs/examples/101/aad-domainservices/main.json
+++ b/docs/examples/101/aad-domainservices/main.json
@@ -1,92 +1,85 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "3554288023213640714"
-    }
-  },
   "parameters": {
     "domainName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Domain Name"
+      }
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    },
+    "sku": {
+      "type": "String",
+      "defaultValue": "Enterprise",
+      "metadata": {
+        "description": "SKU of the AD Domain Service."
+      }
+    },
+    "domainConfigurationType": {
+      "type": "String",
+      "defaultValue": "FullySynced",
+      "metadata": {
+        "description": "Domain Configuration Type."
+      }
+    },
+    "filteredSync": {
+      "type": "String",
+      "defaultValue": "Disabled",
+      "metadata": {
+        "description": "Choose the filtered sync type."
+      }
     },
     "domainServicesVnetName": {
       "type": "string",
-      "defaultValue": "domain-services-vnet"
+      "defaultValue": "domain-services-vnet",
+      "metadata": {
+        "description": "Virtual Network Name"
+      }
     },
     "domainServicesVnetAddressPrefix": {
       "type": "string",
-      "defaultValue": "10.0.0.0/16"
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "Address Prefix"
+      }
     },
     "domainServicesSubnetName": {
       "type": "string",
-      "defaultValue": "domain-services-subnet"
+      "defaultValue": "domain-services-subnet",
+      "metadata": {
+        "description": "Virtual Network Name"
+      }
     },
     "domainServicesSubnetAddressPrefix": {
       "type": "string",
-      "defaultValue": "10.0.0.0/24"
+      "defaultValue": "10.0.0.0/24",
+      "metadata": {
+        "description": "Subnet prefix"
+      }
     }
   },
-  "functions": [],
   "variables": {
-    "domainServicesNSGName": "[format('{0}-nsg', parameters('domainServicesSubnetName'))]",
-    "PSRemotingSlicePIPAddresses": [
-      "52.180.179.108",
-      "52.180.177.87",
-      "13.75.105.168",
-      "52.175.18.134",
-      "52.138.68.41",
-      "52.138.65.157",
-      "104.41.159.212",
-      "104.45.138.161",
-      "52.169.125.119",
-      "52.169.218.0",
-      "52.187.19.1",
-      "52.187.120.237",
-      "13.78.172.246",
-      "52.161.110.169",
-      "52.174.189.149",
-      "40.68.160.142",
-      "40.83.144.56",
-      "13.64.151.161"
-    ],
+    "domainServicesNSGName": "[concat(parameters('domainServicesSubnetName'), '-nsg')]",
+    "nsgRefId": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]",
+    "subnetRefId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]",
     "RDPIPAddresses": [
       "207.68.190.32/27",
       "13.106.78.32/27",
       "13.106.174.32/27",
       "13.106.4.96/27"
-    ],
-    "PSRemotingSliceTIPAddresses": [
-      "52.180.183.67",
-      "52.180.181.39",
-      "52.175.28.111",
-      "52.175.16.141",
-      "52.138.70.93",
-      "52.138.64.115",
-      "40.80.146.22",
-      "40.121.211.60",
-      "52.138.143.173",
-      "52.169.87.10",
-      "13.76.171.84",
-      "52.187.169.156",
-      "13.78.174.255",
-      "13.78.191.178",
-      "40.68.163.143",
-      "23.100.14.28",
-      "13.64.188.43",
-      "23.99.93.197"
     ]
   },
   "resources": [
     {
+      "apiVersion": "2020-11-01",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2018-10-01",
       "name": "[variables('domainServicesNSGName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -97,7 +90,7 @@
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "5986",
-              "sourceAddressPrefixes": "[variables('PSRemotingSlicePIPAddresses')]",
+              "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 301,
@@ -136,7 +129,7 @@
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "5986",
-              "sourceAddressPrefixes": "[variables('PSRemotingSliceTIPAddresses')]",
+              "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 302,
@@ -147,45 +140,51 @@
       }
     },
     {
+      "apiVersion": "2020-11-01",
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2018-10-01",
       "name": "[parameters('domainServicesVnetName')]",
       "location": "[parameters('location')]",
+      "dependsOn": ["[variables('domainServicesNSGName')]"],
       "properties": {
         "addressSpace": {
-          "addressPrefixes": [
-            "[parameters('domainServicesVnetAddressPrefix')]"
-          ]
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2018-10-01",
-      "name": "[format('{0}/{1}', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]",
-      "properties": {
-        "addressPrefix": "[parameters('domainServicesSubnetAddressPrefix')]",
-        "networkSecurityGroup": {
-          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]"
+          "addressPrefixes": ["[parameters('domainServicesVnetAddressPrefix')]"]
         }
       },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('domainServicesVnetName'))]"
+      "resources": [
+        {
+          "apiVersion": "2020-11-01",
+          "type": "subnets",
+          "location": "[parameters('location')]",
+          "name": "[parameters('domainServicesSubnetName')]",
+          "dependsOn": ["[parameters('domainServicesVnetName')]"],
+          "properties": {
+            "addressPrefix": "[parameters('domainServicesSubnetAddressPrefix')]",
+            "networkSecurityGroup": {
+              "id": "[variables('nsgRefId')]"
+            }
+          }
+        }
       ]
     },
     {
-      "type": "Microsoft.AAD/domainServices",
-      "apiVersion": "2017-06-01",
+      "type": "Microsoft.AAD/DomainServices",
       "name": "[parameters('domainName')]",
+      "apiVersion": "2020-01-01",
       "location": "[parameters('location')]",
+      "dependsOn": ["[parameters('domainServicesVnetName')]"],
       "properties": {
         "domainName": "[parameters('domainName')]",
-        "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName')), '/')[0], split(format('{0}/{1}', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName')), '/')[1])]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName')), '/')[0], split(format('{0}/{1}', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName')), '/')[1])]"
-      ]
+        "filteredSync": "[parameters('filteredSync')]",
+        "domainConfigurationType": "[parameters('domainConfigurationType')]",
+        "replicaSets": [
+                    {
+                        "subnetId": "[variables('subnetRefId')]",
+                        "location": "[parameters('location')]"
+                    }
+                ],
+        "sku": "[parameters('sku')]"
+      }
     }
-  ]
+  ],
+  "outputs": {}
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.network/aad-domainservices
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11119