### PR TITLE
Migrate example: 301/expressroute-circuit-vnet-connection

### DIFF
--- a/docs/examples/301/expressroute-circuit-vnet-connection/README-MOVED.md
+++ b/docs/examples/301/expressroute-circuit-vnet-connection/README-MOVED.md
@@ -1,0 +1,7 @@
+# Migration of examples
+
+The bicep examples are being integrated into the [Azure QuickStart Template repo](https://github.com/Azure/azure-quickstart-templates).
+
+This sample has been moved to https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.network/expressroute-circuit-vnet-connection.
+
+It will also remain here as reference for the time being.

--- a/docs/examples/301/expressroute-circuit-vnet-connection/main.bicep
+++ b/docs/examples/301/expressroute-circuit-vnet-connection/main.bicep
@@ -1,45 +1,85 @@
-param virtualNetworkName string = 'vnet-01'
-param virtualNetworkPrefix string
+@description('The type of gateway to deploy. For connecting to ExpressRoute circuits, the gateway must be of type ExpressRoute. Other types are Vpn.')
+@allowed([
+  'ExpressRoute'
+])
+param gatewayType string = 'ExpressRoute'
+
+@description('The type of connection. For connecting to ExpressRoute circuits, the connectionType must be of type ExpressRoute. Other types are IPsec and Vnet2Vnet.')
+@allowed([
+  'ExpressRoute'
+])
+param connectionType string = 'ExpressRoute'
+
+@description('The name of the virtual network to create.')
+param virtualNetworkName string
+
+@description('The address space in CIDR notation for the new virtual network.')
+param virtualNetworkAddressPrefix string
+
+@description('The name of the first subnet in the new virtual network.')
 param subnetName string
+
+@description('The address range in CIDR notation for the first subnet.')
 param subnetPrefix string
+
+@description('The address range in CIDR notation for the Gateway subnet. For ExpressRoute enabled Gateways, this must be minimum of /28.')
 param gatewaySubnetPrefix string
+
+@description('The resource name given to the public IP attached to the gateway.')
 param gatewayPublicIPName string
+
+@description('The resource name given to the ExpressRoute gateway.')
 param gatewayName string
+
+@description('The resource name given to the Connection which links VNet Gateway to ExpressRoute circuit.')
 param connectionName string
+
+@description('The name of the ExpressRoute circuit with which the VNet Gateway needs to connect. The Circuit must be already created successfully and must have its circuitProvisioningState property set to \'Enabled\', and serviceProviderProvisioningState property set to \'Provisioned\'. The Circuit must also have a BGP Peering of type AzurePrivatePeering.')
 param circuitName string
+
+@description('Location for all resources.')
 param location string = resourceGroup().location
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+// The name of the subnet where Gateway is to be deployed. This must always be named GatewaySubnet.
+var gatewaySubnetName = 'GatewaySubnet'
+
+var routingWeight = 3
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
   name: virtualNetworkName
   location: location
   properties: {
     addressSpace: {
       addressPrefixes: [
-        virtualNetworkPrefix
+        virtualNetworkAddressPrefix
       ]
     }
   }
 }
 resource subnet 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-  name: '${virtualNetwork.name}/${subnetName}'
+  parent: virtualNetwork
+  name: subnetName
   properties: {
     addressPrefix: subnetPrefix
   }
 }
 resource gatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-  name: '${virtualNetwork.name}/GatewaySubnet'
+  parent: virtualNetwork
+  name: gatewaySubnetName
   properties: {
     addressPrefix: gatewaySubnetPrefix
   }
 }
-resource publicIP 'Microsoft.Network/publicIPAddresses@2020-06-01' = {
+
+resource publicIP 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
   name: gatewayPublicIPName
   location: location
   properties: {
     publicIPAllocationMethod: 'Dynamic'
   }
 }
-resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2020-06-01' = {
+
+resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2021-02-01' = {
   name: gatewayName
   location: location
   properties: {
@@ -57,10 +97,11 @@ resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2020-06
         }
       }
     ]
-    gatewayType: 'ExpressRoute'
+    gatewayType: gatewayType
   }
 }
-resource connection 'Microsoft.Network/connections@2020-06-01' = {
+
+resource connection 'Microsoft.Network/connections@2021-02-01' = {
   name: connectionName
   location: location
   properties: {
@@ -71,7 +112,7 @@ resource connection 'Microsoft.Network/connections@2020-06-01' = {
     peer: {
       id: resourceId('Microsoft.Network/expressRouteCircuits', circuitName)
     }
-    connectionType: 'ExpressRoute'
-    routingWeight: 3
+    connectionType: connectionType
+    routingWeight: routingWeight
   }
 }

--- a/docs/examples/301/expressroute-circuit-vnet-connection/main.json
+++ b/docs/examples/301/expressroute-circuit-vnet-connection/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "15316273553753742049"
+    }
+  },
   "parameters": {
     "gatewayType": {
       "type": "string",
@@ -28,7 +35,7 @@
         "description": "The name of the virtual network to create."
       }
     },
-    "addressPrefix": {
+    "virtualNetworkAddressPrefix": {
       "type": "string",
       "metadata": {
         "description": "The address space in CIDR notation for the new virtual network."
@@ -38,16 +45,6 @@
       "type": "string",
       "metadata": {
         "description": "The name of the first subnet in the new virtual network."
-      }
-    },
-    "gatewaySubnet": {
-      "type": "string",
-      "defaultValue": "GatewaySubnet",
-      "allowedValues": [
-        "GatewaySubnet"
-      ],
-      "metadata": {
-        "description": "The name of the subnet where Gateway is to be deployed. This must always be named GatewaySubnet."
       }
     },
     "subnetPrefix": {
@@ -94,41 +91,50 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "gatewaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('virtualNetworkName'),parameters('gatewaySubnet'))]",
+    "gatewaySubnetName": "GatewaySubnet",
     "routingWeight": 3
   },
   "resources": [
     {
-      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('addressPrefix')]"
+            "[parameters('virtualNetworkAddressPrefix')]"
           ]
-        },
-        "subnets": [
-          {
-            "name": "[parameters('subnetName')]",
-            "properties": {
-              "addressPrefix": "[parameters('subnetPrefix')]"
-            }
-          },
-          {
-            "name": "[parameters('gatewaySubnet')]",
-            "properties": {
-              "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
-            }
-          }
-        ]
+        }
       }
     },
     {
-      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('subnetPrefix')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), variables('gatewaySubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
       "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('gatewayPublicIPName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -136,50 +142,51 @@
       }
     },
     {
-      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworkGateways",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('gatewayName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
-        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
-      ],
       "properties": {
         "ipConfigurations": [
           {
+            "name": "vnetGatewayConfig",
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[variables('gatewaySubnetRef')]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('gatewaySubnetName'))]"
               },
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]"
               }
-            },
-            "name": "vnetGatewayConfig"
+            }
           }
         ],
         "gatewayType": "[parameters('gatewayType')]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('gatewaySubnetName'))]",
+        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]"
+      ]
     },
     {
-      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/connections",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('connectionName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]"
-      ],
       "properties": {
         "virtualNetworkGateway1": {
-          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName'))]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]",
+          "properties": {}
         },
         "peer": {
-          "id": "[resourceId('Microsoft.Network/expressRouteCircuits',parameters('circuitName'))]"
+          "id": "[resourceId('Microsoft.Network/expressRouteCircuits', parameters('circuitName'))]"
         },
         "connectionType": "[parameters('connectionType')]",
         "routingWeight": "[variables('routingWeight')]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]"
+      ]
     }
   ]
 }

--- a/docs/examples/301/expressroute-circuit-vnet-connection/main.json
+++ b/docs/examples/301/expressroute-circuit-vnet-connection/main.json
@@ -1,87 +1,134 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "dev",
-      "templateHash": "3493822942554386929"
-    }
-  },
   "parameters": {
+    "gatewayType": {
+      "type": "string",
+      "defaultValue": "ExpressRoute",
+      "allowedValues": [
+        "ExpressRoute"
+      ],
+      "metadata": {
+        "description": "The type of gateway to deploy. For connecting to ExpressRoute circuits, the gateway must be of type ExpressRoute. Other types are Vpn."
+      }
+    },
+    "connectionType": {
+      "type": "string",
+      "defaultValue": "ExpressRoute",
+      "allowedValues": [
+        "ExpressRoute"
+      ],
+      "metadata": {
+        "description": "The type of connection. For connecting to ExpressRoute circuits, the connectionType must be of type ExpressRoute. Other types are IPsec and Vnet2Vnet."
+      }
+    },
     "virtualNetworkName": {
       "type": "string",
-      "defaultValue": "vnet-01"
+      "metadata": {
+        "description": "The name of the virtual network to create."
+      }
     },
-    "virtualNetworkPrefix": {
-      "type": "string"
+    "addressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The address space in CIDR notation for the new virtual network."
+      }
     },
     "subnetName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "The name of the first subnet in the new virtual network."
+      }
+    },
+    "gatewaySubnet": {
+      "type": "string",
+      "defaultValue": "GatewaySubnet",
+      "allowedValues": [
+        "GatewaySubnet"
+      ],
+      "metadata": {
+        "description": "The name of the subnet where Gateway is to be deployed. This must always be named GatewaySubnet."
+      }
     },
     "subnetPrefix": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "The address range in CIDR notation for the first subnet."
+      }
     },
     "gatewaySubnetPrefix": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "The address range in CIDR notation for the Gateway subnet. For ExpressRoute enabled Gateways, this must be minimum of /28."
+      }
     },
     "gatewayPublicIPName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "The resource name given to the public IP attached to the gateway."
+      }
     },
     "gatewayName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "The resource name given to the ExpressRoute gateway."
+      }
     },
     "connectionName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "The resource name given to the Connection which links VNet Gateway to ExpressRoute circuit."
+      }
     },
     "circuitName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "The name of the ExpressRoute circuit with which the VNet Gateway needs to connect. The Circuit must be already created successfully and must have its circuitProvisioningState property set to 'Enabled', and serviceProviderProvisioningState property set to 'Provisioned'. The Circuit must also have a BGP Peering of type AzurePrivatePeering."
+      }
     },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]"
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
     }
   },
-  "functions": [],
+  "variables": {
+    "gatewaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('virtualNetworkName'),parameters('gatewaySubnet'))]",
+    "routingWeight": 3
+  },
   "resources": [
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-06-01",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('virtualNetworkPrefix')]"
+            "[parameters('addressPrefix')]"
           ]
-        }
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetPrefix')]"
+            }
+          },
+          {
+            "name": "[parameters('gatewaySubnet')]",
+            "properties": {
+              "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
+            }
+          }
+        ]
       }
     },
     {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName'))]",
-      "properties": {
-        "addressPrefix": "[parameters('subnetPrefix')]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2020-06-01",
-      "name": "[format('{0}/GatewaySubnet', parameters('virtualNetworkName'))]",
-      "properties": {
-        "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
-      ]
-    },
-    {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2020-06-01",
       "name": "[parameters('gatewayPublicIPName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -89,51 +136,50 @@
       }
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworkGateways",
-      "apiVersion": "2020-06-01",
       "name": "[parameters('gatewayName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+      ],
       "properties": {
         "ipConfigurations": [
           {
-            "name": "vnetGatewayConfig",
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/GatewaySubnet', parameters('virtualNetworkName')), '/')[0], split(format('{0}/GatewaySubnet', parameters('virtualNetworkName')), '/')[1])]"
+                "id": "[variables('gatewaySubnetRef')]"
               },
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
               }
-            }
+            },
+            "name": "vnetGatewayConfig"
           }
         ],
-        "gatewayType": "ExpressRoute"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/GatewaySubnet', parameters('virtualNetworkName')), '/')[0], split(format('{0}/GatewaySubnet', parameters('virtualNetworkName')), '/')[1])]",
-        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]"
-      ]
+        "gatewayType": "[parameters('gatewayType')]"
+      }
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/connections",
-      "apiVersion": "2020-06-01",
       "name": "[parameters('connectionName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]"
+      ],
       "properties": {
         "virtualNetworkGateway1": {
-          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]",
-          "properties": {}
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName'))]"
         },
         "peer": {
-          "id": "[resourceId('Microsoft.Network/expressRouteCircuits', parameters('circuitName'))]"
+          "id": "[resourceId('Microsoft.Network/expressRouteCircuits',parameters('circuitName'))]"
         },
-        "connectionType": "ExpressRoute",
-        "routingWeight": 3
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]"
-      ]
+        "connectionType": "[parameters('connectionType')]",
+        "routingWeight": "[variables('routingWeight')]"
+      }
     }
   ]
 }


### PR DESCRIPTION
Updated bicep code.
Copied bicep.main to QuickStart sample in https://github.com/Azure/azure-quickstart-templatesquickstarts/microsoft.network/expressroute-circuit-vnet-connection
Added readme to indicate that this sample has now been moved (although it will remain here as well for the time being)

The corresponding PR for the modified quickstart is here: https://github.com/Azure/azure-quickstart-templates/pull/11407