### PR TITLE
Migrate example: 201/vmss-windows-autoscale

### DIFF
--- a/docs/examples/201/vmss-windows-autoscale/README-MOVED.md
+++ b/docs/examples/201/vmss-windows-autoscale/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.compute/vmss-windows-autoscale.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/201/vmss-windows-autoscale/main.bicep
+++ b/docs/examples/201/vmss-windows-autoscale/main.bicep
@@ -180,10 +180,6 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01' = {
       }
     }
   }
-  dependsOn: [
-    loadBalancer
-    virtualNetwork
-  ]
 }
 
 resource autoScaleSettings 'microsoft.insights/autoscalesettings@2015-04-01' = {
@@ -244,7 +240,4 @@ resource autoScaleSettings 'microsoft.insights/autoscalesettings@2015-04-01' = {
       }
     ]
   }
-  dependsOn: [
-    vmss
-  ]
 }

--- a/docs/examples/201/vmss-windows-autoscale/main.bicep
+++ b/docs/examples/201/vmss-windows-autoscale/main.bicep
@@ -1,5 +1,7 @@
+@description('Size of VMs in the VM Scale Set.')
 param vmSku string = 'Standard_A1_v2'
 
+@description('The Windows version for the VM. This will pick a fully patched image of this given Windows version.')
 @allowed([
   '2019-Datacenter'
   '2016-Datacenter'
@@ -8,35 +10,43 @@ param vmSku string = 'Standard_A1_v2'
 ])
 param windowsOSVersion string = '2019-Datacenter'
 
+@description('String used as a base for naming resources. Must be 3-61 characters in length and globally unique across Azure. A hash is prepended to this string for some resources, and resource-specific information is appended.')
 @maxLength(61)
 param vmssName string
 
+@description('Number of VM instances (100 or less).')
 @minValue(1)
 @maxValue(100)
 param instanceCount int
 
+@description('Admin username on all VMs.')
 param adminUsername string
 
+@description('Admin password on all VMs.')
 @secure()
 param adminPassword string
 
+@description('Location for all resources.')
 param location string = resourceGroup().location
 
 var namingInfix = toLower(substring('${vmssName}${uniqueString(resourceGroup().id)}', 0, 9))
 var longNamingInfix = toLower(vmssName)
 var addressPrefix = '10.0.0.0/16'
 var subnetPrefix = '10.0.0.0/24'
+
 var virtualNetworkName = '${namingInfix}vnet'
 var publicIPAddressName = '${namingInfix}pip'
 var subnetName = '${namingInfix}subnet'
 var loadBalancerName = '${namingInfix}lb'
 var natPoolName = '${namingInfix}natpool'
 var bePoolName = '${namingInfix}bepool'
+
 var natStartPort = 50000
 var natEndPort = 50119
 var natBackendPort = 3389
-var nicname = '${namingInfix}nic'
+var nicName = '${namingInfix}nic'
 var ipConfigName = '${namingInfix}ipconfig'
+
 var osType = {
   publisher: 'MicrosoftWindowsServer'
   offer: 'WindowsServer'
@@ -45,7 +55,7 @@ var osType = {
 }
 var imageReference = osType
 
-resource virtualNetwork 'Microsoft.Network/virtualnetworks@2015-05-01-preview' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -65,7 +75,7 @@ resource virtualNetwork 'Microsoft.Network/virtualnetworks@2015-05-01-preview' =
   }
 }
 
-resource publicIP 'Microsoft.Network/publicIPAddresses@2020-06-01' = {
+resource publicIP 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
   name: publicIPAddressName
   location: location
   properties: {
@@ -76,7 +86,7 @@ resource publicIP 'Microsoft.Network/publicIPAddresses@2020-06-01' = {
   }
 }
 
-resource loadBalancer 'Microsoft.Network/loadBalancers@2020-06-01' = {
+resource loadBalancer 'Microsoft.Network/loadBalancers@2021-02-01' = {
   name: loadBalancerName
   location: location
   properties: {
@@ -112,7 +122,7 @@ resource loadBalancer 'Microsoft.Network/loadBalancers@2020-06-01' = {
   }
 }
 
-resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2020-06-01' = {
+resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01' = {
   name: vmssName
   location: location
   sku: {
@@ -141,7 +151,7 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2020-06-01' = {
       networkProfile: {
         networkInterfaceConfigurations: [
           {
-            name: nicname
+            name: nicName
             properties: {
               primary: true
               ipConfigurations: [
@@ -170,6 +180,10 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2020-06-01' = {
       }
     }
   }
+  dependsOn: [
+    loadBalancer
+    virtualNetwork
+  ]
 }
 
 resource autoScaleSettings 'microsoft.insights/autoscalesettings@2015-04-01' = {
@@ -230,4 +244,7 @@ resource autoScaleSettings 'microsoft.insights/autoscalesettings@2015-04-01' = {
       }
     ]
   }
+  dependsOn: [
+    vmss
+  ]
 }

--- a/docs/examples/201/vmss-windows-autoscale/main.json
+++ b/docs/examples/201/vmss-windows-autoscale/main.json
@@ -1,79 +1,90 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "15303513457722336163"
-    }
-  },
   "parameters": {
     "vmSku": {
       "type": "string",
-      "defaultValue": "Standard_A1_v2"
+      "defaultValue": "Standard_A1",
+      "metadata": {
+        "description": "Size of VMs in the VM Scale Set."
+      }
     },
     "windowsOSVersion": {
       "type": "string",
-      "defaultValue": "2019-Datacenter",
+      "defaultValue": "2012-R2-Datacenter",
       "allowedValues": [
-        "2019-Datacenter",
-        "2016-Datacenter",
-        "2012-R2-Datacenter",
-        "2012-Datacenter"
-      ]
+        "2008-R2-SP1",
+        "2012-Datacenter",
+        "2012-R2-Datacenter"
+      ],
+      "metadata": {
+        "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
+      }
     },
     "vmssName": {
       "type": "string",
+      "metadata": {
+        "description": "String used as a base for naming resources. Must be 3-61 characters in length and globally unique across Azure. A hash is prepended to this string for some resources, and resource-specific information is appended."
+      },
       "maxLength": 61
     },
     "instanceCount": {
       "type": "int",
-      "maxValue": 100,
-      "minValue": 1
+      "metadata": {
+        "description": "Number of VM instances (100 or less)."
+      },
+      "maxValue": 100
     },
     "adminUsername": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Admin username on all VMs."
+      }
     },
     "adminPassword": {
-      "type": "secureString"
-    },
-    "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin password on all VMs."
+      }
     }
   },
-  "functions": [],
   "variables": {
-    "namingInfix": "[toLower(substring(format('{0}{1}', parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
+    "namingInfix": "[toLower(substring(concat(parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
     "longNamingInfix": "[toLower(parameters('vmssName'))]",
     "addressPrefix": "10.0.0.0/16",
     "subnetPrefix": "10.0.0.0/24",
-    "virtualNetworkName": "[format('{0}vnet', variables('namingInfix'))]",
-    "publicIPAddressName": "[format('{0}pip', variables('namingInfix'))]",
-    "subnetName": "[format('{0}subnet', variables('namingInfix'))]",
-    "loadBalancerName": "[format('{0}lb', variables('namingInfix'))]",
-    "natPoolName": "[format('{0}natpool', variables('namingInfix'))]",
-    "bePoolName": "[format('{0}bepool', variables('namingInfix'))]",
+    "virtualNetworkName": "[concat(variables('namingInfix'), 'vnet')]",
+    "publicIPAddressName": "[concat(variables('namingInfix'), 'pip')]",
+    "subnetName": "[concat(variables('namingInfix'), 'subnet')]",
+    "loadBalancerName": "[concat(variables('namingInfix'), 'lb')]",
+    "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
+    "lbID": "[resourceId('Microsoft.Network/loadBalancers',variables('loadBalancerName'))]",
+    "natPoolName": "[concat(variables('namingInfix'), 'natpool')]",
+    "bePoolName": "[concat(variables('namingInfix'), 'bepool')]",
     "natStartPort": 50000,
     "natEndPort": 50119,
     "natBackendPort": 3389,
-    "nicname": "[format('{0}nic', variables('namingInfix'))]",
-    "ipConfigName": "[format('{0}ipconfig', variables('namingInfix'))]",
+    "nicName": "[concat(variables('namingInfix'), 'nic')]",
+    "ipConfigName": "[concat(variables('namingInfix'), 'ipconfig')]",
+    "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/loadBalancerFrontEnd')]",
     "osType": {
       "publisher": "MicrosoftWindowsServer",
       "offer": "WindowsServer",
       "sku": "[parameters('windowsOSVersion')]",
       "version": "latest"
     },
-    "imageReference": "[variables('osType')]"
+    "imageReference": "[variables('osType')]",
+    "computeApiVersion": "2017-03-30",
+    "networkApiVersion": "2017-04-01",
+    "storageApiVersion": "2015-06-15",
+    "insightsApiVersion": "2015-04-01"
   },
   "resources": [
     {
-      "type": "Microsoft.Network/virtualnetworks",
-      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
-      "location": "[parameters('location')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -92,9 +103,9 @@
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2020-06-01",
       "name": "[variables('publicIPAddressName')]",
-      "location": "[parameters('location')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -104,16 +115,19 @@
     },
     {
       "type": "Microsoft.Network/loadBalancers",
-      "apiVersion": "2020-06-01",
       "name": "[variables('loadBalancerName')]",
-      "location": "[parameters('location')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2017-04-01",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+      ],
       "properties": {
         "frontendIPConfigurations": [
           {
             "name": "LoadBalancerFrontEnd",
             "properties": {
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                "id": "[variables('publicIPAddressID')]"
               }
             }
           }
@@ -128,7 +142,7 @@
             "name": "[variables('natPoolName')]",
             "properties": {
               "frontendIPConfiguration": {
-                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', variables('loadBalancerName'), 'loadBalancerFrontEnd')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "Tcp",
               "frontendPortRangeStart": "[variables('natStartPort')]",
@@ -137,23 +151,24 @@
             }
           }
         ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
-      ]
+      }
     },
     {
       "type": "Microsoft.Compute/virtualMachineScaleSets",
-      "apiVersion": "2020-06-01",
-      "name": "[parameters('vmssName')]",
-      "location": "[parameters('location')]",
+      "name": "[variables('namingInfix')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2017-03-30",
+      "dependsOn": [
+        "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
       "sku": {
         "name": "[parameters('vmSku')]",
         "tier": "Standard",
         "capacity": "[parameters('instanceCount')]"
       },
       "properties": {
-        "overprovision": true,
+        "overprovision": "true",
         "upgradePolicy": {
           "mode": "Manual"
         },
@@ -173,7 +188,7 @@
           "networkProfile": {
             "networkInterfaceConfigurations": [
               {
-                "name": "[variables('nicname')]",
+                "name": "[variables('nicName')]",
                 "properties": {
                   "primary": true,
                   "ipConfigurations": [
@@ -181,16 +196,16 @@
                       "name": "[variables('ipConfigName')]",
                       "properties": {
                         "subnet": {
-                          "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualnetworks', variables('virtualNetworkName')), variables('subnetName'))]"
+                          "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'), '/subnets/', variables('subnetName'))]"
                         },
                         "loadBalancerBackendAddressPools": [
                           {
-                            "id": "[format('{0}/backendAddressPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('bePoolName'))]"
+                            "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('loadBalancerName'), '/backendAddressPools/', variables('bePoolName'))]"
                           }
                         ],
                         "loadBalancerInboundNatPools": [
                           {
-                            "id": "[format('{0}/inboundNatPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('natPoolName'))]"
+                            "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('loadBalancerName'), '/inboundNatPools/', variables('natPoolName'))]"
                           }
                         ]
                       }
@@ -201,20 +216,19 @@
             ]
           }
         }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
-        "[resourceId('Microsoft.Network/virtualnetworks', variables('virtualNetworkName'))]"
-      ]
+      }
     },
     {
-      "type": "microsoft.insights/autoscalesettings",
+      "type": "Microsoft.Insights/autoscaleSettings",
       "apiVersion": "2015-04-01",
       "name": "cpuautoscale",
-      "location": "[parameters('location')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]"
+      ],
       "properties": {
         "name": "cpuautoscale",
-        "targetResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
+        "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]",
         "enabled": true,
         "profiles": [
           {
@@ -229,13 +243,13 @@
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
                   "metricNamespace": "",
-                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
+                  "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]",
                   "timeGrain": "PT1M",
+                  "statistic": "Average",
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "GreaterThan",
-                  "threshold": 50,
-                  "statistic": "Average"
+                  "threshold": 50
                 },
                 "scaleAction": {
                   "direction": "Increase",
@@ -248,13 +262,13 @@
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
                   "metricNamespace": "",
-                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
+                  "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]",
                   "timeGrain": "PT1M",
+                  "statistic": "Average",
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "LessThan",
-                  "threshold": 30,
-                  "statistic": "Average"
+                  "threshold": 30
                 },
                 "scaleAction": {
                   "direction": "Decrease",
@@ -266,10 +280,7 @@
             ]
           }
         ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]"
-      ]
+      }
     }
   ]
 }

--- a/docs/examples/201/vmss-windows-autoscale/main.json
+++ b/docs/examples/201/vmss-windows-autoscale/main.json
@@ -1,39 +1,48 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "12031640137834232163"
+    }
+  },
   "parameters": {
     "vmSku": {
       "type": "string",
-      "defaultValue": "Standard_A1",
+      "defaultValue": "Standard_A1_v2",
       "metadata": {
         "description": "Size of VMs in the VM Scale Set."
       }
     },
     "windowsOSVersion": {
       "type": "string",
-      "defaultValue": "2012-R2-Datacenter",
+      "defaultValue": "2019-Datacenter",
       "allowedValues": [
-        "2008-R2-SP1",
-        "2012-Datacenter",
-        "2012-R2-Datacenter"
+        "2019-Datacenter",
+        "2016-Datacenter",
+        "2012-R2-Datacenter",
+        "2012-Datacenter"
       ],
       "metadata": {
-        "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
+        "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version."
       }
     },
     "vmssName": {
       "type": "string",
+      "maxLength": 61,
       "metadata": {
         "description": "String used as a base for naming resources. Must be 3-61 characters in length and globally unique across Azure. A hash is prepended to this string for some resources, and resource-specific information is appended."
-      },
-      "maxLength": 61
+      }
     },
     "instanceCount": {
       "type": "int",
+      "maxValue": 100,
+      "minValue": 1,
       "metadata": {
         "description": "Number of VM instances (100 or less)."
-      },
-      "maxValue": 100
+      }
     },
     "adminUsername": {
       "type": "string",
@@ -42,49 +51,50 @@
       }
     },
     "adminPassword": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Admin password on all VMs."
       }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     }
   },
+  "functions": [],
   "variables": {
-    "namingInfix": "[toLower(substring(concat(parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
+    "namingInfix": "[toLower(substring(format('{0}{1}', parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
     "longNamingInfix": "[toLower(parameters('vmssName'))]",
     "addressPrefix": "10.0.0.0/16",
     "subnetPrefix": "10.0.0.0/24",
-    "virtualNetworkName": "[concat(variables('namingInfix'), 'vnet')]",
-    "publicIPAddressName": "[concat(variables('namingInfix'), 'pip')]",
-    "subnetName": "[concat(variables('namingInfix'), 'subnet')]",
-    "loadBalancerName": "[concat(variables('namingInfix'), 'lb')]",
-    "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
-    "lbID": "[resourceId('Microsoft.Network/loadBalancers',variables('loadBalancerName'))]",
-    "natPoolName": "[concat(variables('namingInfix'), 'natpool')]",
-    "bePoolName": "[concat(variables('namingInfix'), 'bepool')]",
+    "virtualNetworkName": "[format('{0}vnet', variables('namingInfix'))]",
+    "publicIPAddressName": "[format('{0}pip', variables('namingInfix'))]",
+    "subnetName": "[format('{0}subnet', variables('namingInfix'))]",
+    "loadBalancerName": "[format('{0}lb', variables('namingInfix'))]",
+    "natPoolName": "[format('{0}natpool', variables('namingInfix'))]",
+    "bePoolName": "[format('{0}bepool', variables('namingInfix'))]",
     "natStartPort": 50000,
     "natEndPort": 50119,
     "natBackendPort": 3389,
-    "nicName": "[concat(variables('namingInfix'), 'nic')]",
-    "ipConfigName": "[concat(variables('namingInfix'), 'ipconfig')]",
-    "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/loadBalancerFrontEnd')]",
+    "nicName": "[format('{0}nic', variables('namingInfix'))]",
+    "ipConfigName": "[format('{0}ipconfig', variables('namingInfix'))]",
     "osType": {
       "publisher": "MicrosoftWindowsServer",
       "offer": "WindowsServer",
       "sku": "[parameters('windowsOSVersion')]",
       "version": "latest"
     },
-    "imageReference": "[variables('osType')]",
-    "computeApiVersion": "2017-03-30",
-    "networkApiVersion": "2017-04-01",
-    "storageApiVersion": "2015-06-15",
-    "insightsApiVersion": "2015-04-01"
+    "imageReference": "[variables('osType')]"
   },
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2021-02-01",
       "name": "[variables('virtualNetworkName')]",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "2017-04-01",
+      "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -103,9 +113,9 @@
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2021-02-01",
       "name": "[variables('publicIPAddressName')]",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "2017-04-01",
+      "location": "[parameters('location')]",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -115,19 +125,16 @@
     },
     {
       "type": "Microsoft.Network/loadBalancers",
+      "apiVersion": "2021-02-01",
       "name": "[variables('loadBalancerName')]",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "2017-04-01",
-      "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
-      ],
+      "location": "[parameters('location')]",
       "properties": {
         "frontendIPConfigurations": [
           {
             "name": "LoadBalancerFrontEnd",
             "properties": {
               "publicIPAddress": {
-                "id": "[variables('publicIPAddressID')]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               }
             }
           }
@@ -142,7 +149,7 @@
             "name": "[variables('natPoolName')]",
             "properties": {
               "frontendIPConfiguration": {
-                "id": "[variables('frontEndIPConfigID')]"
+                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', variables('loadBalancerName'), 'loadBalancerFrontEnd')]"
               },
               "protocol": "Tcp",
               "frontendPortRangeStart": "[variables('natStartPort')]",
@@ -151,24 +158,23 @@
             }
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+      ]
     },
     {
       "type": "Microsoft.Compute/virtualMachineScaleSets",
-      "name": "[variables('namingInfix')]",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "2017-03-30",
-      "dependsOn": [
-        "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-      ],
+      "apiVersion": "2021-03-01",
+      "name": "[parameters('vmssName')]",
+      "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('vmSku')]",
         "tier": "Standard",
         "capacity": "[parameters('instanceCount')]"
       },
       "properties": {
-        "overprovision": "true",
+        "overprovision": true,
         "upgradePolicy": {
           "mode": "Manual"
         },
@@ -196,16 +202,16 @@
                       "name": "[variables('ipConfigName')]",
                       "properties": {
                         "subnet": {
-                          "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'), '/subnets/', variables('subnetName'))]"
+                          "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnetName'))]"
                         },
                         "loadBalancerBackendAddressPools": [
                           {
-                            "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('loadBalancerName'), '/backendAddressPools/', variables('bePoolName'))]"
+                            "id": "[format('{0}/backendAddressPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('bePoolName'))]"
                           }
                         ],
                         "loadBalancerInboundNatPools": [
                           {
-                            "id": "[concat('/subscriptions/', subscription().subscriptionId,'/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('loadBalancerName'), '/inboundNatPools/', variables('natPoolName'))]"
+                            "id": "[format('{0}/inboundNatPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('natPoolName'))]"
                           }
                         ]
                       }
@@ -216,19 +222,20 @@
             ]
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+      ]
     },
     {
-      "type": "Microsoft.Insights/autoscaleSettings",
+      "type": "microsoft.insights/autoscalesettings",
       "apiVersion": "2015-04-01",
       "name": "cpuautoscale",
-      "location": "[resourceGroup().location]",
-      "dependsOn": [
-        "[concat('Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]"
-      ],
+      "location": "[parameters('location')]",
       "properties": {
         "name": "cpuautoscale",
-        "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]",
+        "targetResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
         "enabled": true,
         "profiles": [
           {
@@ -243,13 +250,13 @@
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
                   "metricNamespace": "",
-                  "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]",
+                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
                   "timeGrain": "PT1M",
-                  "statistic": "Average",
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "GreaterThan",
-                  "threshold": 50
+                  "threshold": 50,
+                  "statistic": "Average"
                 },
                 "scaleAction": {
                   "direction": "Increase",
@@ -262,13 +269,13 @@
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
                   "metricNamespace": "",
-                  "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]",
+                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
                   "timeGrain": "PT1M",
-                  "statistic": "Average",
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "LessThan",
-                  "threshold": 30
+                  "threshold": 30,
+                  "statistic": "Average"
                 },
                 "scaleAction": {
                   "direction": "Decrease",
@@ -280,7 +287,10 @@
             ]
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.compute/vmss-windows-autoscale
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11401