### PR TITLE
add appconfig/feature flag example, fixes issue #3608

### DIFF
--- a/docs/examples/101/app-config-with-feature-flags/main.bicep
+++ b/docs/examples/101/app-config-with-feature-flags/main.bicep
@@ -1,0 +1,35 @@
+param location string = resourceGroup().location
+param appConfigSku string = 'free'
+var uniquestr = uniqueString(resourceGroup().id)
+var appconfigName = 'myappconfig${uniquestr}'
+
+var flag01name = 'flag01'
+var flag02name = 'flag02'
+var ffcontenttype = 'application/vnd.microsoft.appconfig.ff+json;charset=utf-8'
+
+//the feature flag resources are embedded because of the bicep naming rules 
+//for names that don't match the segment length, it appears the feature flag resource 
+//name requires an additional '/' which has to be represented with the '~2F'
+resource appconfig 'Microsoft.AppConfiguration/configurationStores@2021-03-01-preview'={
+  location: location
+  name: appconfigName
+  sku: {
+    name: appConfigSku
+  }
+  resource flag01 'keyValues@2021-03-01-preview' = {
+    name: '.appconfig.featureflag~2F${flag01name}'
+    properties:{
+      value: '{	"id": "${flag01name}",	"description": "",	"enabled": false,	"conditions": {		"client_filters": []	}}'
+      contentType: ffcontenttype
+    }
+  }
+  resource flag02 'keyValues@2021-03-01-preview' = {
+    name: '.appconfig.featureflag~2F${flag02name}'
+    properties:{
+      value: '{	"id": "${flag02name}",	"description": "",	"enabled": false,	"conditions": {		"client_filters": []	}}'
+      contentType: ffcontenttype
+    }
+  }
+}
+
+output connstr string = appconfig.listKeys().value[0].ConnectionString

--- a/docs/examples/101/app-config-with-feature-flags/main.bicep
+++ b/docs/examples/101/app-config-with-feature-flags/main.bicep
@@ -1,35 +1,35 @@
 param location string = resourceGroup().location
 param appConfigSku string = 'free'
-var uniquestr = uniqueString(resourceGroup().id)
-var appconfigName = 'myappconfig${uniquestr}'
+var uniqueStr = uniqueString(resourceGroup().id)
+var appConfigName = 'myappconfig${uniqueStr}'
 
-var flag01name = 'flag01'
-var flag02name = 'flag02'
-var ffcontenttype = 'application/vnd.microsoft.appconfig.ff+json;charset=utf-8'
+var flag01Name = 'flag01'
+var flag02Name = 'flag02'
+var ffContentType = 'application/vnd.microsoft.appconfig.ff+json;charset=utf-8'
 
 //the feature flag resources are embedded because of the bicep naming rules 
 //for names that don't match the segment length, it appears the feature flag resource 
 //name requires an additional '/' which has to be represented with the '~2F'
-resource appconfig 'Microsoft.AppConfiguration/configurationStores@2021-03-01-preview'={
+resource appConfig 'Microsoft.AppConfiguration/configurationStores@2021-03-01-preview'={
   location: location
-  name: appconfigName
+  name: appConfigName
   sku: {
     name: appConfigSku
   }
   resource flag01 'keyValues@2021-03-01-preview' = {
-    name: '.appconfig.featureflag~2F${flag01name}'
+    name: '.appconfig.featureflag~2F${flag01Name}'
     properties:{
-      value: '{	"id": "${flag01name}",	"description": "",	"enabled": false,	"conditions": {		"client_filters": []	}}'
-      contentType: ffcontenttype
+      value: '{	"id": "${flag01Name}",	"description": "",	"enabled": false,	"conditions": {		"client_filters": []	}}'
+      contentType: ffContentType
     }
   }
   resource flag02 'keyValues@2021-03-01-preview' = {
-    name: '.appconfig.featureflag~2F${flag02name}'
+    name: '.appconfig.featureflag~2F${flag02Name}'
     properties:{
-      value: '{	"id": "${flag02name}",	"description": "",	"enabled": false,	"conditions": {		"client_filters": []	}}'
-      contentType: ffcontenttype
+      value: '{	"id": "${flag02Name}",	"description": "",	"enabled": false,	"conditions": {		"client_filters": []	}}'
+      contentType: ffContentType
     }
   }
 }
 
-output connstr string = appconfig.listKeys().value[0].ConnectionString
+output connstr string = appConfig.listKeys().value[0].ConnectionString

--- a/docs/examples/101/app-config-with-feature-flags/main.json
+++ b/docs/examples/101/app-config-with-feature-flags/main.json
@@ -20,41 +20,41 @@
   },
   "functions": [],
   "variables": {
-    "uniquestr": "[uniqueString(resourceGroup().id)]",
-    "appconfigName": "[format('myappconfig{0}', variables('uniquestr'))]",
-    "flag01name": "flag01",
-    "flag02name": "flag02",
-    "ffcontenttype": "application/vnd.microsoft.appconfig.ff+json;charset=utf-8"
+    "uniqueStr": "[uniqueString(resourceGroup().id)]",
+    "appConfigName": "[format('myappconfig{0}', variables('uniqueStr'))]",
+    "flag01Name": "flag01",
+    "flag02Name": "flag02",
+    "ffContentType": "application/vnd.microsoft.appconfig.ff+json;charset=utf-8"
   },
   "resources": [
     {
       "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
       "apiVersion": "2021-03-01-preview",
-      "name": "[format('{0}/{1}', variables('appconfigName'), format('.appconfig.featureflag~2F{0}', variables('flag01name')))]",
+      "name": "[format('{0}/{1}', variables('appConfigName'), format('.appconfig.featureflag~2F{0}', variables('flag01Name')))]",
       "properties": {
-        "value": "[format('{{\t\"id\": \"{0}\",\t\"description\": \"\",\t\"enabled\": false,\t\"conditions\": {{\t\t\"client_filters\": []\t}}}}', variables('flag01name'))]",
-        "contentType": "[variables('ffcontenttype')]"
+        "value": "[format('{{\t\"id\": \"{0}\",\t\"description\": \"\",\t\"enabled\": false,\t\"conditions\": {{\t\t\"client_filters\": []\t}}}}', variables('flag01Name'))]",
+        "contentType": "[variables('ffContentType')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.AppConfiguration/configurationStores', variables('appconfigName'))]"
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', variables('appConfigName'))]"
       ]
     },
     {
       "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
       "apiVersion": "2021-03-01-preview",
-      "name": "[format('{0}/{1}', variables('appconfigName'), format('.appconfig.featureflag~2F{0}', variables('flag02name')))]",
+      "name": "[format('{0}/{1}', variables('appConfigName'), format('.appconfig.featureflag~2F{0}', variables('flag02Name')))]",
       "properties": {
-        "value": "[format('{{\t\"id\": \"{0}\",\t\"description\": \"\",\t\"enabled\": false,\t\"conditions\": {{\t\t\"client_filters\": []\t}}}}', variables('flag02name'))]",
-        "contentType": "[variables('ffcontenttype')]"
+        "value": "[format('{{\t\"id\": \"{0}\",\t\"description\": \"\",\t\"enabled\": false,\t\"conditions\": {{\t\t\"client_filters\": []\t}}}}', variables('flag02Name'))]",
+        "contentType": "[variables('ffContentType')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.AppConfiguration/configurationStores', variables('appconfigName'))]"
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', variables('appConfigName'))]"
       ]
     },
     {
       "type": "Microsoft.AppConfiguration/configurationStores",
       "apiVersion": "2021-03-01-preview",
-      "name": "[variables('appconfigName')]",
+      "name": "[variables('appConfigName')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('appConfigSku')]"
@@ -64,7 +64,7 @@
   "outputs": {
     "connstr": {
       "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.AppConfiguration/configurationStores', variables('appconfigName')), '2021-03-01-preview').value[0].ConnectionString]"
+      "value": "[listKeys(resourceId('Microsoft.AppConfiguration/configurationStores', variables('appConfigName')), '2021-03-01-preview').value[0].ConnectionString]"
     }
   }
 }

--- a/docs/examples/101/app-config-with-feature-flags/main.json
+++ b/docs/examples/101/app-config-with-feature-flags/main.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.412.5873",
+      "templateHash": "11908641062425101149"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    },
+    "appConfigSku": {
+      "type": "string",
+      "defaultValue": "free"
+    }
+  },
+  "functions": [],
+  "variables": {
+    "uniquestr": "[uniqueString(resourceGroup().id)]",
+    "appconfigName": "[format('myappconfig{0}', variables('uniquestr'))]",
+    "flag01name": "flag01",
+    "flag02name": "flag02",
+    "ffcontenttype": "application/vnd.microsoft.appconfig.ff+json;charset=utf-8"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+      "apiVersion": "2021-03-01-preview",
+      "name": "[format('{0}/{1}', variables('appconfigName'), format('.appconfig.featureflag~2F{0}', variables('flag01name')))]",
+      "properties": {
+        "value": "[format('{{\t\"id\": \"{0}\",\t\"description\": \"\",\t\"enabled\": false,\t\"conditions\": {{\t\t\"client_filters\": []\t}}}}', variables('flag01name'))]",
+        "contentType": "[variables('ffcontenttype')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', variables('appconfigName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+      "apiVersion": "2021-03-01-preview",
+      "name": "[format('{0}/{1}', variables('appconfigName'), format('.appconfig.featureflag~2F{0}', variables('flag02name')))]",
+      "properties": {
+        "value": "[format('{{\t\"id\": \"{0}\",\t\"description\": \"\",\t\"enabled\": false,\t\"conditions\": {{\t\t\"client_filters\": []\t}}}}', variables('flag02name'))]",
+        "contentType": "[variables('ffcontenttype')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', variables('appconfigName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.AppConfiguration/configurationStores",
+      "apiVersion": "2021-03-01-preview",
+      "name": "[variables('appconfigName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('appConfigSku')]"
+      }
+    }
+  ],
+  "outputs": {
+    "connstr": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.AppConfiguration/configurationStores', variables('appconfigName')), '2021-03-01-preview').value[0].ConnectionString]"
+    }
+  }
+}


### PR DESCRIPTION
fixes issue #3608

Add a specific example for App Config Feature Flags as the syntax is a bit complex

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [x] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [x] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
