### PR TITLE
Update azure-cli container reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run Bicep E2E Tests (linux-musl-x64)
         if: ${{ matrix.rid == 'linux-musl-x64' }}
-        uses: docker://microsoft/azure-cli:latest
+        uses: docker://mcr.microsoft.com/azure-cli:latest
         with:
           entrypoint: sh
           args: -c "apk add --update nodejs npm && npm ci --prefix ./src/Bicep.Cli.E2eTests && npm test --prefix ./src/Bicep.Cli.E2eTests"


### PR DESCRIPTION
This has been moved to MCR - details here:
https://hub.docker.com/r/microsoft/azure-cli
https://github.com/microsoft/containerregistry/blob/master/docs/dockerhub-to-mcr-repo-mapping.md