### PR TITLE
Migrate example: 101/mg-policy

### DIFF
--- a/docs/examples/101/mg-policy/README-MOVED.md
+++ b/docs/examples/101/mg-policy/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/mg-policy/main.bicep
+++ b/docs/examples/101/mg-policy/main.bicep
@@ -1,6 +1,9 @@
 targetScope = 'managementGroup'
 
+@description('Target Management Group')
 param targetMG string
+
+@description('An array of the allowed locations, all other locations will be denied by the created policy.')
 param allowedLocations array = [
   'australiaeast'
   'australiasoutheast'
@@ -8,10 +11,10 @@ param allowedLocations array = [
 ]
 
 var mgScope = tenantResourceId('Microsoft.Management/managementGroups', targetMG)
-var policyDefinition = 'LocationRestriction'
+var policyDefinitionName = 'LocationRestriction'
 
-resource policy 'Microsoft.Authorization/policyDefinitions@2020-03-01' = {
-  name: policyDefinition
+resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-03-01' = {
+  name: policyDefinitionName
   properties: {
     policyType: 'Custom'
     mode: 'All'
@@ -34,6 +37,6 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01'
   name: 'location-lock'
   properties: {
     scope: mgScope
-    policyDefinitionId: extensionResourceId(mgScope, 'Microsoft.Authorization/policyDefinitions', policy.name)
+    policyDefinitionId: extensionResourceId(mgScope, 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)
   }
 }

--- a/docs/examples/101/mg-policy/main.json
+++ b/docs/examples/101/mg-policy/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "2022767932279852077"
+    }
+  },
   "parameters": {
     "targetMG": {
       "type": "string",
@@ -20,20 +27,20 @@
       }
     }
   },
+  "functions": [],
   "variables": {
     "mgScope": "[tenantResourceId('Microsoft.Management/managementGroups', parameters('targetMG'))]",
-    "policyDefinition": "LocationRestriction"
+    "policyDefinitionName": "LocationRestriction"
   },
   "resources": [
     {
       "type": "Microsoft.Authorization/policyDefinitions",
-      "name": "[variables('policyDefinition')]",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2020-03-01",
+      "name": "[variables('policyDefinitionName')]",
       "properties": {
         "policyType": "Custom",
         "mode": "All",
-        "parameters": {
-        },
+        "parameters": {},
         "policyRule": {
           "if": {
             "not": {
@@ -49,15 +56,15 @@
     },
     {
       "type": "Microsoft.Authorization/policyAssignments",
+      "apiVersion": "2020-03-01",
       "name": "location-lock",
-      "apiVersion": "2019-09-01",
-      "dependsOn": [
-        "[variables('policyDefinition')]"
-      ],
       "properties": {
         "scope": "[variables('mgScope')]",
-        "policyDefinitionId": "[extensionResourceId(variables('mgScope'), 'Microsoft.Authorization/policyDefinitions', variables('policyDefinition'))]"
-      }
+        "policyDefinitionId": "[extensionResourceId(variables('mgScope'), 'Microsoft.Authorization/policyDefinitions', variables('policyDefinitionName'))]"
+      },
+      "dependsOn": [
+        "[format('Microsoft.Authorization/policyDefinitions/{0}', variables('policyDefinitionName'))]"
+      ]
     }
   ]
 }

--- a/docs/examples/101/mg-policy/main.json
+++ b/docs/examples/101/mg-policy/main.json
@@ -1,16 +1,12 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "2994900047115443601"
-    }
-  },
   "parameters": {
     "targetMG": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Target Management Group"
+      }
     },
     "allowedLocations": {
       "type": "array",
@@ -18,10 +14,12 @@
         "australiaeast",
         "australiasoutheast",
         "australiacentral"
-      ]
+      ],
+      "metadata": {
+        "description": "An array of the allowed locations, all other locations will be denied by the created policy."
+      }
     }
   },
-  "functions": [],
   "variables": {
     "mgScope": "[tenantResourceId('Microsoft.Management/managementGroups', parameters('targetMG'))]",
     "policyDefinition": "LocationRestriction"
@@ -29,12 +27,13 @@
   "resources": [
     {
       "type": "Microsoft.Authorization/policyDefinitions",
-      "apiVersion": "2020-03-01",
       "name": "[variables('policyDefinition')]",
+      "apiVersion": "2019-09-01",
       "properties": {
         "policyType": "Custom",
         "mode": "All",
-        "parameters": {},
+        "parameters": {
+        },
         "policyRule": {
           "if": {
             "not": {
@@ -50,15 +49,15 @@
     },
     {
       "type": "Microsoft.Authorization/policyAssignments",
-      "apiVersion": "2020-03-01",
       "name": "location-lock",
+      "apiVersion": "2019-09-01",
+      "dependsOn": [
+        "[variables('policyDefinition')]"
+      ],
       "properties": {
         "scope": "[variables('mgScope')]",
         "policyDefinitionId": "[extensionResourceId(variables('mgScope'), 'Microsoft.Authorization/policyDefinitions', variables('policyDefinition'))]"
-      },
-      "dependsOn": [
-        "[format('Microsoft.Authorization/policyDefinitions/{0}', variables('policyDefinition'))]"
-      ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesmanagementgroup-deployments/mg-policy
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11123