### PR TITLE
Refactor: Create `ResourceMetadata` class to decouple resource analysis from `ResourceSymbol`

### DIFF
--- a/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
@@ -65,7 +65,7 @@ resource parent 'My.RP/parentType@2020-01-01' = {
                 new { name = "sibling", type = "My.RP/parentType/childType@2020-01-02", },
             };
 
-            model.Root.GetAllResourceDeclarations()
+            model.GetAllResources().Select(x => x.Symbol)
               .Select(s => new { name = s.Name, type = (s.Type as ResourceType)?.TypeReference.FormatName(), })
               .OrderBy(n => n.name)
               .Should().BeEquivalentTo(expected);
@@ -104,7 +104,7 @@ resource parent 'My.RP/parentType@2020-01-01' = {
                 new { name = "parent", type = "My.RP/parentType@2020-01-01", },
             };
 
-            model.Root.GetAllResourceDeclarations()
+            model.GetAllResources().Select(x => x.Symbol)
               .Select(s => new { name = s.Name, type = (s.Type as ResourceType)?.TypeReference.FormatName(), })
               .OrderBy(n => n.name)
               .Should().BeEquivalentTo(expected);
@@ -154,19 +154,19 @@ output fromGrandchild string = parent::child::grandchild.properties.style
 
             model.GetAllDiagnostics().Should().BeEmpty();
 
-            var parent = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "parent");
+            var parent = model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "parent");
             var references = model.FindReferences(parent);
             references.Should().HaveCount(6);
 
-            var child = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "child");
+            var child = model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "child");
             references = model.FindReferences(child);
             references.Should().HaveCount(6);
 
-            var grandchild = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "grandchild");
+            var grandchild = model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "grandchild");
             references = model.FindReferences(grandchild);
             references.Should().HaveCount(4);
 
-            var sibling = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "sibling");
+            var sibling = model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "sibling");
             references = model.FindReferences(sibling);
             references.Should().HaveCount(1);
 
@@ -417,13 +417,13 @@ resource parent 'My.RP/parentType@2020-01-01' = {
             var model = compilation.GetEntrypointSemanticModel();
             model.GetAllDiagnostics().Should().BeEmpty();
 
-            var parent = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "parent");
+            var parent = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "parent").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(parent).Should().BeEmpty();
 
-            var child = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "child");
+            var child = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "child").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(child).Select(x => x.Resource).Should().Equal(new[] { parent, });
 
-            var grandchild = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "grandchild");
+            var grandchild = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "grandchild").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(grandchild).Select(x => x.Resource).Should().Equal(new[] { parent, child, }); // order matters
         }
 
@@ -466,19 +466,19 @@ resource parent 'My.RP/parentType@2020-01-01' = {
             var model = compilation.GetEntrypointSemanticModel();
             model.GetAllDiagnostics().Should().BeEmpty();
 
-            var parent = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "parent");
+            var parent = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "parent").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(parent).Should().BeEmpty();
 
-            var child = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "child");
+            var child = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "child").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(child).Select(x => x.Resource).Should().Equal(new[] { parent, });
 
-            var childGrandChild = (ResourceSymbol)model.GetSymbolInfo(child.DeclaringResource.GetBody().Resources.Single())!;
+            var childGrandChild = model.ResourceMetadata.TryLookup(child.Symbol.DeclaringResource.GetBody().Resources.Single())!;
             model.ResourceAncestors.GetAncestors(childGrandChild).Select(x => x.Resource).Should().Equal(new[] { parent, child, });
 
-            var sibling = model.Root.GetAllResourceDeclarations().Single(r => r.Name == "sibling");
+            var sibling = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "sibling").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(child).Select(x => x.Resource).Should().Equal(new[] { parent, });
 
-            var siblingGrandChild = (ResourceSymbol)model.GetSymbolInfo(sibling.DeclaringResource.GetBody().Resources.Single())!;
+            var siblingGrandChild = model.ResourceMetadata.TryLookup(sibling.Symbol.DeclaringResource.GetBody().Resources.Single())!;
             model.ResourceAncestors.GetAncestors(siblingGrandChild).Select(x => x.Resource).Should().Equal(new[] { parent, sibling, });
         }
 

--- a/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NestedResourceTests.cs
@@ -65,7 +65,7 @@ resource parent 'My.RP/parentType@2020-01-01' = {
                 new { name = "sibling", type = "My.RP/parentType/childType@2020-01-02", },
             };
 
-            model.GetAllResources().Select(x => x.Symbol)
+            model.AllResources.Select(x => x.Symbol)
               .Select(s => new { name = s.Name, type = (s.Type as ResourceType)?.TypeReference.FormatName(), })
               .OrderBy(n => n.name)
               .Should().BeEquivalentTo(expected);
@@ -104,7 +104,7 @@ resource parent 'My.RP/parentType@2020-01-01' = {
                 new { name = "parent", type = "My.RP/parentType@2020-01-01", },
             };
 
-            model.GetAllResources().Select(x => x.Symbol)
+            model.AllResources.Select(x => x.Symbol)
               .Select(s => new { name = s.Name, type = (s.Type as ResourceType)?.TypeReference.FormatName(), })
               .OrderBy(n => n.name)
               .Should().BeEquivalentTo(expected);
@@ -154,19 +154,19 @@ output fromGrandchild string = parent::child::grandchild.properties.style
 
             model.GetAllDiagnostics().Should().BeEmpty();
 
-            var parent = model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "parent");
+            var parent = model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "parent");
             var references = model.FindReferences(parent);
             references.Should().HaveCount(6);
 
-            var child = model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "child");
+            var child = model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "child");
             references = model.FindReferences(child);
             references.Should().HaveCount(6);
 
-            var grandchild = model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "grandchild");
+            var grandchild = model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "grandchild");
             references = model.FindReferences(grandchild);
             references.Should().HaveCount(4);
 
-            var sibling = model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "sibling");
+            var sibling = model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "sibling");
             references = model.FindReferences(sibling);
             references.Should().HaveCount(1);
 
@@ -417,13 +417,13 @@ resource parent 'My.RP/parentType@2020-01-01' = {
             var model = compilation.GetEntrypointSemanticModel();
             model.GetAllDiagnostics().Should().BeEmpty();
 
-            var parent = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "parent").DeclaringSyntax)!;
+            var parent = model.ResourceMetadata.TryLookup(model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "parent").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(parent).Should().BeEmpty();
 
-            var child = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "child").DeclaringSyntax)!;
+            var child = model.ResourceMetadata.TryLookup(model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "child").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(child).Select(x => x.Resource).Should().Equal(new[] { parent, });
 
-            var grandchild = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "grandchild").DeclaringSyntax)!;
+            var grandchild = model.ResourceMetadata.TryLookup(model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "grandchild").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(grandchild).Select(x => x.Resource).Should().Equal(new[] { parent, child, }); // order matters
         }
 
@@ -466,16 +466,16 @@ resource parent 'My.RP/parentType@2020-01-01' = {
             var model = compilation.GetEntrypointSemanticModel();
             model.GetAllDiagnostics().Should().BeEmpty();
 
-            var parent = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "parent").DeclaringSyntax)!;
+            var parent = model.ResourceMetadata.TryLookup(model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "parent").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(parent).Should().BeEmpty();
 
-            var child = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "child").DeclaringSyntax)!;
+            var child = model.ResourceMetadata.TryLookup(model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "child").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(child).Select(x => x.Resource).Should().Equal(new[] { parent, });
 
             var childGrandChild = model.ResourceMetadata.TryLookup(child.Symbol.DeclaringResource.GetBody().Resources.Single())!;
             model.ResourceAncestors.GetAncestors(childGrandChild).Select(x => x.Resource).Should().Equal(new[] { parent, child, });
 
-            var sibling = model.ResourceMetadata.TryLookup(model.GetAllResources().Select(x => x.Symbol).Single(r => r.Name == "sibling").DeclaringSyntax)!;
+            var sibling = model.ResourceMetadata.TryLookup(model.AllResources.Select(x => x.Symbol).Single(r => r.Name == "sibling").DeclaringSyntax)!;
             model.ResourceAncestors.GetAncestors(child).Select(x => x.Resource).Should().Equal(new[] { parent, });
 
             var siblingGrandChild = model.ResourceMetadata.TryLookup(sibling.Symbol.DeclaringResource.GetBody().Resources.Single())!;

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -1751,10 +1751,10 @@ resource p2 'Microsoft.Network/dnsZones@2018-05-01' = {
 ");
             result.Should().HaveDiagnostics(new[]
             {
-                ("BCP179", DiagnosticLevel.Warning, "The loop item variable \"thing\" must be referenced in at least one of the value expressions of the following properties: \"name\", \"parent\""),
                 ("BCP170", DiagnosticLevel.Error, "Expected resource name to not contain any \"/\" characters. Child resources with a parent resource reference (via the parent property or via nesting) must not contain a fully-qualified name."),
-                ("BCP179", DiagnosticLevel.Warning, "The loop item variable \"thing2\" must be referenced in at least one of the value expressions of the following properties: \"name\""),
+                ("BCP179", DiagnosticLevel.Warning, "The loop item variable \"thing\" must be referenced in at least one of the value expressions of the following properties: \"name\", \"parent\""),
                 ("BCP170", DiagnosticLevel.Error, "Expected resource name to not contain any \"/\" characters. Child resources with a parent resource reference (via the parent property or via nesting) must not contain a fully-qualified name.")
+                ("BCP179", DiagnosticLevel.Warning, "The loop item variable \"thing2\" must be referenced in at least one of the value expressions of the following properties: \"name\""),
             });
             result.Template.Should().BeNull();
         }

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -1751,10 +1751,10 @@ resource p2 'Microsoft.Network/dnsZones@2018-05-01' = {
 ");
             result.Should().HaveDiagnostics(new[]
             {
-                ("BCP170", DiagnosticLevel.Error, "Expected resource name to not contain any \"/\" characters. Child resources with a parent resource reference (via the parent property or via nesting) must not contain a fully-qualified name."),
                 ("BCP179", DiagnosticLevel.Warning, "The loop item variable \"thing\" must be referenced in at least one of the value expressions of the following properties: \"name\", \"parent\""),
-                ("BCP170", DiagnosticLevel.Error, "Expected resource name to not contain any \"/\" characters. Child resources with a parent resource reference (via the parent property or via nesting) must not contain a fully-qualified name.")
+                ("BCP170", DiagnosticLevel.Error, "Expected resource name to not contain any \"/\" characters. Child resources with a parent resource reference (via the parent property or via nesting) must not contain a fully-qualified name."),
                 ("BCP179", DiagnosticLevel.Warning, "The loop item variable \"thing2\" must be referenced in at least one of the value expressions of the following properties: \"name\""),
+                ("BCP170", DiagnosticLevel.Error, "Expected resource name to not contain any \"/\" characters. Child resources with a parent resource reference (via the parent property or via nesting) must not contain a fully-qualified name."),
             });
             result.Template.Should().BeNull();
         }

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -102,6 +102,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if {
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[55:56) [BCP018 (Error)] Expected the "(" character at this location. (CodeDescription: none) |{|
   name: 'foo'
+//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // empty condition
@@ -111,6 +112,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if () {
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[56:57) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (CodeDescription: none) |)|
   name: 'foo'
+//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // #completionTest(57, 59) -> symbols
@@ -119,6 +121,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (     ) {
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[61:62) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (CodeDescription: none) |)|
   name: 'foo'
+//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // invalid condition type
@@ -127,6 +130,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (123) {
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[55:60) [BCP046 (Error)] Expected a value of type "bool". (CodeDescription: none) |(123)|
   name: 'foo'
+//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // runtime functions are no allowed in resource conditions
@@ -135,6 +139,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (reference('Micorosft.Ma
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[57:66) [BCP066 (Error)] Function "reference" is not valid at this location. It can only be used in resource declarations. (CodeDescription: none) |reference|
   name: 'foo'
+//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (listKeys('foo', '2020-05-01').bar == true) {
@@ -142,6 +147,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (listKeys('foo', '2020-0
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[57:65) [BCP066 (Error)] Function "listKeys" is not valid at this location. It can only be used in resource declarations. (CodeDescription: none) |listKeys|
   name: 'foo'
+//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // duplicate property at the top level
@@ -169,6 +175,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |foo|
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
+//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
   properties: {
     foo: 'a'
 //@[4:7) [BCP025 (Error)] The property "foo" is declared multiple times in this object. Remove or rename the duplicate properties. (CodeDescription: none) |foo|
@@ -182,6 +189,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |foo|
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
+//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
   properties: {
     foo: 'a'
 //@[4:7) [BCP025 (Error)] The property "foo" is declared multiple times in this object. Remove or rename the duplicate properties. (CodeDescription: none) |foo|
@@ -195,6 +203,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |foo|
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
+//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
   location: [
 //@[12:18) [BCP036 (Error)] The property "location" expected a value of type "string" but the provided value is of type "array". (CodeDescription: none) |[\r\n  ]|
   ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -102,7 +102,6 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if {
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[55:56) [BCP018 (Error)] Expected the "(" character at this location. (CodeDescription: none) |{|
   name: 'foo'
-//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // empty condition
@@ -112,7 +111,6 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if () {
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[56:57) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (CodeDescription: none) |)|
   name: 'foo'
-//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // #completionTest(57, 59) -> symbols
@@ -121,7 +119,6 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (     ) {
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[61:62) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (CodeDescription: none) |)|
   name: 'foo'
-//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // invalid condition type
@@ -130,7 +127,6 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (123) {
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[55:60) [BCP046 (Error)] Expected a value of type "bool". (CodeDescription: none) |(123)|
   name: 'foo'
-//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // runtime functions are no allowed in resource conditions
@@ -139,7 +135,6 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (reference('Micorosft.Ma
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[57:66) [BCP066 (Error)] Function "reference" is not valid at this location. It can only be used in resource declarations. (CodeDescription: none) |reference|
   name: 'foo'
-//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (listKeys('foo', '2020-05-01').bar == true) {
@@ -147,7 +142,6 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (listKeys('foo', '2020-0
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
 //@[57:65) [BCP066 (Error)] Function "listKeys" is not valid at this location. It can only be used in resource declarations. (CodeDescription: none) |listKeys|
   name: 'foo'
-//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
 }
 
 // duplicate property at the top level
@@ -175,7 +169,6 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |foo|
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
-//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
   properties: {
     foo: 'a'
 //@[4:7) [BCP025 (Error)] The property "foo" is declared multiple times in this object. Remove or rename the duplicate properties. (CodeDescription: none) |foo|
@@ -189,7 +182,6 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |foo|
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
-//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
   properties: {
     foo: 'a'
 //@[4:7) [BCP025 (Error)] The property "foo" is declared multiple times in this object. Remove or rename the duplicate properties. (CodeDescription: none) |foo|
@@ -203,7 +195,6 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 //@[9:12) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |foo|
 //@[13:50) [BCP081 (Warning)] Resource type "Microsoft.Foo/foos@2020-02-02-alpha" does not have types available. (CodeDescription: none) |'Microsoft.Foo/foos@2020-02-02-alpha'|
   name: 'foo'
-//@[8:13) [BCP121 (Error)] Resources: "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo" are defined with this same name in a file. Rename them or split into different modules. (CodeDescription: none) |'foo'|
   location: [
 //@[12:18) [BCP036 (Error)] The property "location" expected a value of type "string" but the provided value is of type "array". (CodeDescription: none) |[\r\n  ]|
   ]

--- a/src/Bicep.Core/Emit/EmitLimitationInfo.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
 
 namespace Bicep.Core.Emit
 {
@@ -13,9 +14,9 @@ namespace Bicep.Core.Emit
 
         public ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> ModuleScopeData { get; }
 
-        public ImmutableDictionary<ResourceSymbol, ScopeHelper.ScopeData> ResourceScopeData { get; }
+        public ImmutableDictionary<ResourceMetadata, ScopeHelper.ScopeData> ResourceScopeData { get; }
 
-        public EmitLimitationInfo(IReadOnlyList<IDiagnostic> diagnostics, ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> moduleScopeData, ImmutableDictionary<ResourceSymbol, ScopeHelper.ScopeData> resourceScopeData)
+        public EmitLimitationInfo(IReadOnlyList<IDiagnostic> diagnostics, ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> moduleScopeData, ImmutableDictionary<ResourceMetadata, ScopeHelper.ScopeData> resourceScopeData)
         {
             Diagnostics = diagnostics;
             ModuleScopeData = moduleScopeData;

--- a/src/Bicep.Core/Emit/EmitterContext.cs
+++ b/src/Bicep.Core/Emit/EmitterContext.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using Bicep.Core.DataFlow;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
 
 namespace Bicep.Core.Emit
 {
@@ -26,6 +27,6 @@ namespace Bicep.Core.Emit
 
         public ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> ModuleScopeData => SemanticModel.EmitLimitationInfo.ModuleScopeData;
 
-        public ImmutableDictionary<ResourceSymbol, ScopeHelper.ScopeData> ResourceScopeData => SemanticModel.EmitLimitationInfo.ResourceScopeData;
+        public ImmutableDictionary<ResourceMetadata, ScopeHelper.ScopeData> ResourceScopeData => SemanticModel.EmitLimitationInfo.ResourceScopeData;
     }
 }

--- a/src/Bicep.Core/Emit/ExpressionEmitter.cs
+++ b/src/Bicep.Core/Emit/ExpressionEmitter.cs
@@ -93,7 +93,7 @@ namespace Bicep.Core.Emit
 
         public void EmitUnqualifiedResourceId(ResourceMetadata resource, SyntaxBase? indexExpression, SyntaxBase newContext)
         {
-            var converterForContext = converter.CreateConverterForIndexReplacement(ExpressionConverter.GetResourceNameSyntax(resource), indexExpression, newContext);
+            var converterForContext = converter.CreateConverterForIndexReplacement(resource.NameSyntax, indexExpression, newContext);
 
             var unqualifiedResourceId = converterForContext.GetUnqualifiedResourceId(resource);
             var serialized = ExpressionSerializer.SerializeExpression(unqualifiedResourceId);
@@ -103,7 +103,7 @@ namespace Bicep.Core.Emit
 
         public void EmitResourceIdReference(ResourceMetadata resource, SyntaxBase? indexExpression, SyntaxBase newContext)
         {
-            var converterForContext = this.converter.CreateConverterForIndexReplacement(ExpressionConverter.GetResourceNameSyntax(resource), indexExpression, newContext);
+            var converterForContext = this.converter.CreateConverterForIndexReplacement(resource.NameSyntax, indexExpression, newContext);
 
             var resourceIdExpression = converterForContext.GetFullyQualifiedResourceId(resource);
             var serialized = ExpressionSerializer.SerializeExpression(resourceIdExpression);
@@ -325,14 +325,14 @@ namespace Bicep.Core.Emit
                 };
 
                 if (context.SemanticModel.ResourceMetadata.TryLookup(baseSyntax) is not {} resource ||
-                    !string.Equals(resource.GetResourceTypeReference().FullyQualifiedType, "microsoft.keyvault/vaults", StringComparison.OrdinalIgnoreCase))
+                    !string.Equals(resource.TypeReference.FullyQualifiedType, "microsoft.keyvault/vaults", StringComparison.OrdinalIgnoreCase))
                 {
                     throw new InvalidOperationException("Cannot emit parameter's KeyVault secret reference.");
                 }
 
                 var keyVaultId = instanceFunctionCall.BaseExpression switch
                 {
-                    ArrayAccessSyntax arrayAccessSyntax => converter.CreateConverterForIndexReplacement(ExpressionConverter.GetResourceNameSyntax(resource), arrayAccessSyntax.IndexExpression, instanceFunctionCall)
+                    ArrayAccessSyntax arrayAccessSyntax => converter.CreateConverterForIndexReplacement(resource.NameSyntax, arrayAccessSyntax.IndexExpression, instanceFunctionCall)
                                                                     .GetFullyQualifiedResourceId(resource),
                     _ => converter.GetFullyQualifiedResourceId(resource)
                 };

--- a/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
@@ -50,20 +50,20 @@ namespace Bicep.Core.Emit
 
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
         {
-            if (this.model.GetSymbolInfo(syntax) is not ResourceSymbol resourceSymbol)
+            if (model.ResourceMetadata.TryLookup(syntax) is not {} resource)
             {
                 // When invoked by BicepDeploymentGraphHandler, it's possible that the declaration is unbound.
                 return;
             }
 
             // Resource ancestors are always dependencies.
-            var ancestors = this.model.ResourceAncestors.GetAncestors(resourceSymbol);
+            var ancestors = this.model.ResourceAncestors.GetAncestors(resource);
 
             // save previous declaration as we may call this recursively
             var prevDeclaration = this.currentDeclaration;
 
-            this.currentDeclaration = resourceSymbol;
-            this.resourceDependencies[resourceSymbol] = new HashSet<ResourceDependency>(ancestors.Select(a => new ResourceDependency(a.Resource, a.IndexExpression)));
+            this.currentDeclaration = resource.Symbol;
+            this.resourceDependencies[resource.Symbol] = new HashSet<ResourceDependency>(ancestors.Select(a => new ResourceDependency(a.Resource.Symbol, a.IndexExpression)));
             base.VisitResourceDeclarationSyntax(syntax);
 
             // restore previous declaration

--- a/src/Bicep.Core/Emit/ScopeHelper.cs
+++ b/src/Bicep.Core/Emit/ScopeHelper.cs
@@ -8,6 +8,7 @@ using Azure.Deployments.Expression.Expressions;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
@@ -41,7 +42,7 @@ namespace Bicep.Core.Emit
             /// <summary>
             /// The symbol of the resource being extended or null.
             /// </summary>
-            public ResourceSymbol? ResourceScopeSymbol { get; set; }
+            public ResourceMetadata? ResourceScope { get; set; }
 
             /// <summary>
             /// The expression for the loop index. This is used with loops when indexing into resource collections. 
@@ -126,37 +127,36 @@ namespace Bicep.Core.Emit
                         1 => new ScopeData { RequestedScope = ResourceScope.ResourceGroup, ResourceGroupProperty = type.Arguments[0].Expression, IndexExpression = indexExpression },
                         _ => new ScopeData { RequestedScope = ResourceScope.ResourceGroup, SubscriptionIdProperty = type.Arguments[0].Expression, ResourceGroupProperty = type.Arguments[1].Expression, IndexExpression = indexExpression },
                     };
-
                 case { } when scopeSymbol is ResourceSymbol targetResourceSymbol:
-                    if (targetResourceSymbol.IsCollection && indexExpression is null)
+                    if (semanticModel.ResourceMetadata.TryLookup(targetResourceSymbol.DeclaringSyntax) is not {} targetResource)
+                    {
+                        return null;
+                    }
+
+                    if (targetResource.Symbol.IsCollection && indexExpression is null)
                     {
                         // the target is a resource collection, but the user didn't apply an array indexer to it
                         // the type check will produce a good error
                         return null;
                     }
 
-                    if (targetResourceSymbol.Type is ErrorType)
+                    if (targetResource.Symbol.Type is ErrorType)
                     {
                         // the scope resource has errors
                         return null;
                     }
 
-                    var resourceType = targetResourceSymbol.Type switch
-                    {
-                        ResourceType singleResourceType => singleResourceType,
-                        ArrayType { Item: ResourceType itemResourceType } => itemResourceType,
-                        _ => throw new NotImplementedException($"Target resource symbol has an unexpected type '{targetResourceSymbol.GetType().Name}'.")
-                    };
+                    var resourceType = targetResource.Symbol.TryGetResourceType() ?? throw new NotImplementedException($"Target resource symbol has an unexpected type '{targetResource.Symbol.GetType().Name}'.");
 
                     if (StringComparer.OrdinalIgnoreCase.Equals(resourceType.TypeReference.FullyQualifiedType, AzResourceTypeProvider.ResourceTypeResourceGroup))
                     {
                         // special-case 'Microsoft.Resources/resourceGroups' in order to allow it to create a resourceGroup-scope resource
-                        var rgScopeProperty = targetResourceSymbol.SafeGetBodyProperty(LanguageConstants.ResourceScopePropertyName);
-                        var rgNameProperty = targetResourceSymbol.SafeGetBodyProperty(LanguageConstants.ResourceNamePropertyName);
+                        var rgScopeProperty = targetResource.Symbol.SafeGetBodyProperty(LanguageConstants.ResourceScopePropertyName);
+                        var rgNameProperty = targetResource.Symbol.SafeGetBodyProperty(LanguageConstants.ResourceNamePropertyName);
 
                         // ignore diagnostics - these will be collected separately in the pass over resources
                         var hasErrors = false;
-                        var rgScopeData = ScopeHelper.ValidateScope(semanticModel, (_, _, _) => { hasErrors = true; }, resourceType.ValidParentScopes, targetResourceSymbol.DeclaringResource.Value, rgScopeProperty);
+                        var rgScopeData = ScopeHelper.ValidateScope(semanticModel, (_, _, _) => { hasErrors = true; }, resourceType.ValidParentScopes, targetResource.Symbol.DeclaringResource.Value, rgScopeProperty);
                         if (rgNameProperty is not null && !hasErrors)
                         {
                             if (!supportedScopes.HasFlag(ResourceScope.ResourceGroup))
@@ -175,10 +175,9 @@ namespace Bicep.Core.Emit
                         return null;
                     }
 
-                    return new ScopeData { RequestedScope = ResourceScope.Resource, ResourceScopeSymbol = targetResourceSymbol, IndexExpression = indexExpression };
+                    return new ScopeData { RequestedScope = ResourceScope.Resource, ResourceScope = targetResource, IndexExpression = indexExpression };
 
                 case { } when scopeSymbol is ModuleSymbol targetModuleSymbol:
-                    
                     if (targetModuleSymbol.IsCollection == (indexExpression is not null))
                     {
                         // using a single module as a scope of another module is not allowed
@@ -254,18 +253,17 @@ namespace Bicep.Core.Emit
                     // but until we have it, we should generate unqualified resource Ids. There should not be a risk of collision, because we do not allow mixing of resource scopes in a single bicep file.
                     return ExpressionConverter.GenerateUnqualifiedResourceId(fullyQualifiedType, nameSegments);
                 case ResourceScope.Resource:
-                    if (scopeData.ResourceScopeSymbol is null)
+                    if (scopeData.ResourceScope is not {} resource)
                     {
                         throw new InvalidOperationException("Cannot format resourceId with non-null resource scope symbol");
                     }
 
-                    var parentTypeReference = scopeData.ResourceScopeSymbol.GetResourceTypeReference();
                     var parentResourceId = FormatFullyQualifiedResourceId(
                         context,
                         converter,
-                        context.ResourceScopeData[scopeData.ResourceScopeSymbol],
-                        parentTypeReference.FullyQualifiedType,
-                        converter.GetResourceNameSegments(scopeData.ResourceScopeSymbol, parentTypeReference));
+                        context.ResourceScopeData[resource],
+                        resource.GetResourceTypeReference().FullyQualifiedType,
+                        converter.GetResourceNameSegments(resource));
 
                     return ExpressionConverter.GenerateExtensionResourceId(
                         parentResourceId,
@@ -286,18 +284,17 @@ namespace Bicep.Core.Emit
                 case ResourceScope.ManagementGroup:
                     return ExpressionConverter.GenerateUnqualifiedResourceId(fullyQualifiedType, nameSegments);
                 case ResourceScope.Resource:
-                    if (scopeData.ResourceScopeSymbol is null)
+                    if (scopeData.ResourceScope is not {} resource)
                     {
                         throw new InvalidOperationException("Cannot format resourceId with non-null resource scope symbol");
                     }
 
-                    var parentTypeReference = scopeData.ResourceScopeSymbol.GetResourceTypeReference();
                     var parentResourceId = FormatUnqualifiedResourceId(
                         context,
                         converter,
-                        context.ResourceScopeData[scopeData.ResourceScopeSymbol],
-                        parentTypeReference.FullyQualifiedType,
-                        converter.GetResourceNameSegments(scopeData.ResourceScopeSymbol, parentTypeReference));
+                        context.ResourceScopeData[resource],
+                        resource.GetResourceTypeReference().FullyQualifiedType,
+                        converter.GetResourceNameSegments(resource));
 
                     return ExpressionConverter.GenerateExtensionResourceId(
                         parentResourceId,
@@ -308,14 +305,14 @@ namespace Bicep.Core.Emit
             }
         }
 
-        public static void EmitResourceScopeProperties(ResourceScope targetScope, ScopeData scopeData, ExpressionEmitter expressionEmitter, SyntaxBase newContext)
+        public static void EmitResourceScopeProperties(SemanticModel semanticModel, ScopeData scopeData, ExpressionEmitter expressionEmitter, SyntaxBase newContext)
         {
-            if (scopeData.ResourceScopeSymbol is { } scopeResource)
+            if (scopeData.ResourceScope is {} scopeResource)
             {
                 // emit the resource id of the resource being extended
                 expressionEmitter.EmitProperty("scope", () => expressionEmitter.EmitUnqualifiedResourceId(scopeResource, scopeData.IndexExpression, newContext));
             }
-            else if (scopeData.RequestedScope == ResourceScope.Tenant && targetScope != ResourceScope.Tenant)
+            else if (scopeData.RequestedScope == ResourceScope.Tenant && semanticModel.TargetScope != ResourceScope.Tenant)
             {
                 // emit the "/" to allow cross-scope deployment of a Tenant resource from another deployment scope
                 expressionEmitter.EmitProperty("scope", "/");
@@ -382,37 +379,37 @@ namespace Bicep.Core.Emit
             return new(LanguageConstants.ResourceScopePropertyName, scopeReference, scopePropertyFlags);
         }
 
-        private static ResourceSymbol? GetRootResourceSymbol(IReadOnlyDictionary<ResourceSymbol, ScopeData> scopeInfo, ResourceSymbol resourceSymbol)
+        private static ResourceMetadata? GetRootResource(IReadOnlyDictionary<ResourceMetadata, ScopeData> scopeInfo, ResourceMetadata resource)
         {
-            if (!scopeInfo.TryGetValue(resourceSymbol, out var scopeData))
+            if (!scopeInfo.TryGetValue(resource, out var scopeData))
             {
                 return null;
             }
 
-            if (scopeData.ResourceScopeSymbol is not null)
+            if (scopeData.ResourceScope is not null)
             {
-                return GetRootResourceSymbol(scopeInfo, scopeData.ResourceScopeSymbol);
+                return GetRootResource(scopeInfo, scopeData.ResourceScope);
             }
 
-            return resourceSymbol;
+            return resource;
         }
 
-        private static void ValidateResourceScopeRestrictions(SemanticModel semanticModel, IReadOnlyDictionary<ResourceSymbol, ScopeData> scopeInfo, ResourceSymbol resourceSymbol, Action<DiagnosticBuilder.DiagnosticBuilderDelegate> writeScopeDiagnostic)
+        private static void ValidateResourceScopeRestrictions(SemanticModel semanticModel, IReadOnlyDictionary<ResourceMetadata, ScopeData> scopeInfo, ResourceMetadata resource, Action<DiagnosticBuilder.DiagnosticBuilderDelegate> writeScopeDiagnostic)
         {
-            if (resourceSymbol.DeclaringResource.IsExistingResource())
+            if (resource.IsExistingResource())
             {
                 // we don't have any cross-scope restrictions on 'existing' resource declarations
                 return;
             }
 
-            if (semanticModel.Binder.TryGetCycle(resourceSymbol) is not null)
+            if (semanticModel.Binder.TryGetCycle(resource.Symbol) is not null)
             {
                 return;
             }
             
-            var rootResourceSymbol = GetRootResourceSymbol(scopeInfo, resourceSymbol);
-            if (rootResourceSymbol is null ||
-                !scopeInfo.TryGetValue(rootResourceSymbol, out var scopeData))
+            var rootResource = GetRootResource(scopeInfo, resource);
+            if (rootResource is null ||
+                !scopeInfo.TryGetValue(rootResource, out var scopeData))
             {
                 // invalid scope should have already generated errors
                 return;
@@ -429,7 +426,7 @@ namespace Bicep.Core.Emit
                 scopeData.ManagementGroupNameProperty is null  &&
                 scopeData.SubscriptionIdProperty is null &&
                 scopeData.ResourceGroupProperty is null &&
-                scopeData.ResourceScopeSymbol is null);
+                scopeData.ResourceScope is null);
 
             if (!matchesTargetScope)
             {
@@ -437,89 +434,80 @@ namespace Bicep.Core.Emit
             }
         }
 
-        public static ImmutableDictionary<ResourceSymbol, ScopeData> GetResoureScopeInfo(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
+        public static ImmutableDictionary<ResourceMetadata, ScopeData> GetResourceScopeInfo(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
             void logInvalidScopeDiagnostic(IPositionable positionable, ResourceScope suppliedScope, ResourceScope supportedScopes)
                 => diagnosticWriter.Write(positionable, x => x.UnsupportedResourceScope(suppliedScope, supportedScopes));
 
-            // local function
-            ResourceType? GetResourceType(ResourceSymbol resourceSymbol) => resourceSymbol.Type switch
-            {
-                ResourceType resourceType => resourceType,
-                ArrayType { Item: ResourceType resourceType } => resourceType,
-                _ => null
-            };
-
-            var scopeInfo = new Dictionary<ResourceSymbol, ScopeData>();
-            var ancestorsLookup = semanticModel.Root.GetAllResourceDeclarations()
+            var scopeInfo = new Dictionary<ResourceMetadata, ScopeData>();
+            var ancestorsLookup = semanticModel.GetAllResources()
                 .ToDictionary(
                     x => x,
                     x => semanticModel.ResourceAncestors.GetAncestors(x));
 
             // process symbols in order of ancestor depth.
             // this is because we want to avoid recomputing the scope for child resources which inherit it from their parents.
-            foreach (var (resourceSymbol, ancestors) in ancestorsLookup.OrderBy(kvp => kvp.Value.Length))
+            foreach (var (resource, ancestors) in ancestorsLookup.OrderBy(kvp => kvp.Value.Length))
             {
-                var resourceType = GetResourceType(resourceSymbol);
-                if (resourceType is null)
+                if (resource.Symbol.TryGetResourceType() is not {} resourceType)
                 {
                     // missing type should be caught during type validation
                     continue;
                 }
 
-                var scopeProperty = resourceSymbol.SafeGetBodyProperty(LanguageConstants.ResourceScopePropertyName);
+                var scopeProperty = resource.Symbol.SafeGetBodyProperty(LanguageConstants.ResourceScopePropertyName);
 
                 if (ancestors.Any())
                 {
                     if (scopeProperty is not null)
                     {
                         // it doesn't make sense to have scope on a descendent resource; it should be inherited from the oldest ancestor.
-                        diagnosticWriter.Write(scopeProperty.Value, x => x.ScopeUnsupportedOnChildResource(ancestors.Last().Resource.Name));
+                        diagnosticWriter.Write(scopeProperty.Value, x => x.ScopeUnsupportedOnChildResource(ancestors.Last().Resource.Symbol.Name));
                         // TODO: format the ancestor name using the resource accessor (::) for nested resources
                         continue;
                     }
 
                     var firstAncestor = ancestors.First();
-                    if (!resourceSymbol.DeclaringResource.IsExistingResource() && 
-                        firstAncestor.Resource.DeclaringResource.IsExistingResource() && 
-                        firstAncestor.Resource.SafeGetBodyProperty(LanguageConstants.ResourceScopePropertyName) is {} firstAncestorScope)
+                    if (!resource.IsExistingResource() && 
+                        firstAncestor.Resource.IsExistingResource() && 
+                        firstAncestor.Resource.Symbol.SafeGetBodyProperty(LanguageConstants.ResourceScopePropertyName) is {} firstAncestorScope)
                     {
                         // it doesn't make sense to have scope on a descendent resource; it should be inherited from the oldest ancestor.
-                        diagnosticWriter.Write(resourceSymbol.DeclaringResource.Value, x => x.ScopeDisallowedForAncestorResource(firstAncestor.Resource.Name));
+                        diagnosticWriter.Write(resource.Symbol.DeclaringResource.Value, x => x.ScopeDisallowedForAncestorResource(firstAncestor.Resource.Symbol.Name));
                         // TODO: format the ancestor name using the resource accessor (::) for nested resources
                         continue;
                     }
 
-                    if (semanticModel.Binder.TryGetCycle(resourceSymbol) is not null)
+                    if (semanticModel.Binder.TryGetCycle(resource.Symbol) is not null)
                     {
                         continue;
                     }
 
                     // we really just want the scope allocated to the oldest ancestor.
                     // since we are looping in order of depth, we can just read back the value from a previous iteration.
-                    scopeInfo[resourceSymbol] = scopeInfo[firstAncestor.Resource];
+                    scopeInfo[resource] = scopeInfo[firstAncestor.Resource];
                     continue;
                 }
 
-                var scopeData = ScopeHelper.ValidateScope(semanticModel, logInvalidScopeDiagnostic, resourceType.ValidParentScopes, resourceSymbol.DeclaringResource.Value, scopeProperty);
+                var scopeData = ScopeHelper.ValidateScope(semanticModel, logInvalidScopeDiagnostic, resourceType.ValidParentScopes, resource.Symbol.DeclaringResource.Value, scopeProperty);
 
                 if (scopeData is null)
                 {
                     scopeData = new ScopeData { RequestedScope = semanticModel.TargetScope };
                 }
 
-                scopeInfo[resourceSymbol] = scopeData;
+                scopeInfo[resource] = scopeData;
             }
 
-            foreach (var resourceSymbol in semanticModel.Root.ResourceDeclarations)
+            foreach (var resourceToValidate in semanticModel.GetAllResources())
             {
-                var scopeProperty = resourceSymbol.SafeGetBodyProperty(LanguageConstants.ResourceScopePropertyName);
+                var scopeProperty = resourceToValidate.Symbol.SafeGetBodyProperty(LanguageConstants.ResourceScopePropertyName);
                 
                 ValidateResourceScopeRestrictions(
                     semanticModel,
                     scopeInfo,
-                    resourceSymbol,
-                    buildDiagnostic => diagnosticWriter.Write(scopeProperty?.Value ?? resourceSymbol.DeclaringResource.Value, buildDiagnostic));
+                    resourceToValidate,
+                    buildDiagnostic => diagnosticWriter.Write(scopeProperty?.Value ?? resourceToValidate.Symbol.DeclaringResource.Value, buildDiagnostic));
             }
 
             return scopeInfo.ToImmutableDictionary();
@@ -579,20 +567,11 @@ namespace Bicep.Core.Emit
             void LogInvalidScopeDiagnostic(IPositionable positionable, ResourceScope suppliedScope, ResourceScope supportedScopes)
                 => diagnosticWriter.Write(positionable, x => x.UnsupportedModuleScope(suppliedScope, supportedScopes));
 
-            // local function
-            ModuleType? GetModuleType(ModuleSymbol symbol) => symbol.Type switch
-            {
-                ModuleType moduleType => moduleType,
-                ArrayType {Item: ModuleType moduleType} => moduleType,
-                _ => null
-            };
-
             var scopeInfo = new Dictionary<ModuleSymbol, ScopeData>();
 
             foreach (var moduleSymbol in semanticModel.Root.ModuleDeclarations)
             {
-                var moduleType = GetModuleType(moduleSymbol);
-                if (moduleType is null)
+                if (moduleSymbol.TryGetModuleType() is not {} moduleType)
                 {
                     // missing type should be caught during type validation
                     continue;

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -18,6 +18,7 @@ using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Bicep.Core.Semantics.Metadata;
 
 namespace Bicep.Core.Emit
 {
@@ -264,14 +265,14 @@ namespace Bicep.Core.Emit
             jsonWriter.WritePropertyName("resources");
             jsonWriter.WriteStartArray();
 
-            foreach (var resourceSymbol in this.context.SemanticModel.Root.GetAllResourceDeclarations())
+            foreach (var resource in this.context.SemanticModel.GetAllResources())
             {
-                if (resourceSymbol.DeclaringResource.IsExistingResource())
+                if (resource.IsExistingResource())
                 {
                     continue;
                 }
 
-                this.EmitResource(jsonWriter, resourceSymbol, emitter);
+                this.EmitResource(jsonWriter, resource, emitter);
             }
 
             foreach (var moduleSymbol in this.context.SemanticModel.Root.ModuleDeclarations)
@@ -294,11 +295,11 @@ namespace Bicep.Core.Emit
             };
         }
 
-        private void EmitResource(JsonTextWriter jsonWriter, ResourceSymbol resourceSymbol, ExpressionEmitter emitter)
+        private void EmitResource(JsonTextWriter jsonWriter, ResourceMetadata resource, ExpressionEmitter emitter)
         {
             jsonWriter.WriteStartObject();
 
-            var typeReference = resourceSymbol.GetResourceTypeReference();
+            var typeReference = resource.GetResourceTypeReference();
 
             // Note: conditions STACK with nesting.
             //
@@ -308,24 +309,24 @@ namespace Bicep.Core.Emit
             var conditions = new List<SyntaxBase>();
             var loops = new List<(string name, ForSyntax @for, SyntaxBase? input)>();
 
-            var ancestors = this.context.SemanticModel.ResourceAncestors.GetAncestors(resourceSymbol);
+            var ancestors = this.context.SemanticModel.ResourceAncestors.GetAncestors(resource);
             foreach (var ancestor in ancestors)
             {
                 if (ancestor.AncestorType == ResourceAncestorGraph.ResourceAncestorType.Nested &&
-                    ancestor.Resource.DeclaringResource.Value is IfConditionSyntax ifCondition)
+                    ancestor.Resource.Symbol.DeclaringResource.Value is IfConditionSyntax ifCondition)
                 {
                     conditions.Add(ifCondition.ConditionExpression);
                 }
 
                 if (ancestor.AncestorType == ResourceAncestorGraph.ResourceAncestorType.Nested &&
-                    ancestor.Resource.DeclaringResource.Value is ForSyntax @for)
+                    ancestor.Resource.Symbol.DeclaringResource.Value is ForSyntax @for)
                 {
-                    loops.Add((ancestor.Resource.Name, @for, null));
+                    loops.Add((ancestor.Resource.Symbol.Name, @for, null));
                 }
             }
 
             // Unwrap the 'real' resource body if there's a condition
-            var body = resourceSymbol.DeclaringResource.Value;
+            var body = resource.Symbol.DeclaringResource.Value;
             switch (body)
             {
                 case IfConditionSyntax ifCondition:
@@ -334,7 +335,7 @@ namespace Bicep.Core.Emit
                     break;
 
                 case ForSyntax @for:
-                    loops.Add((resourceSymbol.Name, @for, null));
+                    loops.Add((resource.Symbol.Name, @for, null));
                     if (@for.Body is IfConditionSyntax loopFilter)
                     {
                         body = loopFilter.Body;
@@ -371,7 +372,7 @@ namespace Bicep.Core.Emit
 
             if (loops.Count == 1)
             {
-                var batchSize = GetBatchSize(resourceSymbol.DeclaringResource);
+                var batchSize = GetBatchSize(resource.Symbol.DeclaringResource);
                 emitter.EmitProperty("copy", () => emitter.EmitCopyObject(loops[0].name, loops[0].@for, loops[0].input, batchSize: batchSize));
             }
             else if (loops.Count > 1)
@@ -381,16 +382,16 @@ namespace Bicep.Core.Emit
 
             emitter.EmitProperty("type", typeReference.FullyQualifiedType);
             emitter.EmitProperty("apiVersion", typeReference.ApiVersion);
-            if (context.SemanticModel.EmitLimitationInfo.ResourceScopeData.TryGetValue(resourceSymbol, out var scopeData))
+            if (context.SemanticModel.EmitLimitationInfo.ResourceScopeData.TryGetValue(resource, out var scopeData))
             {
-                ScopeHelper.EmitResourceScopeProperties(context.SemanticModel.TargetScope, scopeData, emitter, body);
+                ScopeHelper.EmitResourceScopeProperties(context.SemanticModel, scopeData, emitter, body);
             }
 
-            emitter.EmitProperty("name", emitter.GetFullyQualifiedResourceName(resourceSymbol));
+            emitter.EmitProperty("name", emitter.GetFullyQualifiedResourceName(resource));
 
             emitter.EmitObjectProperties((ObjectSyntax)body, ResourcePropertiesToOmit);
 
-            this.EmitDependsOn(jsonWriter, resourceSymbol, emitter, body);
+            this.EmitDependsOn(jsonWriter, resource.Symbol, emitter, body);
 
             jsonWriter.WriteEndObject();
         }
@@ -577,7 +578,10 @@ namespace Bicep.Core.Emit
                             break;
                         }
 
-                        emitter.EmitResourceIdReference(resourceDependency, dependency.IndexExpression, newContext);
+                        var resource = context.SemanticModel.ResourceMetadata.TryLookup(resourceDependency.DeclaringSyntax) ??
+                            throw new ArgumentException($"Unable to find resource metadata for dependency '{dependency.Resource.Name}'");
+
+                        emitter.EmitResourceIdReference(resource, dependency.IndexExpression, newContext);
                         break;
                     case ModuleSymbol moduleDependency:
                         if (moduleDependency.IsCollection && dependency.IndexExpression == null)

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -265,9 +265,9 @@ namespace Bicep.Core.Emit
             jsonWriter.WritePropertyName("resources");
             jsonWriter.WriteStartArray();
 
-            foreach (var resource in this.context.SemanticModel.GetAllResources())
+            foreach (var resource in this.context.SemanticModel.AllResources)
             {
-                if (resource.IsExistingResource())
+                if (resource.IsExistingResource)
                 {
                     continue;
                 }
@@ -298,8 +298,6 @@ namespace Bicep.Core.Emit
         private void EmitResource(JsonTextWriter jsonWriter, ResourceMetadata resource, ExpressionEmitter emitter)
         {
             jsonWriter.WriteStartObject();
-
-            var typeReference = resource.GetResourceTypeReference();
 
             // Note: conditions STACK with nesting.
             //
@@ -380,8 +378,8 @@ namespace Bicep.Core.Emit
                 throw new InvalidOperationException("nested loops are not supported");
             }
 
-            emitter.EmitProperty("type", typeReference.FullyQualifiedType);
-            emitter.EmitProperty("apiVersion", typeReference.ApiVersion);
+            emitter.EmitProperty("type", resource.TypeReference.FullyQualifiedType);
+            emitter.EmitProperty("apiVersion", resource.TypeReference.ApiVersion);
             if (context.SemanticModel.EmitLimitationInfo.ResourceScopeData.TryGetValue(resource, out var scopeData))
             {
                 ScopeHelper.EmitResourceScopeProperties(context.SemanticModel, scopeData, emitter, body);

--- a/src/Bicep.Core/Semantics/FileSymbol.cs
+++ b/src/Bicep.Core/Semantics/FileSymbol.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Azure.Deployments.Core.Extensions;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Semantics
@@ -81,8 +82,6 @@ namespace Bicep.Core.Semantics
         public override IEnumerable<ErrorDiagnostic> GetDiagnostics() => DuplicateIdentifierValidatorVisitor.GetDiagnostics(this);
 
         public IEnumerable<DeclaredSymbol> GetDeclarationsByName(string name) => this.declarationsByName[name];
-
-        public IEnumerable<ResourceSymbol> GetAllResourceDeclarations() => ResourceSymbolVisitor.GetAllResources(this);
 
         private sealed class DuplicateIdentifierValidatorVisitor : SymbolVisitor
         {

--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadata.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Resources;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    public class ResourceMetadata
+    {
+        public ResourceMetadata(
+            ResourceType type,
+            SyntaxBase nameSyntax,
+            ResourceSymbol symbol,
+            ResourceMetadataParent? parent,
+            SyntaxBase? scopeSyntax,
+            bool isExistingResource)
+        {
+            // TODO: turn this into a record when the target framework supports it
+            Type = type;
+            NameSyntax = nameSyntax;
+            Symbol = symbol;
+            Parent = parent;
+            ScopeSyntax = scopeSyntax;
+            IsExistingResource = isExistingResource;
+        }
+
+        public ResourceSymbol Symbol { get; }
+
+        public ResourceTypeReference TypeReference => Type.TypeReference;
+
+        public ResourceType Type { get; }
+
+        public ResourceMetadataParent? Parent { get; }
+
+        public SyntaxBase NameSyntax { get; }
+
+        public SyntaxBase? ScopeSyntax { get; }
+
+        public bool IsExistingResource { get; }
+    }
+}

--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
@@ -73,10 +73,6 @@ namespace Bicep.Core.Semantics.Metadata
         {
             switch (syntax)
             {
-                case VariableDeclarationSyntax variableDeclarationSyntax:
-                {
-                    return this.TryLookup(variableDeclarationSyntax.Value);
-                }
                 case ResourceAccessSyntax _:
                 case VariableAccessSyntax _:
                 {

--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Concurrent;
+using Bicep.Core.Resources;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    public class ResourceMetadata
+    {
+        public ResourceMetadata(ResourceSymbol symbol)
+        {
+            Symbol = symbol;
+        }
+
+        public ResourceSymbol Symbol { get; }
+
+        public ResourceTypeReference GetResourceTypeReference()
+            => Symbol.GetResourceTypeReference();
+
+        public bool IsExistingResource()
+            => Symbol.DeclaringResource.IsExistingResource();
+    }
+
+    public class ResourceMetadataCache : SyntaxMetadataCacheBase<ResourceMetadata?>
+    {
+        private readonly SemanticModel semanticModel;
+        private readonly ConcurrentDictionary<ResourceSymbol, ResourceMetadata> symbolLookup;
+
+        public ResourceMetadataCache(SemanticModel semanticModel)
+        {
+            this.semanticModel = semanticModel;
+            this.symbolLookup = new();
+        }
+
+        protected override ResourceMetadata? Calculate(SyntaxBase syntax)
+        {
+            if (this.semanticModel.GetSymbolInfo(syntax) is ResourceSymbol symbol)
+            {
+                // Avoid duplicating metadata for the same symbol, so that ResourceMetadata can be compared by reference.
+                return symbolLookup.GetOrAdd(
+                    symbol,
+                    symbol => new ResourceMetadata(symbol));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
@@ -3,23 +3,59 @@
 using System.Collections.Concurrent;
 using Bicep.Core.Resources;
 using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Semantics.Metadata
 {
+    public class ResourceMetadataParent
+    {
+        public ResourceMetadataParent(ResourceMetadata metadata, SyntaxBase? indexExpression, bool isNested)
+        {
+            // TODO: turn this into a record when the target framework supports it
+            Metadata = metadata;
+            IndexExpression = indexExpression;
+            IsNested = isNested;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
+        public SyntaxBase? IndexExpression { get; }
+
+        public bool IsNested { get; }
+    }
+
     public class ResourceMetadata
     {
-        public ResourceMetadata(ResourceSymbol symbol)
+        public ResourceMetadata(
+            ResourceType type,
+            SyntaxBase nameSyntax,
+            ResourceSymbol symbol,
+            ResourceMetadataParent? parent,
+            SyntaxBase? scopeSyntax,
+            bool isExistingResource)
         {
+            // TODO: turn this into a record when the target framework supports it
+            Type = type;
+            NameSyntax = nameSyntax;
             Symbol = symbol;
+            Parent = parent;
+            ScopeSyntax = scopeSyntax;
+            IsExistingResource = isExistingResource;
         }
 
         public ResourceSymbol Symbol { get; }
 
-        public ResourceTypeReference GetResourceTypeReference()
-            => Symbol.GetResourceTypeReference();
+        public ResourceTypeReference TypeReference => Type.TypeReference;
 
-        public bool IsExistingResource()
-            => Symbol.DeclaringResource.IsExistingResource();
+        public ResourceType Type { get; }
+
+        public ResourceMetadataParent? Parent { get; }
+
+        public SyntaxBase NameSyntax { get; }
+
+        public SyntaxBase? ScopeSyntax { get; }
+
+        public bool IsExistingResource { get; }
     }
 
     public class ResourceMetadataCache : SyntaxMetadataCacheBase<ResourceMetadata?>
@@ -35,12 +71,82 @@ namespace Bicep.Core.Semantics.Metadata
 
         protected override ResourceMetadata? Calculate(SyntaxBase syntax)
         {
-            if (this.semanticModel.GetSymbolInfo(syntax) is ResourceSymbol symbol)
+            switch (syntax)
             {
-                // Avoid duplicating metadata for the same symbol, so that ResourceMetadata can be compared by reference.
-                return symbolLookup.GetOrAdd(
-                    symbol,
-                    symbol => new ResourceMetadata(symbol));
+                case VariableDeclarationSyntax variableDeclarationSyntax:
+                {
+                    return this.TryLookup(variableDeclarationSyntax.Value);
+                }
+                case ResourceAccessSyntax _:
+                case VariableAccessSyntax _:
+                {
+                    var symbol = semanticModel.GetSymbolInfo(syntax);
+                    if (symbol is DeclaredSymbol declaredSymbol)
+                    {
+                        return this.TryLookup(declaredSymbol.DeclaringSyntax);
+                    }
+
+                    break;
+                }
+                case ResourceDeclarationSyntax resourceDeclarationSyntax:
+                {
+                    // Skip analysis for ErrorSymbol and similar cases, these are invalid cases, and won't be emitted.
+                    var symbol = semanticModel.GetSymbolInfo(syntax) as ResourceSymbol;
+                    if (symbol is null || 
+                        symbol.TryGetResourceType() is not {} resourceType ||
+                        symbol.SafeGetBodyPropertyValue(LanguageConstants.ResourceNamePropertyName) is not {} nameSyntax)
+                    {
+                        break;
+                    }
+
+                    if (semanticModel.Binder.GetNearestAncestor<ResourceDeclarationSyntax>(syntax) is {} nestedParentSyntax)
+                    {
+                        // nested resource parent syntax
+                        if (TryLookup(nestedParentSyntax) is {} parentMetadata)
+                        {
+                            return new(
+                                resourceType,
+                                nameSyntax,
+                                symbol,
+                                new(parentMetadata,  null, true),
+                                symbol.SafeGetBodyPropertyValue(LanguageConstants.ResourceScopePropertyName),
+                                symbol.DeclaringResource.IsExistingResource());
+                        }
+                    }
+                    else if (symbol.SafeGetBodyPropertyValue(LanguageConstants.ResourceParentPropertyName) is {} referenceParentSyntax)
+                    {
+                        SyntaxBase? indexExpression = null;
+                        if (referenceParentSyntax is ArrayAccessSyntax arrayAccess)
+                        {
+                            referenceParentSyntax = arrayAccess.BaseExpression;
+                            indexExpression = arrayAccess.IndexExpression;
+                        }
+
+                        // parent property reference syntax
+                        if (TryLookup(referenceParentSyntax) is {} parentMetadata)
+                        {
+                            return new(
+                                resourceType,
+                                nameSyntax,
+                                symbol,
+                                new(parentMetadata, indexExpression, false),
+                                symbol.SafeGetBodyPropertyValue(LanguageConstants.ResourceScopePropertyName),
+                                symbol.DeclaringResource.IsExistingResource());
+                        }
+                    }
+                    else
+                    {
+                        return new(
+                            resourceType,
+                            nameSyntax,
+                            symbol,
+                            null,
+                            symbol.SafeGetBodyPropertyValue(LanguageConstants.ResourceScopePropertyName),
+                            symbol.DeclaringResource.IsExistingResource());
+                    }
+
+                    break;
+                }
             }
 
             return null;

--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
@@ -3,63 +3,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
-using Bicep.Core.Resources;
 using Bicep.Core.Syntax;
-using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Semantics.Metadata
 {
-    public class ResourceMetadataParent
-    {
-        public ResourceMetadataParent(ResourceMetadata metadata, SyntaxBase? indexExpression, bool isNested)
-        {
-            // TODO: turn this into a record when the target framework supports it
-            Metadata = metadata;
-            IndexExpression = indexExpression;
-            IsNested = isNested;
-        }
-
-        public ResourceMetadata Metadata { get; }
-
-        public SyntaxBase? IndexExpression { get; }
-
-        public bool IsNested { get; }
-    }
-
-    public class ResourceMetadata
-    {
-        public ResourceMetadata(
-            ResourceType type,
-            SyntaxBase nameSyntax,
-            ResourceSymbol symbol,
-            ResourceMetadataParent? parent,
-            SyntaxBase? scopeSyntax,
-            bool isExistingResource)
-        {
-            // TODO: turn this into a record when the target framework supports it
-            Type = type;
-            NameSyntax = nameSyntax;
-            Symbol = symbol;
-            Parent = parent;
-            ScopeSyntax = scopeSyntax;
-            IsExistingResource = isExistingResource;
-        }
-
-        public ResourceSymbol Symbol { get; }
-
-        public ResourceTypeReference TypeReference => Type.TypeReference;
-
-        public ResourceType Type { get; }
-
-        public ResourceMetadataParent? Parent { get; }
-
-        public SyntaxBase NameSyntax { get; }
-
-        public SyntaxBase? ScopeSyntax { get; }
-
-        public bool IsExistingResource { get; }
-    }
-
     public class ResourceMetadataCache : SyntaxMetadataCacheBase<ResourceMetadata?>
     {
         private readonly SemanticModel semanticModel;

--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadataParent.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadataParent.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    public class ResourceMetadataParent
+    {
+        public ResourceMetadataParent(ResourceMetadata metadata, SyntaxBase? indexExpression, bool isNested)
+        {
+            // TODO: turn this into a record when the target framework supports it
+            Metadata = metadata;
+            IndexExpression = indexExpression;
+            IsNested = isNested;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
+        public SyntaxBase? IndexExpression { get; }
+
+        public bool IsNested { get; }
+    }
+}

--- a/src/Bicep.Core/Semantics/Metadata/SyntaxMetadataCacheBase.cs
+++ b/src/Bicep.Core/Semantics/Metadata/SyntaxMetadataCacheBase.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Concurrent;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    public abstract class SyntaxMetadataCacheBase<TMetadata>
+    {
+        private readonly ConcurrentDictionary<SyntaxBase, TMetadata> cache;
+
+        protected SyntaxMetadataCacheBase()
+        {
+            cache = new();
+        }
+        
+        protected abstract TMetadata Calculate(SyntaxBase syntax);
+
+        public TMetadata? TryLookup(SyntaxBase syntax)
+        {
+            return cache.GetOrAdd(
+                syntax,
+                syntax => Calculate(syntax));
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/ModuleSymbol.cs
+++ b/src/Bicep.Core/Semantics/ModuleSymbol.cs
@@ -48,12 +48,7 @@ namespace Bicep.Core.Semantics
 
         public bool IsCollection => this.Type is ArrayType;
 
-        public ModuleType? TryGetModuleType() => this.Type switch
-        {
-            ModuleType moduleType => moduleType,
-            ArrayType { Item: ModuleType moduleType } => moduleType,
-            _ => null,
-        };
+        public ModuleType? TryGetModuleType() => ModuleType.TryUnwrap(this.Type);
 
         public ObjectType? TryGetBodyObjectType() => this.TryGetModuleType()?.Body.Type as ObjectType;
     }

--- a/src/Bicep.Core/Semantics/ResourceSymbol.cs
+++ b/src/Bicep.Core/Semantics/ResourceSymbol.cs
@@ -33,9 +33,6 @@ namespace Bicep.Core.Semantics
 
         public ResourceType? TryGetResourceType() => ResourceType.TryUnwrap(this.Type);
 
-        public ResourceTypeReference GetResourceTypeReference() =>
-            this.TryGetResourceTypeReference() ??  throw new ArgumentException($"Resource symbol does not have a valid type (found {this.Type.Name})");
-
         public ResourceTypeReference? TryGetResourceTypeReference() => this.TryGetResourceType()?.TypeReference;
 
         public ObjectType? TryGetBodyObjectType() => this.TryGetResourceType()?.Body.Type as ObjectType;

--- a/src/Bicep.Core/Semantics/ResourceSymbol.cs
+++ b/src/Bicep.Core/Semantics/ResourceSymbol.cs
@@ -31,12 +31,7 @@ namespace Bicep.Core.Semantics
 
         public bool IsCollection => this.Type is ArrayType;
 
-        public ResourceType? TryGetResourceType() => this.Type switch
-        {
-            ResourceType resourceType => resourceType,
-            ArrayType { Item: ResourceType resourceType } => resourceType,
-            _ => null,
-        };
+        public ResourceType? TryGetResourceType() => ResourceType.TryUnwrap(this.Type);
 
         public ResourceTypeReference GetResourceTypeReference() =>
             this.TryGetResourceTypeReference() ??  throw new ArgumentException($"Resource symbol does not have a valid type (found {this.Type.Name})");

--- a/src/Bicep.Core/TypeSystem/ModuleType.cs
+++ b/src/Bicep.Core/TypeSystem/ModuleType.cs
@@ -23,5 +23,13 @@ namespace Bicep.Core.TypeSystem
         public ITypeReference Body { get; }
 
         public ResourceScope Scope => ResourceScope.Module;
+
+        public static ModuleType? TryUnwrap(TypeSymbol typeSymbol)
+            => typeSymbol switch
+            {
+                ModuleType moduleType => moduleType,
+                ArrayType { Item: ModuleType moduleType } => moduleType,
+                _ => null
+            };
     }
 }

--- a/src/Bicep.Core/TypeSystem/ResourceType.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceType.cs
@@ -27,5 +27,13 @@ namespace Bicep.Core.TypeSystem
         public ITypeReference Body { get; }
 
         public ResourceScope Scope => ResourceScope.Resource;
+
+        public static ResourceType? TryUnwrap(TypeSymbol typeSymbol)
+            => typeSymbol switch
+            {
+                ResourceType resourceType => resourceType,
+                ArrayType { Item: ResourceType resourceType } => resourceType,
+                _ => null
+            };
     }
 }

--- a/src/Bicep.Core/Utils/ResourceDefinition.cs
+++ b/src/Bicep.Core/Utils/ResourceDefinition.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Utils
@@ -10,11 +11,11 @@ namespace Bicep.Core.Utils
     internal class ResourceDefinition
     {
         public string ResourceName { get; }
-        public ResourceSymbol? ResourceScope { get; }
+        public ResourceMetadata? ResourceScope { get; }
         public string FullyQualifiedResourceType { get; }
         public StringSyntax ResourceNamePropertyValue { get; }
 
-        public ResourceDefinition(string resourceName, ResourceSymbol? resourceScope, string fullyQualifiedResourceType, StringSyntax resourceNamePropertyValue)
+        public ResourceDefinition(string resourceName, ResourceMetadata? resourceScope, string fullyQualifiedResourceType, StringSyntax resourceNamePropertyValue)
         {
             ResourceName = resourceName;
             ResourceScope = resourceScope;

--- a/src/Bicep.Decompiler/Rewriters/ParentChildResourceNameRewriter.cs
+++ b/src/Bicep.Decompiler/Rewriters/ParentChildResourceNameRewriter.cs
@@ -91,8 +91,10 @@ namespace Bicep.Core.Decompiler.Rewriters
                 return syntax;
             }
 
-            foreach (var otherResourceSymbol in semanticModel.Root.GetAllResourceDeclarations())
+            foreach (var otherResource in semanticModel.GetAllResources())
             {
+                var otherResourceSymbol = otherResource.Symbol;
+
                 if (otherResourceSymbol.Type is not ResourceType otherResourceType ||
                     otherResourceType.TypeReference.Types.Length != resourceType.TypeReference.Types.Length - 1 ||
                     !resourceType.TypeReference.TypesString.StartsWith($"{otherResourceType.TypeReference.TypesString}/", StringComparison.OrdinalIgnoreCase))

--- a/src/Bicep.Decompiler/Rewriters/ParentChildResourceNameRewriter.cs
+++ b/src/Bicep.Decompiler/Rewriters/ParentChildResourceNameRewriter.cs
@@ -91,7 +91,7 @@ namespace Bicep.Core.Decompiler.Rewriters
                 return syntax;
             }
 
-            foreach (var otherResource in semanticModel.GetAllResources())
+            foreach (var otherResource in semanticModel.AllResources)
             {
                 var otherResourceSymbol = otherResource.Symbol;
 

--- a/src/Bicep.LangServer.IntegrationTests/DeploymentGraphTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DeploymentGraphTests.cs
@@ -111,8 +111,7 @@ resource res5 'Test.Rp/basicTests@2020-01-01' = {
                 new BicepDeploymentGraphNode("mod2::res4", "Test.Rp/basicTests", false, CreateTextRange(1, 0, 3, 1), false, false, Path.GetFullPath(module2Uri.GetFileSystemPath())),
                 new BicepDeploymentGraphNode("nonExistingMod", "<module>", false, CreateTextRange(23, 0, 24, 1), false, true, Path.GetFullPath("/path/to/nonExistingModule.bicep")),
                 new BicepDeploymentGraphNode("res1", "Test.Rp/basicTests", false, CreateTextRange(1, 0, 3, 1), false, false, Path.GetFullPath(mainUri.GetFileSystemPath())),
-                new BicepDeploymentGraphNode("res2", "Test.Rp/readWriteTests", false, CreateTextRange(5, 0, 10, 1), false, true, Path.GetFullPath(mainUri.GetFileSystemPath())),
-                new BicepDeploymentGraphNode("unknownRes", "<unknown>", false, CreateTextRange(12, 0, 12, 23), false, true, Path.GetFullPath(mainUri.GetFileSystemPath())));
+                new BicepDeploymentGraphNode("res2", "Test.Rp/readWriteTests", false, CreateTextRange(5, 0, 10, 1), false, true, Path.GetFullPath(mainUri.GetFileSystemPath())));
             deploymentGraph!.Edges.Should().Equal(
                 new BicepDeploymentGraphEdge("mod2::nestedMod", "mod2::res4"),
                 new BicepDeploymentGraphEdge("res2", "mod1"));

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -442,8 +442,8 @@ namespace Bicep.LanguageServer.Completions
             if (context.EnclosingDeclaration is ResourceDeclarationSyntax resourceDeclarationSyntax &&
                 model.GetDeclaredType(resourceDeclarationSyntax) is ResourceType resourceType)
             {
-                bool isResourceNested = model.GetSymbolInfo(resourceDeclarationSyntax) is ResourceSymbol resourceSymbol &&
-                    model.ResourceAncestors.GetAncestors(resourceSymbol).Any(x => x.AncestorType == ResourceAncestorType.Nested);
+                bool isResourceNested = model.ResourceMetadata.TryLookup(resourceDeclarationSyntax) is {} resource &&
+                    model.ResourceAncestors.GetAncestors(resource).Any(x => x.AncestorType == ResourceAncestorType.Nested);
                 IEnumerable<Snippet> snippets = SnippetsProvider.GetResourceBodyCompletionSnippets(resourceType, resourceDeclarationSyntax.IsExistingResource(), isResourceNested);
 
                 foreach (Snippet snippet in snippets)

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -442,9 +442,8 @@ namespace Bicep.LanguageServer.Completions
             if (context.EnclosingDeclaration is ResourceDeclarationSyntax resourceDeclarationSyntax &&
                 model.GetDeclaredType(resourceDeclarationSyntax) is ResourceType resourceType)
             {
-                bool isResourceNested = model.ResourceMetadata.TryLookup(resourceDeclarationSyntax) is {} resource &&
-                    model.ResourceAncestors.GetAncestors(resource).Any(x => x.AncestorType == ResourceAncestorType.Nested);
-                IEnumerable<Snippet> snippets = SnippetsProvider.GetResourceBodyCompletionSnippets(resourceType, resourceDeclarationSyntax.IsExistingResource(), isResourceNested);
+                var isResourceNested = model.Binder.GetNearestAncestor<ResourceDeclarationSyntax>(resourceDeclarationSyntax) is {};
+                var snippets = SnippetsProvider.GetResourceBodyCompletionSnippets(resourceType, resourceDeclarationSyntax.IsExistingResource(), isResourceNested);
 
                 foreach (Snippet snippet in snippets)
                 {

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentGraphHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentGraphHandler.cs
@@ -88,8 +88,8 @@ namespace Bicep.LanguageServer.Handlers
 
                     if (symbol is ResourceSymbol resourceSymbol)
                     {
-                        var resourceType = TryGetTypeReference(resourceSymbol)?.FullyQualifiedType ?? "<unknown>";
-                        var isCollection = resourceSymbol.Type is ArrayType { Item: ResourceType };
+                        var resourceType = resourceSymbol.TryGetResourceTypeReference()?.FullyQualifiedType ?? "<unknown>";
+                        var isCollection = resourceSymbol.IsCollection;
                         var resourceSpan = resourceSymbol.DeclaringResource.Span;
                         var range = resourceSpan.ToRange(context.LineStarts);
                         var resourceHasError = errors.Any(error => TextSpan.AreOverlapping(resourceSpan, error.Span));
@@ -105,7 +105,7 @@ namespace Bicep.LanguageServer.Handlers
                             ? Path.GetFullPath(Path.Combine(directory, moduleRelativePath))
                             : null;
 
-                        var isCollection = moduleSymbol.Type is ArrayType { Item: ModuleType };
+                        var isCollection = moduleSymbol.IsCollection;
                         var moduleSpan = moduleSymbol.DeclaringModule.Span;
                         var range = moduleSpan.ToRange(context.LineStarts);
                         var moduleHasError = errors.Any(error => TextSpan.AreOverlapping(moduleSpan, error.Span));
@@ -152,12 +152,5 @@ namespace Bicep.LanguageServer.Handlers
                 edges.OrderBy(edge => $"{edge.SourceId}>{edge.TargetId}"),
                 entrySemanticModel.GetAllDiagnostics().Count(x => x.Level == DiagnosticLevel.Error));
         }
-
-        private static ResourceTypeReference? TryGetTypeReference(ResourceSymbol resourceSymbol) => resourceSymbol.Type switch
-        {
-            ResourceType resourceType => resourceType.TypeReference,
-            ArrayType { Item: ResourceType resourceType } => resourceType.TypeReference,
-            _ => null
-        };
     }
 }


### PR DESCRIPTION
Preparation for #2245.

See discussion under https://github.com/Azure/bicep/issues/2245#issuecomment-886758072 for information on how this fits in with the overall plan.