### PR TITLE
Created resourceGroup-snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -1985,6 +1985,35 @@
     }
   },
   {
+    "label": "res-rg",
+    "kind": "snippet",
+    "detail": "Resource Group",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource 'resourceGroup' 'Microsoft.Resources/resourceGroups@2021-04-01' = {\n  name: 'name'\n  location: 'eastasia'\n  tags:{\n    'tag': 'tagValue'   \n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-rg",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:'resourceGroup'} 'Microsoft.Resources/resourceGroups@2021-04-01' = {\n  name: ${2:'name'}\n  location: ${3|'eastasia','southeastasia','centralus','eastus','eastus2','westus','northcentralus','southcentralus','northeurope','westeurope','japanwest','japaneast','brazilsouth','australiaeast','australiasoutheast','southindia','centralindia','westindia','canadacentral','canadaeast','uksouth','ukwest','westcentralus','westus2','koreacentral','koreasouth','francecentral','francesouth','australiacentral','australiacentral2','uaecentral','uaenorth','southafricanorth','southafricawest','switzerlandnorth','switzerlandwest','germanynorth','germanywestcentral','norwaywest','norwayeast','brazilsoutheast','westus3','swedencentral'|}\n  tags:{\n    'tag': 'tagValue'   \n  }\n}\n"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "TopLevelDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "res-rg"
+          }
+        }
+      ]
+    }
+  },
+  {
     "label": "res-route-table",
     "kind": "snippet",
     "detail": "Route Table",

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-rg/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-rg/main.bicep
@@ -1,0 +1,5 @@
+﻿// $1 = resourceGroup
+// $2 = 'name'
+// $3 = 'westeurope'
+targetScope = 'subscription'
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-rg/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-rg/main.combined.bicep
@@ -1,0 +1,13 @@
+// $1 = resourceGroup
+// $2 = 'name'
+// $3 = 'westeurope'
+targetScope = 'subscription'
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: 'name'
+  location: 'westeurope'
+  tags:{
+    'tag': 'tagValue'   
+  }
+}
+// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-rg/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-rg/main.combined.bicep
@@ -10,4 +10,3 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer/Snippets/Templates/res-rg.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-rg.bicep
@@ -1,0 +1,9 @@
+// Resource Group
+targetScope = 'subscription'
+resource /*${1:'resourceGroup'}*/resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: /*${2:'name'}*/'name'
+  location: /*${3|'eastasia','southeastasia','centralus','eastus','eastus2','westus','northcentralus','southcentralus','northeurope','westeurope','japanwest','japaneast','brazilsouth','australiaeast','australiasoutheast','southindia','centralindia','westindia','canadacentral','canadaeast','uksouth','ukwest','westcentralus','westus2','koreacentral','koreasouth','francecentral','francesouth','australiacentral','australiacentral2','uaecentral','uaenorth','southafricanorth','southafricawest','switzerlandnorth','switzerlandwest','germanynorth','germanywestcentral','norwaywest','norwayeast','brazilsoutheast','westus3','swedencentral'|}*/'location'
+  tags:{
+    'tag': 'tagValue'   
+  }
+}


### PR DESCRIPTION
Added a small snippet for creating a resource group.

* [x] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"
