### PR TITLE
disabled build summary until CLI and PS catch up

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -51,7 +51,6 @@ namespace Bicep.Cli.IntegrationTests
             {
                 result.Should().Be(0);
                 output.Should().BeEmpty();
-                error.Should().MatchRegex(BuildSummarySucceededRegex);
                 AssertNoErrors(error);
             }
 
@@ -80,7 +79,6 @@ namespace Bicep.Cli.IntegrationTests
             {
                 result.Should().Be(0);
                 output.Should().NotBeEmpty();
-                error.Should().MatchRegex(BuildSummarySucceededRegex);
                 AssertNoErrors(error);
             }
 
@@ -110,7 +108,6 @@ namespace Bicep.Cli.IntegrationTests
             {
                 result.Should().Be(1);
                 output.Should().BeEmpty();
-                error.Should().MatchRegex(BuildSummaryFailedRegex);
                 error.Should().ContainAll(diagnostics);
             }
         }
@@ -126,7 +123,6 @@ namespace Bicep.Cli.IntegrationTests
 
             result.Should().Be(1);
             output.Should().BeEmpty();
-            error.Should().MatchRegex(BuildSummaryFailedRegex);
 
             var diagnostics = GetAllDiagnostics(bicepFilePath);
             error.Should().ContainAll(diagnostics);
@@ -146,7 +142,6 @@ output myOutput string = 'hello!'
 
             File.Exists(outputFilePath).Should().BeTrue();
             result.Should().Be(0);
-            error.Should().MatchRegex(BuildSummarySucceededRegex);
         }
 
         [TestMethod]
@@ -193,7 +188,6 @@ output myOutput string = 'hello!'
 
             File.Exists(expectedOutputFile).Should().BeTrue();
             result.Should().Be(0);
-            error.Should().MatchRegex(BuildSummarySucceededRegex);
         }
 
         [DataRow("DoesNotExist.bicep", new[] { "--stdout" }, @"An error occurred reading file. Could not find file '.+DoesNotExist.bicep'")]

--- a/src/Bicep.Cli.IntegrationTests/TestBase.cs
+++ b/src/Bicep.Cli.IntegrationTests/TestBase.cs
@@ -16,9 +16,6 @@ namespace Bicep.Cli.IntegrationTests
 {
     public class TestBase
     {
-        protected const string BuildSummaryFailedRegex = @"Build failed: (\d*) Warning\(s\), ([1-9][0-9]*) Error\(s\)";
-        protected const string BuildSummarySucceededRegex = @"Build succeeded: (\d*) Warning\(s\), 0 Error\(s\)";
-
         protected static (string output, string error, int result) Bicep(params string[] args)
         {
             return TextWriterHelper.InvokeWriterAction((@out, err) =>

--- a/src/Bicep.Cli/Commands/BuildCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildCommand.cs
@@ -46,13 +46,8 @@ namespace Bicep.Cli.Commands
                 }
             }
 
-            if (args.NoSummary is false)
-            {
-                diagnosticLogger.LogSummary();
-            }
-
             // return non-zero exit code on errors
-           return diagnosticLogger.ErrorCount > 0 ? 1 : 0;
+            return diagnosticLogger.ErrorCount > 0 ? 1 : 0;
         }
     }
 }


### PR DESCRIPTION
This is temporarily fixes #3638. We will need to change AZ PS/CLI to send the `--no-summary` switch to the Bicep CLI for versions >= 0.4.412. Once the fix is released in AZ PS/CLI, we can revert this change.

I intentionally left the `--no-summary` switch so that AZ PS/CLI can call it without any issues.