### PR TITLE
Migrate example: 201/cdn-with-storage-account

### DIFF
--- a/docs/examples/201/cdn-with-storage-account/README-MOVED.md
+++ b/docs/examples/201/cdn-with-storage-account/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.cdn/cdn-with-storage-account.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/201/cdn-with-storage-account/main.bicep
+++ b/docs/examples/201/cdn-with-storage-account/main.bicep
@@ -1,30 +1,41 @@
+@description('Location for all resources.')
 param location string = resourceGroup().location
 
 var storageAccountName = 'storage${uniqueString(resourceGroup().id)}'
-var endPointName = 'endpoint-${uniqueString(resourceGroup().id)}'
-var profileName = 'CdnProfile1'
+var endpointName = 'endpoint-${uniqueString(resourceGroup().id)}'
+var profileName = 'cdn-${uniqueString(resourceGroup().id)}'
 var storageAccountHostName = replace(replace(storageAccount.properties.primaryEndpoints.blob, 'https://', ''), '/', '')
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-  location: location
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' = {
   name: storageAccountName
+  location: location
+  tags: {
+    displayName: storageAccountName
+  }
   kind: 'StorageV2'
   sku: {
     name: 'Standard_LRS'
   }
 }
 
-resource cdnProfile 'Microsoft.Cdn/profiles@2020-04-15' = {
-  location: location
+resource cdnProfile 'Microsoft.Cdn/profiles@2020-09-01' = {
   name: profileName
+  location: location
+  tags: {
+    displayName: profileName
+  }
   sku: {
-    name: 'Standard_Akamai'
+    name: 'Standard_Verizon'
   }
 }
 
-resource endpoint 'Microsoft.Cdn/profiles/endpoints@2020-04-15' = {
+resource endpoint 'Microsoft.Cdn/profiles/endpoints@2020-09-01' = {
+  parent: cdnProfile
+  name: endpointName
   location: location
-  name: endPointName
+  tags: {
+    displayName: endpointName
+  }
   properties: {
     originHostHeader: storageAccountHostName
     isHttpAllowed: true

--- a/docs/examples/201/cdn-with-storage-account/main.json
+++ b/docs/examples/201/cdn-with-storage-account/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "6691240461596735890"
+    }
+  },
   "parameters": {
     "location": {
       "type": "string",
@@ -10,85 +17,82 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "storageAccountName": "[concat('storage', uniqueString(resourceGroup().id))]",
-    "endpointName": "[concat('endpoint-', uniqueString(resourceGroup().id))]",
-    "profileName": "[concat('cdn-', uniqueString(resourceGroup().id))]"
+    "storageAccountName": "[format('storage{0}', uniqueString(resourceGroup().id))]",
+    "endpointName": "[format('endpoint-{0}', uniqueString(resourceGroup().id))]",
+    "profileName": "[format('cdn-{0}', uniqueString(resourceGroup().id))]"
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountName')]",
       "apiVersion": "2021-01-01",
+      "name": "[variables('storageAccountName')]",
       "location": "[parameters('location')]",
       "tags": {
         "displayName": "[variables('storageAccountName')]"
       },
-      "kind": "Storage",
+      "kind": "StorageV2",
       "sku": {
         "name": "Standard_LRS"
-      },
-      "properties": {}
+      }
     },
     {
-      "name": "[variables('profileName')]",
       "type": "Microsoft.Cdn/profiles",
+      "apiVersion": "2020-09-01",
+      "name": "[variables('profileName')]",
       "location": "[parameters('location')]",
-      "apiVersion": "2016-04-02",
       "tags": {
         "displayName": "[variables('profileName')]"
       },
       "sku": {
         "name": "Standard_Verizon"
+      }
+    },
+    {
+      "type": "Microsoft.Cdn/profiles/endpoints",
+      "apiVersion": "2020-09-01",
+      "name": "[format('{0}/{1}', variables('profileName'), variables('endpointName'))]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "displayName": "[variables('endpointName')]"
       },
-      "properties": {},
-      "resources": [
-        {
-          "apiVersion": "2016-04-02",
-          "name": "[variables('endpointName')]",
-          "type": "endpoints",
-          "dependsOn": [
-            "[variables('profileName')]",
-            "[variables('storageAccountName')]"
-          ],
-          "location": "[parameters('location')]",
-          "tags": {
-            "displayName": "[variables('endpointName')]"
-          },
-          "properties": {
-            "originHostHeader": "[replace(replace(reference(variables('storageAccountName')).primaryEndpoints.blob,'https://',''),'/','')]",
-            "isHttpAllowed": true,
-            "isHttpsAllowed": true,
-            "queryStringCachingBehavior": "IgnoreQueryString",
-            "contentTypesToCompress": [
-              "text/plain",
-              "text/html",
-              "text/css",
-              "application/x-javascript",
-              "text/javascript"
-            ],
-            "isCompressionEnabled": true,
-            "origins": [
-              {
-                "name": "origin1",
-                "properties": {
-                  "hostName": "[replace(replace(reference(variables('storageAccountName')).primaryEndpoints.blob,'https://',''),'/','')]"
-                }
-              }
-            ]
+      "properties": {
+        "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob, 'https://', ''), '/', '')]",
+        "isHttpAllowed": true,
+        "isHttpsAllowed": true,
+        "queryStringCachingBehavior": "IgnoreQueryString",
+        "contentTypesToCompress": [
+          "text/plain",
+          "text/html",
+          "text/css",
+          "application/x-javascript",
+          "text/javascript"
+        ],
+        "isCompressionEnabled": true,
+        "origins": [
+          {
+            "name": "origin1",
+            "properties": {
+              "hostName": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob, 'https://', ''), '/', '')]"
+            }
           }
-        }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Cdn/profiles', variables('profileName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
       ]
     }
   ],
   "outputs": {
     "hostName": {
       "type": "string",
-      "value": "[reference(variables('endpointName')).hostName]"
+      "value": "[reference(resourceId('Microsoft.Cdn/profiles/endpoints', variables('profileName'), variables('endpointName'))).hostName]"
     },
     "originHostHeader": {
       "type": "string",
-      "value": "[reference(variables('endpointName')).originHostHeader]"
+      "value": "[reference(resourceId('Microsoft.Cdn/profiles/endpoints', variables('profileName'), variables('endpointName'))).originHostHeader]"
     }
   }
 }

--- a/docs/examples/201/cdn-with-storage-account/main.json
+++ b/docs/examples/201/cdn-with-storage-account/main.json
@@ -1,85 +1,94 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "5876420350969690989"
-    }
-  },
   "parameters": {
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     }
   },
-  "functions": [],
   "variables": {
-    "storageAccountName": "[format('storage{0}', uniqueString(resourceGroup().id))]",
-    "endPointName": "[format('endpoint-{0}', uniqueString(resourceGroup().id))]",
-    "profileName": "CdnProfile1"
+    "storageAccountName": "[concat('storage', uniqueString(resourceGroup().id))]",
+    "endpointName": "[concat('endpoint-', uniqueString(resourceGroup().id))]",
+    "profileName": "[concat('cdn-', uniqueString(resourceGroup().id))]"
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "apiVersion": "2020-08-01-preview",
       "name": "[variables('storageAccountName')]",
+      "apiVersion": "2021-01-01",
       "location": "[parameters('location')]",
-      "kind": "StorageV2",
+      "tags": {
+        "displayName": "[variables('storageAccountName')]"
+      },
+      "kind": "Storage",
       "sku": {
         "name": "Standard_LRS"
-      }
-    },
-    {
-      "type": "Microsoft.Cdn/profiles",
-      "apiVersion": "2020-04-15",
-      "name": "[variables('profileName')]",
-      "location": "[parameters('location')]",
-      "sku": {
-        "name": "Standard_Akamai"
-      }
-    },
-    {
-      "type": "Microsoft.Cdn/profiles/endpoints",
-      "apiVersion": "2020-04-15",
-      "name": "[variables('endPointName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob, 'https://', ''), '/', '')]",
-        "isHttpAllowed": true,
-        "isHttpsAllowed": true,
-        "queryStringCachingBehavior": "IgnoreQueryString",
-        "contentTypesToCompress": [
-          "text/plain",
-          "text/html",
-          "text/css",
-          "application/x-javascript",
-          "text/javascript"
-        ],
-        "isCompressionEnabled": true,
-        "origins": [
-          {
-            "name": "origin1",
-            "properties": {
-              "hostName": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob, 'https://', ''), '/', '')]"
-            }
-          }
-        ]
       },
-      "dependsOn": [
-        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      "properties": {}
+    },
+    {
+      "name": "[variables('profileName')]",
+      "type": "Microsoft.Cdn/profiles",
+      "location": "[parameters('location')]",
+      "apiVersion": "2016-04-02",
+      "tags": {
+        "displayName": "[variables('profileName')]"
+      },
+      "sku": {
+        "name": "Standard_Verizon"
+      },
+      "properties": {},
+      "resources": [
+        {
+          "apiVersion": "2016-04-02",
+          "name": "[variables('endpointName')]",
+          "type": "endpoints",
+          "dependsOn": [
+            "[variables('profileName')]",
+            "[variables('storageAccountName')]"
+          ],
+          "location": "[parameters('location')]",
+          "tags": {
+            "displayName": "[variables('endpointName')]"
+          },
+          "properties": {
+            "originHostHeader": "[replace(replace(reference(variables('storageAccountName')).primaryEndpoints.blob,'https://',''),'/','')]",
+            "isHttpAllowed": true,
+            "isHttpsAllowed": true,
+            "queryStringCachingBehavior": "IgnoreQueryString",
+            "contentTypesToCompress": [
+              "text/plain",
+              "text/html",
+              "text/css",
+              "application/x-javascript",
+              "text/javascript"
+            ],
+            "isCompressionEnabled": true,
+            "origins": [
+              {
+                "name": "origin1",
+                "properties": {
+                  "hostName": "[replace(replace(reference(variables('storageAccountName')).primaryEndpoints.blob,'https://',''),'/','')]"
+                }
+              }
+            ]
+          }
+        }
       ]
     }
   ],
   "outputs": {
     "hostName": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Cdn/profiles/endpoints', split(variables('endPointName'), '/')[0], split(variables('endPointName'), '/')[1])).hostName]"
+      "value": "[reference(variables('endpointName')).hostName]"
     },
     "originHostHeader": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Cdn/profiles/endpoints', split(variables('endPointName'), '/')[0], split(variables('endPointName'), '/')[1])).originHostHeader]"
+      "value": "[reference(variables('endpointName')).originHostHeader]"
     }
   }
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.cdn/cdn-with-storage-account
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11398