### PR TITLE
Migrate example: 101/aci-linuxcontainer-public-ip

### DIFF
--- a/docs/examples/101/aci-linuxcontainer-public-ip/README-MOVED.md
+++ b/docs/examples/101/aci-linuxcontainer-public-ip/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/aci-linuxcontainer-public-ip/main.bicep
+++ b/docs/examples/101/aci-linuxcontainer-public-ip/main.bicep
@@ -1,15 +1,27 @@
-param name string
-param image string = 'mcr.microsoft.com/azuredocs/aci-helloworld'
-param port int = 80
-param cpuCores int = 1
-param memoryinGb int = 2
+@description('Name for the container group')
+param name string = 'acilinuxpublicipcontainergroup'
 
+@description('Container image to deploy. Should be of the form repoName/imagename:tag for images stored in public Docker Hub, or a fully qualified URI for other registries. Images from private registries require additional registry credentials.')
+param image string = 'mcr.microsoft.com/azuredocs/aci-helloworld'
+
+@description('Port to open on the container and the public IP address.')
+param port int = 80
+
+@description('The number of CPU cores to allocate to the container.')
+param cpuCores int = 1
+
+@description('The amount of memory to allocate to the container in gigabytes.')
+param memoryInGb int = 2
+
+@description('The behavior of Azure runtime if container has stopped.')
 @allowed([
   'Always'
   'Never'
   'OnFailure'
 ])
 param restartPolicy string = 'Always'
+
+@description('Location for all resources.')
 param location string = resourceGroup().location
 
 resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2019-12-01' = {
@@ -30,7 +42,7 @@ resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2019-12-01'
           resources: {
             requests: {
               cpu: cpuCores
-              memoryInGB: memoryinGb
+              memoryInGB: memoryInGb
             }
           }
         }

--- a/docs/examples/101/aci-linuxcontainer-public-ip/main.json
+++ b/docs/examples/101/aci-linuxcontainer-public-ip/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "14952033248081756653"
+    }
+  },
   "parameters": {
     "name": {
       "type": "string",
@@ -17,24 +24,36 @@
       }
     },
     "port": {
-      "type": "string",
-      "defaultValue": "80",
+      "type": "int",
+      "defaultValue": 80,
       "metadata": {
         "description": "Port to open on the container and the public IP address."
       }
     },
     "cpuCores": {
-      "type": "string",
-      "defaultValue": "1.0",
+      "type": "int",
+      "defaultValue": 1,
       "metadata": {
         "description": "The number of CPU cores to allocate to the container."
       }
     },
     "memoryInGb": {
-      "type": "string",
-      "defaultValue": "1.5",
+      "type": "int",
+      "defaultValue": 2,
       "metadata": {
         "description": "The amount of memory to allocate to the container in gigabytes."
+      }
+    },
+    "restartPolicy": {
+      "type": "string",
+      "defaultValue": "Always",
+      "allowedValues": [
+        "Always",
+        "Never",
+        "OnFailure"
+      ],
+      "metadata": {
+        "description": "The behavior of Azure runtime if container has stopped."
       }
     },
     "location": {
@@ -43,20 +62,9 @@
       "metadata": {
         "description": "Location for all resources."
       }
-    },
-    "restartPolicy": {
-      "type": "string",
-      "defaultValue": "always",
-      "allowedValues": [
-        "never",
-        "always",
-        "onfailure"
-      ],
-      "metadata": {
-        "description": "The behavior of Azure runtime if container has stopped."
-      }
     }
   },
+  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ContainerInstance/containerGroups",
@@ -71,13 +79,14 @@
               "image": "[parameters('image')]",
               "ports": [
                 {
-                  "port": "[parameters('port')]"
+                  "port": "[parameters('port')]",
+                  "protocol": "TCP"
                 }
               ],
               "resources": {
                 "requests": {
                   "cpu": "[parameters('cpuCores')]",
-                  "memoryInGb": "[parameters('memoryInGb')]"
+                  "memoryInGB": "[parameters('memoryInGb')]"
                 }
               }
             }
@@ -89,8 +98,8 @@
           "type": "Public",
           "ports": [
             {
-              "protocol": "Tcp",
-              "port": "[parameters('port')]"
+              "port": "[parameters('port')]",
+              "protocol": "TCP"
             }
           ]
         }
@@ -100,7 +109,7 @@
   "outputs": {
     "containerIPv4Address": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups/', parameters('name'))).ipAddress.ip]"
+      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups', parameters('name'))).ipAddress.ip]"
     }
   }
 }

--- a/docs/examples/101/aci-linuxcontainer-public-ip/main.json
+++ b/docs/examples/101/aci-linuxcontainer-public-ip/main.json
@@ -1,48 +1,62 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "16581188593486218125"
-    }
-  },
   "parameters": {
     "name": {
-      "type": "string"
+      "type": "string",
+      "defaultValue": "acilinuxpublicipcontainergroup",
+      "metadata": {
+        "description": "Name for the container group"
+      }
     },
     "image": {
       "type": "string",
-      "defaultValue": "mcr.microsoft.com/azuredocs/aci-helloworld"
+      "defaultValue": "mcr.microsoft.com/azuredocs/aci-helloworld",
+      "metadata": {
+        "description": "Container image to deploy. Should be of the form repoName/imagename:tag for images stored in public Docker Hub, or a fully qualified URI for other registries. Images from private registries require additional registry credentials."
+      }
     },
     "port": {
-      "type": "int",
-      "defaultValue": 80
+      "type": "string",
+      "defaultValue": "80",
+      "metadata": {
+        "description": "Port to open on the container and the public IP address."
+      }
     },
     "cpuCores": {
-      "type": "int",
-      "defaultValue": 1
-    },
-    "memoryinGb": {
-      "type": "int",
-      "defaultValue": 2
-    },
-    "restartPolicy": {
       "type": "string",
-      "defaultValue": "Always",
-      "allowedValues": [
-        "Always",
-        "Never",
-        "OnFailure"
-      ]
+      "defaultValue": "1.0",
+      "metadata": {
+        "description": "The number of CPU cores to allocate to the container."
+      }
+    },
+    "memoryInGb": {
+      "type": "string",
+      "defaultValue": "1.5",
+      "metadata": {
+        "description": "The amount of memory to allocate to the container in gigabytes."
+      }
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    },
+    "restartPolicy": {
+      "type": "string",
+      "defaultValue": "always",
+      "allowedValues": [
+        "never",
+        "always",
+        "onfailure"
+      ],
+      "metadata": {
+        "description": "The behavior of Azure runtime if container has stopped."
+      }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ContainerInstance/containerGroups",
@@ -57,14 +71,13 @@
               "image": "[parameters('image')]",
               "ports": [
                 {
-                  "port": "[parameters('port')]",
-                  "protocol": "TCP"
+                  "port": "[parameters('port')]"
                 }
               ],
               "resources": {
                 "requests": {
                   "cpu": "[parameters('cpuCores')]",
-                  "memoryInGB": "[parameters('memoryinGb')]"
+                  "memoryInGb": "[parameters('memoryInGb')]"
                 }
               }
             }
@@ -76,8 +89,8 @@
           "type": "Public",
           "ports": [
             {
-              "port": "[parameters('port')]",
-              "protocol": "TCP"
+              "protocol": "Tcp",
+              "port": "[parameters('port')]"
             }
           ]
         }
@@ -87,7 +100,7 @@
   "outputs": {
     "containerIPv4Address": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups', parameters('name'))).ipAddress.ip]"
+      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups/', parameters('name'))).ipAddress.ip]"
     }
   }
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11120