### PR TITLE
Migrate example: 201/cloud-shell-vnet

### DIFF
--- a/docs/examples/201/cloud-shell-vnet/README-MOVED.md
+++ b/docs/examples/201/cloud-shell-vnet/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/demos/cloud-shell-vnet.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/201/cloud-shell-vnet/main.bicep
+++ b/docs/examples/201/cloud-shell-vnet/main.bicep
@@ -38,9 +38,13 @@ var networkRoleDefinitionId = resourceId('Microsoft.Authorization/roleDefinition
 var privateDnsZoneName = ((toLower(environment().name) == 'azureusgovernment') ? 'privatelink.servicebus.usgovcloudapi.net' : 'privatelink.servicebus.windows.net')
 var vnetResourceId = resourceId('Microsoft.Network/virtualNetworks', existingVNETName)
 
-// asdf todo
+resource existingVNET 'Microsoft.Network/virtualNetworks@2020-04-01' existing = {
+  name: existingVNETName
+}
+
 resource containerSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-04-01' = {
-  name: '${existingVNETName}/${containerSubnetName}'
+  parent: existingVNET
+  name: containerSubnetName
   properties: {
     addressPrefix: containerSubnetAddressPrefix
     serviceEndpoints: [
@@ -113,9 +117,9 @@ resource relayNamespace_roleAssignment 'Microsoft.Authorization/roleAssignments@
   }
 }
 
-// asdf TODO
 resource relaySubnet 'Microsoft.Network/virtualNetworks/subnets@2020-04-01' = {
-  name: '${existingVNETName}/${relaySubnetName}'
+  parent: existingVNET
+  name: relaySubnetName
   properties: {
     addressPrefix: relaySubnetAddressPrefix
     privateEndpointNetworkPolicies: 'Disabled'
@@ -147,9 +151,9 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2020-04-01' = {
   }
 }
 
-// asdf todo
 resource storageSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-04-01' = {
-  name: '${existingVNETName}/${storageSubnetName}'
+  parent: existingVNET
+  name: storageSubnetName
   properties: {
     addressPrefix: storageSubnetAddressPrefix
     serviceEndpoints: [

--- a/docs/examples/201/cloud-shell-vnet/main.bicep
+++ b/docs/examples/201/cloud-shell-vnet/main.bicep
@@ -1,26 +1,35 @@
-// Name of the existing VNET to inject Cloud Shell into.
+@description('Name of the existing VNET to inject Cloud Shell into.')
 param existingVNETName string
-// Name of Azure Relay Namespace.
+
+@description('Name of Azure Relay Namespace.')
 param relayNamespaceName string
 // Object Id of Azure Container Instance Service Principal. 
 // We have to grant this permission to create hybrid connections in the Azure Relay you specify.
-// To get it - Get-AzADServicePrincipal -DisplayNameBeginsWith \'Azure Container Instance\'
+// To get it: Get-AzADServicePrincipal -DisplayNameBeginsWith \'Azure Container Instance\'
 param azureContainerInstanceOID string
-// Name of the subnet to use for cloud shell containers.
+
+@description('Name of the subnet to use for cloud shell containers.')
 param containerSubnetName string = 'cloudshellsubnet'
-// Address space of the subnet to add for cloud shell. e.g. 10.0.1.0/26
+
+@description('Address space of the subnet to add for cloud shell. e.g. 10.0.1.0/26')
 param containerSubnetAddressPrefix string
-// Name of the subnet to use for private link of relay namespace.
+
+@description('Name of the subnet to use for private link of relay namespace.')
 param relaySubnetName string = 'relaysubnet'
-// Address space of the subnet to add for relay. e.g. 10.0.2.0/26
+
+@description('Address space of the subnet to add for relay. e.g. 10.0.2.0/26')
 param relaySubnetAddressPrefix string
-// Name of the subnet to use for storage account.
+
+@description('Name of the subnet to use for storage account.')
 param storageSubnetName string = 'storagesubnet'
-// Address space of the subnet to add for storage. e.g. 10.0.3.0/26
+
+@description('Address space of the subnet to add for storage. e.g. 10.0.3.0/26')
 param storageSubnetAddressPrefix string
-// Name of Private Endpoint for Azure Relay.
+
+@description('Name of Private Endpoint for Azure Relay.')
 param privateEndpointName string = 'cloudshellRelayEndpoint'
-// Location for all resources.
+
+@description('Location for all resources.')
 param location string = resourceGroup().location
 
 var networkProfileName = 'aci-networkProfile-${location}'
@@ -29,6 +38,7 @@ var networkRoleDefinitionId = resourceId('Microsoft.Authorization/roleDefinition
 var privateDnsZoneName = ((toLower(environment().name) == 'azureusgovernment') ? 'privatelink.servicebus.usgovcloudapi.net' : 'privatelink.servicebus.windows.net')
 var vnetResourceId = resourceId('Microsoft.Network/virtualNetworks', existingVNETName)
 
+// asdf todo
 resource containerSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-04-01' = {
   name: '${existingVNETName}/${containerSubnetName}'
   properties: {
@@ -76,7 +86,7 @@ resource networkProfile 'Microsoft.Network/networkProfiles@2019-11-01' = {
   }
 }
 
-resource networkProfile_roleAssignment 'Microsoft.Authorization/roleAssignments@2018-09-01-preview' = {
+resource networkProfile_roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   scope: networkProfile
   name: guid(networkRoleDefinitionId, azureContainerInstanceOID, networkProfile.name)
   properties: {
@@ -94,7 +104,7 @@ resource relayNamespace 'Microsoft.Relay/namespaces@2018-01-01-preview' = {
   }
 }
 
-resource relayNamespace_roleAssignment 'Microsoft.Authorization/roleAssignments@2018-09-01-preview' = {
+resource relayNamespace_roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   scope: relayNamespace
   name: guid(contributorRoleDefinitionId, azureContainerInstanceOID, relayNamespace.name)
   properties: {
@@ -103,6 +113,7 @@ resource relayNamespace_roleAssignment 'Microsoft.Authorization/roleAssignments@
   }
 }
 
+// asdf TODO
 resource relaySubnet 'Microsoft.Network/virtualNetworks/subnets@2020-04-01' = {
   name: '${existingVNETName}/${relaySubnetName}'
   properties: {
@@ -136,6 +147,7 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2020-04-01' = {
   }
 }
 
+// asdf todo
 resource storageSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-04-01' = {
   name: '${existingVNETName}/${storageSubnetName}'
   properties: {
@@ -160,7 +172,8 @@ resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-01-01' = {
 }
 
 resource privateDnsZoneARecord 'Microsoft.Network/privateDnsZones/A@2020-01-01' = {
-  name: '${privateDnsZone.name}/${relayNamespaceName}'
+  parent: privateDnsZone
+  name: relayNamespaceName
   properties: {
     ttl: 3600
     aRecords: [
@@ -172,7 +185,8 @@ resource privateDnsZoneARecord 'Microsoft.Network/privateDnsZones/A@2020-01-01' 
 }
 
 resource privateDnsZoneVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-01-01' = {
-  name: '${privateDnsZone.name}/${relayNamespaceName}'
+  parent: privateDnsZone
+  name: relayNamespaceName
   location: 'global'
   properties: {
     registrationEnabled: false

--- a/docs/examples/201/cloud-shell-vnet/main.json
+++ b/docs/examples/201/cloud-shell-vnet/main.json
@@ -1,259 +1,302 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "1998416353155394596"
-    }
-  },
-  "parameters": {
-    "existingVNETName": {
-      "type": "string"
-    },
-    "relayNamespaceName": {
-      "type": "string"
-    },
-    "azureContainerInstanceOID": {
-      "type": "string"
-    },
-    "containerSubnetName": {
-      "type": "string",
-      "defaultValue": "cloudshellsubnet"
-    },
-    "containerSubnetAddressPrefix": {
-      "type": "string"
-    },
-    "relaySubnetName": {
-      "type": "string",
-      "defaultValue": "relaysubnet"
-    },
-    "relaySubnetAddressPrefix": {
-      "type": "string"
-    },
-    "storageSubnetName": {
-      "type": "string",
-      "defaultValue": "storagesubnet"
-    },
-    "storageSubnetAddressPrefix": {
-      "type": "string"
-    },
-    "privateEndpointName": {
-      "type": "string",
-      "defaultValue": "cloudshellRelayEndpoint"
-    },
-    "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]"
-    }
-  },
-  "functions": [],
-  "variables": {
-    "networkProfileName": "[format('aci-networkProfile-{0}', parameters('location'))]",
-    "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-    "networkRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
-    "privateDnsZoneName": "[if(equals(toLower(environment().name), 'azureusgovernment'), 'privatelink.servicebus.usgovcloudapi.net', 'privatelink.servicebus.windows.net')]",
-    "vnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks', parameters('existingVNETName'))]"
-  },
-  "resources": [
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2020-04-01",
-      "name": "[format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName'))]",
-      "properties": {
-        "addressPrefix": "[parameters('containerSubnetAddressPrefix')]",
-        "serviceEndpoints": [
-          {
-            "service": "Microsoft.Storage",
-            "locations": [
-              "[parameters('location')]"
-            ]
-          }
-        ],
-        "delegations": [
-          {
-            "name": "CloudShellDelegation",
-            "properties": {
-              "serviceName": "Microsoft.ContainerInstance/containerGroups"
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "existingVNETName": {
+            "type": "String",
+            "metadata": {
+                "description": "Name of the existing VNET to inject Cloud Shell into."
             }
-          }
-        ]
-      }
+        },
+        "relayNamespaceName": {
+            "type": "String",
+            "metadata": {
+                "description": "Name of Azure Relay Namespace."
+            }
+        },
+        "azureContainerInstanceOID": {
+            "type": "String",
+            "metadata": {
+                "description": "Object Id of Azure Container Instance Service Principal. We have to grant this permission to create hybrid connections in the Azure Relay you specify. To get it - Get-AzADServicePrincipal -DisplayNameBeginsWith 'Azure Container Instance'"
+            }
+        },
+        "containerSubnetName": {
+            "defaultValue": "cloudshellsubnet",
+            "type": "String",
+            "metadata": {
+                "description": "Name of the subnet to use for cloud shell containers."
+            }
+        },
+        "containerSubnetAddressPrefix": {
+            "type": "String",
+            "metadata": {
+                "description": "Address space of the subnet to add for cloud shell. e.g. 10.0.1.0/26"
+            }
+        },
+        "relaySubnetName": {
+            "defaultValue": "relaysubnet",
+            "type": "String",
+            "metadata": {
+                "description": "Name of the subnet to use for private link of relay namespace."
+            }
+        },
+        "relaySubnetAddressPrefix": {
+            "type": "String",
+            "metadata": {
+                "description": "Address space of the subnet to add for relay. e.g. 10.0.2.0/26"
+            }
+        },
+        "storageSubnetName": {
+            "defaultValue": "storagesubnet",
+            "type": "String",
+            "metadata": {
+                "description": "Name of the subnet to use for storage account."
+            }
+        },
+        "storageSubnetAddressPrefix": {
+            "type": "String",
+            "metadata": {
+                "description": "Address space of the subnet to add for storage. e.g. 10.0.3.0/26"
+            }
+        },
+        "privateEndpointName": {
+            "defaultValue": "cloudshellRelayEndpoint",
+            "type": "String",
+            "metadata": {
+                "description": "Name of Private Endpoint for Azure Relay."
+            }
+        },
+        "location": {
+            "defaultValue": "[resourceGroup().location]",
+            "type": "String",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        }
     },
-    {
-      "type": "Microsoft.Network/networkProfiles",
-      "apiVersion": "2019-11-01",
-      "name": "[variables('networkProfileName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "containerNetworkInterfaceConfigurations": [
-          {
-            "name": "[format('eth-{0}', parameters('containerSubnetName'))]",
+    "variables": {
+        "networkProfileName": "[concat('aci-networkProfile-', parameters('location'))]",
+        "networkProfileRef": "[resourceId('Microsoft.Network/networkProfiles', variables('networkProfileName'))]",
+        "containerSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]",
+        "relayNamespaceRef": "[resourceId('Microsoft.Relay/namespaces/', parameters('relayNamespaceName'))]",
+        "relaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]",
+        "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+        "networkRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+        "privateDnsZoneName": "[if(equals(toLower(environment().name), 'azureusgovernment'), 'privatelink.servicebus.usgovcloudapi.net', 'privatelink.servicebus.windows.net')]",
+        "networkRef": "[resourceId('Microsoft.Network/virtualNetworks', parameters('existingVNETName'))]",
+        "privateEndpointRef": "[resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "2020-04-01",
+            "name": "[concat(parameters('existingVNETName'), '/', parameters('containerSubnetName'))]",
+            "location": "[parameters('location')]",
             "properties": {
-              "ipConfigurations": [
-                {
-                  "name": "[format('ipconfig-{0}', parameters('containerSubnetName'))]",
-                  "properties": {
-                    "subnet": {
-                      "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName')), '/')[0], split(format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName')), '/')[1])]"
+                "addressPrefix": "[parameters('containerSubnetAddressPrefix')]",
+                "serviceEndpoints": [
+                    {
+                        "service": "Microsoft.Storage",
+                        "locations": [
+                            "[parameters('location')]"
+                        ]
                     }
-                  }
-                }
-              ]
+                ],
+                "delegations": [
+                    {
+                        "name": "CloudShellDelegation",
+                        "properties": {
+                            "serviceName": "Microsoft.ContainerInstance/containerGroups"
+                        }
+                    }
+                ]
             }
-          }
-        ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName')), '/')[0], split(format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName')), '/')[1])]"
-      ]
-    },
-    {
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2018-09-01-preview",
-      "scope": "[format('Microsoft.Network/networkProfiles/{0}', variables('networkProfileName'))]",
-      "name": "[guid(variables('networkRoleDefinitionId'), parameters('azureContainerInstanceOID'), variables('networkProfileName'))]",
-      "properties": {
-        "roleDefinitionId": "[variables('networkRoleDefinitionId')]",
-        "principalId": "[parameters('azureContainerInstanceOID')]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkProfiles', variables('networkProfileName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Relay/namespaces",
-      "apiVersion": "2018-01-01-preview",
-      "name": "[parameters('relayNamespaceName')]",
-      "location": "[parameters('location')]",
-      "sku": {
-        "name": "Standard",
-        "tier": "Standard"
-      }
-    },
-    {
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2018-09-01-preview",
-      "scope": "[format('Microsoft.Relay/namespaces/{0}', parameters('relayNamespaceName'))]",
-      "name": "[guid(variables('contributorRoleDefinitionId'), parameters('azureContainerInstanceOID'), parameters('relayNamespaceName'))]",
-      "properties": {
-        "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-        "principalId": "[parameters('azureContainerInstanceOID')]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2020-04-01",
-      "name": "[format('{0}/{1}', parameters('existingVNETName'), parameters('relaySubnetName'))]",
-      "properties": {
-        "addressPrefix": "[parameters('relaySubnetAddressPrefix')]",
-        "privateEndpointNetworkPolicies": "Disabled",
-        "privateLinkServiceNetworkPolicies": "Enabled"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName')), '/')[0], split(format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName')), '/')[1])]"
-      ]
-    },
-    {
-      "type": "Microsoft.Network/privateEndpoints",
-      "apiVersion": "2020-04-01",
-      "name": "[parameters('privateEndpointName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "privateLinkServiceConnections": [
-          {
-            "name": "[parameters('privateEndpointName')]",
+        },
+        {
+            "type": "Microsoft.Network/networkProfiles",
+            "apiVersion": "2019-11-01",
+            "name": "[variables('networkProfileName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('containerSubnetRef')]"
+            ],
             "properties": {
-              "privateLinkServiceId": "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]",
-              "groupIds": [
-                "namespace"
-              ]
+                "containerNetworkInterfaceConfigurations": [
+                    {
+                        "name": "[concat('eth-', parameters('containerSubnetName'))]",
+                        "properties": {
+                            "ipConfigurations": [
+                                {
+                                    "name": "[concat('ipconfig-', parameters('containerSubnetName'))]",
+                                    "properties": {
+                                        "subnet": {
+                                            "id": "[variables('containerSubnetRef')]"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
-          }
-        ],
-        "subnet": {
-          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('existingVNETName'), parameters('relaySubnetName')), '/')[0], split(format('{0}/{1}', parameters('existingVNETName'), parameters('relaySubnetName')), '/')[1])]"
+        },
+        {
+            "scope": "[format('Microsoft.Network/networkProfiles/{0}', variables('networkProfileName'))]",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-04-01-preview",
+            "name": "[guid(variables('networkRoleDefinitionId'), parameters('azureContainerInstanceOID'), variables('networkProfileName'))]",
+            "dependsOn": [
+                "[variables('networkProfileRef')]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('networkRoleDefinitionId')]",
+                "principalId": "[parameters('azureContainerInstanceOID')]",
+                "scope": "[variables('networkProfileRef')]"
+            }
+        },
+        {
+            "type": "Microsoft.Relay/namespaces",
+            "apiVersion": "2018-01-01-preview",
+            "name": "[parameters('relayNamespaceName')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "Standard",
+                "tier": "Standard"
+            }
+        },
+        {
+            "scope": "[format('Microsoft.Relay/namespaces/{0}', parameters('relayNamespaceName'))]",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-04-01-preview",
+            "name": "[guid(variables('contributorRoleDefinitionId'), parameters('azureContainerInstanceOID'), parameters('relayNamespaceName'))]",
+            "dependsOn": [
+                "[variables('relayNamespaceRef')]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
+                "principalId": "[parameters('azureContainerInstanceOID')]",
+                "scope": "[variables('relayNamespaceRef')]"
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "2020-04-01",
+            "name": "[concat(parameters('existingVNETName'), '/', parameters('relaySubnetName'))]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('containerSubnetRef')]"
+            ],
+            "properties": {
+                "addressPrefix": "[parameters('relaySubnetAddressPrefix')]",
+                "privateEndpointNetworkPolicies": "Disabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateEndpoints",
+            "apiVersion": "2020-04-01",
+            "name": "[parameters('privateEndpointName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('relaySubnetRef')]",
+                "[variables('relayNamespaceRef')]"
+            ],
+            "properties": {
+                "privateLinkServiceConnections": [
+                    {
+                        "name": "[parameters('privateEndpointName')]",
+                        "properties": {
+                            "privateLinkServiceId": "[variables('relayNamespaceRef')]",
+                            "groupIds": [
+                                "namespace"
+                            ]
+                        }
+                    }
+                ],
+                "subnet": {
+                    "id": "[variables('relaySubnetRef')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "apiVersion": "2020-04-01",
+            "name": "[concat(parameters('existingVNETName'), '/', parameters('storageSubnetName'))]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[variables('relaySubnetRef')]"
+            ],
+            "properties": {
+                "addressPrefix": "[parameters('storageSubnetAddressPrefix')]",
+                "serviceEndpoints": [
+                    {
+                        "service": "Microsoft.Storage",
+                        "locations": [
+                            "[parameters('location')]"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones",
+            "apiVersion": "2020-01-01",
+            "name": "[variables('privateDnsZoneName')]",
+            "location": "global",
+            "properties": {
+                "maxNumberOfRecordSets": 25000,
+                "maxNumberOfVirtualNetworkLinks": 1000,
+                "maxNumberOfVirtualNetworkLinksWithRegistration": 100,
+                "numberOfRecordSets": 2,
+                "numberOfVirtualNetworkLinks": 1,
+                "numberOfVirtualNetworkLinksWithRegistration": 0
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones/A",
+            "apiVersion": "2020-01-01",
+            "name": "[concat(variables('privateDnsZoneName'),'/', parameters('relayNamespaceName'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
+                "[variables('privateEndpointRef')]"
+            ],
+            "properties": {
+                "ttl": 3600,
+                "aRecords": [
+                    {
+                        "ipv4Address": "[first(first(reference(parameters('privateEndpointName'),'2020-04-01','Full').properties.customDnsConfigs).ipAddresses)]"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+            "apiVersion": "2020-01-01",
+            "name": "[concat(variables('privateDnsZoneName'), '/', parameters('relayNamespaceName'))]",
+            "location": "global",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+            ],
+            "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                    "id": "[variables('networkRef')]"
+                }
+            }
         }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('existingVNETName'), parameters('relaySubnetName')), '/')[0], split(format('{0}/{1}', parameters('existingVNETName'), parameters('relaySubnetName')), '/')[1])]"
-      ]
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2020-04-01",
-      "name": "[format('{0}/{1}', parameters('existingVNETName'), parameters('storageSubnetName'))]",
-      "properties": {
-        "addressPrefix": "[parameters('storageSubnetAddressPrefix')]",
-        "serviceEndpoints": [
-          {
-            "service": "Microsoft.Storage",
-            "locations": [
-              "[parameters('location')]"
-            ]
-          }
-        ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('existingVNETName'), parameters('relaySubnetName')), '/')[0], split(format('{0}/{1}', parameters('existingVNETName'), parameters('relaySubnetName')), '/')[1])]"
-      ]
-    },
-    {
-      "type": "Microsoft.Network/privateDnsZones",
-      "apiVersion": "2020-01-01",
-      "name": "[variables('privateDnsZoneName')]",
-      "location": "global"
-    },
-    {
-      "type": "Microsoft.Network/privateDnsZones/A",
-      "apiVersion": "2020-01-01",
-      "name": "[format('{0}/{1}', variables('privateDnsZoneName'), parameters('relayNamespaceName'))]",
-      "properties": {
-        "ttl": 3600,
-        "aRecords": [
-          {
-            "ipv4Address": "[first(first(reference(resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))).customDnsConfigs).ipAddresses)]"
-          }
-        ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
-        "[resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-      "apiVersion": "2020-01-01",
-      "name": "[format('{0}/{1}', variables('privateDnsZoneName'), parameters('relayNamespaceName'))]",
-      "location": "global",
-      "properties": {
-        "registrationEnabled": false,
-        "virtualNetwork": {
-          "id": "[variables('vnetResourceId')]"
+    ],
+    "outputs": {
+        "vnetName": {
+            "type": "String",
+            "value": "[parameters('existingVNETName')]"
+        },
+        "containerSubnetName": {
+            "type": "String",
+            "value": "[parameters('containerSubnetName')]"
+        },
+        "storageSubnetName": {
+            "type": "String",
+            "value": "[parameters('storageSubnetName')]"
         }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
-      ]
     }
-  ],
-  "outputs": {
-    "vnetId": {
-      "type": "string",
-      "value": "[variables('vnetResourceId')]"
-    },
-    "containerSubnetId": {
-      "type": "string",
-      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName')), '/')[0], split(format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName')), '/')[1])]"
-    },
-    "storageSubnetId": {
-      "type": "string",
-      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('existingVNETName'), parameters('storageSubnetName')), '/')[0], split(format('{0}/{1}', parameters('existingVNETName'), parameters('storageSubnetName')), '/')[1])]"
-    }
-  }
 }

--- a/docs/examples/201/cloud-shell-vnet/main.json
+++ b/docs/examples/201/cloud-shell-vnet/main.json
@@ -1,302 +1,289 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "existingVNETName": {
-            "type": "String",
-            "metadata": {
-                "description": "Name of the existing VNET to inject Cloud Shell into."
-            }
-        },
-        "relayNamespaceName": {
-            "type": "String",
-            "metadata": {
-                "description": "Name of Azure Relay Namespace."
-            }
-        },
-        "azureContainerInstanceOID": {
-            "type": "String",
-            "metadata": {
-                "description": "Object Id of Azure Container Instance Service Principal. We have to grant this permission to create hybrid connections in the Azure Relay you specify. To get it - Get-AzADServicePrincipal -DisplayNameBeginsWith 'Azure Container Instance'"
-            }
-        },
-        "containerSubnetName": {
-            "defaultValue": "cloudshellsubnet",
-            "type": "String",
-            "metadata": {
-                "description": "Name of the subnet to use for cloud shell containers."
-            }
-        },
-        "containerSubnetAddressPrefix": {
-            "type": "String",
-            "metadata": {
-                "description": "Address space of the subnet to add for cloud shell. e.g. 10.0.1.0/26"
-            }
-        },
-        "relaySubnetName": {
-            "defaultValue": "relaysubnet",
-            "type": "String",
-            "metadata": {
-                "description": "Name of the subnet to use for private link of relay namespace."
-            }
-        },
-        "relaySubnetAddressPrefix": {
-            "type": "String",
-            "metadata": {
-                "description": "Address space of the subnet to add for relay. e.g. 10.0.2.0/26"
-            }
-        },
-        "storageSubnetName": {
-            "defaultValue": "storagesubnet",
-            "type": "String",
-            "metadata": {
-                "description": "Name of the subnet to use for storage account."
-            }
-        },
-        "storageSubnetAddressPrefix": {
-            "type": "String",
-            "metadata": {
-                "description": "Address space of the subnet to add for storage. e.g. 10.0.3.0/26"
-            }
-        },
-        "privateEndpointName": {
-            "defaultValue": "cloudshellRelayEndpoint",
-            "type": "String",
-            "metadata": {
-                "description": "Name of Private Endpoint for Azure Relay."
-            }
-        },
-        "location": {
-            "defaultValue": "[resourceGroup().location]",
-            "type": "String",
-            "metadata": {
-                "description": "Location for all resources."
-            }
-        }
-    },
-    "variables": {
-        "networkProfileName": "[concat('aci-networkProfile-', parameters('location'))]",
-        "networkProfileRef": "[resourceId('Microsoft.Network/networkProfiles', variables('networkProfileName'))]",
-        "containerSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]",
-        "relayNamespaceRef": "[resourceId('Microsoft.Relay/namespaces/', parameters('relayNamespaceName'))]",
-        "relaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]",
-        "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-        "networkRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
-        "privateDnsZoneName": "[if(equals(toLower(environment().name), 'azureusgovernment'), 'privatelink.servicebus.usgovcloudapi.net', 'privatelink.servicebus.windows.net')]",
-        "networkRef": "[resourceId('Microsoft.Network/virtualNetworks', parameters('existingVNETName'))]",
-        "privateEndpointRef": "[resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))]"
-    },
-    "resources": [
-        {
-            "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2020-04-01",
-            "name": "[concat(parameters('existingVNETName'), '/', parameters('containerSubnetName'))]",
-            "location": "[parameters('location')]",
-            "properties": {
-                "addressPrefix": "[parameters('containerSubnetAddressPrefix')]",
-                "serviceEndpoints": [
-                    {
-                        "service": "Microsoft.Storage",
-                        "locations": [
-                            "[parameters('location')]"
-                        ]
-                    }
-                ],
-                "delegations": [
-                    {
-                        "name": "CloudShellDelegation",
-                        "properties": {
-                            "serviceName": "Microsoft.ContainerInstance/containerGroups"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/networkProfiles",
-            "apiVersion": "2019-11-01",
-            "name": "[variables('networkProfileName')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[variables('containerSubnetRef')]"
-            ],
-            "properties": {
-                "containerNetworkInterfaceConfigurations": [
-                    {
-                        "name": "[concat('eth-', parameters('containerSubnetName'))]",
-                        "properties": {
-                            "ipConfigurations": [
-                                {
-                                    "name": "[concat('ipconfig-', parameters('containerSubnetName'))]",
-                                    "properties": {
-                                        "subnet": {
-                                            "id": "[variables('containerSubnetRef')]"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "scope": "[format('Microsoft.Network/networkProfiles/{0}', variables('networkProfileName'))]",
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2020-04-01-preview",
-            "name": "[guid(variables('networkRoleDefinitionId'), parameters('azureContainerInstanceOID'), variables('networkProfileName'))]",
-            "dependsOn": [
-                "[variables('networkProfileRef')]"
-            ],
-            "properties": {
-                "roleDefinitionId": "[variables('networkRoleDefinitionId')]",
-                "principalId": "[parameters('azureContainerInstanceOID')]",
-                "scope": "[variables('networkProfileRef')]"
-            }
-        },
-        {
-            "type": "Microsoft.Relay/namespaces",
-            "apiVersion": "2018-01-01-preview",
-            "name": "[parameters('relayNamespaceName')]",
-            "location": "[parameters('location')]",
-            "sku": {
-                "name": "Standard",
-                "tier": "Standard"
-            }
-        },
-        {
-            "scope": "[format('Microsoft.Relay/namespaces/{0}', parameters('relayNamespaceName'))]",
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2020-04-01-preview",
-            "name": "[guid(variables('contributorRoleDefinitionId'), parameters('azureContainerInstanceOID'), parameters('relayNamespaceName'))]",
-            "dependsOn": [
-                "[variables('relayNamespaceRef')]"
-            ],
-            "properties": {
-                "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-                "principalId": "[parameters('azureContainerInstanceOID')]",
-                "scope": "[variables('relayNamespaceRef')]"
-            }
-        },
-        {
-            "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2020-04-01",
-            "name": "[concat(parameters('existingVNETName'), '/', parameters('relaySubnetName'))]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[variables('containerSubnetRef')]"
-            ],
-            "properties": {
-                "addressPrefix": "[parameters('relaySubnetAddressPrefix')]",
-                "privateEndpointNetworkPolicies": "Disabled",
-                "privateLinkServiceNetworkPolicies": "Enabled"
-            }
-        },
-        {
-            "type": "Microsoft.Network/privateEndpoints",
-            "apiVersion": "2020-04-01",
-            "name": "[parameters('privateEndpointName')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[variables('relaySubnetRef')]",
-                "[variables('relayNamespaceRef')]"
-            ],
-            "properties": {
-                "privateLinkServiceConnections": [
-                    {
-                        "name": "[parameters('privateEndpointName')]",
-                        "properties": {
-                            "privateLinkServiceId": "[variables('relayNamespaceRef')]",
-                            "groupIds": [
-                                "namespace"
-                            ]
-                        }
-                    }
-                ],
-                "subnet": {
-                    "id": "[variables('relaySubnetRef')]"
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2020-04-01",
-            "name": "[concat(parameters('existingVNETName'), '/', parameters('storageSubnetName'))]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[variables('relaySubnetRef')]"
-            ],
-            "properties": {
-                "addressPrefix": "[parameters('storageSubnetAddressPrefix')]",
-                "serviceEndpoints": [
-                    {
-                        "service": "Microsoft.Storage",
-                        "locations": [
-                            "[parameters('location')]"
-                        ]
-                    }
-                ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/privateDnsZones",
-            "apiVersion": "2020-01-01",
-            "name": "[variables('privateDnsZoneName')]",
-            "location": "global",
-            "properties": {
-                "maxNumberOfRecordSets": 25000,
-                "maxNumberOfVirtualNetworkLinks": 1000,
-                "maxNumberOfVirtualNetworkLinksWithRegistration": 100,
-                "numberOfRecordSets": 2,
-                "numberOfVirtualNetworkLinks": 1,
-                "numberOfVirtualNetworkLinksWithRegistration": 0
-            }
-        },
-        {
-            "type": "Microsoft.Network/privateDnsZones/A",
-            "apiVersion": "2020-01-01",
-            "name": "[concat(variables('privateDnsZoneName'),'/', parameters('relayNamespaceName'))]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
-                "[variables('privateEndpointRef')]"
-            ],
-            "properties": {
-                "ttl": 3600,
-                "aRecords": [
-                    {
-                        "ipv4Address": "[first(first(reference(parameters('privateEndpointName'),'2020-04-01','Full').properties.customDnsConfigs).ipAddresses)]"
-                    }
-                ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-            "apiVersion": "2020-01-01",
-            "name": "[concat(variables('privateDnsZoneName'), '/', parameters('relayNamespaceName'))]",
-            "location": "global",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
-            ],
-            "properties": {
-                "registrationEnabled": false,
-                "virtualNetwork": {
-                    "id": "[variables('networkRef')]"
-                }
-            }
-        }
-    ],
-    "outputs": {
-        "vnetName": {
-            "type": "String",
-            "value": "[parameters('existingVNETName')]"
-        },
-        "containerSubnetName": {
-            "type": "String",
-            "value": "[parameters('containerSubnetName')]"
-        },
-        "storageSubnetName": {
-            "type": "String",
-            "value": "[parameters('storageSubnetName')]"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "17233081184271710711"
     }
+  },
+  "parameters": {
+    "existingVNETName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the existing VNET to inject Cloud Shell into."
+      }
+    },
+    "relayNamespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of Azure Relay Namespace."
+      }
+    },
+    "azureContainerInstanceOID": {
+      "type": "string"
+    },
+    "containerSubnetName": {
+      "type": "string",
+      "defaultValue": "cloudshellsubnet",
+      "metadata": {
+        "description": "Name of the subnet to use for cloud shell containers."
+      }
+    },
+    "containerSubnetAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address space of the subnet to add for cloud shell. e.g. 10.0.1.0/26"
+      }
+    },
+    "relaySubnetName": {
+      "type": "string",
+      "defaultValue": "relaysubnet",
+      "metadata": {
+        "description": "Name of the subnet to use for private link of relay namespace."
+      }
+    },
+    "relaySubnetAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address space of the subnet to add for relay. e.g. 10.0.2.0/26"
+      }
+    },
+    "storageSubnetName": {
+      "type": "string",
+      "defaultValue": "storagesubnet",
+      "metadata": {
+        "description": "Name of the subnet to use for storage account."
+      }
+    },
+    "storageSubnetAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address space of the subnet to add for storage. e.g. 10.0.3.0/26"
+      }
+    },
+    "privateEndpointName": {
+      "type": "string",
+      "defaultValue": "cloudshellRelayEndpoint",
+      "metadata": {
+        "description": "Name of Private Endpoint for Azure Relay."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    }
+  },
+  "functions": [],
+  "variables": {
+    "networkProfileName": "[format('aci-networkProfile-{0}', parameters('location'))]",
+    "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+    "networkRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+    "privateDnsZoneName": "[if(equals(toLower(environment().name), 'azureusgovernment'), 'privatelink.servicebus.usgovcloudapi.net', 'privatelink.servicebus.windows.net')]",
+    "vnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks', parameters('existingVNETName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-04-01",
+      "name": "[format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('containerSubnetAddressPrefix')]",
+        "serviceEndpoints": [
+          {
+            "service": "Microsoft.Storage",
+            "locations": [
+              "[parameters('location')]"
+            ]
+          }
+        ],
+        "delegations": [
+          {
+            "name": "CloudShellDelegation",
+            "properties": {
+              "serviceName": "Microsoft.ContainerInstance/containerGroups"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/networkProfiles",
+      "apiVersion": "2019-11-01",
+      "name": "[variables('networkProfileName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "containerNetworkInterfaceConfigurations": [
+          {
+            "name": "[format('eth-{0}', parameters('containerSubnetName'))]",
+            "properties": {
+              "ipConfigurations": [
+                {
+                  "name": "[format('ipconfig-{0}', parameters('containerSubnetName'))]",
+                  "properties": {
+                    "subnet": {
+                      "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "scope": "[format('Microsoft.Network/networkProfiles/{0}', variables('networkProfileName'))]",
+      "name": "[guid(variables('networkRoleDefinitionId'), parameters('azureContainerInstanceOID'), variables('networkProfileName'))]",
+      "properties": {
+        "roleDefinitionId": "[variables('networkRoleDefinitionId')]",
+        "principalId": "[parameters('azureContainerInstanceOID')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkProfiles', variables('networkProfileName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Relay/namespaces",
+      "apiVersion": "2018-01-01-preview",
+      "name": "[parameters('relayNamespaceName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "scope": "[format('Microsoft.Relay/namespaces/{0}', parameters('relayNamespaceName'))]",
+      "name": "[guid(variables('contributorRoleDefinitionId'), parameters('azureContainerInstanceOID'), parameters('relayNamespaceName'))]",
+      "properties": {
+        "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
+        "principalId": "[parameters('azureContainerInstanceOID')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-04-01",
+      "name": "[format('{0}/{1}', parameters('existingVNETName'), parameters('relaySubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('relaySubnetAddressPrefix')]",
+        "privateEndpointNetworkPolicies": "Disabled",
+        "privateLinkServiceNetworkPolicies": "Enabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateEndpoints",
+      "apiVersion": "2020-04-01",
+      "name": "[parameters('privateEndpointName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "privateLinkServiceConnections": [
+          {
+            "name": "[parameters('privateEndpointName')]",
+            "properties": {
+              "privateLinkServiceId": "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]",
+              "groupIds": [
+                "namespace"
+              ]
+            }
+          }
+        ],
+        "subnet": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-04-01",
+      "name": "[format('{0}/{1}', parameters('existingVNETName'), parameters('storageSubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('storageSubnetAddressPrefix')]",
+        "serviceEndpoints": [
+          {
+            "service": "Microsoft.Storage",
+            "locations": [
+              "[parameters('location')]"
+            ]
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones",
+      "apiVersion": "2020-01-01",
+      "name": "[variables('privateDnsZoneName')]",
+      "location": "global"
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones/A",
+      "apiVersion": "2020-01-01",
+      "name": "[format('{0}/{1}', variables('privateDnsZoneName'), parameters('relayNamespaceName'))]",
+      "properties": {
+        "ttl": 3600,
+        "aRecords": [
+          {
+            "ipv4Address": "[first(first(reference(resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))).customDnsConfigs).ipAddresses)]"
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
+        "[resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+      "apiVersion": "2020-01-01",
+      "name": "[format('{0}/{1}', variables('privateDnsZoneName'), parameters('relayNamespaceName'))]",
+      "location": "global",
+      "properties": {
+        "registrationEnabled": false,
+        "virtualNetwork": {
+          "id": "[variables('vnetResourceId')]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "vnetId": {
+      "type": "string",
+      "value": "[variables('vnetResourceId')]"
+    },
+    "containerSubnetId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
+    },
+    "storageSubnetId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('storageSubnetName'))]"
+    }
+  }
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesdemos/cloud-shell-vnet
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11341