### PR TITLE
Migrate example: 301/servicebus-namespace-vnet

### DIFF
--- a/docs/examples/301/servicebus-namespace-vnet/README-MOVED.md
+++ b/docs/examples/301/servicebus-namespace-vnet/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.servicebus/servicebus-namespace-vnet.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/301/servicebus-namespace-vnet/main.bicep
+++ b/docs/examples/301/servicebus-namespace-vnet/main.bicep
@@ -1,6 +1,13 @@
+@description('Name of the Service Bus namespace')
 param serviceBusNamespaceName string
-param virtualNetworkName string
+
+@description('Name of the Virtual Network Rule')
+param vnetRuleName string
+
+@description('Name of the Virtual Network Sub Net')
 param subnetName string
+
+@description('Location for Namespace')
 param location string = resourceGroup().location
 
 resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
@@ -13,8 +20,8 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2018-01-01-preview
   properties: {}
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2017-09-01' = {
-  name: virtualNetworkName
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+  name: '{vnetRuleName}-vn'
   location: location
   properties: {
     addressSpace: {
@@ -22,25 +29,25 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2017-09-01' = {
         '10.0.0.0/23'
       ]
     }
-    subnets: [
+  }
+}
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-02-01' = {
+  name: subnetName
+  properties: {
+    addressPrefix: '10.0.0.0/23'
+    serviceEndpoints: [
       {
-        name: subnetName
-        properties: {
-          addressPrefix: '10.0.0.0/23'
-          serviceEndpoints: [
-            {
-              service: 'Microsoft.ServiceBus'
-            }
-          ]
-        }
+        service: 'Microsoft.ServiceBus'
       }
     ]
   }
 }
 
-resource namespaceVirtualNetworkRule 'Microsoft.ServiceBus/namespaces/VirtualNetworkRules@2018-01-01-preview' = {
-  name: '${serviceBusNamespace.name}/${virtualNetwork.name}'
+resource namespaceVirtualNetworkRule 'Microsoft.ServiceBus/namespaces/virtualnetworkrules@2018-01-01-preview' = {
+  parent: serviceBusNamespace
+  name: vnetRuleName
   properties: {
-    virtualNetworkSubnetId: resourceId('Microsoft.Network/virtualNetworks/subnets/', virtualNetwork.name, subnetName)
+    virtualNetworkSubnetId: subnet.id
   }
 }

--- a/docs/examples/301/servicebus-namespace-vnet/main.json
+++ b/docs/examples/301/servicebus-namespace-vnet/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "12364990647599381153"
+    }
+  },
   "parameters": {
     "serviceBusNamespaceName": {
       "type": "string",
@@ -28,58 +35,56 @@
       }
     }
   },
-  "variables": {
-    "namespaceVirtualNetworkRuleName": "[concat(parameters('serviceBusNamespaceName'), concat('/', parameters('vnetRuleName')))]"
-  },
+  "functions": [],
   "resources": [
     {
+      "type": "Microsoft.ServiceBus/namespaces",
       "apiVersion": "2018-01-01-preview",
       "name": "[parameters('serviceBusNamespaceName')]",
-      "type": "Microsoft.ServiceBus/namespaces",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Premium",
         "tier": "Premium"
       },
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "2020-07-01",
-      "name": "[parameters('vnetRuleName')]",
-      "location": "[parameters('location')]",
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2021-02-01",
+      "name": "{vnetRuleName}-vn",
+      "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
             "10.0.0.0/23"
           ]
-        },
-        "subnets": [
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2021-02-01",
+      "name": "[parameters('subnetName')]",
+      "properties": {
+        "addressPrefix": "10.0.0.0/23",
+        "serviceEndpoints": [
           {
-            "name": "[parameters('subnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.0.0/23",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.ServiceBus"
-                }
-              ]
-            }
+            "service": "Microsoft.ServiceBus"
           }
         ]
       }
     },
     {
+      "type": "Microsoft.ServiceBus/namespaces/virtualnetworkrules",
       "apiVersion": "2018-01-01-preview",
-      "name": "[variables('namespaceVirtualNetworkRuleName')]",
-      "type": "Microsoft.ServiceBus/namespaces/VirtualNetworkRules",
-      "dependsOn": [
-        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]"
-      ],
+      "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('vnetRuleName'))]",
       "properties": {
-        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('vnetRuleName'),  parameters('subnetName'))]"
-      }
+        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]"
+      ]
     }
-  ],
-  "outputs": { }
+  ]
 }

--- a/docs/examples/301/servicebus-namespace-vnet/main.json
+++ b/docs/examples/301/servicebus-namespace-vnet/main.json
@@ -1,46 +1,53 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "14889434749996442139"
-    }
-  },
   "parameters": {
     "serviceBusNamespaceName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Service Bus namespace"
+      }
     },
-    "virtualNetworkName": {
-      "type": "string"
+    "vnetRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Virtual Network Rule"
+      }
     },
     "subnetName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Virtual Network Sub Net"
+      }
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for Namespace"
+      }
     }
   },
-  "functions": [],
+  "variables": {
+    "namespaceVirtualNetworkRuleName": "[concat(parameters('serviceBusNamespaceName'), concat('/', parameters('vnetRuleName')))]"
+  },
   "resources": [
     {
-      "type": "Microsoft.ServiceBus/namespaces",
       "apiVersion": "2018-01-01-preview",
       "name": "[parameters('serviceBusNamespaceName')]",
+      "type": "Microsoft.ServiceBus/namespaces",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Premium",
         "tier": "Premium"
       },
-      "properties": {}
+      "properties": { }
     },
     {
-      "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2017-09-01",
-      "name": "[parameters('virtualNetworkName')]",
+      "apiVersion": "2020-07-01",
+      "name": "[parameters('vnetRuleName')]",
       "location": "[parameters('location')]",
+      "type": "Microsoft.Network/virtualNetworks",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -63,16 +70,16 @@
       }
     },
     {
-      "type": "Microsoft.ServiceBus/namespaces/virtualnetworkrules",
       "apiVersion": "2018-01-01-preview",
-      "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('virtualNetworkName'))]",
-      "properties": {
-        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('virtualNetworkName'), parameters('subnetName'))]"
-      },
+      "name": "[variables('namespaceVirtualNetworkRuleName')]",
+      "type": "Microsoft.ServiceBus/namespaces/VirtualNetworkRules",
       "dependsOn": [
-        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
-      ]
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]"
+      ],
+      "properties": {
+        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('vnetRuleName'),  parameters('subnetName'))]"
+      }
     }
-  ]
+  ],
+  "outputs": { }
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.servicebus/servicebus-namespace-vnet
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11404