### PR TITLE
Remove dependency on env variable for local VSIX testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,13 +10,10 @@
                 "--enable-proposed-api",
                 "--extensionDevelopmentPath=${workspaceRoot}/src/vscode-bicep"
             ],
-            "env": {
-                "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/src/Bicep.LangServer/bin/Debug/net5.0/Bicep.LangServer.dll"
-            },
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
-            "preLaunchTask": "vscodeext-build"
+            "preLaunchTask": "Build VSIX"
         },
         {
             "name": "Bicep Playground",
@@ -27,13 +24,13 @@
             "cwd": "${workspaceFolder}/src/playground",
             "autoAttachChildProcesses": true,
             "stopOnEntry": false,
-            "preLaunchTask": "playground-build-wasm"
+            "preLaunchTask": "Build WASM for Playground"
         },
         {
             "name": "Bicep CLI",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "build-cli",
+            "preLaunchTask": "Build CLI",
             "program": "${workspaceFolder}/src/Bicep.Cli/bin/Debug/net5.0/Bicep.dll",
             "args": [
                 "build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build",
+            "label": "Build Solution",
             "command": "dotnet",
             "type": "process",
             "args": [
@@ -14,7 +14,7 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "build-cli",
+            "label": "Build CLI",
             "command": "dotnet",
             "type": "process",
             "args": [
@@ -26,19 +26,21 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "build-langserver",
+            "label": "Build Language Server for VSIX",
             "command": "dotnet",
             "type": "process",
             "args": [
                 "build",
                 "${workspaceFolder}/src/Bicep.LangServer/Bicep.LangServer.csproj",
                 "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "/consoleloggerparameters:NoSummary",
+                "--output",
+                "${workspaceFolder}/src/vscode-bicep/bicepLanguageServer"
             ],
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "vscodeext-build",
+            "label": "Build VSIX",
             "command": "npm",
             "args": ["run", "build", "--loglevel", "silent"],
             "type": "shell",
@@ -47,11 +49,11 @@
                 "cwd": "${workspaceFolder}/src/vscode-bicep"
             },
             "dependsOn": [
-                "build-langserver"
+                "Build Language Server for VSIX"
             ]
         },
         {
-            "label": "playground-build-wasm",
+            "label": "Build WASM for Playground",
             "command": "npm",
             "args": ["run", "build-wasm"],
             "type": "shell",


### PR DESCRIPTION
This unblocks local extension testing in GitHub codespaces, by actually building into the `bicepLanguageServer` directory, rather than linking to it with an environmental variable (more in-line with how the build is actually packaged for release).

I haven't removed support for the env variable entirely, as I believe @shenglol and possibly others use it via the launch tasks configured in `src/vscode-bicep/launch.json`.