### PR TITLE
Migrate example: 101/api-management-create-with-msi

### DIFF
--- a/docs/examples/101/api-management-create-with-msi/README-MOVED.md
+++ b/docs/examples/101/api-management-create-with-msi/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/api-management-create-with-msi/main.bicep
+++ b/docs/examples/101/api-management-create-with-msi/main.bicep
@@ -1,22 +1,28 @@
+@description('The email address of the owner of the service')
 @minLength(1)
 param publisherEmail string
 
+@description('The name of the owner of the service')
 @minLength(1)
 param publisherName string
 
+@description('The pricing tier of this API Management service')
 @allowed([
+  'Basic'
   'Consumption'
   'Developer'
-  'Basic'
   'Standard'
   'Premium'
 ])
 param sku string = 'Developer'
 
+@description('The instance size of this API Management service.')
 param skuCount int = 1
+
+@description('Location for all resources.')
 param location string = resourceGroup().location
 
-resource apiManagement 'Microsoft.ApiManagement/service@2020-06-01-preview' = {
+resource apiManagement 'Microsoft.ApiManagement/service@2020-12-01' = {
   name: 'apiservice${uniqueString(resourceGroup().id)}'
   location: location
   sku: {
@@ -24,8 +30,8 @@ resource apiManagement 'Microsoft.ApiManagement/service@2020-06-01-preview' = {
     capacity: skuCount
   }
   properties: {
-    publisherName: publisherName
     publisherEmail: publisherEmail
+    publisherName: publisherName
   }
   identity: {
     type: 'SystemAssigned'

--- a/docs/examples/101/api-management-create-with-msi/main.json
+++ b/docs/examples/101/api-management-create-with-msi/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "4952456891125984913"
+    }
+  },
   "parameters": {
     "publisherEmail": {
       "type": "string",
@@ -18,6 +25,7 @@
     },
     "sku": {
       "type": "string",
+      "defaultValue": "Developer",
       "allowedValues": [
         "Basic",
         "Consumption",
@@ -25,7 +33,6 @@
         "Standard",
         "Premium"
       ],
-      "defaultValue": "Developer",
       "metadata": {
         "description": "The pricing tier of this API Management service"
       }
@@ -45,14 +52,12 @@
       }
     }
   },
-  "variables": {
-    "apiManagementServiceName": "[concat('apiservice', uniqueString(resourceGroup().id))]"
-  },
+  "functions": [],
   "resources": [
     {
-      "apiVersion": "2019-12-01",
-      "name": "[variables('apiManagementServiceName')]",
       "type": "Microsoft.ApiManagement/service",
+      "apiVersion": "2020-12-01",
+      "name": "[format('apiservice{0}', uniqueString(resourceGroup().id))]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('sku')]",

--- a/docs/examples/101/api-management-create-with-msi/main.json
+++ b/docs/examples/101/api-management-create-with-msi/main.json
@@ -1,56 +1,66 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "8703478997880227239"
-    }
-  },
   "parameters": {
     "publisherEmail": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "metadata": {
+        "description": "The email address of the owner of the service"
+      }
     },
     "publisherName": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "metadata": {
+        "description": "The name of the owner of the service"
+      }
     },
     "sku": {
       "type": "string",
-      "defaultValue": "Developer",
       "allowedValues": [
+        "Basic",
         "Consumption",
         "Developer",
-        "Basic",
         "Standard",
         "Premium"
-      ]
+      ],
+      "defaultValue": "Developer",
+      "metadata": {
+        "description": "The pricing tier of this API Management service"
+      }
     },
     "skuCount": {
       "type": "int",
-      "defaultValue": 1
+      "defaultValue": 1,
+      "metadata": {
+        "description": "The instance size of this API Management service."
+      }
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     }
   },
-  "functions": [],
+  "variables": {
+    "apiManagementServiceName": "[concat('apiservice', uniqueString(resourceGroup().id))]"
+  },
   "resources": [
     {
+      "apiVersion": "2019-12-01",
+      "name": "[variables('apiManagementServiceName')]",
       "type": "Microsoft.ApiManagement/service",
-      "apiVersion": "2020-06-01-preview",
-      "name": "[format('apiservice{0}', uniqueString(resourceGroup().id))]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('sku')]",
         "capacity": "[parameters('skuCount')]"
       },
       "properties": {
-        "publisherName": "[parameters('publisherName')]",
-        "publisherEmail": "[parameters('publisherEmail')]"
+        "publisherEmail": "[parameters('publisherEmail')]",
+        "publisherName": "[parameters('publisherName')]"
       },
       "identity": {
         "type": "SystemAssigned"


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.apimanagement/api-management-create-with-msi
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11122