### PR TITLE
Block errors and warnings in snippet samples

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -110,7 +110,8 @@ namespace Bicep.LangServer.IntegrationTests
                 {
                     var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(bicepContentsReplaced, "\n", diagnostics, diag => OutputHelper.GetDiagLoggingString(bicepContentsReplaced, outputDirectory, diag));
                     Execute.Assertion.FailWith($"Expected \"main.combined.bicep\" file to not contain errors or warnings, but found {diagnostics.Count()}. " +
-                        $"Please fix errors/warnings mentioned in below section: \n {sourceTextWithDiags}");
+                        $"Please fix errors/warnings mentioned in below section in \"main.combined.bicep\" file:\n " +
+                        $"{sourceTextWithDiags}");
                 }
 
                 bicepContentsReplaced.Should().EqualWithLineByLineDiffOutput(

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/module/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/module/main.combined.bicep
@@ -6,4 +6,3 @@ module testModule 'main.bicep' = {
   name: 'myModule'
   
 }// Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/output/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/output/main.combined.bicep
@@ -3,4 +3,3 @@
 // $2 = int
 
 output testOutput int = 1// Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults-allowed-values/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults-allowed-values/main.bicep
@@ -1,6 +1,13 @@
-﻿// $1 = testParam
+﻿// $1 = ttl
 // $2 = int
 // $3 = 1
 // $4 = 2
 
 // Insert snippet here
+
+resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  name: 'zone/A'
+  properties: {
+    TTL: ttl
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults-allowed-values/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults-allowed-values/main.combined.bicep
@@ -1,4 +1,4 @@
-// $1 = testParam
+// $1 = ttl
 // $2 = int
 // $3 = 1
 // $4 = 2
@@ -6,6 +6,11 @@
 @allowed([
   1
 ])
-param testParam int = 2// Insert snippet here
-//@[6:15) [no-unused-params (Warning)] Parameter "testParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |testParam|
+param ttl int = 2// Insert snippet here
 
+resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  name: 'zone/A'
+  properties: {
+    TTL: ttl
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults/main.bicep
@@ -1,5 +1,12 @@
-﻿// $1 = testParam
+﻿// $1 = ttl
 // $2 = int
 // $3 = 1
 
 // Insert snippet here
+
+resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  name: 'zone/A'
+  properties: {
+    TTL: ttl
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-defaults/main.combined.bicep
@@ -1,7 +1,12 @@
-// $1 = testParam
+// $1 = ttl
 // $2 = int
 // $3 = 1
 
-param testParam int = 1// Insert snippet here
-//@[6:15) [no-unused-params (Warning)] Parameter "testParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |testParam|
+param ttl int = 1// Insert snippet here
 
+resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  name: 'zone/A'
+  properties: {
+    TTL: ttl
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-secure-string/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-secure-string/main.bicep
@@ -1,3 +1,12 @@
-﻿// $1 = testParam
+﻿// $1 = location
 
 // Insert snippet here
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
+  name: 'name'
+  location: location
+  sku: {
+    name: 'F1'
+    capacity: 1
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-secure-string/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param-secure-string/main.combined.bicep
@@ -1,6 +1,13 @@
-// $1 = testParam
+// $1 = location
 
 @secure()
-param testParam string// Insert snippet here
-//@[6:15) [no-unused-params (Warning)] Parameter "testParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |testParam|
+param location string// Insert snippet here
 
+resource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
+  name: 'name'
+  location: location
+  sku: {
+    name: 'F1'
+    capacity: 1
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param/main.bicep
@@ -1,4 +1,11 @@
-﻿// $1 = testParam
+﻿// $1 = ttl
 // $2 = int
 
 // Insert snippet here
+
+resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  name: 'zone/A'
+  properties: {
+    TTL: ttl
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/param/main.combined.bicep
@@ -1,6 +1,11 @@
-// $1 = testParam
+// $1 = ttl
 // $2 = int
 
-param testParam int// Insert snippet here
-//@[6:15) [no-unused-params (Warning)] Parameter "testParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |testParam|
+param ttl int// Insert snippet here
 
+resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  name: 'zone/A'
+  properties: {
+    TTL: ttl
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-aks-cluster/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-aks-cluster/main.combined.bicep
@@ -39,4 +39,3 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-api-management-instance/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-api-management-instance/main.combined.bicep
@@ -20,4 +20,3 @@ resource apiManagementInstance 'Microsoft.ApiManagement/service@2020-12-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-gateway-waf/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-gateway-waf/main.combined.bicep
@@ -30,4 +30,3 @@ resource applicationGatewayFirewall 'Microsoft.Network/ApplicationGatewayWebAppl
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-gateway/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-gateway/main.combined.bicep
@@ -110,4 +110,3 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2020-11-01' =
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights-alert-rules/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights-alert-rules/main.combined.bicep
@@ -32,4 +32,3 @@ resource appInsightsAlertRules 'Microsoft.Insights/alertrules@2016-03-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights-auto-scale-settings/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights-auto-scale-settings/main.combined.bicep
@@ -77,4 +77,3 @@ resource appInsightsAutoScaleSettings 'Microsoft.Insights/autoscalesettings@2015
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-insights/main.combined.bicep
@@ -11,4 +11,3 @@ resource appInsightsComponents 'Microsoft.Insights/components@2020-02-02-preview
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-plan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-plan/main.combined.bicep
@@ -10,4 +10,3 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-security-group/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-app-security-group/main.combined.bicep
@@ -6,4 +6,3 @@ resource applicationSecurityGroup 'Microsoft.Network/applicationSecurityGroups@2
   location: resourceGroup().location
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-account/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-account/main.combined.bicep
@@ -12,4 +12,3 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' 
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-cert/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-cert/main.combined.bicep
@@ -21,4 +21,3 @@ resource automationCertificate 'Microsoft.Automation/automationAccounts/certific
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-cred/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-cred/main.combined.bicep
@@ -19,4 +19,3 @@ resource automationCredential 'Microsoft.Automation/automationAccounts/credentia
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-job-schedule/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-job-schedule/main.combined.bicep
@@ -21,4 +21,3 @@ resource automationJobSchedule 'Microsoft.Automation/automationAccounts/jobSched
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-module/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-module/main.combined.bicep
@@ -16,4 +16,3 @@ resource automationAccountVariable 'Microsoft.Automation/automationAccounts/modu
     }
   }
 }// Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-runbook/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-runbook/main.combined.bicep
@@ -28,4 +28,3 @@ resource automationRunbook 'Microsoft.Automation/automationAccounts/runbooks@201
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-schedule/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-schedule/main.combined.bicep
@@ -21,4 +21,3 @@ resource automationSchedule 'Microsoft.Automation/automationAccounts/schedules@2
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-variable/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-automation-variable/main.combined.bicep
@@ -19,4 +19,3 @@ resource automationVariable 'Microsoft.Automation/automationAccounts/variables@2
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-availability-set/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-availability-set/main.combined.bicep
@@ -6,4 +6,3 @@ resource availabilitySet 'Microsoft.Compute/availabilitySets@2020-12-01' = {
   location: resourceGroup().location
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-group/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-group/main.combined.bicep
@@ -47,4 +47,3 @@ resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2021-03-01'
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.combined.bicep
@@ -14,4 +14,3 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' =
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-account/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-account/main.combined.bicep
@@ -35,4 +35,3 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-03-15' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-keyspace/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-keyspace/main.combined.bicep
@@ -15,4 +15,3 @@ resource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-table/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-table/main.combined.bicep
@@ -25,4 +25,3 @@ resource cassandraKeyspaceTable 'Microsoft.DocumentDb/databaseAccounts/apis/keys
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-database/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-database/main.combined.bicep
@@ -15,4 +15,3 @@ resource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-graph/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-graph/main.combined.bicep
@@ -65,4 +65,3 @@ resource cosmosDBGremlinGraph 'Microsoft.DocumentDb/databaseAccounts/apis/databa
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-mongo-database/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-mongo-database/main.combined.bicep
@@ -12,4 +12,3 @@ resource mongoDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-3
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-container/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-container/main.combined.bicep
@@ -59,4 +59,3 @@ resource sqlContainerName 'Microsoft.DocumentDb/databaseAccounts/apis/databases/
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-database/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-database/main.combined.bicep
@@ -15,4 +15,3 @@ resource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31'
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-tablestorage-table/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-tablestorage-table/main.combined.bicep
@@ -15,4 +15,3 @@ resource cosmosTable 'Microsoft.DocumentDB/databaseAccounts/apis/tables@2016-03-
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-data-lake/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-data-lake/main.combined.bicep
@@ -12,4 +12,3 @@ resource dataLakeStore 'Microsoft.DataLakeStore/accounts@2016-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-dns-record/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-dns-record/main.combined.bicep
@@ -18,4 +18,3 @@ resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-dns-zone/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-dns-zone/main.combined.bicep
@@ -6,4 +6,3 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   location: 'global'
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-firewall/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-firewall/main.combined.bicep
@@ -142,4 +142,3 @@ resource firewall 'Microsoft.Network/azureFirewalls@2020-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-function/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-function/main.combined.bicep
@@ -52,4 +52,3 @@ resource azureFunction 'Microsoft.Web/sites@2020-12-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-ip-prefix/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-ip-prefix/main.combined.bicep
@@ -14,4 +14,3 @@ resource publicIPPrefix 'Microsoft.Network/publicIPPrefixes@2019-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-ip/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-ip/main.combined.bicep
@@ -13,4 +13,3 @@ resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2019-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault-secret/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault-secret/main.combined.bicep
@@ -9,4 +9,3 @@ resource keyVaultSecret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-keyvault/main.combined.bicep
@@ -33,4 +33,3 @@ resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-loadbalancer-external/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-loadbalancer-external/main.combined.bicep
@@ -83,4 +83,3 @@ resource loadBalancerExternal 'Microsoft.Network/loadBalancers@2020-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-loadbalancer-internal/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-loadbalancer-internal/main.combined.bicep
@@ -69,4 +69,3 @@ resource loadBalancerInternal 'Microsoft.Network/loadBalancers@2020-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-solution/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-solution/main.combined.bicep
@@ -24,4 +24,3 @@ resource logAnalyticsSolution 'Microsoft.OperationsManagement/solutions@2015-11-
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-workspace/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-workspace/main.combined.bicep
@@ -12,4 +12,3 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-logic-app-connector/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-logic-app-connector/main.combined.bicep
@@ -12,4 +12,3 @@ resource logicAppConnector 'Microsoft.Web/connections@2015-08-01-preview' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-logic-app/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-logic-app/main.combined.bicep
@@ -12,4 +12,3 @@ resource logicApp 'Microsoft.Logic/integrationAccounts@2016-06-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-managed-identity/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-managed-identity/main.combined.bicep
@@ -6,4 +6,3 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-
   location: resourceGroup().location
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-media/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-media/main.combined.bicep
@@ -16,4 +16,3 @@ resource mediaServices 'Microsoft.Media/mediaServices@2020-05-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-mysql/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-mysql/main.combined.bicep
@@ -14,4 +14,3 @@ resource mySQLdb 'Microsoft.DBforMySQL/servers@2017-12-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nic/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nic/main.combined.bicep
@@ -23,4 +23,3 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2020-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nsg/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nsg/main.combined.bicep
@@ -34,4 +34,3 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2019-11-0
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nsgrule/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nsgrule/main.combined.bicep
@@ -25,4 +25,3 @@ resource networkSecurityGroupSecurityRule 'Microsoft.Network/networkSecurityGrou
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-plan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-plan/main.combined.bicep
@@ -12,4 +12,3 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-assignment/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-assignment/main.combined.bicep
@@ -46,4 +46,3 @@ resource policyAssignment 'Microsoft.Authorization/policyAssignments@2020-09-01'
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-definition-audit-effect/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-definition-audit-effect/main.combined.bicep
@@ -56,4 +56,3 @@ resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01'
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-definition-deploy-effect/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-definition-deploy-effect/main.combined.bicep
@@ -121,4 +121,3 @@ resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01'
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-definition-modify-effect/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-definition-modify-effect/main.combined.bicep
@@ -72,4 +72,3 @@ resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-09-01'
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-exemption/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-exemption/main.combined.bicep
@@ -27,4 +27,3 @@ resource policyExemption 'Microsoft.Authorization/policyExemptions@2020-07-01-pr
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-remediation/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-remediation/main.combined.bicep
@@ -19,4 +19,3 @@ resource policyRemediation 'Microsoft.PolicyInsights/remediations@2019-07-01' = 
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policyset-definition/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policyset-definition/main.combined.bicep
@@ -62,4 +62,3 @@ resource policySetDefinition 'Microsoft.Authorization/policySetDefinitions@2020-
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-recovery-service-vault/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-recovery-service-vault/main.combined.bicep
@@ -12,4 +12,3 @@ resource recoveryServiceVault 'Microsoft.RecoveryServices/vaults@2021-01-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-redis/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-redis/main.combined.bicep
@@ -13,4 +13,3 @@ resource redisCache 'Microsoft.Cache/Redis@2019-07-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-table-route/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-table-route/main.combined.bicep
@@ -13,4 +13,3 @@ resource routeTableRoute 'Microsoft.Network/routeTables/routes@2019-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-table/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-table/main.combined.bicep
@@ -24,4 +24,3 @@ resource routeTable 'Microsoft.Network/routeTables@2019-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-shared-image-gallery/main.combined.bicep
@@ -10,4 +10,3 @@ resource sharedImageGallery 'Microsoft.Compute/galleries@2020-09-30' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql-db-import/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql-db-import/main.combined.bicep
@@ -27,4 +27,3 @@ resource sqlDatabaseImport 'Microsoft.Sql/servers/databases/extensions@2014-04-0
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql-server-firewall-rules/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql-server-firewall-rules/main.combined.bicep
@@ -24,4 +24,3 @@ resource sqlServerFirewallRules 'Microsoft.Sql/servers/firewallRules@2020-11-01-
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql/main.combined.bicep
@@ -23,4 +23,3 @@ resource sqlServerDatabase 'Microsoft.Sql/servers/databases@2014-04-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-storage/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-storage/main.combined.bicep
@@ -14,4 +14,3 @@ resource storageaccount 'Microsoft.Storage/storageAccounts@2021-02-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-template-spec/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-template-spec/main.combined.bicep
@@ -12,4 +12,3 @@ resource templateSpec 'Microsoft.Resources/templateSpecs@2019-06-01-preview' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-traffic-manager/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-traffic-manager/main.combined.bicep
@@ -44,4 +44,3 @@ resource trafficManagerProfile 'Microsoft.Network/trafficManagerProfiles@2018-04
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-virtual-wan/main.combined.bicep
@@ -15,4 +15,3 @@ resource virtualWan 'Microsoft.Network/virtualWans@2020-07-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-dsc/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-dsc/main.combined.bicep
@@ -27,4 +27,3 @@ resource windowsVMDsc 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' 
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-script-linux/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-script-linux/main.combined.bicep
@@ -29,4 +29,3 @@ resource linuxVMExtensions 'Microsoft.Compute/virtualMachines/extensions@2019-07
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-script-windows/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-script-windows/main.combined.bicep
@@ -29,4 +29,3 @@ resource windowsVMExtensions 'Microsoft.Compute/virtualMachines/extensions@2020-
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-ubuntu/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-ubuntu/main.combined.bicep
@@ -48,4 +48,3 @@ resource ubuntuVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows-diagnostics/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows-diagnostics/main.combined.bicep
@@ -25,4 +25,3 @@ resource windowsVMDiagnostics 'Microsoft.Compute/virtualMachines/extensions@2020
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows/main.combined.bicep
@@ -48,4 +48,3 @@ resource windowsVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet-peering/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet-peering/main.combined.bicep
@@ -19,4 +19,3 @@ resource peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vnet/main.combined.bicep
@@ -29,4 +29,3 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2019-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-local-gateway/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-local-gateway/main.combined.bicep
@@ -16,4 +16,3 @@ resource localNetworkGateway 'Microsoft.Network/localNetworkGateways@2019-11-01'
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-vnet-connection/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-vnet-connection/main.combined.bicep
@@ -24,4 +24,3 @@ resource vpnVnetConnection 'Microsoft.Network/connections@2020-11-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-vnet-gateway/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vpn-vnet-gateway/main.combined.bicep
@@ -38,4 +38,3 @@ resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2020-11
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-web-app-deploy/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-web-app-deploy/main.combined.bicep
@@ -22,4 +22,3 @@ resource webApplicationExtension 'Microsoft.Web/sites/extensions@2020-12-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-web-app/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-web-app/main.combined.bicep
@@ -13,4 +13,3 @@ resource webApplication 'Microsoft.Web/sites@2018-11-01' = {
     serverFarmId: resourceId('Microsoft.Web/serverfarms', 'appServicePlan')
   }
 }// Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-appgroup/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-appgroup/main.combined.bicep
@@ -14,4 +14,3 @@ resource applicationGroup 'Microsoft.DesktopVirtualization/applicationgroups@201
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-hostpool/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-hostpool/main.combined.bicep
@@ -16,4 +16,3 @@ resource hostPool 'Microsoft.DesktopVirtualization/hostpools@2019-12-10-preview'
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-workspace/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-wvd-workspace/main.combined.bicep
@@ -10,4 +10,3 @@ resource workSpace 'Microsoft.DesktopVirtualization/workspaces@2019-12-10-previe
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-defaults/main.combined.bicep
@@ -9,4 +9,3 @@ resource testIdentifier 'Microsoft.Advisor/recommendations/suppressions@2020-01-
     suppressionId: any(1)
   }
 }// Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-without-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-child-without-defaults/main.combined.bicep
@@ -6,4 +6,3 @@ resource nsg 'Microsoft.Aad/domainServices/ouContainer@2017-06-01' = {
   name: 'testResource/'
   
 }// Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-defaults/main.combined.bicep
@@ -10,4 +10,3 @@ resource nsg 'Microsoft.Aad/domainServices@2017-06-01' = {
     
   }
 }// Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-without-defaults/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/resource-without-defaults/main.combined.bicep
@@ -7,4 +7,3 @@ resource nsg 'Microsoft.Aad/domainServices@2017-06-01' = {
   name: 'testResource'
   
 }// Insert snippet here
-

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/var/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/var/main.bicep
@@ -1,4 +1,11 @@
 ﻿// $0 = 1
-// $1 = test
+// $1 = ttl
 
 // Insert snippet here
+
+resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  name: 'zone/A'
+  properties: {
+    TTL: ttl
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/var/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/var/main.combined.bicep
@@ -1,6 +1,11 @@
 // $0 = 1
-// $1 = test
+// $1 = ttl
 
-var test = 1// Insert snippet here
-//@[4:8) [no-unused-vars (Warning)] Variable "test" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |test|
+var ttl = 1// Insert snippet here
 
+resource dnsRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  name: 'zone/A'
+  properties: {
+    TTL: ttl
+  }
+}


### PR DESCRIPTION
Fixes #2943

- Updated ValidateSnippetCompletionAfterPlaceholderReplacements test. The test should now fail if main.combined.bicep corresponding to snippet template has errors/warnings
- Cleaned up linter warnings in test samples