### PR TITLE
Migrate example: 101/expressroute-circuit-create

### DIFF
--- a/docs/examples/101/expressroute-circuit-create/README-MOVED.md
+++ b/docs/examples/101/expressroute-circuit-create/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.network/expressroute-circuit-create.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/101/expressroute-circuit-create/main.bicep
+++ b/docs/examples/101/expressroute-circuit-create/main.bicep
@@ -1,23 +1,33 @@
+@description('This is the name of the ExpressRoute circuit')
 param circuitName string
+
+@description('This is the name of the ExpressRoute Service Provider. It must exactly match one of the Service Providers from List ExpressRoute Service Providers API call.')
 param serviceProviderName string
+
+@description('This is the name of the peering location and not the ARM resource location. It must exactly match one of the available peering locations from List ExpressRoute Service Providers API call.')
 param peeringLocation string
+
+@description('This is the bandwidth in Mbps of the circuit being created. It must exactly match one of the available bandwidth offers List ExpressRoute Service Providers API call.')
 param bandwidthInMbps int
 
+@description('Chosen SKU Tier of ExpressRoute circuit. Choose from Premium or Standard SKU tiers.')
 @allowed([
   'Standard'
   'Premium'
 ])
 param skuTier string = 'Standard'
 
+@description('Chosen SKU family of ExpressRoute circuit. Choose from MeteredData or UnlimitedData SKU families.')
 @allowed([
   'MeteredData'
   'UnlimitedData'
 ])
 param skuFamily string = 'MeteredData'
 
+@description('Location for all resources.')
 param location string = resourceGroup().location
 
-resource circuit 'Microsoft.Network/expressRouteCircuits@2020-06-01' = {
+resource circuit 'Microsoft.Network/expressRouteCircuits@2021-02-01' = {
   name: circuitName
   location: location
   sku: {

--- a/docs/examples/101/expressroute-circuit-create/main.json
+++ b/docs/examples/101/expressroute-circuit-create/main.json
@@ -1,58 +1,75 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "17199063837123482295"
-    }
-  },
   "parameters": {
     "circuitName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "This is the name of the ExpressRoute circuit"
+      }
     },
     "serviceProviderName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "This is the name of the ExpressRoute Service Provider. It must exactly match one of the Service Providers from List ExpressRoute Service Providers API call."
+      }
     },
     "peeringLocation": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "This is the name of the peering location and not the ARM resource location. It must exactly match one of the available peering locations from List ExpressRoute Service Providers API call."
+      }
     },
     "bandwidthInMbps": {
-      "type": "int"
+      "type": "int",
+      "metadata": {
+        "description": "This is the bandwidth in Mbps of the circuit being created. It must exactly match one of the available bandwidth offers List ExpressRoute Service Providers API call."
+      }
     },
-    "skuTier": {
+    "sku_tier": {
       "type": "string",
       "defaultValue": "Standard",
       "allowedValues": [
         "Standard",
         "Premium"
-      ]
+      ],
+      "metadata": {
+        "description": "Chosen SKU Tier of ExpressRoute circuit. Choose from Premium or Standard SKU tiers."
+      }
     },
-    "skuFamily": {
+    "sku_family": {
       "type": "string",
       "defaultValue": "MeteredData",
       "allowedValues": [
         "MeteredData",
         "UnlimitedData"
-      ]
+      ],
+      "metadata": {
+        "description": "Chosen SKU family of ExpressRoute circuit. Choose from MeteredData or UnlimitedData SKU families."
+      }
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     }
   },
-  "functions": [],
   "resources": [
     {
+      "apiVersion": "2019-04-01",
       "type": "Microsoft.Network/expressRouteCircuits",
-      "apiVersion": "2020-06-01",
       "name": "[parameters('circuitName')]",
       "location": "[parameters('location')]",
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      },
       "sku": {
-        "name": "[format('{0}_{1}', parameters('skuTier'), parameters('skuFamily'))]",
-        "tier": "[parameters('skuTier')]",
-        "family": "[parameters('skuFamily')]"
+        "name": "[concat(parameters('sku_tier'),'_', parameters('sku_family'))]",
+        "tier": "[parameters('sku_tier')]",
+        "family": "[parameters('sku_family')]"
       },
       "properties": {
         "serviceProviderProperties": {

--- a/docs/examples/101/expressroute-circuit-create/main.json
+++ b/docs/examples/101/expressroute-circuit-create/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "12018690323025637593"
+    }
+  },
   "parameters": {
     "circuitName": {
       "type": "string",
@@ -26,7 +33,7 @@
         "description": "This is the bandwidth in Mbps of the circuit being created. It must exactly match one of the available bandwidth offers List ExpressRoute Service Providers API call."
       }
     },
-    "sku_tier": {
+    "skuTier": {
       "type": "string",
       "defaultValue": "Standard",
       "allowedValues": [
@@ -37,7 +44,7 @@
         "description": "Chosen SKU Tier of ExpressRoute circuit. Choose from Premium or Standard SKU tiers."
       }
     },
-    "sku_family": {
+    "skuFamily": {
       "type": "string",
       "defaultValue": "MeteredData",
       "allowedValues": [
@@ -56,20 +63,17 @@
       }
     }
   },
+  "functions": [],
   "resources": [
     {
-      "apiVersion": "2019-04-01",
       "type": "Microsoft.Network/expressRouteCircuits",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('circuitName')]",
       "location": "[parameters('location')]",
-      "tags": {
-        "key1": "value1",
-        "key2": "value2"
-      },
       "sku": {
-        "name": "[concat(parameters('sku_tier'),'_', parameters('sku_family'))]",
-        "tier": "[parameters('sku_tier')]",
-        "family": "[parameters('sku_family')]"
+        "name": "[format('{0}_{1}', parameters('skuTier'), parameters('skuFamily'))]",
+        "tier": "[parameters('skuTier')]",
+        "family": "[parameters('skuFamily')]"
       },
       "properties": {
         "serviceProviderProperties": {


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.network/expressroute-circuit-create
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11395