### PR TITLE
Migrate example: 101/nat-gateway-vnet

### DIFF
--- a/docs/examples/101/nat-gateway-vnet/README-MOVED.md
+++ b/docs/examples/101/nat-gateway-vnet/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/nat-gateway-vnet/main.json
+++ b/docs/examples/101/nat-gateway-vnet/main.json
@@ -1,69 +1,77 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "6286385429065988966"
+    }
+  },
   "parameters": {
-    "vnetname": {
+    "vnetName": {
+      "type": "string",
       "defaultValue": "myVnet",
-      "type": "String",
       "metadata": {
         "description": "Name of the virtual network"
       }
     },
-    "subnetname": {
+    "subnetName": {
+      "type": "string",
       "defaultValue": "mySubnet",
-      "type": "String",
       "metadata": {
         "description": "Name of the subnet for virtual network"
       }
     },
-    "vnetaddressspace": {
+    "vnetAddressSpace": {
+      "type": "string",
       "defaultValue": "192.168.0.0/16",
-      "type": "String",
       "metadata": {
         "description": "Address space for virtual network"
       }
     },
-    "vnetsubnetprefix": {
+    "vnetSubnetPrefix": {
+      "type": "string",
       "defaultValue": "192.168.0.0/24",
-      "type": "String",
       "metadata": {
         "description": "Subnet prefix for virtual network"
       }
     },
-    "natgatewayname": {
+    "natGatewayName": {
+      "type": "string",
       "defaultValue": "myNATgateway",
-      "type": "String",
       "metadata": {
         "description": "Name of the NAT gateway resource"
       }
     },
-    "publicipdns": {
-      "defaultValue": "[concat('gw-', uniqueString(resourceGroup().id))]",
-      "type": "String",
+    "publicIpDns": {
+      "type": "string",
+      "defaultValue": "[format('gw-{0}', uniqueString(resourceGroup().id))]",
       "metadata": {
         "description": "dns of the public ip address, leave blank for no dns"
       }
     },
     "location": {
+      "type": "string",
       "defaultValue": "[resourceGroup().location]",
-      "type": "String",
       "metadata": {
         "description": "Location of resources"
       }
     }
   },
+  "functions": [],
   "variables": {
-    "publicIpName": "[concat(parameters('natgatewayname'), 'ip')]",
+    "publicIpName": "[format('{0}-ip', parameters('natGatewayName'))]",
     "publicIpAddresses": [
       {
-        "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicipname'))]"
+        "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
       }
     ]
   },
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2019-11-01",
+      "apiVersion": "2020-06-01",
       "name": "[variables('publicIpName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -74,47 +82,44 @@
         "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 4,
         "dnsSettings": {
-          "domainNameLabel": "[parameters('publicipdns')]"
+          "domainNameLabel": "[parameters('publicIpDns')]"
         }
       }
     },
     {
       "type": "Microsoft.Network/natGateways",
-      "apiVersion": "2019-11-01",
-      "name": "[parameters('natgatewayname')]",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('natGatewayName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicipname'))]"
-      ],
       "sku": {
         "name": "Standard"
       },
       "properties": {
         "idleTimeoutInMinutes": 4,
-        "publicIpAddresses": "[if(not(empty(parameters('publicipdns'))), variables('publicIpAddresses'), json('null'))]"
-      }
+        "publicIpAddresses": "[if(not(empty(parameters('publicIpDns'))), variables('publicIpAddresses'), null())]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+      ]
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2019-11-01",
-      "name": "[parameters('vnetname')]",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('vnetName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
-      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('vnetaddressspace')]"
+            "[parameters('vnetAddressSpace')]"
           ]
         },
         "subnets": [
           {
-            "name": "[parameters('subnetname')]",
+            "name": "[parameters('subnetName')]",
             "properties": {
-              "addressPrefix": "[parameters('vnetsubnetprefix')]",
+              "addressPrefix": "[parameters('vnetSubnetPrefix')]",
               "natGateway": {
-                "id": "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
+                "id": "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
               },
               "privateEndpointNetworkPolicies": "Enabled",
               "privateLinkServiceNetworkPolicies": "Enabled"
@@ -123,24 +128,27 @@
         ],
         "enableDdosProtection": false,
         "enableVmProtection": false
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
+      ]
     },
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2019-11-01",
-      "name": "[concat(parameters('vnetname'), '/mySubnet')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetname'))]",
-        "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
-      ],
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('vnetName'), 'mySubnet')]",
       "properties": {
-        "addressPrefix": "[parameters('vnetsubnetprefix')]",
+        "addressPrefix": "[parameters('vnetSubnetPrefix')]",
         "natGateway": {
-          "id": "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
+          "id": "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
         },
         "privateEndpointNetworkPolicies": "Enabled",
         "privateLinkServiceNetworkPolicies": "Enabled"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
+      ]
     }
   ]
 }

--- a/docs/examples/101/nat-gateway-vnet/main.json
+++ b/docs/examples/101/nat-gateway-vnet/main.json
@@ -1,51 +1,69 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "5385832247820330281"
-    }
-  },
   "parameters": {
-    "vnetName": {
-      "type": "string",
-      "defaultValue": "myVnet"
+    "vnetname": {
+      "defaultValue": "myVnet",
+      "type": "String",
+      "metadata": {
+        "description": "Name of the virtual network"
+      }
     },
-    "subNetName": {
-      "type": "string",
-      "defaultValue": "mySubnet"
+    "subnetname": {
+      "defaultValue": "mySubnet",
+      "type": "String",
+      "metadata": {
+        "description": "Name of the subnet for virtual network"
+      }
     },
-    "vnetAddressSpace": {
-      "type": "string",
-      "defaultValue": "192.168.0.0/16"
+    "vnetaddressspace": {
+      "defaultValue": "192.168.0.0/16",
+      "type": "String",
+      "metadata": {
+        "description": "Address space for virtual network"
+      }
     },
-    "vnetSubnetPrefix": {
-      "type": "string",
-      "defaultValue": "192.168.0.0/24"
+    "vnetsubnetprefix": {
+      "defaultValue": "192.168.0.0/24",
+      "type": "String",
+      "metadata": {
+        "description": "Subnet prefix for virtual network"
+      }
     },
-    "natGatewayName": {
-      "type": "string",
-      "defaultValue": "myNATgateway"
+    "natgatewayname": {
+      "defaultValue": "myNATgateway",
+      "type": "String",
+      "metadata": {
+        "description": "Name of the NAT gateway resource"
+      }
     },
-    "publicIpDNS": {
-      "type": "string",
-      "defaultValue": "[format('gw-{0}', uniqueString(resourceGroup().id))]"
+    "publicipdns": {
+      "defaultValue": "[concat('gw-', uniqueString(resourceGroup().id))]",
+      "type": "String",
+      "metadata": {
+        "description": "dns of the public ip address, leave blank for no dns"
+      }
     },
     "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "type": "String",
+      "metadata": {
+        "description": "Location of resources"
+      }
     }
   },
-  "functions": [],
   "variables": {
-    "publicIpName": "[format('{0}-ip', parameters('natGatewayName'))]"
+    "publicIpName": "[concat(parameters('natgatewayname'), 'ip')]",
+    "publicIpAddresses": [
+      {
+        "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicipname'))]"
+      }
+    ]
   },
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2019-11-01",
       "name": "[variables('publicIpName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -56,48 +74,47 @@
         "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 4,
         "dnsSettings": {
-          "domainNameLabel": "[parameters('publicIpDNS')]"
+          "domainNameLabel": "[parameters('publicipdns')]"
         }
       }
     },
     {
       "type": "Microsoft.Network/natGateways",
-      "apiVersion": "2020-06-01",
-      "name": "[parameters('natGatewayName')]",
+      "apiVersion": "2019-11-01",
+      "name": "[parameters('natgatewayname')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicipname'))]"
+      ],
       "sku": {
         "name": "Standard"
       },
       "properties": {
         "idleTimeoutInMinutes": 4,
-        "publicIpAddresses": [
-          {
-            "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
-          }
-        ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
-      ]
+        "publicIpAddresses": "[if(not(empty(parameters('publicipdns'))), variables('publicIpAddresses'), json('null'))]"
+      }
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-06-01",
-      "name": "[parameters('vnetName')]",
+      "apiVersion": "2019-11-01",
+      "name": "[parameters('vnetname')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('vnetAddressSpace')]"
+            "[parameters('vnetaddressspace')]"
           ]
         },
         "subnets": [
           {
-            "name": "[parameters('subNetName')]",
+            "name": "[parameters('subnetname')]",
             "properties": {
-              "addressPrefix": "[parameters('vnetSubnetPrefix')]",
+              "addressPrefix": "[parameters('vnetsubnetprefix')]",
               "natGateway": {
-                "id": "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
+                "id": "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
               },
               "privateEndpointNetworkPolicies": "Enabled",
               "privateLinkServiceNetworkPolicies": "Enabled"
@@ -106,27 +123,24 @@
         ],
         "enableDdosProtection": false,
         "enableVmProtection": false
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
-      ]
+      }
     },
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subNetName'))]",
+      "apiVersion": "2019-11-01",
+      "name": "[concat(parameters('vnetname'), '/mySubnet')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetname'))]",
+        "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
+      ],
       "properties": {
-        "addressPrefix": "[parameters('vnetSubnetPrefix')]",
+        "addressPrefix": "[parameters('vnetsubnetprefix')]",
         "natGateway": {
-          "id": "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
+          "id": "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
         },
         "privateEndpointNetworkPolicies": "Enabled",
         "privateLinkServiceNetworkPolicies": "Enabled"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
-      ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.network/nat-gateway-vnet
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11209