### PR TITLE
Migrate example: 201/aci-wordpress

### DIFF
--- a/docs/examples/201/aci-wordpress/README-MOVED.md
+++ b/docs/examples/201/aci-wordpress/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/application-workloads/wordpress/aci-wordpress.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/201/aci-wordpress/main.bicep
+++ b/docs/examples/201/aci-wordpress/main.bicep
@@ -175,8 +175,8 @@ resource wpAci 'Microsoft.ContainerInstance/containerGroups@2019-12-01' = {
           ]
           resources: {
             requests: {
-              cpu: cpuCores
-              memoryInGB: memoryInGb
+              cpu: any(cpuCores)
+              memoryInGB: any(memoryInGb)
             }
           }
         }

--- a/docs/examples/201/aci-wordpress/main.bicep
+++ b/docs/examples/201/aci-wordpress/main.bicep
@@ -1,3 +1,4 @@
+@description('Storage Account type')
 @allowed([
   'Standard_LRS'
   'Standard_GRS'
@@ -5,29 +6,36 @@
 ])
 param storageAccountType string = 'Standard_LRS'
 
+@description('Storage Account Name')
 param storageAccountName string = uniqueString(resourceGroup().id)
+
+@description('WordPress Site Name')
 param siteName string = storageAccountName
 
+@description('MySQL database password')
 @secure()
 param mySqlPassword string
 
+@description('Location for all resources.')
 param location string = resourceGroup().location
 
-var cpuCores = any('0.5') // TODO: workaround for https://github.com/Azure/bicep/issues/486
-var memoryInGb = any('0.7') // TODO: workaround for https://github.com/Azure/bicep/issues/486
+var cpuCores = '0.5'
+var memoryInGb = '0.7'
+var wordpressContainerGroupName = 'wordpress-containerinstance'
+var wordpressShareName = 'wordpress-share'
+var mysqlShareName = 'mysql-share'
 var scriptName = 'createFileShare'
-var wpShareName = 'wordpress-share'
-var sqlShareName = 'mysql-share'
+var identityName = 'scratch'
 
-resource mi 'microsoft.managedIdentity/userAssignedIdentities@2018-11-30' = {
-  name: 'scratch'
+resource mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: identityName
   location: location
 }
 
 var roleDefinitionId = resourceId('microsoft.authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
 var roleAssignmentName = guid(mi.name, roleDefinitionId, resourceGroup().id)
 
-resource miRoleAssign 'microsoft.authorization/roleAssignments@2020-04-01-preview' = {
+resource miRoleAssign 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   name: roleAssignmentName
   properties: {
     roleDefinitionId: roleDefinitionId
@@ -38,22 +46,22 @@ resource miRoleAssign 'microsoft.authorization/roleAssignments@2020-04-01-previe
 
 var uamiId = resourceId(mi.type, mi.name)
 
-resource stg 'microsoft.storage/storageAccounts@2019-06-01' = {
-  dependsOn: [
-    miRoleAssign
-  ]
+resource stg 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: storageAccountName
   location: location
   sku: {
     name: storageAccountType
   }
   kind: 'StorageV2'
+  dependsOn: [
+    miRoleAssign
+  ]
 }
 
 // create file share for wordpress
-var wpScriptToExecute = 'Get-AzStorageAccount -StorageAccountName ${storageAccountName} -ResourceGroupName ${resourceGroup().name} | New-AzStorageShare -Name ${wpShareName}'
-resource dScriptWp 'Microsoft.Resources/deploymentScripts@2019-10-01-preview' = {
-  name: '${scriptName}-${wpShareName}'
+var wpScriptToExecute = 'Get-AzStorageAccount -StorageAccountName ${storageAccountName} -ResourceGroupName ${resourceGroup().name} | New-AzStorageShare -Name ${wordpressShareName}'
+resource dScriptWp 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: '${scriptName}-${wordpressShareName}'
   location: location
   kind: 'AzurePowerShell'
   identity: {
@@ -76,9 +84,9 @@ resource dScriptWp 'Microsoft.Resources/deploymentScripts@2019-10-01-preview' = 
 }
 
 // create second file share for sql
-var sqlScriptToExecute = 'Get-AzStorageAccount -StorageAccountName ${storageAccountName} -ResourceGroupName ${resourceGroup().name} | New-AzStorageShare -Name ${sqlShareName}'
-resource dScriptSql 'Microsoft.Resources/deploymentScripts@2019-10-01-preview' = {
-  name: '${scriptName}-${sqlShareName}'
+var sqlScriptToExecute = 'Get-AzStorageAccount -StorageAccountName ${storageAccountName} -ResourceGroupName ${resourceGroup().name} | New-AzStorageShare -Name ${mysqlShareName}'
+resource dScriptSql 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: '${scriptName}-${mysqlShareName}'
   location: location
   kind: 'AzurePowerShell'
   identity: {
@@ -97,17 +105,16 @@ resource dScriptSql 'Microsoft.Resources/deploymentScripts@2019-10-01-preview' =
     cleanupPreference: 'OnSuccess'
     retentionInterval: 'P1D'
     timeout: 'PT5M'
-    // forceUpdateTag: currentTime // ensures script will run every time
   }
 }
 
-resource wpAci 'microsoft.containerInstance/containerGroups@2019-12-01' = {
+resource wpAci 'Microsoft.ContainerInstance/containerGroups@2019-12-01' = {
+  name: wordpressContainerGroupName
+  location: location
   dependsOn: [
     dScriptSql
     dScriptWp
   ]
-  name: 'wordpress-containerinstance'
-  location: location
   properties: {
     containers: [
       {
@@ -127,7 +134,7 @@ resource wpAci 'microsoft.containerInstance/containerGroups@2019-12-01' = {
             }
             {
               name: 'WORDPRESS_DB_PASSWORD'
-              secureValue: mySqlPassword // changed this from 'value' => 'secureValue'
+              value: mySqlPassword
             }
           ]
           volumeMounts: [
@@ -138,8 +145,8 @@ resource wpAci 'microsoft.containerInstance/containerGroups@2019-12-01' = {
           ]
           resources: {
             requests: {
-              cpu: cpuCores
-              memoryInGB: memoryInGb
+              cpu: any(cpuCores)
+              memoryInGB: any(memoryInGb)
             }
           }
         }
@@ -178,7 +185,7 @@ resource wpAci 'microsoft.containerInstance/containerGroups@2019-12-01' = {
     volumes: [
       {
         azureFile: {
-          shareName: wpShareName
+          shareName: wordpressShareName
           storageAccountKey: listKeys(stg.name, stg.apiVersion).keys[0].value
           storageAccountName: stg.name
         }
@@ -186,7 +193,7 @@ resource wpAci 'microsoft.containerInstance/containerGroups@2019-12-01' = {
       }
       {
         azureFile: {
-          shareName: sqlShareName
+          shareName: mysqlShareName
           storageAccountKey: listKeys(stg.name, stg.apiVersion).keys[0].value
           storageAccountName: stg.name
         }

--- a/docs/examples/201/aci-wordpress/main.json
+++ b/docs/examples/201/aci-wordpress/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "1837751667478667193"
+    }
+  },
   "parameters": {
     "storageAccountType": {
       "type": "string",
@@ -16,20 +23,20 @@
     },
     "storageAccountName": {
       "type": "string",
-      "defaultValue": "[uniquestring(resourceGroup().id)]",
+      "defaultValue": "[uniqueString(resourceGroup().id)]",
       "metadata": {
         "description": "Storage Account Name"
       }
     },
     "siteName": {
       "type": "string",
-      "defaultValue": "[uniquestring(resourceGroup().id)]",
+      "defaultValue": "[parameters('storageAccountName')]",
       "metadata": {
         "description": "WordPress Site Name"
       }
     },
-    "mysqlPassword": {
-      "type": "securestring",
+    "mySqlPassword": {
+      "type": "secureString",
       "metadata": {
         "description": "MySQL database password"
       }
@@ -42,6 +49,7 @@
       }
     }
   },
+  "functions": [],
   "variables": {
     "cpuCores": "0.5",
     "memoryInGb": "0.7",
@@ -50,118 +58,106 @@
     "mysqlShareName": "mysql-share",
     "scriptName": "createFileShare",
     "identityName": "scratch",
-    "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-    "roleDefinitionName": "[guid(variables('identityName'), variables('roleDefinitionId'), resourceGroup().id)]"
+    "roleDefinitionId": "[resourceId('microsoft.authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+    "roleAssignmentName": "[guid(variables('identityName'), variables('roleDefinitionId'), resourceGroup().id)]",
+    "uamiId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
+    "wpScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('wordpressShareName'))]",
+    "sqlScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('mysqlShareName'))]"
   },
   "resources": [
     {
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-      "name": "[variables('identityName')]",
       "apiVersion": "2018-11-30",
+      "name": "[variables('identityName')]",
       "location": "[parameters('location')]"
     },
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[variables('roleDefinitionName')]",
-      "dependsOn": [
-        "[variables('identityName')]"
-      ],
+      "name": "[variables('roleAssignmentName')]",
       "properties": {
         "roleDefinitionId": "[variables('roleDefinitionId')]",
-        "principalId": "[reference(variables('identityName')).principalId]",
-        "scope": "[resourceGroup().id]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))).principalId]",
         "principalType": "ServicePrincipal"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
+      ]
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2021-04-01",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "2019-06-01",
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('storageAccountType')]"
       },
       "kind": "StorageV2",
       "dependsOn": [
-        "[variables('roleDefinitionName')]" // need to create a slight delay for the roleAssignment to replicate before the deployment script can run
+        "[resourceId('Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
       ]
     },
     {
       "type": "Microsoft.Resources/deploymentScripts",
       "apiVersion": "2020-10-01",
-      "name": "[concat(variables('scriptName'), '-', variables('wordpressShareName'))]",
+      "name": "[format('{0}-{1}', variables('scriptName'), variables('wordpressShareName'))]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[parameters('storageAccountName')]"
-      ],
       "kind": "AzurePowerShell",
       "identity": {
-        "type": "userAssigned",
+        "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": { /*ttk bug*/
-          }
+          "[variables('uamiId')]": {}
         }
       },
       "properties": {
-        "forceUpdateTag": "1",
         "azPowerShellVersion": "3.0",
-        "arguments": "[format(' -storageAccountName {0} -fileShareName {1} -resourceGroupName {2}', parameters('storageAccountName'), variables('wordpressShareName'), resourceGroup().name)]",
-        "scriptContent": "
-                param(
-                    [string] $storageAccountName,
-                    [string] $fileShareName,
-                    [string] $resourceGroupName
-                )
-                Get-AzStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName | New-AzStorageShare -Name $fileShareName
-                ",
-        "timeout": "PT5M",
+        "storageAccountSettings": {
+          "storageAccountName": "[parameters('storageAccountName')]",
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2021-04-01').keys[0].value]"
+        },
+        "scriptContent": "[variables('wpScriptToExecute')]",
         "cleanupPreference": "OnSuccess",
-        "retentionInterval": "P1D"
-      }
-    },
-        {
-      "type": "Microsoft.Resources/deploymentScripts",
-      "apiVersion": "2020-10-01",
-      "name": "[concat(variables('scriptName'), '-', variables('mysqlShareName'))]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[parameters('storageAccountName')]"
-      ],
-      "kind": "AzurePowerShell",
-      "identity": {
-        "type": "userAssigned",
-        "userAssignedIdentities": {
-          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": { /*ttk bug*/
-          }
-        }
+        "retentionInterval": "P1D",
+        "timeout": "PT5M"
       },
-      "properties": {
-        "forceUpdateTag": "1",
-        "azPowerShellVersion": "3.0",
-        "arguments": "[format(' -storageAccountName {0} -fileShareName {1} -resourceGroupName {2}', parameters('storageAccountName'), variables('mysqlShareName'), resourceGroup().name)]",
-        "scriptContent": "
-                param(
-                    [string] $storageAccountName,
-                    [string] $fileShareName,
-                    [string] $resourceGroupName
-                )
-                Get-AzStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName | New-AzStorageShare -Name $fileShareName
-                ",
-        "timeout": "PT5M",
-        "cleanupPreference": "OnSuccess",
-        "retentionInterval": "P1D"
-      }
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
     },
     {
-      "name": "[variables('wordpresscontainerGroupName')]",
+      "type": "Microsoft.Resources/deploymentScripts",
+      "apiVersion": "2020-10-01",
+      "name": "[format('{0}-{1}', variables('scriptName'), variables('mysqlShareName'))]",
+      "location": "[parameters('location')]",
+      "kind": "AzurePowerShell",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[variables('uamiId')]": {}
+        }
+      },
+      "properties": {
+        "azPowerShellVersion": "3.0",
+        "storageAccountSettings": {
+          "storageAccountName": "[parameters('storageAccountName')]",
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2021-04-01').keys[0].value]"
+        },
+        "scriptContent": "[variables('sqlScriptToExecute')]",
+        "cleanupPreference": "OnSuccess",
+        "retentionInterval": "P1D",
+        "timeout": "PT5M"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
+    },
+    {
       "type": "Microsoft.ContainerInstance/containerGroups",
       "apiVersion": "2019-12-01",
+      "name": "[variables('wordpressContainerGroupName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Resources/deploymentScripts', concat(variables('scriptName'), '-', variables('wordpressShareName')))]",
-        "[resourceId('Microsoft.Resources/deploymentScripts', concat(variables('scriptName'), '-', variables('mysqlShareName')))]"
-      ],
       "properties": {
         "containers": [
           {
@@ -170,7 +166,7 @@
               "image": "wordpress:4.9-apache",
               "ports": [
                 {
-                  "protocol": "Tcp",
+                  "protocol": "TCP",
                   "port": 80
                 }
               ],
@@ -181,7 +177,7 @@
                 },
                 {
                   "name": "WORDPRESS_DB_PASSWORD",
-                  "value": "[parameters('mysqlPassword')]"
+                  "value": "[parameters('mySqlPassword')]"
                 }
               ],
               "volumeMounts": [
@@ -193,7 +189,7 @@
               "resources": {
                 "requests": {
                   "cpu": "[variables('cpuCores')]",
-                  "memoryInGb": "[variables('memoryInGb')]"
+                  "memoryInGB": "[variables('memoryInGb')]"
                 }
               }
             }
@@ -204,14 +200,14 @@
               "image": "mysql:5.6",
               "ports": [
                 {
-                  "protocol": "Tcp",
+                  "protocol": "TCP",
                   "port": 3306
                 }
               ],
               "environmentVariables": [
                 {
                   "name": "MYSQL_ROOT_PASSWORD",
-                  "value": "[parameters('mysqlPassword')]"
+                  "value": "[parameters('mySqlPassword')]"
                 }
               ],
               "volumeMounts": [
@@ -223,7 +219,7 @@
               "resources": {
                 "requests": {
                   "cpu": "[variables('cpuCores')]",
-                  "memoryInGb": "[variables('memoryInGb')]"
+                  "memoryInGB": "[variables('memoryInGb')]"
                 }
               }
             }
@@ -233,7 +229,7 @@
           {
             "azureFile": {
               "shareName": "[variables('wordpressShareName')]",
-              "storageAccountKey": "[listKeys(parameters('storageAccountName'),'2019-06-01').keys[0].value]",
+              "storageAccountKey": "[listKeys(parameters('storageAccountName'), '2021-04-01').keys[0].value]",
               "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "wordpressfile"
@@ -241,7 +237,7 @@
           {
             "azureFile": {
               "shareName": "[variables('mysqlShareName')]",
-              "storageAccountKey": "[listKeys(parameters('storageAccountName'),'2019-06-01').keys[0].value]",
+              "storageAccountKey": "[listKeys(parameters('storageAccountName'), '2021-04-01').keys[0].value]",
               "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "mysqlfile"
@@ -250,7 +246,7 @@
         "ipAddress": {
           "ports": [
             {
-              "protocol": "Tcp",
+              "protocol": "TCP",
               "port": 80
             }
           ],
@@ -258,13 +254,18 @@
           "dnsNameLabel": "[parameters('siteName')]"
         },
         "osType": "Linux"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-{1}', variables('scriptName'), variables('mysqlShareName')))]",
+        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-{1}', variables('scriptName'), variables('wordpressShareName')))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
     }
   ],
   "outputs": {
     "siteFQDN": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups/', variables('wordpresscontainerGroupName'))).ipAddress.fqdn]"
+      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups', variables('wordpressContainerGroupName'))).ipAddress.fqdn]"
     }
   }
 }

--- a/docs/examples/201/aci-wordpress/main.json
+++ b/docs/examples/201/aci-wordpress/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1837751667478667193"
+      "templateHash": "12923669768121792116"
     }
   },
   "parameters": {
@@ -60,9 +60,8 @@
     "identityName": "scratch",
     "roleDefinitionId": "[resourceId('microsoft.authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
     "roleAssignmentName": "[guid(variables('identityName'), variables('roleDefinitionId'), resourceGroup().id)]",
-    "uamiId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
-    "wpScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('wordpressShareName'))]",
-    "sqlScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('mysqlShareName'))]"
+    "sqlScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('mysqlShareName'))]",
+    "wpScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('wordpressShareName'))]"
   },
   "resources": [
     {
@@ -106,7 +105,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[variables('uamiId')]": {}
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": {}
         }
       },
       "properties": {
@@ -134,7 +133,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[variables('uamiId')]": {}
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": {}
         }
       },
       "properties": {

--- a/docs/examples/201/aci-wordpress/main.json
+++ b/docs/examples/201/aci-wordpress/main.json
@@ -1,13 +1,6 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "12550037993522335025"
-    }
-  },
   "parameters": {
     "storageAccountType": {
       "type": "string",
@@ -16,131 +9,159 @@
         "Standard_LRS",
         "Standard_GRS",
         "Standard_ZRS"
-      ]
+      ],
+      "metadata": {
+        "description": "Storage Account type"
+      }
     },
     "storageAccountName": {
       "type": "string",
-      "defaultValue": "[uniqueString(resourceGroup().id)]"
+      "defaultValue": "[uniquestring(resourceGroup().id)]",
+      "metadata": {
+        "description": "Storage Account Name"
+      }
     },
     "siteName": {
       "type": "string",
-      "defaultValue": "[parameters('storageAccountName')]"
+      "defaultValue": "[uniquestring(resourceGroup().id)]",
+      "metadata": {
+        "description": "WordPress Site Name"
+      }
     },
-    "mySqlPassword": {
-      "type": "secureString"
+    "mysqlPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "MySQL database password"
+      }
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     }
   },
-  "functions": [],
   "variables": {
     "cpuCores": "0.5",
     "memoryInGb": "0.7",
+    "wordpressContainerGroupName": "wordpress-containerinstance",
+    "wordpressShareName": "wordpress-share",
+    "mysqlShareName": "mysql-share",
     "scriptName": "createFileShare",
-    "wpShareName": "wordpress-share",
-    "sqlShareName": "mysql-share",
-    "roleDefinitionId": "[resourceId('microsoft.authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-    "roleAssignmentName": "[guid('scratch', variables('roleDefinitionId'), resourceGroup().id)]",
-    "uamiId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'scratch')]",
-    "wpScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('wpShareName'))]",
-    "sqlScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('sqlShareName'))]"
+    "identityName": "scratch",
+    "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+    "roleDefinitionName": "[guid(variables('identityName'), variables('roleDefinitionId'), resourceGroup().id)]"
   },
   "resources": [
     {
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "name": "[variables('identityName')]",
       "apiVersion": "2018-11-30",
-      "name": "scratch",
       "location": "[parameters('location')]"
     },
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[variables('roleAssignmentName')]",
+      "name": "[variables('roleDefinitionName')]",
+      "dependsOn": [
+        "[variables('identityName')]"
+      ],
       "properties": {
         "roleDefinitionId": "[variables('roleDefinitionId')]",
-        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'scratch')).principalId]",
+        "principalId": "[reference(variables('identityName')).principalId]",
+        "scope": "[resourceGroup().id]",
         "principalType": "ServicePrincipal"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'scratch')]"
-      ]
+      }
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "apiVersion": "2019-06-01",
       "name": "[parameters('storageAccountName')]",
+      "apiVersion": "2019-06-01",
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('storageAccountType')]"
       },
       "kind": "StorageV2",
       "dependsOn": [
-        "[resourceId('Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
+        "[variables('roleDefinitionName')]" // need to create a slight delay for the roleAssignment to replicate before the deployment script can run
       ]
     },
     {
       "type": "Microsoft.Resources/deploymentScripts",
-      "apiVersion": "2019-10-01-preview",
-      "name": "[format('{0}-{1}', variables('scriptName'), variables('wpShareName'))]",
+      "apiVersion": "2020-10-01",
+      "name": "[concat(variables('scriptName'), '-', variables('wordpressShareName'))]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[parameters('storageAccountName')]"
+      ],
       "kind": "AzurePowerShell",
       "identity": {
-        "type": "UserAssigned",
+        "type": "userAssigned",
         "userAssignedIdentities": {
-          "[variables('uamiId')]": {}
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": { /*ttk bug*/
+          }
         }
       },
       "properties": {
+        "forceUpdateTag": "1",
         "azPowerShellVersion": "3.0",
-        "storageAccountSettings": {
-          "storageAccountName": "[parameters('storageAccountName')]",
-          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]"
-        },
-        "scriptContent": "[variables('wpScriptToExecute')]",
+        "arguments": "[format(' -storageAccountName {0} -fileShareName {1} -resourceGroupName {2}', parameters('storageAccountName'), variables('wordpressShareName'), resourceGroup().name)]",
+        "scriptContent": "
+                param(
+                    [string] $storageAccountName,
+                    [string] $fileShareName,
+                    [string] $resourceGroupName
+                )
+                Get-AzStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName | New-AzStorageShare -Name $fileShareName
+                ",
+        "timeout": "PT5M",
         "cleanupPreference": "OnSuccess",
-        "retentionInterval": "P1D",
-        "timeout": "PT5M"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'scratch')]",
-        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-      ]
+        "retentionInterval": "P1D"
+      }
     },
-    {
+        {
       "type": "Microsoft.Resources/deploymentScripts",
-      "apiVersion": "2019-10-01-preview",
-      "name": "[format('{0}-{1}', variables('scriptName'), variables('sqlShareName'))]",
+      "apiVersion": "2020-10-01",
+      "name": "[concat(variables('scriptName'), '-', variables('mysqlShareName'))]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[parameters('storageAccountName')]"
+      ],
       "kind": "AzurePowerShell",
       "identity": {
-        "type": "UserAssigned",
+        "type": "userAssigned",
         "userAssignedIdentities": {
-          "[variables('uamiId')]": {}
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": { /*ttk bug*/
+          }
         }
       },
       "properties": {
+        "forceUpdateTag": "1",
         "azPowerShellVersion": "3.0",
-        "storageAccountSettings": {
-          "storageAccountName": "[parameters('storageAccountName')]",
-          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]"
-        },
-        "scriptContent": "[variables('sqlScriptToExecute')]",
+        "arguments": "[format(' -storageAccountName {0} -fileShareName {1} -resourceGroupName {2}', parameters('storageAccountName'), variables('mysqlShareName'), resourceGroup().name)]",
+        "scriptContent": "
+                param(
+                    [string] $storageAccountName,
+                    [string] $fileShareName,
+                    [string] $resourceGroupName
+                )
+                Get-AzStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName | New-AzStorageShare -Name $fileShareName
+                ",
+        "timeout": "PT5M",
         "cleanupPreference": "OnSuccess",
-        "retentionInterval": "P1D",
-        "timeout": "PT5M"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'scratch')]",
-        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-      ]
+        "retentionInterval": "P1D"
+      }
     },
     {
+      "name": "[variables('wordpresscontainerGroupName')]",
       "type": "Microsoft.ContainerInstance/containerGroups",
       "apiVersion": "2019-12-01",
-      "name": "wordpress-containerinstance",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deploymentScripts', concat(variables('scriptName'), '-', variables('wordpressShareName')))]",
+        "[resourceId('Microsoft.Resources/deploymentScripts', concat(variables('scriptName'), '-', variables('mysqlShareName')))]"
+      ],
       "properties": {
         "containers": [
           {
@@ -149,7 +170,7 @@
               "image": "wordpress:4.9-apache",
               "ports": [
                 {
-                  "protocol": "TCP",
+                  "protocol": "Tcp",
                   "port": 80
                 }
               ],
@@ -160,7 +181,7 @@
                 },
                 {
                   "name": "WORDPRESS_DB_PASSWORD",
-                  "secureValue": "[parameters('mySqlPassword')]"
+                  "value": "[parameters('mysqlPassword')]"
                 }
               ],
               "volumeMounts": [
@@ -172,7 +193,7 @@
               "resources": {
                 "requests": {
                   "cpu": "[variables('cpuCores')]",
-                  "memoryInGB": "[variables('memoryInGb')]"
+                  "memoryInGb": "[variables('memoryInGb')]"
                 }
               }
             }
@@ -183,14 +204,14 @@
               "image": "mysql:5.6",
               "ports": [
                 {
-                  "protocol": "TCP",
+                  "protocol": "Tcp",
                   "port": 3306
                 }
               ],
               "environmentVariables": [
                 {
                   "name": "MYSQL_ROOT_PASSWORD",
-                  "value": "[parameters('mySqlPassword')]"
+                  "value": "[parameters('mysqlPassword')]"
                 }
               ],
               "volumeMounts": [
@@ -202,7 +223,7 @@
               "resources": {
                 "requests": {
                   "cpu": "[variables('cpuCores')]",
-                  "memoryInGB": "[variables('memoryInGb')]"
+                  "memoryInGb": "[variables('memoryInGb')]"
                 }
               }
             }
@@ -211,16 +232,16 @@
         "volumes": [
           {
             "azureFile": {
-              "shareName": "[variables('wpShareName')]",
-              "storageAccountKey": "[listKeys(parameters('storageAccountName'), '2019-06-01').keys[0].value]",
+              "shareName": "[variables('wordpressShareName')]",
+              "storageAccountKey": "[listKeys(parameters('storageAccountName'),'2019-06-01').keys[0].value]",
               "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "wordpressfile"
           },
           {
             "azureFile": {
-              "shareName": "[variables('sqlShareName')]",
-              "storageAccountKey": "[listKeys(parameters('storageAccountName'), '2019-06-01').keys[0].value]",
+              "shareName": "[variables('mysqlShareName')]",
+              "storageAccountKey": "[listKeys(parameters('storageAccountName'),'2019-06-01').keys[0].value]",
               "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "mysqlfile"
@@ -229,7 +250,7 @@
         "ipAddress": {
           "ports": [
             {
-              "protocol": "TCP",
+              "protocol": "Tcp",
               "port": 80
             }
           ],
@@ -237,18 +258,13 @@
           "dnsNameLabel": "[parameters('siteName')]"
         },
         "osType": "Linux"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-{1}', variables('scriptName'), variables('sqlShareName')))]",
-        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-{1}', variables('scriptName'), variables('wpShareName')))]",
-        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-      ]
+      }
     }
   ],
   "outputs": {
     "siteFQDN": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups', 'wordpress-containerinstance')).ipAddress.fqdn]"
+      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups/', variables('wordpresscontainerGroupName'))).ipAddress.fqdn]"
     }
   }
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesapplication-workloads/wordpress/aci-wordpress
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11342