### PR TITLE
Module registry infrastructure

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/TestBase.cs
+++ b/src/Bicep.Cli.IntegrationTests/TestBase.cs
@@ -3,7 +3,9 @@
 
 using Bicep.Cli.UnitTests;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
 using Bicep.Core.Text;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Utils;
@@ -37,7 +39,8 @@ namespace Bicep.Cli.IntegrationTests
 
         protected static IEnumerable<string> GetAllDiagnostics(string bicepFilePath)
         {
-            var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath));
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver));
+            var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath));
             var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), sourceFileGrouping);
 
             var output = new List<string>();

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -8,6 +8,8 @@ using Bicep.Cli.Logging;
 using Bicep.Cli.Services;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +29,7 @@ namespace Bicep.Cli
         }
 
         public static int Main(string[] args)
-        {            
+        {
             string profilePath = MulticoreJIT.GetMulticoreJITPath();
             ProfileOptimization.SetProfileRoot(profilePath);
             ProfileOptimization.StartProfile("bicep.profile");
@@ -101,7 +103,9 @@ namespace Bicep.Cli
                 // Handles the context of this invocation
                 .AddSingleton(invocationContext)
 
-                // Adds the various services that
+                // Adds the various services required by the commands
+                .AddSingleton<IFileResolver, FileResolver>()
+                .AddSingleton<IModuleRegistryProvider, DefaultModuleRegistryProvider>()
                 .AddSingleton<DecompilationWriter>()
                 .AddSingleton<CompilationWriter>()
                 .AddSingleton<CompilationService>()

--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -6,9 +6,12 @@ using System.IO;
 using System.Linq;
 using Bicep.Core.Emit;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Modules;
 using Bicep.Core.Parsing;
+using Bicep.Core.Registry;
 using Bicep.Core.Samples;
 using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
@@ -37,7 +40,8 @@ namespace Bicep.Core.IntegrationTests.Emit
             var compiledFilePath = FileHelper.GetResultFilePath(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainCompiled));
 
             // emitting the template should be successful
-            var result = this.EmitTemplate(SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath)), compiledFilePath, BicepTestConstants.DevAssemblyFileVersion);
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver));
+            var result = this.EmitTemplate(SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath)), compiledFilePath, BicepTestConstants.DevAssemblyFileVersion);
             result.Diagnostics.Should().NotHaveErrors();
             result.Status.Should().Be(EmitStatus.Succeeded);
 
@@ -78,7 +82,9 @@ namespace Bicep.Core.IntegrationTests.Emit
             MemoryStream memoryStream = new MemoryStream();
 
             // emitting the template should be successful
-            var result = this.EmitTemplate(SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath)), memoryStream, BicepTestConstants.DevAssemblyFileVersion);
+            FileResolver fileResolver = BicepTestConstants.FileResolver;
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver));
+            var result = this.EmitTemplate(SourceFileGroupingBuilder.Build(fileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath)), memoryStream, BicepTestConstants.DevAssemblyFileVersion);
             result.Diagnostics.Should().NotHaveErrors();
             result.Status.Should().Be(EmitStatus.Succeeded);
 
@@ -103,7 +109,9 @@ namespace Bicep.Core.IntegrationTests.Emit
             string filePath = FileHelper.GetResultFilePath(this.TestContext, $"{dataSet.Name}_Compiled_Original.json");
 
             // emitting the template should fail
-            var result = this.EmitTemplate(SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath)), filePath, BicepTestConstants.DevAssemblyFileVersion);
+            FileResolver fileResolver = BicepTestConstants.FileResolver;
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver));
+            var result = this.EmitTemplate(SourceFileGroupingBuilder.Build(fileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath)), filePath, BicepTestConstants.DevAssemblyFileVersion);
             result.Diagnostics.Should().NotBeEmpty();
             result.Status.Should().Be(EmitStatus.Failed);
         }

--- a/src/Bicep.Core.Samples/DataSetsExtensions.cs
+++ b/src/Bicep.Core.Samples/DataSetsExtensions.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Utils;
@@ -30,7 +32,8 @@ namespace Bicep.Core.Samples
         {
             outputDirectory = dataSet.SaveFilesToTestDirectory(testContext);
             fileUri = PathHelper.FilePathToFileUrl(Path.Combine(outputDirectory, DataSet.TestFileMain));
-            var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, new Workspace(), fileUri);
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver));
+            var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), fileUri);
 
             return new Compilation(AzResourceTypeProvider.CreateWithAzTypes(), sourceFileGrouping);
         }

--- a/src/Bicep.Core.Samples/ExamplesTests.cs
+++ b/src/Bicep.Core.Samples/ExamplesTests.cs
@@ -26,6 +26,9 @@ using Newtonsoft.Json.Linq;
 using Bicep.Core.Configuration;
 using Bicep.Core.Analyzers.Linter;
 using Bicep.Core.UnitTests.Configuration;
+using Bicep.Core.Modules;
+using Bicep.Core.Registry;
+using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Samples
 {
@@ -119,8 +122,9 @@ namespace Bicep.Core.Samples
             var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(TestContext, typeof(ExamplesTests).Assembly, parentStream);
             var bicepFileName = Path.Combine(outputDirectory, Path.GetFileName(example.BicepStreamName));
             var jsonFileName = Path.Combine(outputDirectory, Path.GetFileName(example.JsonStreamName));
-            
-            var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, new Workspace(), PathHelper.FilePathToFileUrl(bicepFileName));
+
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver));
+            var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFileName));
             var compilation = new Compilation(AzResourceTypeProvider.CreateWithAzTypes(), sourceFileGrouping);
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), BicepTestConstants.DevAssemblyFileVersion);
 

--- a/src/Bicep.Core.UnitTests/Assertions/DiagnosticBuilderAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/DiagnosticBuilderAssertions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace Bicep.Core.UnitTests.Assertions
+{
+    public static class DiagnosticBuilderExtensions
+    {
+        public static DiagnosticBuilderAssertions Should(this DiagnosticBuilder.DiagnosticBuilderDelegate diagnosticBuilder) => new(diagnosticBuilder);
+    }
+
+    public class DiagnosticBuilderAssertions : ReferenceTypeAssertions<DiagnosticBuilder.DiagnosticBuilderDelegate, DiagnosticBuilderAssertions>
+    {
+        public DiagnosticBuilderAssertions(DiagnosticBuilder.DiagnosticBuilderDelegate diagnosticBuilder)
+        {
+            this.Subject = diagnosticBuilder;
+        }
+
+        protected override string Identifier => "DiagnosticBuilderDelegate";
+
+        public AndConstraint<DiagnosticBuilderAssertions> HaveCodeAndSeverity(string code, DiagnosticLevel level, string because = "", params object[] becauseArgs)
+        {
+            Diagnostic diagnostic = GetDiagnosticFromSubject();
+
+            using (new AssertionScope())
+            {
+                diagnostic.Should().HaveCodeAndSeverity(code, level, because, becauseArgs);
+            }
+
+            return new(this);
+        }
+
+        public AndConstraint<DiagnosticBuilderAssertions> HaveMessage(string message, string because = "", params object[] becauseArgs)
+        {
+            Diagnostic diagnostic = GetDiagnosticFromSubject();
+
+            using (new AssertionScope())
+{
+                diagnostic.Should().HaveMessage(message, because, becauseArgs);
+            }
+
+            return new(this);
+        }
+
+        private Diagnostic GetDiagnosticFromSubject() => this.Subject(DiagnosticBuilder.ForPosition(new TextSpan(0, 0)));
+    }
+}

--- a/src/Bicep.Core.UnitTests/Assertions/ErrorBuilderAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/ErrorBuilderAssertions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace Bicep.Core.UnitTests.Assertions
+{
+    public static class ErrorBuilderExtensions
+    {
+        public static ErrorBuilderAssertions Should(this DiagnosticBuilder.ErrorBuilderDelegate errorBuilder) => new(errorBuilder);
+    }
+
+    public class ErrorBuilderAssertions : ReferenceTypeAssertions<DiagnosticBuilder.ErrorBuilderDelegate, ErrorBuilderAssertions>
+    {
+        public ErrorBuilderAssertions(DiagnosticBuilder.ErrorBuilderDelegate errorBuilder)
+        {
+            this.Subject = errorBuilder;
+        }
+
+        protected override string Identifier => "ErrorBuilderDelegate";
+
+        public AndConstraint<ErrorBuilderAssertions> HaveCode(string code, string because = "", params object[] becauseArgs)
+        {
+            ErrorDiagnostic error = GetErrorFromSubject();
+
+            using (new AssertionScope())
+            {
+                error.Should().HaveCodeAndSeverity(code, DiagnosticLevel.Error, because, becauseArgs);
+            }
+
+            return new(this);
+        }
+
+        public AndConstraint<ErrorBuilderAssertions> HaveMessage(string message, string because = "", params object[] becauseArgs)
+        {
+            ErrorDiagnostic error = GetErrorFromSubject();
+
+            using (new AssertionScope())
+{
+                error.Should().HaveMessage(message, because, becauseArgs);
+            }
+
+            return new(this);
+        }
+
+        private ErrorDiagnostic GetErrorFromSubject() => this.Subject(DiagnosticBuilder.ForPosition(new TextSpan(0, 0)));
+    }
+}

--- a/src/Bicep.Core.UnitTests/BicepTestConstants.cs
+++ b/src/Bicep.Core.UnitTests/BicepTestConstants.cs
@@ -9,6 +9,6 @@ namespace Bicep.Core.UnitTests
     {
         public const string DevAssemblyFileVersion = "dev";
         public const string GeneratorTemplateHashPath = "metadata._generator.templateHash";
-        public static readonly FileResolver FileResolver = new ();        
+        public static readonly FileResolver FileResolver = new();
     }
 }

--- a/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 
@@ -103,6 +104,11 @@ namespace Bicep.Core.UnitTests.Diagnostics
                 return new List<string> { $"<value_{index}" };
             }
 
+            if (parameter.ParameterType == typeof(ImmutableArray<string>))
+            {
+                return new[] { $"<value_{index}" }.ToImmutableArray();
+            }
+
             if (parameter.ParameterType == typeof(Uri))
             {
                 return new Uri("file:///path/to/main.bicep");
@@ -144,7 +150,12 @@ namespace Bicep.Core.UnitTests.Diagnostics
                 return ResourceScope.ResourceGroup;
             }
 
-            return $"<param_{index}>";
+            if (parameter.ParameterType == typeof(string) || parameter.ParameterType == typeof(IEnumerable<char>))
+            {
+                return $"<param_{index}>";
+            }
+
+            throw new AssertFailedException($"Unable to generate mock parameter value of type '{parameter.ParameterType}' for the diagnostic builder method.");
         }
     }
 }

--- a/src/Bicep.Core.UnitTests/FileSystem/FileResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/FileSystem/FileResolverTests.cs
@@ -171,15 +171,15 @@ namespace Bicep.Core.UnitTests.FileSystem
 
             // make parent dir
             Directory.CreateDirectory(tempDir);
-            fileResolver.TryDirExists(PathHelper.FilePathToFileUrl(tempDir)).Should().BeTrue();
-            fileResolver.TryDirExists(PathHelper.FilePathToFileUrl(tempFile)).Should().BeFalse();
+            fileResolver.DirExists(PathHelper.FilePathToFileUrl(tempDir)).Should().BeTrue();
+            fileResolver.DirExists(PathHelper.FilePathToFileUrl(tempFile)).Should().BeFalse();
             // add a file to parent dir
             File.WriteAllText(tempFile, "abcd\r\ndef");
-            fileResolver.TryDirExists(PathHelper.FilePathToFileUrl(tempDir)).Should().BeTrue();
-            fileResolver.TryDirExists(PathHelper.FilePathToFileUrl(tempFile)).Should().BeFalse();
+            fileResolver.DirExists(PathHelper.FilePathToFileUrl(tempDir)).Should().BeTrue();
+            fileResolver.DirExists(PathHelper.FilePathToFileUrl(tempFile)).Should().BeFalse();
             // make child dir
             Directory.CreateDirectory(tempChildDir);
-            fileResolver.TryDirExists(PathHelper.FilePathToFileUrl(tempChildDir)).Should().BeTrue();
+            fileResolver.DirExists(PathHelper.FilePathToFileUrl(tempChildDir)).Should().BeTrue();
         }
 
         [DataTestMethod]

--- a/src/Bicep.Core.UnitTests/Json/JsonAssert.cs
+++ b/src/Bicep.Core.UnitTests/Json/JsonAssert.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Bicep.Core.UnitTests.Utils;
-using FluentAssertions.Primitives;
 using JsonDiffPatchDotNet;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;

--- a/src/Bicep.Core.UnitTests/Modules/LocalModuleReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/LocalModuleReferenceTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Modules;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Modules
+{
+    [TestClass]
+    public class LocalModuleReferenceTests
+    {
+        [DataRow("test.bicep","test.bicep")]
+        [DataRow("../bar/foo.bicep", "../bar/foo.bicep")]
+        [DataRow("./t.json", "./t.json")]
+        [DataTestMethod]
+        public void SameModulePathsShouldBeEqual(string package1, string package2)
+        {
+            var (first, second) = ParsePair(package1, package2);
+
+            first.Equals(second).Should().BeTrue();
+            first.GetHashCode().Should().Be(second.GetHashCode());
+        }
+
+        [DataRow("test.bicep", "Test.bicep")]
+        [DataRow("../bar/foo.bicep", "foo.bicep")]
+        [DataRow("./t.json", "./t.JSON")]
+        [DataTestMethod]
+        public void DifferentPathsShouldNotBeEqual(string package1, string package2)
+        {
+            var (first, second) = ParsePair(package1, package2);
+
+            first.Equals(second).Should().BeFalse();
+            first.GetHashCode().Should().NotBe(second.GetHashCode());
+        }
+
+        [DataRow("./test.bicep")]
+        [DataRow("foo/bar/test.bicep")]
+        [DataRow("../bar/test.bicep")]
+        [DataTestMethod]
+        public void TryParseModuleReference_ValidLocalReference_ShouldParse(string value)
+        {
+            var reference = Parse(value);
+            reference.Path.Should().Be(value);
+        }
+
+        private static LocalModuleReference Parse(string package)
+        {
+            var parsed = LocalModuleReference.TryParse(package, out var failureBuilder);
+            parsed.Should().NotBeNull();
+            failureBuilder.Should().BeNull();
+            return parsed!;
+        }
+
+        // TODO: Add equality tests
+        private static (LocalModuleReference, LocalModuleReference) ParsePair(string first, string second) => (Parse(first), Parse(second));
+    }
+}

--- a/src/Bicep.Core.UnitTests/Modules/ModuleReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/ModuleReferenceTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Modules;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Reflection;
+
+namespace Bicep.Core.UnitTests.Modules
+{
+    [TestClass]
+    public class ModuleReferenceTests
+    {
+        [TestMethod]
+        public void ModuleReferenceShouldBeDerivedAtLeastOnce()
+        {
+            var subClasses = GetModuleRefSubClasses().ToList();
+
+            subClasses.Should().HaveCountGreaterOrEqualTo(1);
+            subClasses.Should().Contain(item => (Type)item[0] == typeof(LocalModuleReference));
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetModuleRefSubClasses), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet))]
+        public void ModuleRefSubClassesShouldOverrideEqualsAndHashCode(Type type)
+        {
+            /* 
+             * The module reference subclasses must implement Equals() and GetHashCode() so reference deduping works correctly.
+             */
+            static MethodInfo? GetDeclaredMethod(Type type, string name) => type.GetMethod(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.InvokeMethod | BindingFlags.DeclaredOnly);
+
+            var equals = GetDeclaredMethod(type, nameof(object.Equals));
+            equals.Should().NotBeNull();
+            equals!.ReturnType.Should().Be(typeof(bool));
+            equals.GetParameters().Should().SatisfyRespectively(x => x.ParameterType.Should().Be(typeof(object)));
+
+            var getHashCode = GetDeclaredMethod(type, nameof(object.GetHashCode));
+            getHashCode.Should().NotBeNull();
+            getHashCode!.ReturnType.Should().Be(typeof(int));
+            getHashCode.GetParameters().Should().BeEmpty();
+        }
+
+        private static IEnumerable<object[]> GetModuleRefSubClasses() => typeof(ModuleReference).Assembly
+            .GetTypes()
+            .Where(type => type.IsClass && type.IsSubclassOf(typeof(ModuleReference)))
+            .Select(type => new[] { type });
+    }
+}

--- a/src/Bicep.Core.UnitTests/Registry/ModuleRegistryDispatcherTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/ModuleRegistryDispatcherTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Modules;
+using Bicep.Core.Registry;
+using Bicep.Core.Syntax;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.Workspaces;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Bicep.Core.UnitTests.Registry
+{
+    [TestClass]
+    public class ModuleRegistryDispatcherTests
+    {
+        private static readonly MockRepository Repository = new MockRepository(MockBehavior.Strict);
+
+        [TestMethod]
+        public void NoRegistries_AvailableSchemes_ShouldReturnEmpty()
+        {
+            var dispatcher = CreateDispatcher();
+            dispatcher.AvailableSchemes.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void NoRegistries_ValidateModuleReference_ShouldReturnError()
+        {
+            var module = CreateModule("fakeScheme:fakeModule");
+            var dispatcher = CreateDispatcher();
+            dispatcher.ValidateModuleReference(module, out var failureBuilder).Should().BeFalse();
+            failureBuilder!.Should().NotBeNull();
+
+            using (new AssertionScope())
+            {
+                failureBuilder!.Should().HaveCode("BCP189");
+                failureBuilder!.Should().HaveMessage("Module references are not supported in this context.");
+            }
+
+            var localModule = CreateModule("test.bicep");
+            dispatcher.ValidateModuleReference(localModule, out var localModuleFailureBuilder).Should().BeFalse();
+            using (new AssertionScope())
+            {
+                localModuleFailureBuilder!.Should().HaveCode("BCP189");
+                localModuleFailureBuilder!.Should().HaveMessage("Module references are not supported in this context.");
+            }
+        }
+
+        [TestMethod]
+        public void NoRegistries_NonValidateMethods_ShouldThrow()
+        {
+            var module = CreateModule("fakeScheme:fakeModule");
+            var moduleDispatcher = CreateDispatcher();
+
+            static void ExpectFailure(Action fail) => fail.Should().Throw<InvalidOperationException>().WithMessage($"The specified module is not valid. Call {nameof(IModuleDispatcher.ValidateModuleReference)}() first.");
+
+            ExpectFailure(() => moduleDispatcher.IsModuleAvailable(module, out _));
+            ExpectFailure(() => moduleDispatcher.TryGetLocalModuleEntryPointUri(new Uri("untitled://two"), module, out _));
+            ExpectFailure(() => moduleDispatcher.RestoreModules(new[] { module }));
+        }
+
+        [TestMethod]
+        public void MockRegistries_AvailableSchemes_ShouldReturnedConfiguredSchemes()
+        {
+            var first = Repository.Create<IModuleRegistry>();
+            first.Setup(m => m.Scheme).Returns("first");
+
+            var second = Repository.Create<IModuleRegistry>();
+            second.Setup(m => m.Scheme).Returns("second");
+
+            var dispatcher = CreateDispatcher(first.Object, second.Object);
+            dispatcher.AvailableSchemes.Should().BeEquivalentTo("first", "second");
+        }
+
+        [TestMethod]
+        public void MockRegistries_ModuleLifecycle()
+        {
+            var fail = Repository.Create<IModuleRegistry>();
+            fail.Setup(m => m.Scheme).Returns("fail");
+
+            var mock = Repository.Create<IModuleRegistry>();
+            mock.Setup(m => m.Scheme).Returns("mock");
+
+            DiagnosticBuilder.ErrorBuilderDelegate? @null = null;
+            var validRef = new MockModuleReference("validRef");
+            mock.Setup(m => m.TryParseModuleReference("validRef", out @null))
+                .Returns(validRef);
+
+            var validRef2 = new MockModuleReference("validRef2");
+            mock.Setup(m => m.TryParseModuleReference("validRef2", out @null))
+                .Returns(validRef2);
+
+            var validRef3 = new MockModuleReference("validRef3");
+            mock.Setup(m => m.TryParseModuleReference("validRef3", out @null))
+                .Returns(validRef3);
+
+            DiagnosticBuilder.ErrorBuilderDelegate? badRefError = x => new ErrorDiagnostic(x.TextSpan, "BCPMock", "Bad ref error");
+            mock.Setup(m => m.TryParseModuleReference("badRef", out badRefError))
+                .Returns((ModuleReference?)null);
+
+            mock.Setup(m => m.IsModuleRestoreRequired(validRef)).Returns(true);
+            mock.Setup(m => m.IsModuleRestoreRequired(validRef2)).Returns(false);
+            mock.Setup(m => m.IsModuleRestoreRequired(validRef3)).Returns(true);
+
+            mock.Setup(m => m.TryGetLocalModuleEntryPointPath(It.IsAny<Uri>(), validRef, out @null))
+                .Returns(new Uri("untitled://validRef"));
+            mock.Setup(m => m.TryGetLocalModuleEntryPointPath(It.IsAny<Uri>(), validRef3, out @null))
+                .Returns(new Uri("untitled://validRef3"));
+
+            mock.Setup(m => m.RestoreModules(It.IsAny<IEnumerable<ModuleReference>>()))
+                .Returns(new Dictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate>
+                {
+                    [validRef3] = x => new ErrorDiagnostic(x.TextSpan, "RegFail", "Failed to restore module")
+                });
+
+            var dispatcher = CreateDispatcher(fail.Object, mock.Object);
+
+            var goodModule = CreateModule("mock:validRef");
+            var goodModule2 = CreateModule("mock:validRef2");
+            var goodModule3 = CreateModule("mock:validRef3");
+            var badModule = CreateModule("mock:badRef");
+
+            dispatcher.ValidateModuleReference(goodModule, out var goodValidationBuilder).Should().BeTrue();
+            goodValidationBuilder!.Should().BeNull();
+            
+            dispatcher.ValidateModuleReference(badModule, out var badValidationBuilder).Should().BeFalse();
+            badValidationBuilder!.Should().NotBeNull();
+            badValidationBuilder!.Should().HaveCode("BCPMock");
+            badValidationBuilder!.Should().HaveMessage("Bad ref error");
+
+            dispatcher.IsModuleAvailable(goodModule, out var goodAvailabilityBuilder).Should().BeFalse();
+            goodAvailabilityBuilder!.Should().HaveCode("BCP190");
+            goodAvailabilityBuilder!.Should().HaveMessage("The module with reference \"mock:validRef\" has not been restored.");
+
+            dispatcher.IsModuleAvailable(goodModule2, out var goodAvailabilityBuilder2).Should().BeTrue();
+            goodAvailabilityBuilder2!.Should().BeNull();
+
+            dispatcher.IsModuleAvailable(goodModule3, out var goodAvailabilityBuilder3).Should().BeFalse();
+            goodAvailabilityBuilder3!.Should().HaveCode("BCP190");
+            goodAvailabilityBuilder3!.Should().HaveMessage("The module with reference \"mock:validRef3\" has not been restored.");
+
+            dispatcher.TryGetLocalModuleEntryPointUri(new Uri("mock://mock"), goodModule, out var entryPointBuilder).Should().Be(new Uri("untitled://validRef"));
+            entryPointBuilder!.Should().BeNull();
+
+            dispatcher.TryGetLocalModuleEntryPointUri(new Uri("mock://mock"), goodModule3, out var entryPointBuilder3).Should().Be(new Uri("untitled://validRef3"));
+            entryPointBuilder3!.Should().BeNull();
+
+            dispatcher.RestoreModules(new[] { goodModule, goodModule3 }).Should().BeTrue();
+
+            dispatcher.IsModuleAvailable(goodModule3, out var goodAvailabilityBuilder3AfterRestore).Should().BeFalse();
+            goodAvailabilityBuilder3AfterRestore!.Should().HaveCode("RegFail");
+            goodAvailabilityBuilder3AfterRestore!.Should().HaveMessage("Failed to restore module");
+        }
+
+        private static IModuleDispatcher CreateDispatcher(params IModuleRegistry[] registries)
+        {
+            var provider = Repository.Create<IModuleRegistryProvider>();
+            provider.Setup(m => m.Registries).Returns(registries.ToImmutableArray());
+
+            return new ModuleDispatcher(provider.Object);
+        }
+
+        private static ModuleDeclarationSyntax CreateModule(string reference)
+        {
+            var file = SourceFileFactory.CreateBicepFile(new System.Uri("untitled://hello"), $"module foo '{reference}' = {{}}");
+            return file.ProgramSyntax.Declarations.OfType<ModuleDeclarationSyntax>().Single();
+        }
+
+        private class MockModuleReference : ModuleReference
+        {
+            public MockModuleReference(string reference)
+                : base("mock")
+            {
+                this.Reference = reference;
+            }
+
+            public string Reference { get; }
+
+            public override string UnqualifiedReference => this.Reference;
+        }
+    }
+}

--- a/src/Bicep.Core.UnitTests/Utils/SourceFileGroupingFactory.cs
+++ b/src/Bicep.Core.UnitTests/Utils/SourceFileGroupingFactory.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
+using Bicep.Core.Syntax;
 using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.UnitTests.Utils
@@ -23,7 +25,7 @@ namespace Bicep.Core.UnitTests.Utils
             var sourceFiles = fileContentsByUri.Select(kvp => SourceFileFactory.CreateSourceFile(kvp.Key, kvp.Value));
             workspace.UpsertSourceFiles(sourceFiles);
 
-            return SourceFileGroupingBuilder.Build(fileResolver, workspace, entryFileUri);
+            return SourceFileGroupingBuilder.Build(fileResolver, new ModuleDispatcher(new DefaultModuleRegistryProvider(fileResolver)), workspace, entryFileUri);
         }
     }
 }

--- a/src/Bicep.Core/FileSystem/FileResolver.cs
+++ b/src/Bicep.Core/FileSystem/FileResolver.cs
@@ -213,6 +213,6 @@ namespace Bicep.Core.FileSystem
 
         public bool DirExists(Uri fileUri) => fileUri.IsFile && Directory.Exists(fileUri.LocalPath);
 
-        public bool Exists(Uri uri) => uri.IsFile && File.Exists(uri.LocalPath);
+        public bool FileExists(Uri uri) => uri.IsFile && File.Exists(uri.LocalPath);
     }
 }

--- a/src/Bicep.Core/FileSystem/FileResolver.cs
+++ b/src/Bicep.Core/FileSystem/FileResolver.cs
@@ -211,10 +211,8 @@ namespace Bicep.Core.FileSystem
             return Directory.GetFiles(fileUri.LocalPath, pattern).Select(s => new Uri(s));
         }
 
-        public bool TryDirExists(Uri fileUri)
-        {
-            return fileUri.IsFile && Directory.Exists(fileUri.LocalPath);
-        }
+        public bool DirExists(Uri fileUri) => fileUri.IsFile && Directory.Exists(fileUri.LocalPath);
 
+        public bool Exists(Uri uri) => uri.IsFile && File.Exists(uri.LocalPath);
     }
 }

--- a/src/Bicep.Core/FileSystem/IFileResolver.cs
+++ b/src/Bicep.Core/FileSystem/IFileResolver.cs
@@ -52,10 +52,10 @@ namespace Bicep.Core.FileSystem
         bool DirExists(Uri fileUri);
 
         /// <summary>
-        /// Checks if the specified URI exists.
+        /// Checks if the specified file URI exists.
         /// </summary>
         /// <param name="uri">The URI to test.</param>
-        bool Exists(Uri uri);
+        bool FileExists(Uri uri);
 
         /// <summary>
         /// Tries to read a file and encode it as base64 string. If an exception is encoutered, returns null and sets a non-null failureMessage.

--- a/src/Bicep.Core/FileSystem/IFileResolver.cs
+++ b/src/Bicep.Core/FileSystem/IFileResolver.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.FileSystem
     public interface IFileResolver
     {
         /// <summary>
-        /// Tries to read a file contents to string. If an exception is encoutered, returns null and sets a non-null failureMessage.
+        /// Tries to read a file contents to string. If an exception is encountered, returns null and sets a non-null failureMessage.
         /// </summary>
         /// <param name="fileUri">The file URI to read.</param>
         /// <param name="fileContents">The contents of the file, if successful.</param>
@@ -46,11 +46,16 @@ namespace Bicep.Core.FileSystem
         IEnumerable<Uri> GetFiles(Uri fileUri, string pattern);
 
         /// <summary>
-        /// Check whether specified URI exsists (depends on URI types). fileUri MUST have a trailing '/'
+        /// Check whether specified URI's directory exists if specified URI is a file:// URI. fileUri MUST have a trailing '/'
         /// </summary>
         /// <param name="fileUri">The fileUri to test</param>
-        bool TryDirExists(Uri fileUri);
+        bool DirExists(Uri fileUri);
 
+        /// <summary>
+        /// Checks if the specified URI exists.
+        /// </summary>
+        /// <param name="uri">The URI to test.</param>
+        bool Exists(Uri uri);
 
         /// <summary>
         /// Tries to read a file and encode it as base64 string. If an exception is encoutered, returns null and sets a non-null failureMessage.

--- a/src/Bicep.Core/FileSystem/InMemoryFileResolver.cs
+++ b/src/Bicep.Core/FileSystem/InMemoryFileResolver.cs
@@ -79,11 +79,9 @@ namespace Bicep.Core.FileSystem
             return relativeUri;
         }
 
-        public bool TryDirExists(Uri fileUri)
-        {
-            return this.fileLookup.Keys
-                .Any(key => key.ToString().StartsWith(fileUri.ToString()));
-        }
+        public bool DirExists(Uri fileUri) => this.fileLookup.Keys.Any(key => key.ToString().StartsWith(fileUri.ToString()));
+
+        public bool Exists(Uri uri) => this.fileLookup.ContainsKey(uri);
 
         public IEnumerable<Uri> GetDirectories(Uri fileUri, string pattern)
         {

--- a/src/Bicep.Core/FileSystem/InMemoryFileResolver.cs
+++ b/src/Bicep.Core/FileSystem/InMemoryFileResolver.cs
@@ -81,7 +81,7 @@ namespace Bicep.Core.FileSystem
 
         public bool DirExists(Uri fileUri) => this.fileLookup.Keys.Any(key => key.ToString().StartsWith(fileUri.ToString()));
 
-        public bool Exists(Uri uri) => this.fileLookup.ContainsKey(uri);
+        public bool FileExists(Uri uri) => this.fileLookup.ContainsKey(uri);
 
         public IEnumerable<Uri> GetDirectories(Uri fileUri, string pattern)
         {

--- a/src/Bicep.Core/Modules/LocalModuleReference.cs
+++ b/src/Bicep.Core/Modules/LocalModuleReference.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using System.Collections.Generic;
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Bicep.Core.Modules
+{
+    /// <summary>
+    /// Represents a reference to a local module (by relative path).
+    /// </summary>
+    public class LocalModuleReference : ModuleReference
+    {
+        private static readonly IEqualityComparer<string> PathComparer = StringComparer.Ordinal;
+
+        private LocalModuleReference(string path)
+            : base(ModuleReferenceSchemes.Local)
+        {
+            this.Path = path;
+        }
+
+        /// <summary>
+        /// Gets the relative path to the module.
+        /// </summary>
+        public string Path { get; }
+
+        public override bool Equals(object obj)
+        {
+            if(obj is not LocalModuleReference other)
+            {
+                return false;
+            }
+
+            return PathComparer.Equals(this.Path, other.Path);
+        }
+
+        public override int GetHashCode() => PathComparer.GetHashCode(this.Path);
+
+        public override string UnqualifiedReference => this.Path;
+
+        public override string FullyQualifiedReference => this.Path;
+
+        public static LocalModuleReference? TryParse(string unqualifiedReference, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            if(!Validate(unqualifiedReference, out failureBuilder))
+            {
+                return null;
+            }
+
+            return new(unqualifiedReference);
+        }
+
+        public static bool Validate(string pathName, [NotNullWhen(false)] out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            if (pathName.Length == 0)
+            {
+                failureBuilder = x => x.FilePathIsEmpty();
+                return false;
+            }
+
+            if (pathName.First() == '/')
+            {
+                failureBuilder = x => x.FilePathBeginsWithForwardSlash();
+                return false;
+            }
+
+            foreach (var pathChar in pathName)
+            {
+                if (pathChar == '\\')
+                {
+                    // enforce '/' rather than '\' for module paths for cross-platform compatibility
+                    failureBuilder = x => x.FilePathContainsBackSlash();
+                    return false;
+                }
+
+                if (forbiddenPathChars.Contains(pathChar))
+                {
+                    failureBuilder = x => x.FilePathContainsForbiddenCharacters(forbiddenPathChars);
+                    return false;
+                }
+
+                if (IsInvalidPathControlCharacter(pathChar))
+                {
+                    failureBuilder = x => x.FilePathContainsControlChars();
+                    return false;
+                }
+            }
+
+            if (forbiddenPathTerminatorChars.Contains(pathName.Last()))
+            {
+                failureBuilder = x => x.FilePathHasForbiddenTerminator(forbiddenPathTerminatorChars);
+                return false;
+            }
+
+            failureBuilder = null;
+            return true;
+        }
+
+        private static readonly ImmutableHashSet<char> forbiddenPathChars = "<>:\"\\|?*".ToImmutableHashSet();
+        private static readonly ImmutableHashSet<char> forbiddenPathTerminatorChars = " .".ToImmutableHashSet();
+
+        private static bool IsInvalidPathControlCharacter(char pathChar)
+        {
+            // TODO: Revisit when we add unicode support to Bicep
+
+            // The following are disallowed as path chars on Windows, so we block them to avoid cross-platform compilation issues.
+            // Note that we're checking this range explicitly, as char.IsControl() includes some characters that are valid path characters.
+            return pathChar >= 0 && pathChar <= 31;
+        }
+    }
+}

--- a/src/Bicep.Core/Modules/ModuleReference.cs
+++ b/src/Bicep.Core/Modules/ModuleReference.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Modules
+{
+    /// <summary>
+    /// Strongly typed representation of a module reference string.
+    /// </summary>
+    public abstract class ModuleReference
+    {
+        protected ModuleReference(string scheme)
+        {
+            this.Scheme = scheme;
+        }
+
+        public string Scheme { get; }
+
+        /// <summary>
+        /// Gets the fully qualified module reference, which includes the scheme.
+        /// </summary>
+        public virtual string FullyQualifiedReference => $"{this.Scheme}:{this.UnqualifiedReference}";
+
+        /// <summary>
+        /// Gets the unqualified module reference, which does not include the scheme.
+        /// </summary>
+        public abstract string UnqualifiedReference { get; }
+    }
+}

--- a/src/Bicep.Core/Modules/ModuleReferenceSchemes.cs
+++ b/src/Bicep.Core/Modules/ModuleReferenceSchemes.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Modules
+{
+    public static class ModuleReferenceSchemes
+    {
+        public const string Local = "";
+    }
+}

--- a/src/Bicep.Core/Registry/DefaultModuleRegistryProvider.cs
+++ b/src/Bicep.Core/Registry/DefaultModuleRegistryProvider.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.FileSystem;
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Registry
+{
+    public class DefaultModuleRegistryProvider : IModuleRegistryProvider
+    {
+        private readonly IFileResolver fileResolver;
+
+        public DefaultModuleRegistryProvider(IFileResolver fileResolver)
+        {
+            this.fileResolver = fileResolver;
+        }
+
+        public ImmutableArray<IModuleRegistry> Registries => new IModuleRegistry[]
+{
+            new LocalModuleRegistry(this.fileResolver)
+        }.ToImmutableArray();
+    }
+}

--- a/src/Bicep.Core/Registry/IModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/IModuleDispatcher.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bicep.Core.Registry
+{
+    public interface IModuleDispatcher
+    {
+        ImmutableArray<string> AvailableSchemes { get; }
+
+        bool ValidateModuleReference(ModuleDeclarationSyntax module, [NotNullWhen(false)] out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder);
+
+        bool IsModuleAvailable(ModuleDeclarationSyntax module, out DiagnosticBuilder.ErrorBuilderDelegate? errorDetailBuilder);
+
+        Uri? TryGetLocalModuleEntryPointUri(Uri parentModuleUri, ModuleDeclarationSyntax module, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder);
+
+        bool RestoreModules(IEnumerable<ModuleDeclarationSyntax> modules);
+    }
+}

--- a/src/Bicep.Core/Registry/IModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/IModuleRegistry.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Modules;
+using System;
+using System.Collections.Generic;
+
+namespace Bicep.Core.Registry
+{
+    /// <summary>
+    /// An implementation of a Bicep module registry.
+    /// </summary>
+    public interface IModuleRegistry
+    {
+        /// <summary>
+        /// Gets the scheme used by this registry in module references.
+        /// </summary>
+        string Scheme { get; }
+
+        /// <summary>
+        /// Attempts to parse the specified unqualified reference or returns a failure builder.
+        /// </summary>
+        /// <param name="reference">The unqualified module reference</param>
+        /// <param name="failureBuilder">set to an error builder if parsing fails when null is returned</param>
+        ModuleReference? TryParseModuleReference(string reference, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder);
+
+        /// <summary>
+        /// Returns true if the specified module is already cached in the local cache. 
+        /// </summary>
+        /// <param name="reference">The reference to the module.</param>
+        bool IsModuleRestoreRequired(ModuleReference reference);
+
+        /// <summary>
+        /// Returns a URI to the entry point module.
+        /// </summary>
+        /// <param name="parentModuleUri">The parent URI</param>
+        /// <param name="reference">The module reference</param>
+        /// <param name="failureBuilder">set to an error builder if parsing fails when null is returned</param>
+        /// <returns></returns>
+        Uri? TryGetLocalModuleEntryPointPath(Uri parentModuleUri, ModuleReference reference, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder);
+
+        /// <summary>
+        /// Downloads the specified modules from the registry and caches them locally.
+        /// Returns a mapping of module references to error builders for modules that failed to be downloaded.
+        /// </summary>
+        /// <param name="references">module references</param>
+        IDictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate> RestoreModules(IEnumerable<ModuleReference> references);
+    }
+}

--- a/src/Bicep.Core/Registry/IModuleRegistryProvider.cs
+++ b/src/Bicep.Core/Registry/IModuleRegistryProvider.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Registry
+{
+    /// <summary>
+    /// Represents the configured module registries for the current instance of Bicep.
+    /// </summary>
+    public interface IModuleRegistryProvider
+    {
+        ImmutableArray<IModuleRegistry> Registries { get; }
+    }
+}

--- a/src/Bicep.Core/Registry/LocalModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/LocalModuleRegistry.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Modules;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Registry
+{
+    public class LocalModuleRegistry : IModuleRegistry
+    {
+        private readonly IFileResolver fileResolver;
+
+        public LocalModuleRegistry(IFileResolver fileResolver)
+        {
+            this.fileResolver = fileResolver;
+        }
+
+        public string Scheme => ModuleReferenceSchemes.Local;
+
+        public ModuleReference? TryParseModuleReference(string reference, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder) => LocalModuleReference.TryParse(reference, out failureBuilder);
+
+        public Uri? TryGetLocalModuleEntryPointPath(Uri parentModuleUri, ModuleReference reference, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            var typed = ConvertReference(reference);
+
+            var localUri = fileResolver.TryResolveFilePath(parentModuleUri, typed.Path);
+            if (localUri is not null)
+            {
+                failureBuilder = null;
+                return localUri;
+            }
+
+            failureBuilder = x => x.FilePathCouldNotBeResolved(typed.Path, parentModuleUri.LocalPath);
+            return null;
+        }
+
+        public IDictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate> RestoreModules(IEnumerable<ModuleReference> references)
+        {
+            // local modules are already present on the file system
+            // and do not require init
+            return ImmutableDictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate>.Empty;
+        }
+
+        public bool IsModuleRestoreRequired(ModuleReference reference) => false;
+
+        private static LocalModuleReference ConvertReference(ModuleReference reference)
+        {
+            if (reference is LocalModuleReference typed)
+            {
+                return typed;
+            }
+
+            throw new ArgumentException($"Reference type '{reference.GetType().Name}' is not supported.");
+        }
+    }
+}

--- a/src/Bicep.Core/Registry/ModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/ModuleDispatcher.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Modules;
+using Bicep.Core.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Bicep.Core.Registry
+{
+    public class ModuleDispatcher : IModuleDispatcher
+    {
+        private readonly ImmutableDictionary<string, IModuleRegistry> registries;
+
+        /*
+         * This data structure behaves like a dictionary but creates a weak reference to the keys stored within.
+         * When the keys stop being reachable and are cleaned up by the GC, they will disappear from this table.
+         */ 
+        private readonly ConditionalWeakTable<ModuleDeclarationSyntax, DiagnosticBuilder.ErrorBuilderDelegate> restoreStatuses;
+
+        public ModuleDispatcher(IModuleRegistryProvider registryProvider)
+        {
+            this.registries = registryProvider.Registries.ToImmutableDictionary(registry => registry.Scheme);
+            this.AvailableSchemes = this.registries.Keys.OrderBy(s => s).ToImmutableArray();
+            this.restoreStatuses = new ConditionalWeakTable<ModuleDeclarationSyntax, DiagnosticBuilder.ErrorBuilderDelegate>();
+        }
+
+        public ImmutableArray<string> AvailableSchemes { get; }
+
+        public bool ValidateModuleReference(ModuleDeclarationSyntax module, [NotNullWhen(false)] out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder) =>
+            this.TryGetModuleReference(module, out failureBuilder) is not null;
+
+        public bool IsModuleAvailable(ModuleDeclarationSyntax module, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            var reference = GetModuleReference(module);
+            if (!this.registries.TryGetValue(reference.Scheme, out var registry))
+            {
+                throw new NotImplementedException($"Unexpected module reference scheme '{reference.Scheme}'");
+            }
+
+            // have we already failed to restore this module?
+            // TODO: This needs to reset after some time
+            if (this.HasRestoreFailed(module, out var restoreFailureBuilder))
+            {
+                failureBuilder = restoreFailureBuilder;
+                return false;
+            }
+
+            if (registry.IsModuleRestoreRequired(reference))
+            {
+                // module is not present on the local file system
+                // TODO: This error needs to have different text in CLI vs the language server
+                failureBuilder = x => x.ModuleRequiresRestore(reference.FullyQualifiedReference);
+                return false;
+            }
+
+            failureBuilder = null;
+            return true;
+        }
+
+        public Uri? TryGetLocalModuleEntryPointUri(Uri parentModuleUri, ModuleDeclarationSyntax module, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            // has restore already failed for this module?
+            if(this.HasRestoreFailed(module, out var restoreFailureBuilder))
+            {
+                failureBuilder = restoreFailureBuilder;
+                return null;
+            }
+
+            var reference = GetModuleReference(module);
+            Type refType = reference.GetType();
+            if (this.registries.TryGetValue(reference.Scheme, out var registry))
+            {
+                return registry.TryGetLocalModuleEntryPointPath(parentModuleUri, reference, out failureBuilder);
+            }
+
+            throw new NotImplementedException($"Unexpected module reference type '{refType.Name}'");
+        }
+
+        public bool RestoreModules(IEnumerable<ModuleDeclarationSyntax> modules)
+        {
+            // WARNING: The various operations on ModuleReference objects here rely on the custom Equals() implementation and NOT on object identity
+
+            if (modules.All(module => this.IsModuleAvailable(module, out _)))
+            {
+                // all the modules have already been restored - no need to do anything
+                return false;
+            }
+
+            // one module ref can be associated with multiple module declarations
+            var referenceToModules = modules.ToLookup(module => GetModuleReference(module));
+
+            var references = modules.Select(module => GetModuleReference(module)).Distinct();
+
+            // split module refs by scheme
+            var referencesByScheme = references.ToLookup(@ref => @ref.Scheme);
+
+            // send each set of refs to its own registry
+            foreach (var scheme in this.registries.Keys.Where(refType => referencesByScheme.Contains(refType)))
+            {
+                var restoreStatuses = this.registries[scheme].RestoreModules(referencesByScheme[scheme]);
+
+                // update restore status for each failed module restore
+                foreach(var (failedReference, failureBuilder) in restoreStatuses)
+                {
+                    foreach(var failedModule in referenceToModules[failedReference])
+                    {
+                        this.SetRestoreFailure(failedModule, failureBuilder);
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private ModuleReference GetModuleReference(ModuleDeclarationSyntax module) =>
+            TryGetModuleReference(module, out _) ?? throw new InvalidOperationException($"The specified module is not valid. Call {nameof(ValidateModuleReference)}() first.");
+
+        private ModuleReference? TryGetModuleReference(ModuleDeclarationSyntax module, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            var moduleReferenceString = SyntaxHelper.TryGetModulePath(module, out var getModulePathFailureBuilder);
+            if (moduleReferenceString is null)
+            {
+                failureBuilder = getModulePathFailureBuilder ?? throw new InvalidOperationException($"Expected {nameof(SyntaxHelper.TryGetModulePath)} to provide failure diagnostics.");
+                return null;
+            }
+
+            return this.TryParseModuleReference(moduleReferenceString, out failureBuilder);
+        }
+
+        private ModuleReference? TryParseModuleReference(string reference, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            var parts = reference.Split(':', 2, System.StringSplitOptions.None);
+            switch (parts.Length)
+            {
+                case 1:
+                    // local path reference
+                    if (registries.TryGetValue(ModuleReferenceSchemes.Local, out var localRegistry))
+                    {
+                        return localRegistry.TryParseModuleReference(parts[0], out failureBuilder);
+                    }
+
+                    failureBuilder = x => x.UnknownModuleReferenceScheme(ModuleReferenceSchemes.Local, this.AvailableSchemes);
+                    return null;
+
+                case 2:
+                    var scheme = parts[0];
+
+                    if (!string.IsNullOrEmpty(scheme) && registries.TryGetValue(scheme, out var registry))
+                    {
+                        // the scheme is recognized
+                        var rawValue = parts[1];
+                        return registry.TryParseModuleReference(rawValue, out failureBuilder);
+                    }
+
+                    // unknown scheme
+                    failureBuilder = x => x.UnknownModuleReferenceScheme(scheme, this.AvailableSchemes);
+                    return null;
+
+                default:
+                    // empty string
+                    failureBuilder = x => x.ModulePathHasNotBeenSpecified();
+                    return null;
+            }
+        }
+
+        private bool HasRestoreFailed(ModuleDeclarationSyntax module, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            // TODO: In cases the user publishes a module after authoring an invalid reference to it, the current logic will permanently block it
+            // until the language server is restarted. We need to reset the failure status after some time or create an alternative mechanism.
+            return this.restoreStatuses.TryGetValue(module, out failureBuilder);
+        }
+
+        private void SetRestoreFailure(ModuleDeclarationSyntax module, DiagnosticBuilder.ErrorBuilderDelegate failureBuilder)
+        {
+            this.restoreStatuses.AddOrUpdate(module, failureBuilder);
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceSymbol.cs
@@ -9,6 +9,7 @@ using Azure.Deployments.Core.Json;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Modules;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.Workspaces;
@@ -417,7 +418,7 @@ namespace Bicep.Core.Semantics.Namespaces
 
         private static Uri? GetFileUriWithDiagnostics(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, string filePath, SyntaxBase filePathArgument)
         {
-            if (!SourceFileGroupingBuilder.ValidateFilePath(filePath, out var validateFilePathFailureBuilder))
+            if (!LocalModuleReference.Validate(filePath, out var validateFilePathFailureBuilder))
             {
                 diagnostics.Write(validateFilePathFailureBuilder.Invoke(DiagnosticBuilder.ForPosition(filePathArgument)));
                 return null;

--- a/src/Bicep.Core/Workspaces/SourceFileGrouping.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGrouping.cs
@@ -11,18 +11,28 @@ namespace Bicep.Core.Workspaces
 {
     public class SourceFileGrouping
     {
-        private readonly ImmutableDictionary<ModuleDeclarationSyntax, ISourceFile> sourceFilesByModuleDeclaration;
-
-        private readonly ImmutableDictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate> errorBuildersByModuleDeclaration;
-
-        public SourceFileGrouping(IFileResolver fileResolver, BicepFile entryPoint, ImmutableHashSet<ISourceFile> sourceFiles, ImmutableDictionary<ModuleDeclarationSyntax, ISourceFile> sourceFilesByModuleDeclaration, ImmutableDictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate> errorBuildersByModuleDeclaration)
+        public SourceFileGrouping(
+            IFileResolver fileResolver,
+            BicepFile entryPoint,
+            ImmutableHashSet<ISourceFile> sourceFiles,
+            ImmutableDictionary<ModuleDeclarationSyntax, ISourceFile> sourceFilesByModuleDeclaration,
+            ImmutableDictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate> errorBuildersByModuleDeclaration,
+            ImmutableHashSet<ModuleDeclarationSyntax> modulesToRestore)
         {
             this.FileResolver = fileResolver;
             this.EntryPoint = entryPoint;
             this.SourceFiles = sourceFiles;
-            this.sourceFilesByModuleDeclaration = sourceFilesByModuleDeclaration;
-            this.errorBuildersByModuleDeclaration = errorBuildersByModuleDeclaration;
+            this.SourceFilesByModuleDeclaration = sourceFilesByModuleDeclaration;
+            this.ErrorBuildersByModuleDeclaration = errorBuildersByModuleDeclaration;
+            this.ModulesToRestore = modulesToRestore;
         }
+
+        public ImmutableDictionary<ModuleDeclarationSyntax, ISourceFile> SourceFilesByModuleDeclaration { get; }
+
+        public ImmutableDictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate> ErrorBuildersByModuleDeclaration { get; }
+
+        public ImmutableHashSet<ModuleDeclarationSyntax> ModulesToRestore { get; }
+
         public IFileResolver FileResolver { get; }
 
         public BicepFile EntryPoint { get; }
@@ -30,11 +40,11 @@ namespace Bicep.Core.Workspaces
         public ImmutableHashSet<ISourceFile> SourceFiles { get; }
 
         public ISourceFile LookUpModuleSourceFile(ModuleDeclarationSyntax moduleDeclaration) =>
-            this.sourceFilesByModuleDeclaration[moduleDeclaration];
+            this.SourceFilesByModuleDeclaration[moduleDeclaration];
 
         public bool TryLookUpModuleErrorDiagnostic(ModuleDeclarationSyntax moduleDeclaration, [NotNullWhen(true)] out ErrorDiagnostic? errorDiagnostic)
         {
-            if (this.errorBuildersByModuleDeclaration.TryGetValue(moduleDeclaration, out var errorBuilder))
+            if (this.ErrorBuildersByModuleDeclaration.TryGetValue(moduleDeclaration, out var errorBuilder))
             {
                 errorDiagnostic = errorBuilder(ForPosition(moduleDeclaration.Path));
                 return true;

--- a/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
@@ -3,11 +3,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Parsing;
+using Bicep.Core.Registry;
 using Bicep.Core.Syntax;
 using Bicep.Core.Utils;
 using static Bicep.Core.Diagnostics.DiagnosticBuilder;
@@ -17,27 +17,65 @@ namespace Bicep.Core.Workspaces
     public class SourceFileGroupingBuilder
     {
         private readonly IFileResolver fileResolver;
+        private readonly IModuleDispatcher moduleDispatcher;
         private readonly IReadOnlyWorkspace workspace;
-        private readonly IDictionary<ModuleDeclarationSyntax, ISourceFile> sourceFilesByModuleDeclaration;
-        private readonly IDictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate> errorBuildersByModuleDeclaration;
-        private readonly IDictionary<Uri, ISourceFile> sourceFilesByUri;
-        private readonly IDictionary<Uri, ErrorBuilderDelegate> errorBuildersByUri;
 
-        private SourceFileGroupingBuilder(IFileResolver fileResolver, IReadOnlyWorkspace workspace)
+        private readonly Dictionary<ModuleDeclarationSyntax, ISourceFile> sourceFilesByModuleDeclaration;
+        private readonly Dictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate> errorBuildersByModuleDeclaration;
+
+        private readonly HashSet<ModuleDeclarationSyntax> modulesToInit;
+
+        // uri -> successfully loaded syntax tree
+        private readonly Dictionary<Uri, ISourceFile> sourceFilesByUri;
+
+        // uri -> syntax tree load failure 
+        private readonly Dictionary<Uri, ErrorBuilderDelegate> errorBuildersByUri;
+
+        private SourceFileGroupingBuilder(IFileResolver fileResolver, IModuleDispatcher moduleDispatcher, IReadOnlyWorkspace workspace)
         {
             this.fileResolver = fileResolver;
+            this.moduleDispatcher = moduleDispatcher;
             this.workspace = workspace;
-            this.sourceFilesByModuleDeclaration = new Dictionary<ModuleDeclarationSyntax, ISourceFile>();
-            this.errorBuildersByModuleDeclaration = new Dictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate>();
-            this.sourceFilesByUri = new Dictionary<Uri, ISourceFile>();
-            this.errorBuildersByUri = new Dictionary<Uri, ErrorBuilderDelegate>();
+            this.sourceFilesByModuleDeclaration = new();
+            this.errorBuildersByModuleDeclaration = new();
+            this.modulesToInit = new();
+            this.sourceFilesByUri = new();
+            this.errorBuildersByUri = new();
         }
 
-        public static SourceFileGrouping Build(IFileResolver fileResolver, IReadOnlyWorkspace workspace, Uri entryFileUri)
+        private SourceFileGroupingBuilder(IFileResolver fileResolver, IModuleDispatcher moduleDispatcher, IReadOnlyWorkspace workspace, SourceFileGrouping current)
         {
-            var builder = new SourceFileGroupingBuilder(fileResolver, workspace);
+            this.fileResolver = fileResolver;
+            this.moduleDispatcher = moduleDispatcher;
+            this.workspace = workspace;
+
+            this.sourceFilesByModuleDeclaration = new(current.SourceFilesByModuleDeclaration);
+            this.errorBuildersByModuleDeclaration = new(current.ErrorBuildersByModuleDeclaration);
+
+            this.modulesToInit = new();
+            
+            this.sourceFilesByUri = current.SourceFiles.ToDictionary(tree => tree.FileUri);
+            this.errorBuildersByUri = new();
+        }
+
+        public static SourceFileGrouping Build(IFileResolver fileResolver, IModuleDispatcher moduleDispatcher, IReadOnlyWorkspace workspace, Uri entryFileUri)
+        {
+            var builder = new SourceFileGroupingBuilder(fileResolver, moduleDispatcher, workspace);
 
             return builder.Build(entryFileUri);
+        }
+
+        public static SourceFileGrouping Rebuild(IModuleDispatcher moduleDispatcher, IReadOnlyWorkspace workspace, SourceFileGrouping current)
+        {
+            var builder = new SourceFileGroupingBuilder(current.FileResolver, moduleDispatcher, workspace, current);
+
+            foreach (var module in current.ModulesToRestore)
+            {
+                builder.sourceFilesByModuleDeclaration.Remove(module);
+                builder.errorBuildersByModuleDeclaration.Remove(module);
+            }
+
+            return builder.Build(current.EntryPoint.FileUri);
         }
 
         private SourceFileGrouping Build(Uri entryFileUri)
@@ -66,7 +104,8 @@ namespace Bicep.Core.Workspaces
                 entryPoint,
                 sourceFilesByUri.Values.ToImmutableHashSet(),
                 sourceFilesByModuleDeclaration.ToImmutableDictionary(),
-                errorBuildersByModuleDeclaration.ToImmutableDictionary());
+                errorBuildersByModuleDeclaration.ToImmutableDictionary(),
+                modulesToInit.ToImmutableHashSet());
         }
 
         private ISourceFile? TryGetSourceFile(Uri fileUri, bool isEntryFile, out ErrorBuilderDelegate? failureBuilder)
@@ -112,7 +151,7 @@ namespace Bicep.Core.Workspaces
         {
             var sourceFile = this.TryGetSourceFile(fileUri, isEntryFile, out var getSourceFileFailureBuilder);
 
-            if (sourceFile == null)
+            if (sourceFile is null)
             {
                 failureBuilder = getSourceFileFailureBuilder;
                 return null;
@@ -127,30 +166,44 @@ namespace Bicep.Core.Workspaces
 
             foreach (var module in GetModuleDeclarations(bicepFile))
             {
-                var moduleUri = this.TryGetNormalizedModuleUri(fileUri, module, out var moduleGetPathFailureBuilder);
-                if (moduleUri == null)
+                if(!this.moduleDispatcher.ValidateModuleReference(module, out var parseReferenceFailureBuilder))
+                {
+                    // module reference is not valid
+                    errorBuildersByModuleDeclaration[module] = parseReferenceFailureBuilder ?? throw new InvalidOperationException($"Expected {nameof(IModuleDispatcher.ValidateModuleReference)} to provide failure diagnostics.");
+                    continue;
+                }
+
+                if(!this.moduleDispatcher.IsModuleAvailable(module, out var restoreErrorBuilder))
+                {
+                    errorBuildersByModuleDeclaration[module] = restoreErrorBuilder ?? throw new InvalidOperationException($"Expected {nameof(IModuleDispatcher.IsModuleAvailable)} to provide failure diagnostics.");
+                    modulesToInit.Add(module);
+                    continue;
+                }
+
+                var moduleFileUri = this.moduleDispatcher.TryGetLocalModuleEntryPointUri(fileUri, module, out var moduleGetPathFailureBuilder);
+                if (moduleFileUri is null)
                 {
                     // TODO: If we upgrade to netstandard2.1, we should be able to use the following to hint to the compiler that failureBuilder is non-null:
                     // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis
-                    errorBuildersByModuleDeclaration[module] = moduleGetPathFailureBuilder ?? throw new InvalidOperationException($"Expected {nameof(TryGetNormalizedModuleUri)} to provide failure diagnostics");
+                    errorBuildersByModuleDeclaration[module] = moduleGetPathFailureBuilder ?? throw new InvalidOperationException($"Expected {nameof(moduleDispatcher.TryGetLocalModuleEntryPointUri)} to provide failure diagnostics.");
                     continue;
                 }
 
                 // only recurse if we've not seen this module before - to avoid infinite loops
-                if (!sourceFilesByUri.TryGetValue(moduleUri, out var moduleFile))
+                if (!sourceFilesByUri.TryGetValue(moduleFileUri, out var moduleFile))
                 {
-                    moduleFile = PopulateRecursive(moduleUri, isEntryFile: false, out var modulePopulateFailureBuilder);
-
-                    if (moduleFile == null)
+                    moduleFile = PopulateRecursive(moduleFileUri, isEntryFile: false, out var modulePopulateFailureBuilder);
+                    
+                    if (moduleFile is null)
                     {
                         // TODO: If we upgrade to netstandard2.1, we should be able to use the following to hint to the compiler that failureBuilder is non-null:
                         // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis
-                        errorBuildersByModuleDeclaration[module] = modulePopulateFailureBuilder ?? throw new InvalidOperationException($"Expected {nameof(PopulateRecursive)} to provide failure diagnostics");
+                        errorBuildersByModuleDeclaration[module] = modulePopulateFailureBuilder ?? throw new InvalidOperationException($"Expected {nameof(PopulateRecursive)} to provide failure diagnostics.");
                         continue;
                     }
                 }
 
-                if (moduleFile == null)
+                if (moduleFile is null)
                 {
                     continue;
                 }
@@ -160,89 +213,6 @@ namespace Bicep.Core.Workspaces
 
             failureBuilder = null;
             return sourceFile;
-        }
-
-        private static readonly ImmutableHashSet<char> forbiddenPathChars = "<>:\"\\|?*".ToImmutableHashSet();
-        private static readonly ImmutableHashSet<char> forbiddenPathTerminatorChars = " .".ToImmutableHashSet();
-        private static bool IsInvalidPathControlCharacter(char pathChar)
-        {
-            // TODO: Revisit when we add unicode support to Bicep
-
-            // The following are disallowed as path chars on Windows, so we block them to avoid cross-platform compilation issues.
-            // Note that we're checking this range explicitly, as char.IsControl() includes some characters that are valid path characters.
-            return pathChar >= 0 && pathChar <= 31;
-        }
-
-        public static bool ValidateFilePath(string pathName, [NotNullWhen(false)] out ErrorBuilderDelegate? failureBuilder)
-        {
-            if (string.IsNullOrWhiteSpace(pathName))
-            {
-                failureBuilder = x => x.FilePathIsEmpty();
-                return false;
-            }
-
-            if (pathName.First() == '/')
-            {
-                failureBuilder = x => x.FilePathBeginsWithForwardSlash();
-                return false;
-            }
-
-            foreach (var pathChar in pathName)
-            {
-                if (pathChar == '\\')
-                {
-                    // enforce '/' rather than '\' for module paths for cross-platform compatibility
-                    failureBuilder = x => x.FilePathContainsBackSlash();
-                    return false;
-                }
-
-                if (forbiddenPathChars.Contains(pathChar))
-                {
-                    failureBuilder = x => x.FilePathContainsForbiddenCharacters(forbiddenPathChars);
-                    return false;
-                }
-
-                if (IsInvalidPathControlCharacter(pathChar))
-                {
-                    failureBuilder = x => x.FilePathContainsControlChars();
-                    return false;
-                }
-            }
-
-            if (forbiddenPathTerminatorChars.Contains(pathName.Last()))
-            {
-                failureBuilder = x => x.FilePathHasForbiddenTerminator(forbiddenPathTerminatorChars);
-                return false;
-            }
-
-            failureBuilder = null;
-            return true;
-        }
-
-        private Uri? TryGetNormalizedModuleUri(Uri parentFileUri, ModuleDeclarationSyntax moduleDeclarationSyntax, out ErrorBuilderDelegate? failureBuilder)
-        {
-            var pathName = SyntaxHelper.TryGetModulePath(moduleDeclarationSyntax, out var getModulePathFailureBuilder);
-            if (pathName == null)
-            {
-                failureBuilder = getModulePathFailureBuilder;
-                return null;
-            }
-
-            if (!ValidateFilePath(pathName, out var validateModulePathFailureBuilder))
-            {
-                failureBuilder = validateModulePathFailureBuilder;
-                return null;
-            }
-
-            var moduleUri = fileResolver.TryResolveFilePath(parentFileUri, pathName);
-            if (moduleUri == null)
-            {
-                failureBuilder = x => x.FilePathCouldNotBeResolved(pathName, parentFileUri.LocalPath);
-                return null;
-            }
-
-            failureBuilder = null;
-            return moduleUri;
         }
 
         private void ReportFailuresForCycles()

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -21,6 +21,10 @@ using Bicep.Decompiler.Exceptions;
 using Bicep.Decompiler;
 using Bicep.Core.Configuration;
 using Bicep.Core.UnitTests.Configuration;
+using Bicep.Core.Modules;
+using Bicep.Core.Registry;
+using Bicep.Core.Syntax;
+using Bicep.Core.UnitTests;
 
 namespace Bicep.Core.IntegrationTests
 {
@@ -96,8 +100,8 @@ namespace Bicep.Core.IntegrationTests
             var workspace = new Workspace();
             workspace.UpsertSourceFiles(bicepFiles);
 
-            var fileResolver = new FileResolver();
-            var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, workspace, bicepUri);
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver));
+            var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, workspace, bicepUri);
             var compilation = new Compilation(typeProvider, sourceFileGrouping);
             var diagnosticsByBicepFile = compilation.GetAllDiagnosticsByBicepFile(new ConfigHelper().GetDisabledLinterConfig());
 

--- a/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Extensions;
+using Bicep.Core.Modules;
+using Bicep.Core.Registry;
+using Bicep.Core.Syntax;
+using Bicep.Core.Workspaces;
+using Bicep.LangServer.IntegrationTests;
+using Bicep.LanguageServer.CompilationManager;
+using Bicep.LanguageServer.Registry;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.LangServer.UnitTests.Registry
+{
+    [TestClass]
+    public class ModuleRestoreSchedulerTests
+    {
+        private static readonly MockRepository Repository = new(MockBehavior.Strict);
+
+        [TestMethod]
+        [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Not needed")]
+        public async Task DisposeAfterCreateShouldNotThrow()
+        {
+            var moduleDispatcher = Repository.Create<IModuleDispatcher>();
+            await using (var scheduler = new ModuleRestoreScheduler(moduleDispatcher.Object))
+            {
+                // intentional extra call to dispose()
+                await scheduler.DisposeAsync();
+            }
+        }
+
+        [TestMethod]
+        [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Not needed")]
+        public async Task DisposeAfterStartShouldNotThrow()
+        {
+            var moduleDispatcher = Repository.Create<IModuleDispatcher>();
+            await using (var scheduler = new ModuleRestoreScheduler(moduleDispatcher.Object))
+            {
+                scheduler.Start();
+
+                // intentional extra call to dispose()
+                await scheduler.DisposeAsync();
+            }
+
+            await using(var scheduler = new ModuleRestoreScheduler(moduleDispatcher.Object))
+            {
+                await Task.Yield();
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
+                scheduler.Start();
+            }
+        }
+
+        [TestMethod]
+        [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Not needed")]
+        public async Task PublicMethodsShouldThrowAfterDispose()
+        {
+            var moduleDispatcher = Repository.Create<IModuleDispatcher>();
+            var scheduler = new ModuleRestoreScheduler(moduleDispatcher.Object);
+            await scheduler.DisposeAsync();
+
+            Action startFail = () => scheduler.Start();
+            startFail.Should().Throw<ObjectDisposedException>();
+
+            Action requestFail = () => scheduler.RequestModuleRestore(Repository.Create<ICompilationManager>().Object, DocumentUri.From("untitled://one"), Enumerable.Empty<ModuleDeclarationSyntax>());
+            requestFail.Should().Throw<ObjectDisposedException>();
+        }
+
+        [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Not needed")]
+        [TestMethod]
+        public async Task RestoreShouldBeScheduledAsRequested()
+        {
+            var provider = Repository.Create<IModuleRegistryProvider>();
+            var mockRegistry = new MockRegistry();
+            provider.Setup(m => m.Registries).Returns(((IModuleRegistry)mockRegistry).AsEnumerable().ToImmutableArray());
+
+            var dispatcher = new ModuleDispatcher(provider.Object);
+
+            var firstUri = DocumentUri.From("foo://one");
+            var firstSource = new TaskCompletionSource<bool>();
+
+            var secondUri = DocumentUri.From("foo://two");
+            var secondSource = new TaskCompletionSource<bool>();
+
+            var thirdUri = DocumentUri.From("foo://three");
+            var thirdSource = new TaskCompletionSource<bool>();
+
+            var compilationManager = Repository.Create<ICompilationManager>();
+            compilationManager.Setup(m => m.RefreshCompilation(firstUri)).Callback<DocumentUri>(uri => firstSource.SetResult(true));
+            compilationManager.Setup(m => m.RefreshCompilation(secondUri)).Callback<DocumentUri>(uri => secondSource.SetResult(true));
+            compilationManager.Setup(m => m.RefreshCompilation(thirdUri)).Callback<DocumentUri>(uri => thirdSource.SetResult(true));
+
+            var firstFileSet = CreateModules("mock:one", "mock:two");
+            var secondFileSet = CreateModules("mock:three", "mock:four");
+            var thirdFileSet = CreateModules("mock:five", "mock:six");
+
+            await using (var scheduler = new ModuleRestoreScheduler(dispatcher))
+            {
+                scheduler.RequestModuleRestore(compilationManager.Object, firstUri, firstFileSet);
+                scheduler.RequestModuleRestore(compilationManager.Object, secondUri, secondFileSet);
+
+                // start processing, which will immediately pick up all the items in the queue
+                scheduler.Start();
+
+                // wait until both compilation managers are notified
+                await IntegrationTestHelper.WithTimeoutAsync(Task.WhenAll(firstSource.Task, secondSource.Task));
+
+                // two separate requests should have been unified into single restore
+                if (mockRegistry.ModuleRestores.TryPop(out var initialRefs))
+                {
+                    mockRegistry.ModuleRestores.Should().BeEmpty();
+                    initialRefs.Select(mr => mr.FullyQualifiedReference).Should().BeEquivalentTo("mock:one", "mock:two", "mock:three", "mock:four");
+                }
+                else
+                {
+                    throw new AssertFailedException("Scheduler did not perform the expected restores.");
+                }
+
+                // request more restores
+                mockRegistry.ModuleRestores.Should().BeEmpty();
+                scheduler.RequestModuleRestore(compilationManager.Object, thirdUri, thirdFileSet);
+
+                // wait for completion
+                await IntegrationTestHelper.WithTimeoutAsync(thirdSource.Task);
+
+                if(mockRegistry.ModuleRestores.TryPop(out var followingRefs))
+                {
+                    mockRegistry.ModuleRestores.Should().BeEmpty();
+                    followingRefs.Select(mr => mr.FullyQualifiedReference).Should().BeEquivalentTo("mock:five", "mock:six");
+                }
+                else
+                {
+                    throw new AssertFailedException("Scheduler did not perform the expected restores.");
+                }
+            }
+        }
+
+        private static ImmutableArray<ModuleDeclarationSyntax> CreateModules(params string[] references)
+        {
+            var buffer = new StringBuilder();
+            foreach(var reference in references)
+            {
+                buffer.AppendLine($"module foo '{reference}' = {{}}");
+            }
+
+            var file = SourceFileFactory.CreateBicepFile(new System.Uri("untitled://hello"), buffer.ToString());
+            return file.ProgramSyntax.Declarations.OfType<ModuleDeclarationSyntax>().ToImmutableArray();
+        }
+
+        private class MockRegistry : IModuleRegistry
+        {
+            public ConcurrentStack<IEnumerable<ModuleReference>> ModuleRestores { get; } = new();
+
+            public string Scheme => "mock";
+
+            public bool IsModuleRestoreRequired(ModuleReference reference) => true;
+
+            public IDictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate> RestoreModules(IEnumerable<ModuleReference> references)
+            {
+                this.ModuleRestores.Push(references);
+                return new Dictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate>();
+            }
+
+            public Uri? TryGetLocalModuleEntryPointPath(Uri parentModuleUri, ModuleReference reference, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ModuleReference? TryParseModuleReference(string reference, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+            {
+                failureBuilder = null;
+                return new MockModuleRef(reference);
+            }
+        }
+
+        private class MockModuleRef : ModuleReference
+        {
+            public MockModuleRef(string value)
+                : base("mock")
+            {
+                this.Value = value;
+            }
+
+            public string Value { get; }
+
+            public override string UnqualifiedReference => this.Value;
+        }
+    }
+}

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
@@ -5,10 +5,14 @@ using System;
 using System.Collections.Generic;
 using Bicep.Core;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
+using Bicep.Core.Syntax;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer;
+using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Providers;
+using Bicep.LanguageServer.Registry;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -26,7 +30,7 @@ namespace Bicep.LangServer.UnitTests
 
             var document = CreateMockDocument(p => receivedParams = p);
             var server = CreateMockServer(document);
-            BicepCompilationManager bicepCompilationManager = new BicepCompilationManager(server.Object, CreateEmptyCompilationProvider(), new Workspace());
+            BicepCompilationManager bicepCompilationManager = new BicepCompilationManager(server.Object, CreateEmptyCompilationProvider(), new Workspace(), BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             if (upsertCompilation)
             {
@@ -65,8 +69,18 @@ namespace Bicep.LangServer.UnitTests
             return server;
         }
 
-        public static ICompilationProvider CreateEmptyCompilationProvider() =>
-            new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), new InMemoryFileResolver(new Dictionary<Uri, string>()));
+        public static ICompilationProvider CreateEmptyCompilationProvider()
+        {
+            var fileResolver = new InMemoryFileResolver(new Dictionary<Uri, string>());
+            return new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), fileResolver, new ModuleDispatcher(new DefaultModuleRegistryProvider(fileResolver)));
+        }
 
+        public static Mock<IModuleRestoreScheduler> CreateMockScheduler()
+        {
+            var scheduler = Repository.Create<IModuleRestoreScheduler>();
+            scheduler.Setup(m => m.RequestModuleRestore(It.IsAny<ICompilationManager>(), It.IsAny<DocumentUri>(), It.IsAny<IEnumerable<ModuleDeclarationSyntax>>()));
+
+            return scheduler;
+        }
     }
 }

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -1,19 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Bicep.Core;
 using Bicep.Core.Extensions;
+using Bicep.Core.Registry;
+using Bicep.Core.Syntax;
+using Bicep.Core.UnitTests;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer;
+using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Providers;
+using Bicep.LanguageServer.Registry;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Bicep.LangServer.UnitTests
 {
@@ -74,7 +80,7 @@ namespace Bicep.LangServer.UnitTests
             var workspace = new Workspace();
             workspace.UpsertSourceFile(originalFile);
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -112,7 +118,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -161,7 +167,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -233,7 +239,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -293,7 +299,7 @@ namespace Bicep.LangServer.UnitTests
         {
             var server = Repository.Create<ILanguageServerFacade>();
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace());
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             var uri = DocumentUri.File(this.TestContext.TestName);
 
@@ -308,7 +314,7 @@ namespace Bicep.LangServer.UnitTests
             var document = BicepCompilationManagerHelper.CreateMockDocument(p => receivedParams = p);
             var server = BicepCompilationManagerHelper.CreateMockServer(document);
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace());
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             var uri = DocumentUri.File(this.TestContext.TestName);
 
@@ -349,7 +355,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace);
+            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             // upsert should fail because of the mock fatal exception
             manager.UpsertCompilation(uri, BaseVersion, "fake", languageId);
@@ -413,7 +419,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace);
+            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             // upsert should fail because of the mock fatal exception
             manager.UpsertCompilation(uri, version, "fake", languageId);

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using Bicep.Core.Configuration;
 using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
 using Bicep.Core.Samples;
+using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Configuration;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
@@ -26,7 +28,9 @@ namespace Bicep.LangServer.UnitTests
         [TestMethod]
         public void Create_ShouldReturnValidCompilation()
         {
-            var provider = new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), CreateEmptyFileResolver());
+            IFileResolver fileResolver = CreateEmptyFileResolver();
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(fileResolver));
+            var provider = new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), fileResolver, dispatcher);
 
             var fileUri = DocumentUri.Parse($"/{DataSets.Parameters_LF.Name}.bicep");
             var sourceFile = SourceFileFactory.CreateSourceFile(fileUri.ToUri(), DataSets.Parameters_LF.Bicep);

--- a/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
+++ b/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
@@ -10,6 +10,8 @@ namespace Bicep.LanguageServer.CompilationManager
     {
         void HandleFileChanges(IEnumerable<FileEvent> fileEvents);
 
+        void RefreshCompilation(DocumentUri uri);
+
         void UpsertCompilation(DocumentUri uri, int? version, string text, string? languageId = null);
 
         void CloseCompilation(DocumentUri uri);

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -281,7 +281,7 @@ namespace Bicep.LanguageServer.Completions
 
             // technically bicep files do not have to follow the bicep extension, so
             // we are not enforcing *.bicep get files command
-            if (FileResolver.TryDirExists(query))
+            if (FileResolver.DirExists(query))
             {
                 files = FileResolver.GetFiles(query, string.Empty);
                 dirs = FileResolver.GetDirectories(query, string.Empty);

--- a/src/Bicep.LangServer/Providers/ICompilationProvider.cs
+++ b/src/Bicep.LangServer/Providers/ICompilationProvider.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using Bicep.Core.Syntax;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -10,5 +9,7 @@ namespace Bicep.LanguageServer.Providers
     public interface ICompilationProvider
     {
         CompilationContext Create(IReadOnlyWorkspace workspace, DocumentUri documentUri);
+
+        CompilationContext Update(IReadOnlyWorkspace workspace, CompilationContext current);
     }
 }

--- a/src/Bicep.LangServer/Registry/IModuleRestoreScheduler.cs
+++ b/src/Bicep.LangServer/Registry/IModuleRestoreScheduler.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Syntax;
+using Bicep.LanguageServer.CompilationManager;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using System.Collections.Generic;
+
+namespace Bicep.LanguageServer.Registry
+{
+    public interface IModuleRestoreScheduler
+    {
+        void Start();
+
+        void RequestModuleRestore(ICompilationManager compilationManager, DocumentUri documentUri, IEnumerable<ModuleDeclarationSyntax> references);
+    }
+}

--- a/src/Bicep.LangServer/Registry/ModuleRestoreScheduler.cs
+++ b/src/Bicep.LangServer/Registry/ModuleRestoreScheduler.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Registry;
+using Bicep.Core.Syntax;
+using Bicep.LanguageServer.CompilationManager;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bicep.LanguageServer.Registry
+{
+    public sealed class ModuleRestoreScheduler : IModuleRestoreScheduler, IAsyncDisposable
+    {
+        private record QueueItem(ICompilationManager CompilationManager, DocumentUri Uri, ImmutableArray<ModuleDeclarationSyntax> References);
+
+        private record CompletionNotification(ICompilationManager CompilationManager, DocumentUri Uri);
+
+        private readonly IModuleDispatcher moduleDispatcher;
+
+        private readonly Queue<QueueItem> queue = new();
+
+        private readonly CancellationTokenSource cancellationTokenSource = new();
+
+        // block on initial wait until signaled
+        private readonly ManualResetEventSlim manualResetEvent = new(false);
+
+        private bool disposed = false;
+        private Task? consumerTask;
+
+        public ModuleRestoreScheduler(IModuleDispatcher moduleDispatcher)
+        {
+            this.moduleDispatcher = moduleDispatcher;
+        }
+
+        /// <summary>
+        /// Requests that the specified modules be restored to the local file system.
+        /// Does not wait for the operation to complete and returns immediately.
+        /// </summary>
+        /// <param name="references">The module references</param>
+        public void RequestModuleRestore(ICompilationManager compilationManager, DocumentUri documentUri, IEnumerable<ModuleDeclarationSyntax> references)
+        {
+            this.CheckDisposed();
+            var item = new QueueItem(compilationManager, documentUri, references.ToImmutableArray());
+            lock (this.queue)
+            {
+                this.queue.Enqueue(item);
+
+                // notify consumer about new items
+                this.manualResetEvent.Set();
+            }
+        }
+
+        public void Start()
+        {
+            this.CheckDisposed();
+            this.consumerTask = Task.Factory.StartNew(this.ProcessQueueItems, this.cancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            // this is a sealed class - no need for full IDisposable implementation
+            if (!this.disposed)
+            {
+                this.disposed = true;
+                if (this.consumerTask is not null)
+                {
+                    this.cancellationTokenSource.Cancel();
+
+                    try
+                    {
+                        await this.consumerTask;
+                    }
+                    catch
+                    {
+                        // the task never completes and can only be canceled
+                        // which is signaled to us by an exception
+                    }
+
+                    this.consumerTask = null;
+                }
+            }
+        }
+
+        private void ProcessQueueItems()
+        {
+            var token = this.cancellationTokenSource.Token;
+            while (true)
+            {
+                this.manualResetEvent.Wait(token);
+
+                var notifications = new HashSet<CompletionNotification>();
+                var references = new List<ModuleDeclarationSyntax>();
+                lock (this.queue)
+                {
+                    this.UnsafeCollectModuleReferences(notifications, references);
+                    Debug.Assert(this.queue.Count == 0, "this.queue.Count == 0");
+
+                    // queue has been consumed - next iteration should block until more items have been added
+                    this.manualResetEvent.Reset();
+                }
+
+                // this blocks until restore is completed
+                // the dispatcher stores the results internally and manages their lifecycle
+                token.ThrowIfCancellationRequested();
+                if(!this.moduleDispatcher.RestoreModules(references))
+                {
+                    // nothing needed to be restored
+                    // no need to notify about completion
+                    continue;
+                }
+
+                // notify compilation manager that restore is completed
+                // to recompile the affected modules
+                token.ThrowIfCancellationRequested();
+                foreach (var notification in notifications)
+                {
+                    notification.CompilationManager.RefreshCompilation(notification.Uri);
+                }
+            }
+        }
+
+        private void UnsafeCollectModuleReferences(HashSet<CompletionNotification> notifications, List<ModuleDeclarationSyntax> references)
+        {
+            while (this.queue.TryDequeue(out var item))
+            {
+                // the record implementation combined with the hashset will dedupe compilation manager/Uri combinations
+                notifications.Add(new(item.CompilationManager, item.Uri));
+                references.AddRange(item.References);
+            }
+        }
+
+        private void CheckDisposed()
+        {
+            if(this.disposed)
+            {
+                throw new ObjectDisposedException($"The {nameof(ModuleRestoreScheduler)} has already been disposed.", innerException: null);
+            }
+        }
+    }
+}

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -3,10 +3,12 @@
 using System;
 using System.IO;
 using System.IO.Pipelines;
+using System.Reactive.Concurrency;
 using System.Threading;
 using System.Threading.Tasks;
 using Bicep.Core.Emit;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Workspaces;
@@ -14,6 +16,7 @@ using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Completions;
 using Bicep.LanguageServer.Handlers;
 using Bicep.LanguageServer.Providers;
+using Bicep.LanguageServer.Registry;
 using Bicep.LanguageServer.Snippets;
 using Bicep.LanguageServer.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
@@ -77,6 +80,9 @@ namespace Bicep.LanguageServer
         {
             await server.Initialize(cancellationToken);
 
+            var scheduler = server.GetService<IModuleRestoreScheduler>();
+            scheduler.Start();
+
             await server.WaitForExit;
         }
 
@@ -88,12 +94,15 @@ namespace Bicep.LanguageServer
             services.AddSingleton<IResourceTypeProvider>(services => creationOptions.ResourceTypeProvider ?? AzResourceTypeProvider.CreateWithAzTypes());
             services.AddSingleton<ISnippetsProvider>(services => creationOptions.SnippetsProvider ?? new SnippetsProvider(fileResolver));
             services.AddSingleton<IFileResolver>(services => fileResolver);
+            services.AddSingleton<IModuleRegistryProvider, DefaultModuleRegistryProvider>();
+            services.AddSingleton<IModuleDispatcher, ModuleDispatcher>();
             services.AddSingleton<ITelemetryProvider, TelemetryProvider>();
             services.AddSingleton<IWorkspace, Workspace>();
             services.AddSingleton<ICompilationManager, BicepCompilationManager>();
             services.AddSingleton<ICompilationProvider, BicepCompilationProvider>();
             services.AddSingleton<ISymbolResolver, BicepSymbolResolver>();
             services.AddSingleton<ICompletionProvider, BicepCompletionProvider>();
+            services.AddSingleton<IModuleRestoreScheduler, ModuleRestoreScheduler>();
         }
     }
 }

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -212,7 +212,8 @@ namespace Bicep.LanguageServer.Snippets
                 bicepFile,
                 ImmutableHashSet.Create<ISourceFile>(bicepFile),
                 ImmutableDictionary.Create<ModuleDeclarationSyntax, ISourceFile>(),
-                ImmutableDictionary.Create<ModuleDeclarationSyntax, DiagnosticBuilder.ErrorBuilderDelegate>());
+                ImmutableDictionary.Create<ModuleDeclarationSyntax, DiagnosticBuilder.ErrorBuilderDelegate>(),
+                ImmutableHashSet<ModuleDeclarationSyntax>.Empty);
 
             Compilation compilation = new Compilation(AzResourceTypeProvider.CreateWithAzTypes(), sourceFileGrouping);
             SemanticModel semanticModel = compilation.GetEntrypointSemanticModel();

--- a/src/Bicep.Wasm/EmptyModuleRegistryProvider.cs
+++ b/src/Bicep.Wasm/EmptyModuleRegistryProvider.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Registry;
+using System.Collections.Immutable;
+
+namespace Bicep.Wasm
+{
+    public class EmptyModuleRegistryProvider : IModuleRegistryProvider
+    {
+        public ImmutableArray<IModuleRegistry> Registries => ImmutableArray<IModuleRegistry>.Empty;
+    }
+}

--- a/src/Bicep.Wasm/Interop.cs
+++ b/src/Bicep.Wasm/Interop.cs
@@ -16,6 +16,9 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Workspaces;
 using Bicep.Core.Extensions;
 using Bicep.Decompiler;
+using Bicep.Core.Modules;
+using Bicep.Core.Registry;
+using Bicep.Core.Syntax;
 
 namespace Bicep.Wasm
 {
@@ -148,7 +151,8 @@ namespace Bicep.Wasm
             workspace.UpsertSourceFile(sourceFile);
 
             var fileResolver = new FileResolver();
-            var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, workspace, fileUri);
+            var dispatcher = new ModuleDispatcher(new EmptyModuleRegistryProvider());
+            var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, dispatcher, workspace, fileUri);
 
             return new Compilation(resourceTypeProvider, sourceFileGrouping);
         }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode Condition="'$(CI)' == 'true'">true</RestoreLockedMode>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <!-- disable nuget packing on all projects by default -->
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Initial commit to bring in the infrastructure pieces from my registry prototype:
- Moved handling of module references (local or remote) to a separate dispatcher that routes a reference to the correct registry implementation
- Added shared patterns for parsing module references
- Added a scheduler component to perform module restore in the background inside the language server and refresh compilations after it's finished.
- Made `TypeAssignmentVisitor` and `DeclaredTypeManager` thread-safe.
- Added various tests.

No remote registries are enabled with this PR. That will be done in later PRs once we close on #2128. 