### PR TITLE
Add list method call on Azure resource references

### DIFF
--- a/docs/examples/101/cosmosdb-webapp/main.bicep
+++ b/docs/examples/101/cosmosdb-webapp/main.bicep
@@ -84,7 +84,7 @@ resource website 'Microsoft.Web/sites@2020-06-01' = {
         }
         {
           name: 'CosmosDb:Key'
-          value: listKeys(cosmosAccount.id, cosmosAccount.apiVersion).primaryMasterKey
+          value: cosmosAccount.listKeys().primaryMasterKey
         }
         {
           name: 'CosmosDb:DatabaseName'

--- a/docs/examples/101/cosmosdb-webapp/main.bicep
+++ b/docs/examples/101/cosmosdb-webapp/main.bicep
@@ -84,7 +84,7 @@ resource website 'Microsoft.Web/sites@2020-06-01' = {
         }
         {
           name: 'CosmosDb:Key'
-          value: cosmosAccount.listKeys().primaryMasterKey
+          value: listKeys(cosmosAccount.id, cosmosAccount.apiVersion).primaryMasterKey
         }
         {
           name: 'CosmosDb:DatabaseName'

--- a/src/Bicep.Core.IntegrationTests/Scenarios/ResourceListFunctionTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/ResourceListFunctionTests.cs
@@ -86,7 +86,7 @@ var disallowed = {
             result.Should().HaveDiagnostics(new[] {
                 ("no-unused-vars", DiagnosticLevel.Warning, "Variable \"allowed\" is declared but never used."),
                 ("no-unused-vars", DiagnosticLevel.Warning, "Variable \"disallowed\" is declared but never used."),
-                ("BCP110", DiagnosticLevel.Error, "The type \"Microsoft.Storage/storageAccounts\" does not contain function \"lis\". Did you mean \"list\"?"),
+                ("BCP109", DiagnosticLevel.Error, "The type \"Microsoft.Storage/storageAccounts\" does not contain function \"lis\"."),
                 ("BCP109", DiagnosticLevel.Error, "The type \"Microsoft.Storage/storageAccounts\" does not contain function \"lsit\"."),
                 ("BCP109", DiagnosticLevel.Error, "The type \"Microsoft.Storage/storageAccounts\" does not contain function \"totallyMadeUpMethod\"."),
             });

--- a/src/Bicep.Core.IntegrationTests/Scenarios/ResourceListFunctionTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/ResourceListFunctionTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.IntegrationTests.Scenarios
+{
+    [TestClass]
+    public class ResourceListFunctionTests
+    {
+        [TestMethod]
+        public void List_wildcard_function_on_resource_references()
+        {
+            var result = CompilationHelper.Compile(@"
+resource stg 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'testacc'
+  location: 'West US'
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+}
+
+output pkStandard string = listKeys(stg.id, stg.apiVersion).keys[0].value
+output pkMethod string = stg.listKeys().keys[0].value
+output pkMethodVersionOverride string = stg.listKeys('2021-01-01').keys[0].value
+output pkMethodPayload string = stg.listKeys(stg.apiVersion, {
+  key1: 'val1'
+})
+");
+
+            result.Should().NotHaveAnyDiagnostics();
+            result.Template.Should().HaveValueAtPath("$.outputs['pkStandard'].value", "[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethod'].value", "[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodVersionOverride'].value", "[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'testacc'), '2021-01-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodPayload'].value", "[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01', createObject('key1', 'val1'))]");
+        }
+
+        [TestMethod]
+        public void List_wildcard_function_on_cross_scope_resource_references()
+        {
+            var result = CompilationHelper.Compile(@"
+resource stg 'Microsoft.Storage/storageAccounts@2019-06-01' existing = {
+  scope: resourceGroup('other')
+  name: 'testacc'
+}
+
+output pkStandard string = listKeys(stg.id, stg.apiVersion).keys[0].value
+output pkMethod string = stg.listKeys().keys[0].value
+output pkMethodVersionOverride string = stg.listKeys('2021-01-01').keys[0].value
+output pkMethodPayload string = stg.listKeys(stg.apiVersion, {
+  key1: 'val1'
+})
+");
+
+            result.Should().NotHaveAnyDiagnostics();
+            result.Template.Should().HaveValueAtPath("$.outputs['pkStandard'].value", "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'other'), 'Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethod'].value", "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'other'), 'Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodVersionOverride'].value", "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'other'), 'Microsoft.Storage/storageAccounts', 'testacc'), '2021-01-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodPayload'].value", "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'other'), 'Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01', createObject('key1', 'val1'))]");
+        }
+
+        [TestMethod]
+        public void Only_list_methods_are_permitted()
+        {
+            var result = CompilationHelper.Compile(@"
+resource stg 'Microsoft.Storage/storageAccounts@2019-06-01' existing = {
+  name: 'testacc'
+}
+
+var allowed = {
+  a: stg.list()
+  b: stg.listA()
+  c: stg.listTotallyMadeUpMethod()
+}
+
+var disallowed = {
+  a: stg.lis()
+  b: stg.lsit()
+  c: stg.totallyMadeUpMethod()
+}
+");
+            result.Should().HaveDiagnostics(new[] {
+                ("no-unused-vars", DiagnosticLevel.Warning, "Variable \"allowed\" is declared but never used."),
+                ("no-unused-vars", DiagnosticLevel.Warning, "Variable \"disallowed\" is declared but never used."),
+                ("BCP110", DiagnosticLevel.Error, "The type \"Microsoft.Storage/storageAccounts\" does not contain function \"lis\". Did you mean \"list\"?"),
+                ("BCP109", DiagnosticLevel.Error, "The type \"Microsoft.Storage/storageAccounts\" does not contain function \"lsit\"."),
+                ("BCP109", DiagnosticLevel.Error, "The type \"Microsoft.Storage/storageAccounts\" does not contain function \"totallyMadeUpMethod\"."),
+            });
+        }
+    }
+}

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/azFunctions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/azFunctions.json
@@ -45,23 +45,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "managementGroup",
     "kind": "function",
     "detail": "managementGroup()",

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
@@ -1167,23 +1167,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
@@ -366,7 +366,7 @@ var test1 = listKeys('abcd')
 // list spelled wrong 
 var test2 = lsitKeys('abcd', '2020-01-01')
 //@[4:9) [no-unused-vars (Warning)] Variable "test2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |test2|
-//@[12:20) [BCP082 (Error)] The name "lsitKeys" does not exist in the current context. Did you mean "listKeys"? (CodeDescription: none) |lsitKeys|
+//@[12:20) [BCP057 (Error)] The name "lsitKeys" does not exist in the current context. (CodeDescription: none) |lsitKeys|
 
 // just 'lis' instead of 'list'
 var test3 = lis('abcd', '2020-01-01')

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -1044,23 +1044,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -1044,23 +1044,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -2623,23 +2623,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -2587,23 +2587,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -2615,23 +2615,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -2846,23 +2846,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -2846,23 +2846,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -2846,23 +2846,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -2846,23 +2846,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -2608,23 +2608,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -2608,23 +2608,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -2608,23 +2608,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -2608,23 +2608,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -3094,23 +3094,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -3094,23 +3094,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -3094,23 +3094,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -3094,23 +3094,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -2601,23 +2601,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -2601,23 +2601,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -2601,23 +2601,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -2601,23 +2601,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -2594,23 +2594,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -2594,23 +2594,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -2594,23 +2594,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -2594,23 +2594,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -2573,23 +2573,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -2573,23 +2573,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -2716,23 +2716,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -2590,23 +2590,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -2604,23 +2604,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -2604,23 +2604,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -2654,23 +2654,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -2618,23 +2618,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -2604,23 +2604,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -823,23 +823,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
@@ -859,23 +859,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -841,23 +841,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
@@ -1192,23 +1192,6 @@
     }
   },
   {
-    "label": "listKeys",
-    "kind": "function",
-    "detail": "listKeys()",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_listKeys",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "listKeys($0)"
-    },
-    "command": {
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "loadFileAsBase64",
     "kind": "function",
     "detail": "loadFileAsBase64()",

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
@@ -7,6 +7,7 @@ using Bicep.Core.Resources;
 using Bicep.Core.Semantics;
 using System.Collections.Immutable;
 using Bicep.Core.Emit;
+using System.Text.RegularExpressions;
 
 namespace Bicep.Core.TypeSystem.Az
 {
@@ -239,6 +240,14 @@ namespace Bicep.Core.TypeSystem.Az
 
         private static IEnumerable<FunctionOverload> GetBicepMethods(ResourceTypeReference resourceType)
         {
+            yield return new FunctionWildcardOverloadBuilder("list*", new Regex("^list[a-zA-Z]*"))
+                .WithReturnType(LanguageConstants.Any)
+                .WithDescription("The syntax for this function varies by name of the list operations. Each implementation returns values for the resource type that supports a list operation. The operation name must start with list. Some common usages are `listKeys`, `listKeyValue`, and `listSecrets`.")
+                .WithOptionalParameter("apiVersion", LanguageConstants.String, "API version of resource runtime state. Typically, in the format, yyyy-mm-dd.")
+                .WithOptionalParameter("functionValues", LanguageConstants.Object, "An object that has values for the function. Only provide this object for functions that support receiving an object with parameter values, such as listAccountSas on a storage account. An example of passing function values is shown in this article.")
+                .WithFlags(FunctionFlags.RequiresInlining)
+                .Build();
+
             switch (resourceType.FullyQualifiedType.ToLowerInvariant())
             {
                 case "microsoft.keyvault/vaults":

--- a/src/Bicep.Core/TypeSystem/FunctionResolver.cs
+++ b/src/Bicep.Core/TypeSystem/FunctionResolver.cs
@@ -73,10 +73,7 @@ namespace Bicep.Core.TypeSystem
             var wildcardOverloads =  FunctionWildcardOverloads.Where(fo => fo.WildcardRegex.IsMatch(name));
 
             // create a new symbol for each unique name that matches the wildcard
-            var cachedSymbol = wildcardOverloads.Any() ? new FunctionSymbol(name, wildcardOverloads) : null;
-            FunctionCache[name] = cachedSymbol;
-
-            return cachedSymbol;
+            return wildcardOverloads.Any() ? new FunctionSymbol(name, wildcardOverloads) : null;
         }
 
         public static IEnumerable<FunctionOverload> GetMatches(


### PR DESCRIPTION
#1915 added all the groundwork for this, but I never got around to adding the support for `.listXYZ()` methods on resource references. This PR adds this functionality.

Related to #667; we've discussed this before, but I couldn't find an issue for this specifically.