### PR TITLE
Migrate example: 101/sqlmi-new-vnet

### DIFF
--- a/docs/examples/101/sqlmi-new-vnet/main.json
+++ b/docs/examples/101/sqlmi-new-vnet/main.json
@@ -1,42 +1,59 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "4598814261157091151"
-    }
-  },
+  "contentVersion": "1.0.0.1",
   "parameters": {
     "managedInstanceName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Enter managed instance name."
+      }
     },
-    "adminLogin": {
-      "type": "string"
+    "administratorLogin": {
+      "type": "string",
+      "metadata": {
+        "description": "Enter user name."
+      }
     },
-    "adminPassword": {
-      "type": "secureString"
+    "administratorLoginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Enter password."
+      }
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Enter location. If you leave this field blank resource group location would be used."
+      }
     },
     "virtualNetworkName": {
       "type": "string",
-      "defaultValue": "vnet-01"
+      "defaultValue": "SQLMI-VNET",
+      "metadata": {
+        "description": "Enter virtual network name. If you leave this field blank name will be created by the template."
+      }
     },
-    "virtualNetworkPrefix": {
+    "addressPrefix": {
       "type": "string",
-      "defaultValue": "10.0.0.0/16"
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "Enter virtual network address prefix."
+      }
     },
     "subnetName": {
       "type": "string",
-      "defaultValue": "subnet-01"
+      "defaultValue": "ManagedInstance",
+      "metadata": {
+        "description": "Enter subnet name."
+      }
     },
     "subnetPrefix": {
       "type": "string",
-      "defaultValue": "10.0.0.0/24"
+      "defaultValue": "10.0.0.0/24",
+      "metadata": {
+        "description": "Enter subnet address prefix."
+      }
     },
     "skuName": {
       "type": "string",
@@ -44,11 +61,14 @@
       "allowedValues": [
         "GP_Gen5",
         "BC_Gen5"
-      ]
+      ],
+      "metadata": {
+        "description": "Enter sku name."
+      }
     },
     "vCores": {
       "type": "int",
-      "defaultValue": 8,
+      "defaultValue": 16,
       "allowedValues": [
         8,
         16,
@@ -57,19 +77,35 @@
         40,
         64,
         80
-      ]
+      ],
+      "metadata": {
+        "description": "Enter number of vCores."
+      }
     },
     "storageSizeInGB": {
       "type": "int",
       "defaultValue": 256,
+      "minValue": 32,
       "maxValue": 8192,
-      "minValue": 32
+      "metadata": {
+        "description": "Enter storage size."
+      }
+    },
+    "licenseType": {
+      "type": "string",
+      "defaultValue": "LicenseIncluded",
+      "allowedValues": [
+        "BasePrice",
+        "LicenseIncluded"
+      ],
+      "metadata": {
+        "description": "Enter license type."
+      }
     }
   },
-  "functions": [],
   "variables": {
-    "networkSecurityGroupName": "[format('{0}-nsg', parameters('managedInstanceName'))]",
-    "routeTableName": "[format('{0}-routetable', parameters('managedInstanceName'))]"
+    "networkSecurityGroupName": "[concat('SQLMI-', parameters('managedInstanceName'), '-NSG')]",
+    "routeTableName": "[concat('SQLMI-', parameters('managedInstanceName'), '-Route-Table')]"
   },
   "resources": [
     {
@@ -152,39 +188,39 @@
       "apiVersion": "2020-06-01",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[variables('routeTableName')]",
+        "[variables('networkSecurityGroupName')]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('virtualNetworkPrefix')]"
+            "[parameters('addressPrefix')]"
           ]
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2020-06-01",
-      "name": "[parameters('subnetName')]",
-      "properties": {
-        "addressPrefix": "[parameters('subnetPrefix')]",
-        "routeTable": {
-          "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
         },
-        "networkSecurityGroup": {
-          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
-        },
-        "delegations": [
+        "subnets": [
           {
-            "name": "managedInstanceDelegation",
+            "name": "[parameters('subnetName')]",
             "properties": {
-              "serviceName": "Microsoft.Sql/managedInstances"
+              "addressPrefix": "[parameters('subnetPrefix')]",
+              "routeTable": {
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
+              },
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              },
+              "delegations": [
+                {
+                  "name": "miDelegation",
+                  "properties": {
+                    "serviceName": "Microsoft.Sql/managedInstances"
+                  }
+                }
+              ]
             }
           }
         ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
-        "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
-      ]
+      }
     },
     {
       "type": "Microsoft.Sql/managedInstances",
@@ -197,17 +233,17 @@
       "identity": {
         "type": "SystemAssigned"
       },
+      "dependsOn": [
+        "[parameters('virtualNetworkName')]"
+      ],
       "properties": {
-        "administratorLogin": "[parameters('adminLogin')]",
-        "administratorLoginPassword": "[parameters('adminPassword')]",
-        "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]",
+        "administratorLogin": "[parameters('administratorLogin')]",
+        "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+        "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]",
         "storageSizeInGB": "[parameters('storageSizeInGB')]",
         "vCores": "[parameters('vCores')]",
-        "licenseType": "LicenseIncluded"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]"
-      ]
+        "licenseType": "[parameters('licenseType')]"
+      }
     }
   ]
 }

--- a/docs/examples/101/sqlmi-new-vnet/main.json
+++ b/docs/examples/101/sqlmi-new-vnet/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.1",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "6137492997883178529"
+    }
+  },
   "parameters": {
     "managedInstanceName": {
       "type": "string",
@@ -15,7 +22,7 @@
       }
     },
     "administratorLoginPassword": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Enter password."
       }
@@ -85,8 +92,8 @@
     "storageSizeInGB": {
       "type": "int",
       "defaultValue": 256,
-      "minValue": 32,
       "maxValue": 8192,
+      "minValue": 32,
       "metadata": {
         "description": "Enter storage size."
       }
@@ -103,9 +110,10 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "networkSecurityGroupName": "[concat('SQLMI-', parameters('managedInstanceName'), '-NSG')]",
-    "routeTableName": "[concat('SQLMI-', parameters('managedInstanceName'), '-Route-Table')]"
+    "networkSecurityGroupName": "[format('SQLMI-{0}-NSG', parameters('managedInstanceName'))]",
+    "routeTableName": "[format('SQLMI-{0}-Route-Table', parameters('managedInstanceName'))]"
   },
   "resources": [
     {
@@ -188,10 +196,6 @@
       "apiVersion": "2020-06-01",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('routeTableName')]",
-        "[variables('networkSecurityGroupName')]"
-      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -211,7 +215,7 @@
               },
               "delegations": [
                 {
-                  "name": "miDelegation",
+                  "name": "managedInstanceDelegation",
                   "properties": {
                     "serviceName": "Microsoft.Sql/managedInstances"
                   }
@@ -220,7 +224,11 @@
             }
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
+        "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
+      ]
     },
     {
       "type": "Microsoft.Sql/managedInstances",
@@ -233,9 +241,6 @@
       "identity": {
         "type": "SystemAssigned"
       },
-      "dependsOn": [
-        "[parameters('virtualNetworkName')]"
-      ],
       "properties": {
         "administratorLogin": "[parameters('administratorLogin')]",
         "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
@@ -243,7 +248,10 @@
         "storageSizeInGB": "[parameters('storageSizeInGB')]",
         "vCores": "[parameters('vCores')]",
         "licenseType": "[parameters('licenseType')]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.sql/sqlmi-new-vnet
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11247