### PR TITLE
Migrate example: 301/insights-alertrules-application-insights

### DIFF
--- a/docs/examples/301/insights-alertrules-application-insights/README-MOVED.md
+++ b/docs/examples/301/insights-alertrules-application-insights/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.insights/insights-alertrules-application-insights.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/301/insights-alertrules-application-insights/main.bicep
+++ b/docs/examples/301/insights-alertrules-application-insights/main.bicep
@@ -1,12 +1,18 @@
-param workspaceName string
-param applicationInsightsName string
-param location string = resourceGroup().location
-
+@description('Enter response time threshold in seconds.')
 @minValue(1)
 @maxValue(10000)
 param responseTimeThreshold int = 3
 
-var responseAlertName = 'ResponseTime-${applicationInsightsName}'
+@description('Name of the workspace where the data will be stored.')
+param workspaceName string = 'myWorkspace'
+
+@description('Name of the application insights resource.')
+param applicationInsightsName string = 'myApplicationInsights'
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+var responseAlertName = 'ResponseTime-${toLower(applicationInsightsName)}'
 
 resource workspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' = {
   name: workspaceName
@@ -17,6 +23,7 @@ resource workspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' = {
     }
   }
 }
+
 resource applicationInsights 'Microsoft.Insights/components@2020-02-02-preview' = {
   name: applicationInsightsName
   location: location
@@ -26,6 +33,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02-preview' 
     WorkspaceResourceId: workspace.id
   }
 }
+
 resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: responseAlertName
   location: 'global'
@@ -58,6 +66,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
     ]
   }
 }
+
 resource emailActionGroup 'microsoft.insights/actionGroups@2019-06-01' = {
   name: 'emailActionGroup'
   location: 'global'

--- a/docs/examples/301/insights-alertrules-application-insights/main.json
+++ b/docs/examples/301/insights-alertrules-application-insights/main.json
@@ -1,40 +1,46 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "13249848785656956504"
-    }
-  },
   "parameters": {
+    "responseTime": {
+      "type": "int",
+      "defaultValue": 3,
+      "minValue": 1,
+      "maxValue": 10000,
+      "metadata": {
+        "description": "Enter response time threshold in seconds."
+      }
+    },
     "workspaceName": {
-      "type": "string"
+      "defaultValue": "myWorkspace",
+      "type": "string",
+      "metadata": {
+        "description": "Name of the workspace where the data will be stored."
+      }
     },
     "applicationInsightsName": {
-      "type": "string"
+      "defaultValue": "myApplicationInsights",
+      "type": "string",
+      "metadata": {
+        "description": "Name of the application insights resource."
+      }
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
-    },
-    "responseTimeThreshold": {
-      "type": "int",
-      "defaultValue": 3,
-      "maxValue": 10000,
-      "minValue": 1
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     }
   },
-  "functions": [],
   "variables": {
-    "responseAlertName": "[format('ResponseTime-{0}', parameters('applicationInsightsName'))]"
+    "responseAlertName": "[concat('ResponseTime-', toLower(parameters('applicationInsightsName')))]"
   },
   "resources": [
     {
-      "type": "Microsoft.OperationalInsights/workspaces",
-      "apiVersion": "2020-10-01",
       "name": "[parameters('workspaceName')]",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2020-08-01",
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
@@ -43,26 +49,30 @@
       }
     },
     {
+      "name": "[parameters('applicationInsightsName')]",
       "type": "Microsoft.Insights/components",
       "apiVersion": "2020-02-02-preview",
-      "name": "[parameters('applicationInsightsName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
+      ],
       "kind": "web",
       "properties": {
         "Application_Type": "web",
         "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      ]
+      }
     },
     {
-      "type": "Microsoft.Insights/metricAlerts",
-      "apiVersion": "2018-03-01",
       "name": "[variables('responseAlertName')]",
+      "type": "Microsoft.Insights/metricAlerts",
       "location": "global",
+      "apiVersion": "2018-03-01",
+      "dependson": [
+        "[resourceId('Microsoft.Insights/components', parameters('applicationInsightsName'))]",
+        "[resourceId('microsoft.insights/actionGroups','emailActionGroup')]"
+      ],
       "properties": {
-        "description": "Response time alert",
+        "description": "response time alert",
         "severity": 0,
         "enabled": true,
         "scopes": [
@@ -77,7 +87,7 @@
               "name": "1st criterion",
               "metricName": "requests/duration",
               "operator": "GreaterThan",
-              "threshold": "[parameters('responseTimeThreshold')]",
+              "threshold": "[parameters('responseTime')]",
               "timeAggregation": "Average",
               "criterionType": "StaticThresholdCriterion"
             }
@@ -85,19 +95,15 @@
         },
         "actions": [
           {
-            "actionGroupId": "[resourceId('microsoft.insights/actionGroups', 'emailActionGroup')]"
+            "actionGroupId": "[resourceId('microsoft.insights/actionGroups','emailActionGroup')]"
           }
         ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Insights/components', parameters('applicationInsightsName'))]",
-        "[resourceId('microsoft.insights/actionGroups', 'emailActionGroup')]"
-      ]
+      }
     },
     {
+      "name": "emailActionGroup",
       "type": "microsoft.insights/actionGroups",
       "apiVersion": "2019-06-01",
-      "name": "emailActionGroup",
       "location": "global",
       "properties": {
         "groupShortName": "string",

--- a/docs/examples/301/insights-alertrules-application-insights/main.json
+++ b/docs/examples/301/insights-alertrules-application-insights/main.json
@@ -1,26 +1,33 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "6932515354107245659"
+    }
+  },
   "parameters": {
-    "responseTime": {
+    "responseTimeThreshold": {
       "type": "int",
       "defaultValue": 3,
-      "minValue": 1,
       "maxValue": 10000,
+      "minValue": 1,
       "metadata": {
         "description": "Enter response time threshold in seconds."
       }
     },
     "workspaceName": {
-      "defaultValue": "myWorkspace",
       "type": "string",
+      "defaultValue": "myWorkspace",
       "metadata": {
         "description": "Name of the workspace where the data will be stored."
       }
     },
     "applicationInsightsName": {
-      "defaultValue": "myApplicationInsights",
       "type": "string",
+      "defaultValue": "myApplicationInsights",
       "metadata": {
         "description": "Name of the application insights resource."
       }
@@ -33,14 +40,15 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "responseAlertName": "[concat('ResponseTime-', toLower(parameters('applicationInsightsName')))]"
+    "responseAlertName": "[format('ResponseTime-{0}', toLower(parameters('applicationInsightsName')))]"
   },
   "resources": [
     {
-      "name": "[parameters('workspaceName')]",
       "type": "Microsoft.OperationalInsights/workspaces",
-      "apiVersion": "2020-08-01",
+      "apiVersion": "2020-10-01",
+      "name": "[parameters('workspaceName')]",
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
@@ -49,30 +57,26 @@
       }
     },
     {
-      "name": "[parameters('applicationInsightsName')]",
       "type": "Microsoft.Insights/components",
       "apiVersion": "2020-02-02-preview",
+      "name": "[parameters('applicationInsightsName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      ],
       "kind": "web",
       "properties": {
         "Application_Type": "web",
         "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
+      ]
     },
     {
-      "name": "[variables('responseAlertName')]",
       "type": "Microsoft.Insights/metricAlerts",
-      "location": "global",
       "apiVersion": "2018-03-01",
-      "dependson": [
-        "[resourceId('Microsoft.Insights/components', parameters('applicationInsightsName'))]",
-        "[resourceId('microsoft.insights/actionGroups','emailActionGroup')]"
-      ],
+      "name": "[variables('responseAlertName')]",
+      "location": "global",
       "properties": {
-        "description": "response time alert",
+        "description": "Response time alert",
         "severity": 0,
         "enabled": true,
         "scopes": [
@@ -87,7 +91,7 @@
               "name": "1st criterion",
               "metricName": "requests/duration",
               "operator": "GreaterThan",
-              "threshold": "[parameters('responseTime')]",
+              "threshold": "[parameters('responseTimeThreshold')]",
               "timeAggregation": "Average",
               "criterionType": "StaticThresholdCriterion"
             }
@@ -95,15 +99,19 @@
         },
         "actions": [
           {
-            "actionGroupId": "[resourceId('microsoft.insights/actionGroups','emailActionGroup')]"
+            "actionGroupId": "[resourceId('microsoft.insights/actionGroups', 'emailActionGroup')]"
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Insights/components', parameters('applicationInsightsName'))]",
+        "[resourceId('microsoft.insights/actionGroups', 'emailActionGroup')]"
+      ]
     },
     {
-      "name": "emailActionGroup",
       "type": "microsoft.insights/actionGroups",
       "apiVersion": "2019-06-01",
+      "name": "emailActionGroup",
       "location": "global",
       "properties": {
         "groupShortName": "string",


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.insights/insights-alertrules-application-insights
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11394