### PR TITLE
Migrate example: 201/vnet-to-vnet-peering

### DIFF
--- a/docs/examples/201/vnet-to-vnet-peering/README-MOVED.md
+++ b/docs/examples/201/vnet-to-vnet-peering/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.network/vnet-to-vnet-peering.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/201/vnet-to-vnet-peering/main.bicep
+++ b/docs/examples/201/vnet-to-vnet-peering/main.bicep
@@ -1,69 +1,87 @@
+@description('Location of the resources')
 param location string = resourceGroup().location
-param vNet1Name string = 'VNet1'
-param vNet2Name string = 'VNet2'
 
-resource vNet1 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-  name: vNet1Name
+@description('Name for vNet 1')
+param vnet1Name string = 'vNet1'
+
+@description('Name for vNet 2')
+param vnet2Name string = 'vNet2'
+
+var vnet1Config = {
+  addressSpacePrefix: '10.0.0.0/24'
+  subnetName: 'subnet1'
+  subnetPrefix: '10.0.0.0/24'
+}
+var vnet2Config = {
+  addressSpacePrefix: '192.168.0.0/24'
+  subnetName: 'subnet1'
+  subnetPrefix: '192.168.0.0/24'
+}
+
+resource vnet1 'Microsoft.Network/virtualNetworks@2020-05-01' = {
+  name: vnet1Name
   location: location
   properties: {
     addressSpace: {
       addressPrefixes: [
-        '10.0.0.0/24'
+        vnet1Config.addressSpacePrefix
       ]
     }
     subnets: [
       {
-        name: 'subnet1'
+        name: vnet1Config.subnetName
         properties: {
-          addressPrefix: '10.0.0.0/24'
+          addressPrefix: vnet1Config.subnetPrefix
         }
       }
     ]
   }
 }
 
-resource VnetPeering1 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-06-01' = {
-  name: '${vNet1.name}/${vNet1.name}-${vNet2.name}'
+resource VnetPeering1 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  parent: vnet1
+  name: '${vnet1Name}-${vnet2Name}'
   properties: {
     allowVirtualNetworkAccess: true
     allowForwardedTraffic: false
     allowGatewayTransit: false
     useRemoteGateways: false
     remoteVirtualNetwork: {
-      id: vNet2.id
+      id: vnet2.id
     }
   }
 }
 
-resource vNet2 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-  name: vNet2Name
+resource vnet2 'Microsoft.Network/virtualNetworks@2020-05-01' = {
+  name: vnet2Name
   location: location
   properties: {
     addressSpace: {
       addressPrefixes: [
-        '192.168.0.0/24'
+        vnet2Config.addressSpacePrefix
       ]
     }
     subnets: [
       {
-        name: 'subnet1'
+        name: vnet2Config.subnetName
         properties: {
-          addressPrefix: '192.168.0.0/24'
+          addressPrefix: vnet2Config.subnetPrefix
         }
       }
     ]
   }
 }
 
-resource VnetPeering2 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-06-01' = {
-  name: '${vNet2.name}/${vNet2.name}-${vNet1.name}'
+resource vnetPeering2 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  parent: vnet2
+  name: '${vnet2Name}-${vnet1Name}'
   properties: {
     allowVirtualNetworkAccess: true
     allowForwardedTraffic: false
     allowGatewayTransit: false
     useRemoteGateways: false
     remoteVirtualNetwork: {
-      id: vNet1.id
+      id: vnet1.id
     }
   }
 }

--- a/docs/examples/201/vnet-to-vnet-peering/main.json
+++ b/docs/examples/201/vnet-to-vnet-peering/main.json
@@ -1,106 +1,131 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "1033464771519658084"
-    }
-  },
-  "parameters": {
-    "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]"
-    },
-    "vNet1Name": {
-      "type": "string",
-      "defaultValue": "VNet1"
-    },
-    "vNet2Name": {
-      "type": "string",
-      "defaultValue": "VNet2"
-    }
-  },
-  "functions": [],
-  "resources": [
-    {
-      "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-06-01",
-      "name": "[parameters('vNet1Name')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "10.0.0.0/24"
-          ]
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "string",
+            "metadata": {
+                "description": "Location of the resources"
+            },
+            "defaultValue": "[resourceGroup().location]"
         },
-        "subnets": [
-          {
-            "name": "subnet1",
-            "properties": {
-              "addressPrefix": "10.0.0.0/24"
+        "vNet1Name": {
+            "type": "string",
+            "defaultValue": "vNet1",
+            "metadata": {
+                "description": "Name for vNet 1"
             }
-          }
-        ]
-      }
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-      "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}-{2}', parameters('vNet1Name'), parameters('vNet1Name'), parameters('vNet2Name'))]",
-      "properties": {
-        "allowVirtualNetworkAccess": true,
-        "allowForwardedTraffic": false,
-        "allowGatewayTransit": false,
-        "useRemoteGateways": false,
-        "remoteVirtualNetwork": {
-          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vNet2Name'))]"
-        }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vNet1Name'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vNet2Name'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-06-01",
-      "name": "[parameters('vNet2Name')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "192.168.0.0/24"
-          ]
         },
-        "subnets": [
-          {
-            "name": "subnet1",
-            "properties": {
-              "addressPrefix": "192.168.0.0/24"
+        "vNet2Name": {
+            "type": "string",
+            "defaultValue": "vNet2",
+            "metadata": {
+                "description": "Name for vNet 2"
             }
-          }
-        ]
-      }
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-      "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}-{2}', parameters('vNet2Name'), parameters('vNet2Name'), parameters('vNet1Name'))]",
-      "properties": {
-        "allowVirtualNetworkAccess": true,
-        "allowForwardedTraffic": false,
-        "allowGatewayTransit": false,
-        "useRemoteGateways": false,
-        "remoteVirtualNetwork": {
-          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vNet1Name'))]"
         }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vNet1Name'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vNet2Name'))]"
-      ]
-    }
-  ]
+    },
+    "variables": {
+        "vNet1": {
+            "addressSpacePrefix": "10.0.0.0/24",
+            "subnetName": "subnet1",
+            "subnetPrefix": "10.0.0.0/24"
+        },
+        "vNet2": {
+            "addressSpacePrefix": "192.168.0.0/24",
+            "subnetName": "subnet1",
+            "subnetPrefix": "192.168.0.0/24"
+        },
+        "vNet1tovNet2PeeringName": "[concat(parameters('vNet1Name'), '-', parameters('vNet2Name'))]",
+        "vNet2tovNet1PeeringName": "[concat(parameters('vNet2Name'), '-', parameters('vNet1Name'))]"
+    },
+    "resources": [
+        {
+            "apiVersion": "2020-05-01",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[parameters('vNet1Name')]",
+            "location": "[parameters('location')]",
+            "comments": "This is the first vNet",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('vNet1').addressSpacePrefix]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('vNet1').subnetName]",
+                        "properties": {
+                            "addressPrefix": "[variables('vNet1').subnetPrefix]"
+                        }
+                    }
+                ]
+            },
+            "resources": [
+                {
+                    "apiVersion": "2020-05-01",
+                    "type": "virtualNetworkPeerings",
+                    "name": "[variables('vNet1tovNet2PeeringName')]",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet1Name'))]",
+                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet2Name'))]"
+                    ],
+                    "comments": "This is the peering from vNet 1 to vNet 2",
+                    "properties": {
+                        "allowVirtualNetworkAccess": true,
+                        "allowForwardedTraffic": false,
+                        "allowGatewayTransit": false,
+                        "useRemoteGateways": false,
+                        "remoteVirtualNetwork": {
+                            "id": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vNet2Name'))]"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "apiVersion": "2020-05-01",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[parameters('vNet2Name')]",
+            "location": "[parameters('location')]",
+            "comments": "This is the second vNet",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('vNet2').addressSpacePrefix]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('vNet2').subnetName]",
+                        "properties": {
+                            "addressPrefix": "[variables('vNet2').subnetPrefix]"
+                        }
+                    }
+                ]
+            },
+            "resources": [
+                {
+                    "apiVersion": "2020-05-01",
+                    "type": "virtualNetworkPeerings",
+                    "name": "[variables('vNet2tovNet1PeeringName')]",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet1Name'))]",
+                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet2Name'))]"
+                    ],
+                    "comments": "This is the peering from vNet 2 to vNet 1",
+                    "properties": {
+                        "allowVirtualNetworkAccess": true,
+                        "allowForwardedTraffic": false,
+                        "allowGatewayTransit": false,
+                        "useRemoteGateways": false,
+                        "remoteVirtualNetwork": {
+                            "id": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vNet1Name'))]"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
 }

--- a/docs/examples/201/vnet-to-vnet-peering/main.json
+++ b/docs/examples/201/vnet-to-vnet-peering/main.json
@@ -1,131 +1,127 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string",
-            "metadata": {
-                "description": "Location of the resources"
-            },
-            "defaultValue": "[resourceGroup().location]"
-        },
-        "vNet1Name": {
-            "type": "string",
-            "defaultValue": "vNet1",
-            "metadata": {
-                "description": "Name for vNet 1"
-            }
-        },
-        "vNet2Name": {
-            "type": "string",
-            "defaultValue": "vNet2",
-            "metadata": {
-                "description": "Name for vNet 2"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "3485675834858320580"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location of the resources"
+      }
     },
-    "variables": {
-        "vNet1": {
-            "addressSpacePrefix": "10.0.0.0/24",
-            "subnetName": "subnet1",
-            "subnetPrefix": "10.0.0.0/24"
-        },
-        "vNet2": {
-            "addressSpacePrefix": "192.168.0.0/24",
-            "subnetName": "subnet1",
-            "subnetPrefix": "192.168.0.0/24"
-        },
-        "vNet1tovNet2PeeringName": "[concat(parameters('vNet1Name'), '-', parameters('vNet2Name'))]",
-        "vNet2tovNet1PeeringName": "[concat(parameters('vNet2Name'), '-', parameters('vNet1Name'))]"
+    "vnet1Name": {
+      "type": "string",
+      "defaultValue": "vNet1",
+      "metadata": {
+        "description": "Name for vNet 1"
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "2020-05-01",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[parameters('vNet1Name')]",
-            "location": "[parameters('location')]",
-            "comments": "This is the first vNet",
-            "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('vNet1').addressSpacePrefix]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('vNet1').subnetName]",
-                        "properties": {
-                            "addressPrefix": "[variables('vNet1').subnetPrefix]"
-                        }
-                    }
-                ]
-            },
-            "resources": [
-                {
-                    "apiVersion": "2020-05-01",
-                    "type": "virtualNetworkPeerings",
-                    "name": "[variables('vNet1tovNet2PeeringName')]",
-                    "location": "[parameters('location')]",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet1Name'))]",
-                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet2Name'))]"
-                    ],
-                    "comments": "This is the peering from vNet 1 to vNet 2",
-                    "properties": {
-                        "allowVirtualNetworkAccess": true,
-                        "allowForwardedTraffic": false,
-                        "allowGatewayTransit": false,
-                        "useRemoteGateways": false,
-                        "remoteVirtualNetwork": {
-                            "id": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vNet2Name'))]"
-                        }
-                    }
-                }
-            ]
+    "vnet2Name": {
+      "type": "string",
+      "defaultValue": "vNet2",
+      "metadata": {
+        "description": "Name for vNet 2"
+      }
+    }
+  },
+  "functions": [],
+  "variables": {
+    "vnet1Config": {
+      "addressSpacePrefix": "10.0.0.0/24",
+      "subnetName": "subnet1",
+      "subnetPrefix": "10.0.0.0/24"
+    },
+    "vnet2Config": {
+      "addressSpacePrefix": "192.168.0.0/24",
+      "subnetName": "subnet1",
+      "subnetPrefix": "192.168.0.0/24"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-05-01",
+      "name": "[parameters('vnet1Name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnet1Config').addressSpacePrefix]"
+          ]
         },
-        {
-            "apiVersion": "2020-05-01",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[parameters('vNet2Name')]",
-            "location": "[parameters('location')]",
-            "comments": "This is the second vNet",
+        "subnets": [
+          {
+            "name": "[variables('vnet1Config').subnetName]",
             "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('vNet2').addressSpacePrefix]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('vNet2').subnetName]",
-                        "properties": {
-                            "addressPrefix": "[variables('vNet2').subnetPrefix]"
-                        }
-                    }
-                ]
-            },
-            "resources": [
-                {
-                    "apiVersion": "2020-05-01",
-                    "type": "virtualNetworkPeerings",
-                    "name": "[variables('vNet2tovNet1PeeringName')]",
-                    "location": "[parameters('location')]",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet1Name'))]",
-                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet2Name'))]"
-                    ],
-                    "comments": "This is the peering from vNet 2 to vNet 1",
-                    "properties": {
-                        "allowVirtualNetworkAccess": true,
-                        "allowForwardedTraffic": false,
-                        "allowGatewayTransit": false,
-                        "useRemoteGateways": false,
-                        "remoteVirtualNetwork": {
-                            "id": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vNet1Name'))]"
-                        }
-                    }
-                }
-            ]
+              "addressPrefix": "[variables('vnet1Config').subnetPrefix]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "[format('{0}/{1}', parameters('vnet1Name'), format('{0}-{1}', parameters('vnet1Name'), parameters('vnet2Name')))]",
+      "properties": {
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": false,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false,
+        "remoteVirtualNetwork": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet2Name'))]"
         }
-    ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet1Name'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet2Name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-05-01",
+      "name": "[parameters('vnet2Name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnet2Config').addressSpacePrefix]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('vnet2Config').subnetName]",
+            "properties": {
+              "addressPrefix": "[variables('vnet2Config').subnetPrefix]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "[format('{0}/{1}', parameters('vnet2Name'), format('{0}-{1}', parameters('vnet2Name'), parameters('vnet1Name')))]",
+      "properties": {
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": false,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false,
+        "remoteVirtualNetwork": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet1Name'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet1Name'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet2Name'))]"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.network/vnet-to-vnet-peering
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11392