### PR TITLE
UploadSignedReleaseArtifacts.ps1 now requires PS Core

### DIFF
--- a/scripts/UploadSignedReleaseArtifacts.ps1
+++ b/scripts/UploadSignedReleaseArtifacts.ps1
@@ -29,6 +29,15 @@ param (
 
 $ErrorActionPreference = 'Stop';
 
+if($PSVersionTable.PSEdition -ne 'Core')
+{
+  # The Compress-Archive cmdlet on Windows PowerShell uses \ as the directory separator charactor
+  # when creating .zip files. When extracted on a non-Windows machine, \ is a valid file name character
+  # so the user gets a flat list of files instead of directories and subdirectories.
+  # This was fixed in PS Core/.net 5.
+  Write-Error "This script requires PowerShell Core to run.";
+}
+
 $org = 'https://dev.azure.com/msazure/';
 $project = 'One';
 $pipelineName = 'BicepMirror-Official'


### PR DESCRIPTION
This fixes #3704. The results of this should be visible when we post the next Bicep release.