### PR TITLE
Fixed ADO build break

### DIFF
--- a/.pipelines/Bicep.yml
+++ b/.pipelines/Bicep.yml
@@ -30,6 +30,7 @@ steps:
 
 - task: PublishTestResults@2
   displayName: Publish Test Results
+  condition: always()
   inputs:
     testResultsFormat: VSTest
     testResultsFiles: '$(Build.SourcesDirectory)/TestResults/**/*.trx'

--- a/.pipelines/Common.yml
+++ b/.pipelines/Common.yml
@@ -201,7 +201,7 @@ stages:
     - task: NodeTool@0 
       displayName: Setup Node.js
       inputs:
-        versionSpec: 10.x
+        versionSpec: 12.x
     
     - script: npm ci
       displayName: npm ci

--- a/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
+++ b/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
@@ -7,16 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="./Files/**/*.json" />
-    <None Remove="./Files/**/*.bicep" />
-    <None Remove="./Files/**/Assets/*.*" />
-  </ItemGroup>
-
-  <ItemGroup>
     <!-- Bicep.Core.Samples -->
     <EmbeddedResource Include="./Files/**/*.json" LogicalName="$([System.String]::new('Bicep.Core.Samples/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" />
     <EmbeddedResource Include="./Files/**/*.bicep" LogicalName="$([System.String]::new('Bicep.Core.Samples/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" />
-    <EmbeddedResource Include="./Files/**/Assets/**/*.*" LogicalName="$([System.String]::new('Bicep.Core.Samples/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" />
+    <EmbeddedResource Include="./Files/**/Assets/**/*" LogicalName="$([System.String]::new('Bicep.Core.Samples/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" />
 
     <!-- Path prefix: docs/examples -->
     <EmbeddedResource Include="../../docs/examples/**/*.json" LogicalName="$([System.String]::new('docs/examples/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" />

--- a/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
@@ -38,13 +38,6 @@ namespace Bicep.Core.UnitTests.Utils
         {
             var outputDirectory = GetUniqueTestOutputPath(testContext);
 
-            testContext.WriteLine($"Manifest prefix: {manifestFilePrefix}");
-            testContext.WriteLine("Manifest names:");
-            foreach(var manifestName in containingAssembly.GetManifestResourceNames())
-            {
-                testContext.WriteLine($"  {manifestName}");
-            }
-
             var filesSaved = false;
             foreach (var embeddedResourceName in containingAssembly.GetManifestResourceNames().Where(file => file.StartsWith(manifestFilePrefix,  StringComparison.Ordinal)))
             {

--- a/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
@@ -37,7 +37,14 @@ namespace Bicep.Core.UnitTests.Utils
         public static string SaveEmbeddedResourcesWithPathPrefix(TestContext testContext, Assembly containingAssembly, string manifestFilePrefix)
         {
             var outputDirectory = GetUniqueTestOutputPath(testContext);
-            
+
+            testContext.WriteLine($"Manifest prefix: {manifestFilePrefix}");
+            testContext.WriteLine("Manifest names:");
+            foreach(var manifestName in containingAssembly.GetManifestResourceNames())
+            {
+                testContext.WriteLine($"  {manifestName}");
+            }
+
             var filesSaved = false;
             foreach (var embeddedResourceName in containingAssembly.GetManifestResourceNames().Where(file => file.StartsWith(manifestFilePrefix,  StringComparison.Ordinal)))
             {
@@ -55,6 +62,8 @@ namespace Bicep.Core.UnitTests.Utils
                 var fileStream = File.Create(filePath);
                 manifestStream.Seek(0, SeekOrigin.Begin);
                 manifestStream.CopyTo(fileStream);
+                testContext.WriteLine($"Bytes written to {filePath}: {fileStream.Position}");
+
                 fileStream.Close();
                 
                 testContext.AddResultFile(filePath);


### PR DESCRIPTION
Fixed wildcards in samples project from `*.*` to `*`. In the image that we use in the ADO build, `*.*` is being interpreted literally which causes only asset files with extensions to be packaged up as resources in the samples assembly. This unfortunately excluded files with names like `binary` or `binaryAsset`. This issue does not occur in GH builds.

Additional changes:
- We are now publishing test results in ADO builds when tests fail.
- Added extra logging in tests to help debug missing binary assets.
- Set VSIX job node version to 12.x to match GitHub builds (build fails without it).