### PR TITLE
Migrate example: 101/vnet-two-subnets

### DIFF
--- a/docs/examples/101/vnet-two-subnets/README-MOVED.md
+++ b/docs/examples/101/vnet-two-subnets/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.network/vnet-two-subnets.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/vnet-two-subnets/main.bicep
+++ b/docs/examples/101/vnet-two-subnets/main.bicep
@@ -1,38 +1,51 @@
-param suffix string = '001'
-param owner string = 'alex'
-param costCenter string = '12345'
-param addressPrefix string = '10.0.0.0/15'
+@description('VNet name')
+param vnetName string = 'VNet1'
 
-var vnetName = 'vnet-${suffix}'
+@description('Address prefix')
+param vnetAddressPrefix string = '10.0.0.0/16'
+
+@description('Subnet 1 Prefix')
+param subnet1Prefix string = '10.0.0.0/24'
+
+@description('Subnet 1 Name')
+param subnet1Name string = 'Subnet1'
+
+@description('Subnet 2 Prefix')
+param subnet2Prefix string = '10.0.1.0/24'
+
+@description('Subnet 2 Name')
+param subnet2Name string = 'Subnet2'
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
 
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
   name: vnetName
-  location: resourceGroup().location
-  tags: {
-    Owner: owner
-    CostCenter: costCenter
-  }
+  location: location
   properties: {
     addressSpace: {
       addressPrefixes: [
-        addressPrefix
+        vnetAddressPrefix
       ]
     }
-    enableVmProtection: false
-    enableDdosProtection: false
-    subnets: [
-      {
-        name: 'subnet001'
-        properties: {
-          addressPrefix: '10.0.0.0/24'
-        }
-      }
-      {
-        name: 'subnet002'
-        properties: {
-          addressPrefix: '10.0.1.0/24'
-        }
-      }
-    ]
   }
+}
+
+resource subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+  parent: vnet
+  name: subnet1Name
+  properties: {
+    addressPrefix: subnet1Prefix
+  }
+}
+
+resource subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+  parent: vnet
+  name: subnet2Name
+  properties: {
+    addressPrefix: subnet2Prefix
+  }
+  dependsOn: [
+    subnet1
+  ]
 }

--- a/docs/examples/101/vnet-two-subnets/main.bicep
+++ b/docs/examples/101/vnet-two-subnets/main.bicep
@@ -45,7 +45,4 @@ resource subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
   properties: {
     addressPrefix: subnet2Prefix
   }
-  dependsOn: [
-    subnet1
-  ]
 }

--- a/docs/examples/101/vnet-two-subnets/main.json
+++ b/docs/examples/101/vnet-two-subnets/main.json
@@ -1,68 +1,98 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "16512295221089606821"
-    }
-  },
   "parameters": {
-    "suffix": {
+    "vnetName": {
       "type": "string",
-      "defaultValue": "001"
+      "defaultValue": "VNet1",
+      "metadata": {
+        "description": "VNet name"
+      }
     },
-    "owner": {
+    "vnetAddressPrefix": {
       "type": "string",
-      "defaultValue": "alex"
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "Address prefix"
+      }
     },
-    "costCenter": {
+    "subnet1Prefix": {
       "type": "string",
-      "defaultValue": "12345"
+      "defaultValue": "10.0.0.0/24",
+      "metadata": {
+        "description": "Subnet 1 Prefix"
+      }
     },
-    "addressPrefix": {
+    "subnet1Name": {
       "type": "string",
-      "defaultValue": "10.0.0.0/15"
+      "defaultValue": "Subnet1",
+      "metadata": {
+        "description": "Subnet 1 Name"
+      }
+    },
+    "subnet2Prefix": {
+      "type": "string",
+      "defaultValue": "10.0.1.0/24",
+      "metadata": {
+        "description": "Subnet 2 Prefix"
+      }
+    },
+    "subnet2Name": {
+      "type": "string",
+      "defaultValue": "Subnet2",
+      "metadata": {
+        "description": "Subnet 2 Name"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     }
   },
-  "functions": [],
-  "variables": {
-    "vnetName": "[format('vnet-{0}', parameters('suffix'))]"
-  },
+  "variables": {},
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-06-01",
-      "name": "[variables('vnetName')]",
-      "location": "[resourceGroup().location]",
-      "tags": {
-        "Owner": "[parameters('owner')]",
-        "CostCenter": "[parameters('costCenter')]"
-      },
+      "apiVersion": "2020-05-01",
+      "name": "[parameters('vnetName')]",
+      "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('addressPrefix')]"
+            "[parameters('vnetAddressPrefix')]"
           ]
-        },
-        "enableVmProtection": false,
-        "enableDdosProtection": false,
-        "subnets": [
-          {
-            "name": "subnet001",
-            "properties": {
-              "addressPrefix": "10.0.0.0/24"
-            }
-          },
-          {
-            "name": "subnet002",
-            "properties": {
-              "addressPrefix": "10.0.1.0/24"
-            }
+        }
+      },
+      "resources": [
+        {
+          "type": "subnets",
+          "apiVersion": "2020-05-01",
+          "location": "[parameters('location')]",
+          "name": "[parameters('subnet1Name')]",
+          "dependsOn": [
+            "[parameters('vnetName')]"
+          ],
+          "properties": {
+            "addressPrefix": "[parameters('subnet1Prefix')]"
           }
-        ]
-      }
+        },
+        {
+          "type": "subnets",
+          "apiVersion": "2020-05-01",
+          "location": "[parameters('location')]",
+          "name": "[parameters('subnet2Name')]",
+          "dependsOn": [
+            "[parameters('vnetName')]",
+            "[parameters('subnet1Name')]"
+          ],
+          "properties": {
+            "addressPrefix": "[parameters('subnet2Prefix')]"
+          }
+        }
+      ]
     }
   ]
 }

--- a/docs/examples/101/vnet-two-subnets/main.json
+++ b/docs/examples/101/vnet-two-subnets/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "5019939737599307807"
+    }
+  },
   "parameters": {
     "vnetName": {
       "type": "string",
@@ -52,11 +59,11 @@
       }
     }
   },
-  "variables": {},
+  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
       "name": "[parameters('vnetName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -65,33 +72,28 @@
             "[parameters('vnetAddressPrefix')]"
           ]
         }
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnet1Name'))]",
+      "properties": {
+        "addressPrefix": "[parameters('subnet1Prefix')]"
       },
-      "resources": [
-        {
-          "type": "subnets",
-          "apiVersion": "2020-05-01",
-          "location": "[parameters('location')]",
-          "name": "[parameters('subnet1Name')]",
-          "dependsOn": [
-            "[parameters('vnetName')]"
-          ],
-          "properties": {
-            "addressPrefix": "[parameters('subnet1Prefix')]"
-          }
-        },
-        {
-          "type": "subnets",
-          "apiVersion": "2020-05-01",
-          "location": "[parameters('location')]",
-          "name": "[parameters('subnet2Name')]",
-          "dependsOn": [
-            "[parameters('vnetName')]",
-            "[parameters('subnet1Name')]"
-          ],
-          "properties": {
-            "addressPrefix": "[parameters('subnet2Prefix')]"
-          }
-        }
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnet2Name'))]",
+      "properties": {
+        "addressPrefix": "[parameters('subnet2Prefix')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
       ]
     }
   ]


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.network/vnet-two-subnets
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11334