### PR TITLE
Applied name change, wvd became avd

### DIFF
--- a/docs/examples/101/avd-backplane/main.bicep
+++ b/docs/examples/101/avd-backplane/main.bicep
@@ -1,4 +1,4 @@
-//Define WVD deployment parameters
+//Define AVD deployment parameters
 param hostpoolName string = 'myFirstHostpool'
 param hostpoolFriendlyName string = 'My Bicep created Host pool'
 param appgroupName string = 'myFirstAppGroup'
@@ -7,14 +7,14 @@ param workspaceName string = 'myFirstWortkspace'
 param workspaceNameFriendlyName string = 'My Bicep created Workspace'
 param applicationgrouptype string = 'Desktop'
 param preferredAppGroupType string = 'Desktop'
-param wvdbackplanelocation string = 'eastus'
+param avdbackplanelocation string = 'eastus'
 param hostPoolType string = 'pooled'
 param loadBalancerType string = 'BreadthFirst'
 
-//Create WVD Hostpool
+//Create AVD Hostpool
 resource hp 'Microsoft.DesktopVirtualization/hostpools@2019-12-10-preview' = {
   name: hostpoolName
-  location: wvdbackplanelocation
+  location: avdbackplanelocation
   properties: {
     friendlyName: hostpoolFriendlyName
     hostPoolType: hostPoolType
@@ -23,10 +23,10 @@ resource hp 'Microsoft.DesktopVirtualization/hostpools@2019-12-10-preview' = {
   }
 }
 
-//Create WVD AppGroup
+//Create AVD AppGroup
 resource ag 'Microsoft.DesktopVirtualization/applicationgroups@2019-12-10-preview' = {
   name: appgroupName
-  location: wvdbackplanelocation
+  location: avdbackplanelocation
   properties: {
     friendlyName: appgroupNameFriendlyName
     applicationGroupType: applicationgrouptype
@@ -34,10 +34,10 @@ resource ag 'Microsoft.DesktopVirtualization/applicationgroups@2019-12-10-previe
   }
 }
 
-//Create WVD Workspace
+//Create AVD Workspace
 resource ws 'Microsoft.DesktopVirtualization/workspaces@2019-12-10-preview' = {
   name: workspaceName
-  location: wvdbackplanelocation
+  location: avdbackplanelocation
   properties: {
     friendlyName: workspaceNameFriendlyName
     applicationGroupReferences: [

--- a/docs/examples/101/avd-backplane/main.json
+++ b/docs/examples/101/avd-backplane/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "18145927333961923723"
+      "version": "dev",
+      "templateHash": "11435914357705837168"
     }
   },
   "parameters": {

--- a/docs/examples/101/avd-backplane/main.json
+++ b/docs/examples/101/avd-backplane/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "dev",
-      "templateHash": "4936000733008039319"
+      "version": "0.4.1.14562",
+      "templateHash": "18145927333961923723"
     }
   },
   "parameters": {
@@ -41,7 +41,7 @@
       "type": "string",
       "defaultValue": "Desktop"
     },
-    "wvdbackplanelocation": {
+    "avdbackplanelocation": {
       "type": "string",
       "defaultValue": "eastus"
     },
@@ -60,7 +60,7 @@
       "type": "Microsoft.DesktopVirtualization/hostPools",
       "apiVersion": "2019-12-10-preview",
       "name": "[parameters('hostpoolName')]",
-      "location": "[parameters('wvdbackplanelocation')]",
+      "location": "[parameters('avdbackplanelocation')]",
       "properties": {
         "friendlyName": "[parameters('hostpoolFriendlyName')]",
         "hostPoolType": "[parameters('hostPoolType')]",
@@ -72,7 +72,7 @@
       "type": "Microsoft.DesktopVirtualization/applicationGroups",
       "apiVersion": "2019-12-10-preview",
       "name": "[parameters('appgroupName')]",
-      "location": "[parameters('wvdbackplanelocation')]",
+      "location": "[parameters('avdbackplanelocation')]",
       "properties": {
         "friendlyName": "[parameters('appgroupNameFriendlyName')]",
         "applicationGroupType": "[parameters('applicationgrouptype')]",
@@ -86,7 +86,7 @@
       "type": "Microsoft.DesktopVirtualization/workspaces",
       "apiVersion": "2019-12-10-preview",
       "name": "[parameters('workspaceName')]",
-      "location": "[parameters('wvdbackplanelocation')]",
+      "location": "[parameters('avdbackplanelocation')]",
       "properties": {
         "friendlyName": "[parameters('workspaceNameFriendlyName')]",
         "applicationGroupReferences": [

--- a/docs/examples/index.json
+++ b/docs/examples/index.json
@@ -320,8 +320,8 @@
         "description": "101/website-with-container"
     },
     {
-        "filePath": "101/wvd-backplane/main.bicep",
-        "description": "101/wvd-backplane"
+        "filePath": "101/avd-backplane/main.bicep",
+        "description": "101/avd-backplane"
     },
     {
         "filePath": "201/1vm-2nics-2subnets-1vnet/main.bicep",


### PR DESCRIPTION
Applied name change across this template and its folder since Windows Virtual Desktop recently became Azure Virtual Desktop

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
