### PR TITLE
Migrate example: 201/traffic-manager-webapp

### DIFF
--- a/docs/examples/201/traffic-manager-webapp/README-MOVED.md
+++ b/docs/examples/201/traffic-manager-webapp/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.network/traffic-manager-webapp.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/201/traffic-manager-webapp/main.bicep
+++ b/docs/examples/201/traffic-manager-webapp/main.bicep
@@ -20,7 +20,7 @@ resource appServicePlan 'Microsoft.Web/serverFarms@2020-12-01' = {
   }
 }
 
-resource webSite 'Microsoft.Web/sites@2021-01-01' = {
+resource webSite 'Microsoft.Web/sites@2020-12-01' = {
   name: uniqueDnsNameForWebApp
   location: location
   properties: {

--- a/docs/examples/201/traffic-manager-webapp/main.bicep
+++ b/docs/examples/201/traffic-manager-webapp/main.bicep
@@ -11,7 +11,7 @@ param location string = resourceGroup().location
 @description('Name of the trafficManager being created')
 param trafficManagerName string
 
-resource appServicePlan 'Microsoft.Web/serverfarms@2021-01-01' = {
+resource appServicePlan 'Microsoft.Web/serverFarms@2020-12-01' = {
   name: appServicePlanName
   location: location
   sku: {

--- a/docs/examples/201/traffic-manager-webapp/main.bicep
+++ b/docs/examples/201/traffic-manager-webapp/main.bicep
@@ -1,11 +1,18 @@
+@description('Relative DNS name for the traffic manager profile, resulting FQDN will be <uniqueDnsName>.trafficmanager.net, must be globally unique.')
 param uniqueDnsName string
+
+@description('Relative DNS name for the WebApps, must be globally unique.  An index will be appended for each Web App.')
 param uniqueDnsNameForWebApp string
-param serverFarmName string
-param trafficManagerName string
+
+@description('Name of the App Service Plan that is being created')
+param appServicePlanName string
 param location string = resourceGroup().location
 
-resource serverFarm 'Microsoft.Web/serverfarms@2020-06-01' = {
-  name: serverFarmName
+@description('Name of the trafficManager being created')
+param trafficManagerName string
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2021-01-01' = {
+  name: appServicePlanName
   location: location
   sku: {
     name: 'S1'
@@ -13,15 +20,15 @@ resource serverFarm 'Microsoft.Web/serverfarms@2020-06-01' = {
   }
 }
 
-resource webSite 'Microsoft.Web/sites@2020-06-01' = {
+resource webSite 'Microsoft.Web/sites@2021-01-01' = {
   name: uniqueDnsNameForWebApp
   location: location
   properties: {
-    serverFarmId: serverFarm.id
+    serverFarmId: appServicePlan.id
   }
 }
 
-resource trafficManagerProfile 'Microsoft.Network/trafficmanagerprofiles@2018-04-01' = {
+resource trafficManagerProfile 'Microsoft.Network/trafficManagerProfiles@2018-08-01' = {
   name: trafficManagerName
   location: 'global'
   properties: {

--- a/docs/examples/201/traffic-manager-webapp/main.json
+++ b/docs/examples/201/traffic-manager-webapp/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "17505730705752757815"
+    }
+  },
   "parameters": {
     "uniqueDnsName": {
       "type": "string",
@@ -14,7 +21,7 @@
         "description": "Relative DNS name for the WebApps, must be globally unique.  An index will be appended for each Web App."
       }
     },
-    "webServerName": {
+    "appServicePlanName": {
       "type": "string",
       "metadata": {
         "description": "Name of the App Service Plan that is being created"
@@ -31,14 +38,12 @@
       }
     }
   },
-
-  "variables": {},
-
+  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Web/serverfarms",
-      "apiVersion": "2019-08-01",
-      "name": "[parameters('webServerName')]",
+      "apiVersion": "2021-01-01",
+      "name": "[parameters('appServicePlanName')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "S1",
@@ -47,19 +52,18 @@
     },
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2019-08-01",
+      "apiVersion": "2021-01-01",
       "name": "[parameters('uniqueDnsNameForWebApp')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms/',parameters('webServerName'))]"
-
-      ],
       "properties": {
-        "serverFarmId": "[parameters('webServerName')]"
-      }
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]"
+      ]
     },
     {
-      "type": "Microsoft.Network/trafficManagerProfiles",
+      "type": "Microsoft.Network/trafficmanagerprofiles",
       "apiVersion": "2018-08-01",
       "name": "[parameters('trafficManagerName')]",
       "location": "global",
@@ -74,22 +78,21 @@
           "protocol": "HTTPS",
           "port": 443,
           "path": "/"
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Network/trafficManagerProfiles/azureEndpoints",
-      "apiVersion": "2018-08-01",
-      "name": "[concat(parameters('trafficManagerName'),'/',parameters('uniqueDnsNameForWebApp'))]",
-      "location": "global",
+        },
+        "endpoints": [
+          {
+            "name": "[parameters('uniqueDnsNameForWebApp')]",
+            "type": "Microsoft.Network/trafficManagerProfiles/azureEndpoints",
+            "properties": {
+              "targetResourceId": "[resourceId('Microsoft.Web/sites', parameters('uniqueDnsNameForWebApp'))]",
+              "endpointStatus": "Enabled"
+            }
+          }
+        ]
+      },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/trafficManagerProfiles/',parameters('trafficManagerName'))]",
-        "[resourceId('Microsoft.Web/sites/',parameters('uniqueDnsNameForWebApp'))]"
-      ],
-      "properties": {
-        "targetResourceId": "[resourceId('Microsoft.Web/sites/', parameters('uniqueDnsNameForWebApp'))]",
-        "endpointStatus": "Enabled"
-      }
+        "[resourceId('Microsoft.Web/sites', parameters('uniqueDnsNameForWebApp'))]"
+      ]
     }
   ]
 }

--- a/docs/examples/201/traffic-manager-webapp/main.json
+++ b/docs/examples/201/traffic-manager-webapp/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17505730705752757815"
+      "templateHash": "7725203689471739007"
     }
   },
   "parameters": {
@@ -42,7 +42,7 @@
   "resources": [
     {
       "type": "Microsoft.Web/serverfarms",
-      "apiVersion": "2021-01-01",
+      "apiVersion": "2020-12-01",
       "name": "[parameters('appServicePlanName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -52,7 +52,7 @@
     },
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2021-01-01",
+      "apiVersion": "2020-12-01",
       "name": "[parameters('uniqueDnsNameForWebApp')]",
       "location": "[parameters('location')]",
       "properties": {

--- a/docs/examples/201/traffic-manager-webapp/main.json
+++ b/docs/examples/201/traffic-manager-webapp/main.json
@@ -1,37 +1,44 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "17027918076956104922"
-    }
-  },
   "parameters": {
     "uniqueDnsName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Relative DNS name for the traffic manager profile, resulting FQDN will be <uniqueDnsName>.trafficmanager.net, must be globally unique."
+      }
     },
     "uniqueDnsNameForWebApp": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Relative DNS name for the WebApps, must be globally unique.  An index will be appended for each Web App."
+      }
     },
-    "serverFarmName": {
-      "type": "string"
-    },
-    "trafficManagerName": {
-      "type": "string"
+    "webServerName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the App Service Plan that is being created"
+      }
     },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
+    },
+    "trafficManagerName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the trafficManager being created"
+      }
     }
   },
-  "functions": [],
+
+  "variables": {},
+
   "resources": [
     {
       "type": "Microsoft.Web/serverfarms",
-      "apiVersion": "2020-06-01",
-      "name": "[parameters('serverFarmName')]",
+      "apiVersion": "2019-08-01",
+      "name": "[parameters('webServerName')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "S1",
@@ -40,19 +47,20 @@
     },
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2019-08-01",
       "name": "[parameters('uniqueDnsNameForWebApp')]",
       "location": "[parameters('location')]",
-      "properties": {
-        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarmName'))]"
-      },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarmName'))]"
-      ]
+        "[resourceId('Microsoft.Web/serverfarms/',parameters('webServerName'))]"
+
+      ],
+      "properties": {
+        "serverFarmId": "[parameters('webServerName')]"
+      }
     },
     {
-      "type": "Microsoft.Network/trafficmanagerprofiles",
-      "apiVersion": "2018-04-01",
+      "type": "Microsoft.Network/trafficManagerProfiles",
+      "apiVersion": "2018-08-01",
       "name": "[parameters('trafficManagerName')]",
       "location": "global",
       "properties": {
@@ -66,21 +74,22 @@
           "protocol": "HTTPS",
           "port": 443,
           "path": "/"
-        },
-        "endpoints": [
-          {
-            "name": "[parameters('uniqueDnsNameForWebApp')]",
-            "type": "Microsoft.Network/trafficManagerProfiles/azureEndpoints",
-            "properties": {
-              "targetResourceId": "[resourceId('Microsoft.Web/sites', parameters('uniqueDnsNameForWebApp'))]",
-              "endpointStatus": "Enabled"
-            }
-          }
-        ]
-      },
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/trafficManagerProfiles/azureEndpoints",
+      "apiVersion": "2018-08-01",
+      "name": "[concat(parameters('trafficManagerName'),'/',parameters('uniqueDnsNameForWebApp'))]",
+      "location": "global",
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', parameters('uniqueDnsNameForWebApp'))]"
-      ]
+        "[resourceId('Microsoft.Network/trafficManagerProfiles/',parameters('trafficManagerName'))]",
+        "[resourceId('Microsoft.Web/sites/',parameters('uniqueDnsNameForWebApp'))]"
+      ],
+      "properties": {
+        "targetResourceId": "[resourceId('Microsoft.Web/sites/', parameters('uniqueDnsNameForWebApp'))]",
+        "endpointStatus": "Enabled"
+      }
     }
   ]
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.network/traffic-manager-webapp
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11387