### PR TITLE
Create child resource snippets

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/resourceObject.json
+++ b/src/Bicep.Core.Samples/Files/Completions/resourceObject.json
@@ -66,35 +66,5 @@
       "range": {},
       "newText": "if (${1:condition}) {\n\t$0\n}"
     }
-  },
-  {
-    "label": "{}",
-    "kind": "snippet",
-    "detail": "{}",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\n{\n\t\n}\n```"
-    },
-    "deprecated": false,
-    "preselect": true,
-    "sortText": "2_{}",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "{\n\t$0\n}"
-    },
-    "command": {
-      "command": "bicep.Telemetry",
-      "arguments": [
-        {
-          "Properties": {
-            "name": "{}",
-            "type": "error"
-          },
-          "EventName": "ResourceBodySnippetInsertion"
-        }
-      ]
-    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
@@ -106,7 +106,7 @@
       "command": "bicep.Telemetry",
       "arguments": [
         {
-          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "EventName": "NestedResourceDeclarationSnippetInsertion",
           "Properties": {
             "name": "resource-with-defaults"
           }
@@ -135,7 +135,7 @@
       "command": "bicep.Telemetry",
       "arguments": [
         {
-          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "EventName": "NestedResourceDeclarationSnippetInsertion",
           "Properties": {
             "name": "resource-without-defaults"
           }

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
@@ -86,7 +86,7 @@
     }
   },
   {
-    "label": "resource",
+    "label": "resource-with-defaults",
     "kind": "snippet",
     "detail": "Nested resource with defaults",
     "documentation": {
@@ -94,31 +94,53 @@
       "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
     },
     "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
+    "preselect": true,
+    "sortText": "2_resource-with-defaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "resource-with-defaults"
+          }
+        }
+      ]
     }
   },
   {
-    "label": "resource",
+    "label": "resource-without-defaults",
     "kind": "snippet",
     "detail": "Nested resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```"
     },
     "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
+    "preselect": true,
+    "sortText": "2_resource-without-defaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "resource-without-defaults"
+          }
+        }
+      ]
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
@@ -32,7 +32,7 @@
     }
   },
   {
-    "label": "resource",
+    "label": "resource-with-defaults",
     "kind": "snippet",
     "detail": "Nested resource with defaults",
     "documentation": {
@@ -40,31 +40,53 @@
       "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
     },
     "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
+    "preselect": true,
+    "sortText": "2_resource-with-defaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "resource-with-defaults"
+          }
+        }
+      ]
     }
   },
   {
-    "label": "resource",
+    "label": "resource-without-defaults",
     "kind": "snippet",
     "detail": "Nested resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```"
     },
     "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
+    "preselect": true,
+    "sortText": "2_resource-without-defaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "resource-without-defaults"
+          }
+        }
+      ]
     }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
@@ -52,7 +52,7 @@
       "command": "bicep.Telemetry",
       "arguments": [
         {
-          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "EventName": "NestedResourceDeclarationSnippetInsertion",
           "Properties": {
             "name": "resource-with-defaults"
           }
@@ -81,7 +81,7 @@
       "command": "bicep.Telemetry",
       "arguments": [
         {
-          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "EventName": "NestedResourceDeclarationSnippetInsertion",
           "Properties": {
             "name": "resource-without-defaults"
           }

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
@@ -140,7 +140,7 @@
     }
   },
   {
-    "label": "resource",
+    "label": "resource-with-defaults",
     "kind": "snippet",
     "detail": "Nested resource with defaults",
     "documentation": {
@@ -148,31 +148,53 @@
       "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
     },
     "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
+    "preselect": true,
+    "sortText": "2_resource-with-defaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "resource-with-defaults"
+          }
+        }
+      ]
     }
   },
   {
-    "label": "resource",
+    "label": "resource-without-defaults",
     "kind": "snippet",
     "detail": "Nested resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```"
     },
     "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
+    "preselect": true,
+    "sortText": "2_resource-without-defaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "resource-without-defaults"
+          }
+        }
+      ]
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
@@ -160,7 +160,7 @@
       "command": "bicep.Telemetry",
       "arguments": [
         {
-          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "EventName": "NestedResourceDeclarationSnippetInsertion",
           "Properties": {
             "name": "resource-with-defaults"
           }
@@ -189,7 +189,7 @@
       "command": "bicep.Telemetry",
       "arguments": [
         {
-          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "EventName": "NestedResourceDeclarationSnippetInsertion",
           "Properties": {
             "name": "resource-without-defaults"
           }

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
@@ -122,7 +122,7 @@
     }
   },
   {
-    "label": "resource",
+    "label": "resource-with-defaults",
     "kind": "snippet",
     "detail": "Nested resource with defaults",
     "documentation": {
@@ -130,31 +130,53 @@
       "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
     },
     "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
+    "preselect": true,
+    "sortText": "2_resource-with-defaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "resource-with-defaults"
+          }
+        }
+      ]
     }
   },
   {
-    "label": "resource",
+    "label": "resource-without-defaults",
     "kind": "snippet",
     "detail": "Nested resource without defaults",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
+      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n```"
     },
     "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
+    "preselect": true,
+    "sortText": "2_resource-without-defaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
+      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "resource-without-defaults"
+          }
+        }
+      ]
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
@@ -142,7 +142,7 @@
       "command": "bicep.Telemetry",
       "arguments": [
         {
-          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "EventName": "NestedResourceDeclarationSnippetInsertion",
           "Properties": {
             "name": "resource-with-defaults"
           }
@@ -171,7 +171,7 @@
       "command": "bicep.Telemetry",
       "arguments": [
         {
-          "EventName": "ChildResourceDeclarationSnippetInsertion",
+          "EventName": "NestedResourceDeclarationSnippetInsertion",
           "Properties": {
             "name": "resource-without-defaults"
           }

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -346,6 +346,76 @@ var test2 = /|* block c|omment *|/
         }
 
         [TestMethod]
+        public async Task VerifyNestedResourceBodyCompletionReturnsCustomSnippetWithoutParentInformation()
+        {
+            string fileWithCursors = @"resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
+  name: 'name'
+  location: resourceGroup().location
+
+  resource automationCredential 'credentials@2019-06-01' = |
+}";
+            var (file, cursors) = ParserHelper.GetFileWithCursors(fileWithCursors);
+            var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(TestContext, file, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
+            var completionLists = await RequestCompletions(client, syntaxTree, cursors);
+
+            completionLists.Count().Should().Be(1);
+
+            var snippetCompletion = completionLists.First()!.Items.Where(x => x.Kind == CompletionItemKind.Snippet && x.Label == "snippet");
+
+            snippetCompletion.Should().SatisfyRespectively(
+                c =>
+                {
+                    c.Label.Should().Be("snippet");
+                    c.Detail.Should().Be("Automation Credential");
+                    c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
+                    c.TextEdit?.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
+  name: ${3:'name'}
+  properties: {
+    userName: ${4:'userName'}
+    password: ${5:'password'}
+    description: ${6:'description'}
+  }
+}");
+                });
+        }
+
+        [TestMethod]
+        public async Task VerifyNestedResourceCompletionReturnsCustomSnippetWithoutParentInformation()
+        {
+            string fileWithCursors = @"resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
+  name: 'name'
+  location: resourceGroup().location
+
+  |
+}";
+            var (file, cursors) = ParserHelper.GetFileWithCursors(fileWithCursors);
+            var syntaxTree = SyntaxTree.Create(new Uri("file:///path/to/main.bicep"), file);
+            var client = await IntegrationTestHelper.StartServerWithTextAsync(TestContext, file, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
+            var completionLists = await RequestCompletions(client, syntaxTree, cursors);
+
+            completionLists.Count().Should().Be(1);
+
+            var snippetCompletion = completionLists.First()!.Items.Where(x => x.Kind == CompletionItemKind.Snippet && x.Label == "res-automation-cred");
+
+            snippetCompletion.Should().SatisfyRespectively(
+                c =>
+                {
+                    c.Label.Should().Be("res-automation-cred");
+                    c.Detail.Should().Be("Automation Credential");
+                    c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
+                    c.TextEdit?.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"resource ${2:automationCredential} 'credentials@2019-06-01' = {
+  name: ${3:'name'}
+  properties: {
+    userName: ${4:'userName'}
+    password: ${5:'password'}
+    description: ${6:'description'}
+  }
+}");
+                });
+        }
+
+        [TestMethod]
         public async Task VerifyResourceBodyCompletionWithoutExistingKeywordIncludesCustomSnippet()
         {
             string text = @"resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = ";

--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -44,7 +44,7 @@ namespace Bicep.LangServer.IntegrationTests
         }
 
         [TestMethod]
-        public async Task VerifyChildResourceDeclarationSnippetInsertionFiresTelemetryEvent()
+        public async Task VerifyNestedResourceDeclarationSnippetInsertionFiresTelemetryEvent()
         {
             string text = @"resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
   name: 'name'

--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -58,7 +58,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             BicepTelemetryEvent bicepTelemetryEvent = await ResolveCompletionAsync(text, "res-automation-cert", new Position(3, 0));
 
-            bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.ChildResourceDeclarationSnippetInsertion);
+            bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.NestedResourceDeclarationSnippetInsertion);
             bicepTelemetryEvent.Properties.Should().Equal(properties);
         }
 

--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -43,6 +43,25 @@ namespace Bicep.LangServer.IntegrationTests
             bicepTelemetryEvent.Properties.Should().Equal(properties);
         }
 
+        [TestMethod]
+        public async Task VerifyChildResourceDeclarationSnippetInsertionFiresTelemetryEvent()
+        {
+            string text = @"resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
+  name: 'name'
+  location: resourceGroup().location
+
+}";
+            IDictionary<string, string> properties = new Dictionary<string, string>
+            {
+                { "name", "res-automation-cert" }
+            };
+
+            BicepTelemetryEvent bicepTelemetryEvent = await ResolveCompletionAsync(text, "res-automation-cert", new Position(3, 0));
+
+            bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.ChildResourceDeclarationSnippetInsertion);
+            bicepTelemetryEvent.Properties.Should().Equal(properties);
+        }
+
         [DataRow("required-properties")]
         [DataRow("snippet")]
         [DataRow("{}")]

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -447,7 +447,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     ResourceScope.ResourceGroup,
                     discriminatedObjectType);
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -487,7 +487,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     ResourceScope.ResourceGroup,
                     discriminatedObjectType);
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -144,7 +144,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
                     ("name", LanguageConstants.String, TypePropertyFlags.Required),
                     ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -192,7 +192,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
            ("name", LanguageConstants.String, TypePropertyFlags.Required),
            ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -255,7 +255,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                    ("name", LanguageConstants.String, TypePropertyFlags.Required)),
                    TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -294,7 +294,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
            ResourceScope.ResourceGroup,
            CreateObjectType("microsoft.aadiam/azureADMetrics@2020-07-01-preview"));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -330,7 +330,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     ResourceScope.ResourceGroup,
                     discriminatedObjectType);
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -370,7 +370,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     ResourceScope.ResourceGroup,
                     discriminatedObjectType);
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
 
             snippets.Should().SatisfyRespectively(
                 x =>

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -359,12 +359,9 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         public void GetNestedResourceDeclarationSnippets_WithChildResources_ShouldReturnCustomAndDefaultResourceSnippets()
         {
             SnippetsProvider snippetsProvider = new SnippetsProvider();
-            TypeSymbol typeSymbol = new ResourceType(
-                    ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts@2019-06-01"),
-                    ResourceScope.ResourceGroup,
-                    CreateObjectType("Microsoft.Automation/automationAccounts@2019-06-01"));
+            ResourceTypeReference resourceTypeReference = ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts@2019-06-01");
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetNestedResourceDeclarationSnippets(typeSymbol);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetNestedResourceDeclarationSnippets(resourceTypeReference);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -405,12 +402,9 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         public void GetNestedResourceDeclarationSnippets_WithNoChildResources_ShouldReturnDefaultResourceSnippets()
         {
             SnippetsProvider snippetsProvider = new SnippetsProvider();
-            TypeSymbol typeSymbol = new ResourceType(
-                    ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/runbooks@2019-06-01"),
-                    ResourceScope.ResourceGroup,
-                    CreateObjectType("Microsoft.Automation/automationAccounts/runbooks@2019-06-01"));
+            ResourceTypeReference resourceTypeReference = ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/runbooks@2019-06-01");
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetNestedResourceDeclarationSnippets(typeSymbol);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetNestedResourceDeclarationSnippets(resourceTypeReference);
 
             snippets.Should().SatisfyRespectively(
                 x =>

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -144,7 +144,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
                     ("name", LanguageConstants.String, TypePropertyFlags.Required),
                     ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -192,7 +192,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
            ("name", LanguageConstants.String, TypePropertyFlags.Required),
            ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -235,7 +235,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         }
 
         [TestMethod]
-        public void GetResourceBodyCompletionSnippets_WithStaticTemplateAndNested_ShouldReturnSnippets()
+        public void GetResourceBodyCompletionSnippets_WithNestedResource_ShouldReturnSnippets()
         {
             SnippetsProvider snippetsProvider = new SnippetsProvider();
             TypeSymbol typeSymbol = new ResourceType(
@@ -245,7 +245,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     ("name", LanguageConstants.String, TypePropertyFlags.Required),
                     ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, true);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: true);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -304,7 +304,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                    ("name", LanguageConstants.String, TypePropertyFlags.Required)),
                    TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -343,7 +343,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
            ResourceScope.ResourceGroup,
            CreateObjectType("microsoft.aadiam/azureADMetrics@2020-07-01-preview"));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -356,7 +356,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         }
 
         [TestMethod]
-        public void GetChildResourceDeclarationSnippets_WithChildResources_ShouldReturnCustomAndDefaultResourceSnippets()
+        public void GetNestedResourceDeclarationSnippets_WithChildResources_ShouldReturnCustomAndDefaultResourceSnippets()
         {
             SnippetsProvider snippetsProvider = new SnippetsProvider();
             TypeSymbol typeSymbol = new ResourceType(
@@ -402,7 +402,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         }
 
         [TestMethod]
-        public void GetChildResourceDeclarationSnippets_WithNoChildResources_ShouldReturnDefaultResourceSnippets()
+        public void GetNestedResourceDeclarationSnippets_WithNoChildResources_ShouldReturnDefaultResourceSnippets()
         {
             SnippetsProvider snippetsProvider = new SnippetsProvider();
             TypeSymbol typeSymbol = new ResourceType(

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -144,7 +144,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
                     ("name", LanguageConstants.String, TypePropertyFlags.Required),
                     ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -192,7 +192,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
            ("name", LanguageConstants.String, TypePropertyFlags.Required),
            ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -238,14 +238,14 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         public void GetResourceBodyCompletionSnippets_WithNestedResource_ShouldReturnSnippets()
         {
             SnippetsProvider snippetsProvider = new SnippetsProvider();
-            TypeSymbol typeSymbol = new ResourceType(
-                    ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/certificates@2019-06-01"),
-                    ResourceScope.ResourceGroup,
-                    CreateObjectType("Microsoft.Automation/automationAccounts/certificates@2019-06-01",
-                    ("name", LanguageConstants.String, TypePropertyFlags.Required),
-                    ("location", LanguageConstants.String, TypePropertyFlags.Required)));
+            ResourceType resourceType = new ResourceType(
+                ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/certificates@2019-06-01"),
+                ResourceScope.ResourceGroup,
+                CreateObjectType("Microsoft.Automation/automationAccounts/certificates@2019-06-01",
+                ("name", LanguageConstants.String, TypePropertyFlags.Required),
+                ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: true);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: true);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -304,7 +304,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                    ("name", LanguageConstants.String, TypePropertyFlags.Required)),
                    TypePropertyFlags.Required)));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -343,7 +343,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
            ResourceScope.ResourceGroup,
            CreateObjectType("microsoft.aadiam/azureADMetrics@2020-07-01-preview"));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -436,12 +436,12 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
 
             var discriminatedObjectType = new DiscriminatedObjectType("discObj", TypeSymbolValidationFlags.Default, "discKey", new[] { objectTypeA, objectTypeB });
 
-            TypeSymbol typeSymbol = new ResourceType(
-                    ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
-                    ResourceScope.ResourceGroup,
-                    discriminatedObjectType);
+            ResourceType resourceType = new ResourceType(
+                ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
+                ResourceScope.ResourceGroup,
+                discriminatedObjectType);
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -476,12 +476,12 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
 
             var discriminatedObjectType = new DiscriminatedObjectType("discObj", TypeSymbolValidationFlags.Default, "discKey", new[] { objectTypeA, objectTypeB });
 
-            TypeSymbol typeSymbol = new ResourceType(
-                    ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
-                    ResourceScope.ResourceGroup,
-                    discriminatedObjectType);
+            ResourceType resourceType = new ResourceType(
+                ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
+                ResourceScope.ResourceGroup,
+                discriminatedObjectType);
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, isExistingResource: false, isResourceNested: false);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
             snippets.Should().SatisfyRespectively(
                 x =>

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -235,6 +235,55 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         }
 
         [TestMethod]
+        public void GetResourceBodyCompletionSnippets_WithStaticTemplateAndNested_ShouldReturnSnippets()
+        {
+            SnippetsProvider snippetsProvider = new SnippetsProvider();
+            TypeSymbol typeSymbol = new ResourceType(
+                    ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/certificates@2019-06-01"),
+                    ResourceScope.ResourceGroup,
+                    CreateObjectType("Microsoft.Automation/automationAccounts/certificates@2019-06-01",
+                    ("name", LanguageConstants.String, TypePropertyFlags.Required),
+                    ("location", LanguageConstants.String, TypePropertyFlags.Required)));
+
+            IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, false, true);
+
+            snippets.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Prefix.Should().Be("{}");
+                    x.Detail.Should().Be("{}");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().Be("{\n\t$0\n}");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("snippet");
+                    x.Detail.Should().Be("Automation Certificate");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().BeEquivalentToIgnoringNewlines(@"{
+  name: ${3:'name'}
+  properties: {
+    base64Value: ${4:'base64Value'}
+    description: ${5:'description'}
+    thumbprint: ${6:'thumbprint'}
+    isExportable: ${7|true,false|}
+  }
+}");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("required-properties");
+                    x.Detail.Should().Be("Required properties");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().BeEquivalentToIgnoringNewlines(@"{
+	name: $1
+	location: $2
+	$0
+}");
+                });
+        }
+
+        [TestMethod]
         public void GetResourceBodyCompletionSnippets_WithNoStaticTemplate_ShouldReturnSnippets()
         {
             TypeSymbol typeSymbol = new ResourceType(
@@ -303,6 +352,74 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     x.Detail.Should().Be("{}");
                     x.CompletionPriority.Should().Be(CompletionPriority.Medium);
                     x.Text.Should().Be("{\n\t$0\n}");
+                });
+        }
+
+        [TestMethod]
+        public void GetChildResourceDeclarationSnippets_WithChildResources_ShouldReturnCustomAndDefaultResourceSnippets()
+        {
+            SnippetsProvider snippetsProvider = new SnippetsProvider();
+            TypeSymbol typeSymbol = new ResourceType(
+                    ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts@2019-06-01"),
+                    ResourceScope.ResourceGroup,
+                    CreateObjectType("Microsoft.Automation/automationAccounts@2019-06-01"));
+
+            IEnumerable<Snippet> snippets = snippetsProvider.GetChildResourceDeclarationSnippets(typeSymbol);
+
+            snippets.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Prefix.Should().Be("resource-with-defaults");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("resource-without-defaults");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("res-automation-cert");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("res-automation-cred");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("res-automation-job-schedule");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("res-automation-runbook");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("res-automation-schedule");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("res-automation-variable");
+                });
+        }
+
+        [TestMethod]
+        public void GetChildResourceDeclarationSnippets_WithNoChildResources_ShouldReturnDefaultResourceSnippets()
+        {
+            SnippetsProvider snippetsProvider = new SnippetsProvider();
+            TypeSymbol typeSymbol = new ResourceType(
+                    ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/runbooks@2019-06-01"),
+                    ResourceScope.ResourceGroup,
+                    CreateObjectType("Microsoft.Automation/automationAccounts/runbooks@2019-06-01"));
+
+            IEnumerable<Snippet> snippets = snippetsProvider.GetChildResourceDeclarationSnippets(typeSymbol);
+
+            snippets.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Prefix.Should().Be("resource-with-defaults");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("resource-without-defaults");
                 });
         }
 

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -364,7 +364,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     ResourceScope.ResourceGroup,
                     CreateObjectType("Microsoft.Automation/automationAccounts@2019-06-01"));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetChildResourceDeclarationSnippets(typeSymbol);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetNestedResourceDeclarationSnippets(typeSymbol);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -410,7 +410,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     ResourceScope.ResourceGroup,
                     CreateObjectType("Microsoft.Automation/automationAccounts/runbooks@2019-06-01"));
 
-            IEnumerable<Snippet> snippets = snippetsProvider.GetChildResourceDeclarationSnippets(typeSymbol);
+            IEnumerable<Snippet> snippets = snippetsProvider.GetNestedResourceDeclarationSnippets(typeSymbol);
 
             snippets.Should().SatisfyRespectively(
                 x =>

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -137,12 +137,12 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
         [TestMethod]
         public void GetResourceBodyCompletionSnippets_WithStaticTemplateAndNoResourceDependencies_ShouldReturnSnippets()
         {
-            TypeSymbol typeSymbol = new ResourceType(
-                    ResourceTypeReference.Parse("Microsoft.DataLakeStore/accounts@2016-11-01"),
-                    ResourceScope.ResourceGroup,
-                    CreateObjectType("Microsoft.DataLakeStore/accounts@2016-11-01",
-                    ("name", LanguageConstants.String, TypePropertyFlags.Required),
-                    ("location", LanguageConstants.String, TypePropertyFlags.Required)));
+            ResourceType resourceType = new ResourceType(
+                ResourceTypeReference.Parse("Microsoft.DataLakeStore/accounts@2016-11-01"),
+                ResourceScope.ResourceGroup,
+                CreateObjectType("Microsoft.DataLakeStore/accounts@2016-11-01",
+                ("name", LanguageConstants.String, TypePropertyFlags.Required),
+                ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
             IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
@@ -185,12 +185,12 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
         [TestMethod]
         public void GetResourceBodyCompletionSnippets_WithStaticTemplateAndResourceDependencies_ShouldReturnSnippets()
         {
-            TypeSymbol typeSymbol = new ResourceType(
-           ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/modules@2015-10-31"),
-           ResourceScope.ResourceGroup,
-           CreateObjectType("Microsoft.Automation/automationAccounts/modules@2015-10-31",
-           ("name", LanguageConstants.String, TypePropertyFlags.Required),
-           ("location", LanguageConstants.String, TypePropertyFlags.Required)));
+            ResourceType resourceType = new ResourceType(
+                ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/modules@2015-10-31"),
+                ResourceScope.ResourceGroup,
+                CreateObjectType("Microsoft.Automation/automationAccounts/modules@2015-10-31",
+                ("name", LanguageConstants.String, TypePropertyFlags.Required),
+                ("location", LanguageConstants.String, TypePropertyFlags.Required)));
 
             IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
@@ -237,7 +237,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         [TestMethod]
         public void GetResourceBodyCompletionSnippets_WithNestedResource_ShouldReturnSnippets()
         {
-            SnippetsProvider snippetsProvider = new SnippetsProvider();
+            SnippetsProvider snippetsProvider = new SnippetsProvider(BicepTestConstants.FileResolver);
             ResourceType resourceType = new ResourceType(
                 ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/certificates@2019-06-01"),
                 ResourceScope.ResourceGroup,
@@ -286,23 +286,23 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         [TestMethod]
         public void GetResourceBodyCompletionSnippets_WithNoStaticTemplate_ShouldReturnSnippets()
         {
-            TypeSymbol typeSymbol = new ResourceType(
-           ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
-           ResourceScope.ResourceGroup,
-           CreateObjectType("microsoft.aadiam/azureADMetrics@2020-07-01-preview",
-           ("name", LanguageConstants.String, TypePropertyFlags.Required),
-           ("location", LanguageConstants.String, TypePropertyFlags.Required),
-           ("kind", LanguageConstants.String, TypePropertyFlags.Required),
-           ("id", LanguageConstants.String, TypePropertyFlags.ReadOnly),
-           ("hostPoolType", LanguageConstants.String, TypePropertyFlags.Required),
-           ("sku", CreateObjectType("applicationGroup",
-                   ("friendlyName", LanguageConstants.String, TypePropertyFlags.None),
-                   ("properties", CreateObjectType("properties",
-                                  ("loadBalancerType", LanguageConstants.String, TypePropertyFlags.Required),
-                                  ("preferredAppGroupType", LanguageConstants.String, TypePropertyFlags.WriteOnly)),
-                                  TypePropertyFlags.Required),
-                   ("name", LanguageConstants.String, TypePropertyFlags.Required)),
-                   TypePropertyFlags.Required)));
+            ResourceType resourceType = new ResourceType(
+                ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
+                ResourceScope.ResourceGroup,
+                CreateObjectType("microsoft.aadiam/azureADMetrics@2020-07-01-preview",
+                ("name", LanguageConstants.String, TypePropertyFlags.Required),
+                ("location", LanguageConstants.String, TypePropertyFlags.Required),
+                ("kind", LanguageConstants.String, TypePropertyFlags.Required),
+                ("id", LanguageConstants.String, TypePropertyFlags.ReadOnly),
+                ("hostPoolType", LanguageConstants.String, TypePropertyFlags.Required),
+                ("sku", CreateObjectType("applicationGroup",
+                        ("friendlyName", LanguageConstants.String, TypePropertyFlags.None),
+                        ("properties", CreateObjectType("properties",
+                                       ("loadBalancerType", LanguageConstants.String, TypePropertyFlags.Required),
+                                       ("preferredAppGroupType", LanguageConstants.String, TypePropertyFlags.WriteOnly)),
+                                           TypePropertyFlags.Required),
+                        ("name", LanguageConstants.String, TypePropertyFlags.Required)),
+                        TypePropertyFlags.Required)));
 
             IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
@@ -338,10 +338,10 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         [TestMethod]
         public void GetResourceBodyCompletionSnippets_WithNoRequiredProperties_ShouldReturnEmptySnippet()
         {
-            TypeSymbol typeSymbol = new ResourceType(
-           ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
-           ResourceScope.ResourceGroup,
-           CreateObjectType("microsoft.aadiam/azureADMetrics@2020-07-01-preview"));
+            ResourceType resourceType = new ResourceType(
+                ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
+                ResourceScope.ResourceGroup,
+                CreateObjectType("microsoft.aadiam/azureADMetrics@2020-07-01-preview"));
 
             IEnumerable<Snippet> snippets = snippetsProvider.GetResourceBodyCompletionSnippets(resourceType, isExistingResource: false, isResourceNested: false);
 
@@ -358,7 +358,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         [TestMethod]
         public void GetNestedResourceDeclarationSnippets_WithChildResources_ShouldReturnCustomAndDefaultResourceSnippets()
         {
-            SnippetsProvider snippetsProvider = new SnippetsProvider();
+            SnippetsProvider snippetsProvider = new SnippetsProvider(BicepTestConstants.FileResolver);
             ResourceTypeReference resourceTypeReference = ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts@2019-06-01");
 
             IEnumerable<Snippet> snippets = snippetsProvider.GetNestedResourceDeclarationSnippets(resourceTypeReference);
@@ -401,7 +401,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         [TestMethod]
         public void GetNestedResourceDeclarationSnippets_WithNoChildResources_ShouldReturnDefaultResourceSnippets()
         {
-            SnippetsProvider snippetsProvider = new SnippetsProvider();
+            SnippetsProvider snippetsProvider = new SnippetsProvider(BicepTestConstants.FileResolver);
             ResourceTypeReference resourceTypeReference = ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/runbooks@2019-06-01");
 
             IEnumerable<Snippet> snippets = snippetsProvider.GetNestedResourceDeclarationSnippets(resourceTypeReference);

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -103,21 +103,23 @@ namespace Bicep.LanguageServer.Completions
             {
                 yield return CreateKeywordCompletion(LanguageConstants.ResourceKeyword, "Resource keyword", context.ReplacementRange);
 
-                TypeSymbol typeSymbol = model.GetTypeInfo(resourceDeclarationSyntax);
-
-                foreach (Snippet snippet in SnippetsProvider.GetNestedResourceDeclarationSnippets(typeSymbol))
+                if (model.GetSymbolInfo(resourceDeclarationSyntax) is ResourceSymbol parentSymbol &&
+                    parentSymbol.TryGetResourceTypeReference() is ResourceTypeReference parentTypeReference)
                 {
-                    string prefix = snippet.Prefix;
-                    BicepTelemetryEvent telemetryEvent = BicepTelemetryEvent.CreateNestedResourceDeclarationSnippetInsertion(prefix);
-                    Command command = Command.Create(TelemetryConstants.CommandName, telemetryEvent);
+                    foreach (Snippet snippet in SnippetsProvider.GetNestedResourceDeclarationSnippets(parentTypeReference))
+                    {
+                        string prefix = snippet.Prefix;
+                        BicepTelemetryEvent telemetryEvent = BicepTelemetryEvent.CreateNestedResourceDeclarationSnippetInsertion(prefix);
+                        Command command = Command.Create(TelemetryConstants.CommandName, telemetryEvent);
 
-                    yield return CreateContextualSnippetCompletion(prefix,
-                        snippet.Detail,
-                        snippet.Text,
-                        context.ReplacementRange,
-                        command,
-                        snippet.CompletionPriority,
-                        preselect: true);
+                        yield return CreateContextualSnippetCompletion(prefix,
+                            snippet.Detail,
+                            snippet.Text,
+                            context.ReplacementRange,
+                            command,
+                            snippet.CompletionPriority,
+                            preselect: true);
+                    }
                 }
             }
         }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Azure.Deployments.Core.Comparers;
@@ -19,6 +20,7 @@ using Bicep.LanguageServer.Extensions;
 using Bicep.LanguageServer.Snippets;
 using Bicep.LanguageServer.Telemetry;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using static Bicep.Core.Semantics.ResourceAncestorGraph;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 using SymbolKind = Bicep.Core.Semantics.SymbolKind;
 
@@ -405,8 +407,11 @@ namespace Bicep.LanguageServer.Completions
         {
             if (context.EnclosingDeclaration is ResourceDeclarationSyntax resourceDeclarationSyntax)
             {
+                bool isResourceNested = model.GetSymbolInfo(resourceDeclarationSyntax) is ResourceSymbol resourceSymbol &&
+                                        model.ResourceAncestors.GetAncestors(resourceSymbol).Any(x => x.AncestorType == ResourceAncestorType.Nested);
+
                 TypeSymbol typeSymbol = model.GetTypeInfo(resourceDeclarationSyntax);
-                IEnumerable<Snippet> snippets = SnippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, resourceDeclarationSyntax.IsExistingResource());
+                IEnumerable<Snippet> snippets = SnippetsProvider.GetResourceBodyCompletionSnippets(typeSymbol, resourceDeclarationSyntax.IsExistingResource(), isResourceNested);
 
                 foreach (Snippet snippet in snippets)
                 {

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Azure.Deployments.Core.Comparers;
@@ -108,10 +107,10 @@ namespace Bicep.LanguageServer.Completions
                 {
                     TypeSymbol typeSymbol = model.GetTypeInfo(resourceDeclarationSyntax);
 
-                    foreach (Snippet snippet in SnippetsProvider.GeNestedChildResourceSnippets(typeSymbol))
+                    foreach (Snippet snippet in SnippetsProvider.GetChildResourceDeclarationSnippets(typeSymbol))
                     {
                         string prefix = snippet.Prefix;
-                        BicepTelemetryEvent telemetryEvent = BicepTelemetryEvent.CreateResourceBodySnippetInsertion(prefix, typeSymbol.Name);
+                        BicepTelemetryEvent telemetryEvent = BicepTelemetryEvent.CreateChildResourceDeclarationSnippetInsertion(prefix);
                         Command command = Command.Create(TelemetryConstants.CommandName, telemetryEvent);
 
                         yield return CreateContextualSnippetCompletion(prefix,

--- a/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
@@ -8,7 +8,7 @@ namespace Bicep.LanguageServer.Snippets
 {
     public interface ISnippetsProvider
     {
-        IEnumerable<Snippet> GetChildResourceDeclarationSnippets(TypeSymbol typeSymbol);
+        IEnumerable<Snippet> GetNestedResourceDeclarationSnippets(TypeSymbol typeSymbol);
 
         IEnumerable<Snippet> GetTopLevelNamedDeclarationSnippets();
 

--- a/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
@@ -8,6 +8,8 @@ namespace Bicep.LanguageServer.Snippets
 {
     public interface ISnippetsProvider
     {
+        IEnumerable<Snippet> GeNestedChildResourceSnippets(TypeSymbol typeSymbol);
+
         IEnumerable<Snippet> GetTopLevelNamedDeclarationSnippets();
 
         IEnumerable<Snippet> GetModuleBodyCompletionSnippets(TypeSymbol typeSymbol);

--- a/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
@@ -8,7 +8,7 @@ namespace Bicep.LanguageServer.Snippets
 {
     public interface ISnippetsProvider
     {
-        IEnumerable<Snippet> GeNestedChildResourceSnippets(TypeSymbol typeSymbol);
+        IEnumerable<Snippet> GetChildResourceDeclarationSnippets(TypeSymbol typeSymbol);
 
         IEnumerable<Snippet> GetTopLevelNamedDeclarationSnippets();
 

--- a/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Resources;
 using Bicep.Core.TypeSystem;
 using System.Collections.Generic;
 
@@ -8,7 +9,7 @@ namespace Bicep.LanguageServer.Snippets
 {
     public interface ISnippetsProvider
     {
-        IEnumerable<Snippet> GetNestedResourceDeclarationSnippets(TypeSymbol typeSymbol);
+        IEnumerable<Snippet> GetNestedResourceDeclarationSnippets(ResourceTypeReference resourceTypeReference);
 
         IEnumerable<Snippet> GetTopLevelNamedDeclarationSnippets();
 

--- a/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
@@ -16,6 +16,6 @@ namespace Bicep.LanguageServer.Snippets
 
         IEnumerable<Snippet> GetObjectBodyCompletionSnippets(TypeSymbol typeSymbol);
 
-        IEnumerable<Snippet> GetResourceBodyCompletionSnippets(TypeSymbol typeSymbol, bool isExistingResource);
+        IEnumerable<Snippet> GetResourceBodyCompletionSnippets(TypeSymbol typeSymbol, bool isExistingResource, bool isResourceNested);
     }
 }

--- a/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
@@ -17,6 +17,6 @@ namespace Bicep.LanguageServer.Snippets
 
         IEnumerable<Snippet> GetObjectBodyCompletionSnippets(TypeSymbol typeSymbol);
 
-        IEnumerable<Snippet> GetResourceBodyCompletionSnippets(TypeSymbol typeSymbol, bool isExistingResource, bool isResourceNested);
+        IEnumerable<Snippet> GetResourceBodyCompletionSnippets(ResourceType resourceType, bool isExistingResource, bool isResourceNested);
     }
 }

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -32,7 +32,7 @@ namespace Bicep.LanguageServer.Snippets
         // Used to cache resource declaration information. Maps resource type to prefix, identifier, body text and description
         private readonly ConcurrentDictionary<string, (string prefix, string identifier, string bodyText, string description)> resourceTypeInfoMap = new();
         // Used to cache resource dependencies. Maps resource type to it's dependencies
-        private readonly ConcurrentDictionary<string, string> nestedResourceTypeToDependentsMap = new();
+        private readonly ConcurrentDictionary<string, string> resourceTypeToDependentsMap = new();
         // Used to cache information about child type symbols in nested resource scenario. Maps resource type to nested type symbols
         private readonly ConcurrentDictionary<string, List<TypeSymbol>> resourceTypeToChildTypeSymbolsMap = new();
         // Used to cache resource body snippets
@@ -189,7 +189,7 @@ namespace Bicep.LanguageServer.Snippets
                     sb.AppendLine(template.Substring(span.Position, span.Length));
                 }
 
-                nestedResourceTypeToDependentsMap.TryAdd(childTypeSymbol.Name, sb.ToString());
+                resourceTypeToDependentsMap.TryAdd(childTypeSymbol.Name, sb.ToString());
             }
         }
 
@@ -284,7 +284,7 @@ namespace Bicep.LanguageServer.Snippets
             {
                 sb.AppendLine(resourceBodyWithDescription.text);
 
-                if (nestedResourceTypeToDependentsMap.TryGetValue(type, out string? resourceDependencies))
+                if (resourceTypeToDependentsMap.TryGetValue(type, out string? resourceDependencies))
                 {
                     sb.Append(resourceDependencies);
                 }
@@ -487,7 +487,7 @@ namespace Bicep.LanguageServer.Snippets
         }
 
         // Nested resources must specify a single type segment, and optionally can specify an api version using the format "<type>@<apiVersion>"
-        // So we'll remove types that exist in parent and return single type with api version 
+        // We'll remove types that exist in parent and return single type with api version 
         private IEnumerable<string> GetNestedResourceTypes(string parentType, TypeSymbol nestedTypeSymbol)
         {
             if (nestedTypeSymbol is ResourceType resourceType)

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -25,8 +25,6 @@ namespace Bicep.LanguageServer.Snippets
 {
     public class SnippetsProvider : ISnippetsProvider
     {
-        private static readonly Regex PlaceholderPattern = new Regex(@"\$({(?<index>\d+):(?<name>[^}]+)}|(?<index>\d+)|{(?<index>\d+)\|((?<name>[^,]+)(.*))\|})", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-
         private const string RequiredPropertiesDescription = "Required properties";
         private const string RequiredPropertiesLabel = "required-properties";
 
@@ -466,7 +464,7 @@ namespace Bicep.LanguageServer.Snippets
             }
         }
 
-        public IEnumerable<Snippet> GeNestedChildResourceSnippets(TypeSymbol typeSymbol)
+        public IEnumerable<Snippet> GetChildResourceDeclarationSnippets(TypeSymbol typeSymbol)
         {
             // leaving out the API version on this, because we expect its more common to inherit from the containing resource.
             yield return new Snippet(@"resource ${1:Identifier} '${2:Type}' = {

--- a/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
+++ b/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
@@ -22,6 +22,16 @@ namespace Bicep.LanguageServer.Telemetry
                 },
             };
 
+        public static BicepTelemetryEvent CreateChildResourceDeclarationSnippetInsertion(string name)
+            => new BicepTelemetryEvent
+            {
+                EventName = TelemetryConstants.EventNames.ChildResourceDeclarationSnippetInsertion,
+                Properties = new()
+                {
+                    ["name"] = name,
+                },
+            };
+
         public static BicepTelemetryEvent CreateResourceBodySnippetInsertion(string name, string type)
             => new BicepTelemetryEvent
             {

--- a/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
+++ b/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
@@ -22,10 +22,10 @@ namespace Bicep.LanguageServer.Telemetry
                 },
             };
 
-        public static BicepTelemetryEvent CreateChildResourceDeclarationSnippetInsertion(string name)
+        public static BicepTelemetryEvent CreateNestedResourceDeclarationSnippetInsertion(string name)
             => new BicepTelemetryEvent
             {
-                EventName = TelemetryConstants.EventNames.ChildResourceDeclarationSnippetInsertion,
+                EventName = TelemetryConstants.EventNames.NestedResourceDeclarationSnippetInsertion,
                 Properties = new()
                 {
                     ["name"] = name,

--- a/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
+++ b/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
@@ -9,6 +9,7 @@ namespace Bicep.LanguageServer.Telemetry
 
         public static class EventNames
         {
+            public const string ChildResourceDeclarationSnippetInsertion = nameof(ChildResourceDeclarationSnippetInsertion);
             public const string TopLevelDeclarationSnippetInsertion = nameof(TopLevelDeclarationSnippetInsertion);
             public const string ResourceBodySnippetInsertion = nameof(ResourceBodySnippetInsertion);
             public const string ModuleBodySnippetInsertion = nameof(ModuleBodySnippetInsertion);

--- a/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
+++ b/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
@@ -9,7 +9,7 @@ namespace Bicep.LanguageServer.Telemetry
 
         public static class EventNames
         {
-            public const string ChildResourceDeclarationSnippetInsertion = nameof(ChildResourceDeclarationSnippetInsertion);
+            public const string NestedResourceDeclarationSnippetInsertion = nameof(NestedResourceDeclarationSnippetInsertion);
             public const string TopLevelDeclarationSnippetInsertion = nameof(TopLevelDeclarationSnippetInsertion);
             public const string ResourceBodySnippetInsertion = nameof(ResourceBodySnippetInsertion);
             public const string ModuleBodySnippetInsertion = nameof(ModuleBodySnippetInsertion);


### PR DESCRIPTION
Fixes #1812 

Adds support to create:
1. Create child resource snippets
2. Fixes a bug in resource body completion in nested scenario
3. Updated resource-with-defaults and resource-without-defaults labels in nested scenario

![BicepIssue1812](https://user-images.githubusercontent.com/30270536/123395263-dc9a4900-d554-11eb-9d43-32097c0cb814.gif)
