### PR TITLE
Various perf fixes to minimize linter CPU impact

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "configurations": [
         {
-            "name": "Bicep VSCode Extension",
+            "name": "VSCode Extension",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
@@ -10,24 +10,16 @@
                 "--enable-proposed-api",
                 "--extensionDevelopmentPath=${workspaceRoot}/src/vscode-bicep"
             ],
+            "env": {
+                "BICEP_TRACING_ENABLED": "true"
+            },
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
             "preLaunchTask": "Build VSIX"
         },
         {
-            "name": "Bicep Playground",
-            "type": "node",
-            "request": "launch",
-            "program": "${workspaceFolder}/src/playground/node_modules/webpack/bin/webpack.js",
-            "args": ["serve"],
-            "cwd": "${workspaceFolder}/src/playground",
-            "autoAttachChildProcesses": true,
-            "stopOnEntry": false,
-            "preLaunchTask": "Build WASM for Playground"
-        },
-        {
-            "name": "Bicep CLI",
+            "name": "CLI",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Build CLI",
@@ -36,9 +28,23 @@
                 "build",
                 "${file}"
             ],
+            "env": {
+                "BICEP_TRACING_ENABLED": "true"
+            },
             "cwd": "${workspaceFolder}/src/Bicep.Cli",
             "console": "internalConsole",
             "stopAtEntry": false
+        },
+        {
+            "name": "Playground",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/playground/node_modules/webpack/bin/webpack.js",
+            "args": ["serve"],
+            "cwd": "${workspaceFolder}/src/playground",
+            "autoAttachChildProcesses": true,
+            "stopOnEntry": false,
+            "preLaunchTask": "Build WASM for Playground"
         },
         {
             "name": "Textmate Tests",

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -15,6 +15,7 @@ using Bicep.Core.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
 using System.Runtime;
 
 namespace Bicep.Cli
@@ -44,7 +45,9 @@ namespace Bicep.Cli
 
         public int Run(string[] args)
         {
-            ServiceProvider serviceProvider = ConfigureServices();
+            var serviceProvider = ConfigureServices();
+
+            Trace.Listeners.Add(new TextWriterTraceListener(this.invocationContext.OutputWriter));
 
             try
             {

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -47,7 +47,10 @@ namespace Bicep.Cli
         {
             var serviceProvider = ConfigureServices();
 
-            Trace.Listeners.Add(new TextWriterTraceListener(this.invocationContext.OutputWriter));
+            if (bool.TryParse(Environment.GetEnvironmentVariable("BICEP_TRACING_ENABLED"), out var enableTracing) && enableTracing)
+            {
+                Trace.Listeners.Add(new TextWriterTraceListener(this.invocationContext.OutputWriter));
+            }
 
             try
             {

--- a/src/Bicep.Cli/TextWriterTraceListener.cs
+++ b/src/Bicep.Cli/TextWriterTraceListener.cs
@@ -18,18 +18,12 @@ namespace Bicep.Cli
 
         public override void Write(string? message)
         {
-            if (message is not null)
-            {
-                textWriter.Write(message);
-            }
+            textWriter.WriteLine($"TRACE: {message}");
         }
 
         public override void WriteLine(string? message)
         {
-            if (message is not null)
-            {
-                textWriter.WriteLine(message);
-            }
+            textWriter.WriteLine($"TRACE: {message}");
         }
     }
 }

--- a/src/Bicep.Cli/TextWriterTraceListener.cs
+++ b/src/Bicep.Cli/TextWriterTraceListener.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Bicep.Cli
+{
+    public class TextWriterTraceListener : TraceListener
+    {
+        private readonly TextWriter textWriter;
+
+        public TextWriterTraceListener(TextWriter textWriter)
+        {
+            this.textWriter = textWriter;
+        }
+
+        public override void Write(string? message)
+        {
+            if (message is not null)
+            {
+                textWriter.Write(message);
+            }
+        }
+
+        public override void WriteLine(string? message)
+        {
+            if (message is not null)
+            {
+                textWriter.WriteLine(message);
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Bicep.Core/Extensions/EnumerableExtensions.cs
@@ -74,6 +74,14 @@ namespace Bicep.Core.Extensions
                 }
             }
         }
+
+        public static ILookup<T, T> InvertLookup<T>(this ILookup<T, T> source)
+            => source.SelectMany(group => group.Select(val => (group.Key, val)))
+                .ToLookup(x => x.val, x => x.Key);
+
+        public static ImmutableDictionary<TKey, ImmutableHashSet<TValue>> ToImmutableDictionary<TKey, TValue>(this ILookup<TKey, TValue> source)
+            where TKey : notnull
+            => source.ToImmutableDictionary(x => x.Key, x => x.ToImmutableHashSet());
     }
 }
 

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -25,7 +25,7 @@ namespace Bicep.Core.Semantics
 
         public ArmTemplateSemanticModel(ArmTemplateFile sourceFile)
         {
-            Trace.Write($"Building semantic model for {sourceFile.FileUri}");
+            Trace.WriteLine($"Building semantic model for {sourceFile.FileUri}");
 
             this.SourceFile = sourceFile;
 

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -25,7 +25,7 @@ namespace Bicep.Core.Semantics
 
         public ArmTemplateSemanticModel(ArmTemplateFile sourceFile)
         {
-            Debug.Write($"Building semantic model for {sourceFile.FileUri}");
+            Trace.Write($"Building semantic model for {sourceFile.FileUri}");
 
             this.SourceFile = sourceFile;
 

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -25,7 +25,7 @@ namespace Bicep.Core.Semantics
 
         public ArmTemplateSemanticModel(ArmTemplateFile sourceFile)
         {
-            Trace.Write($"Building semantic model for {sourceFile.FileUri}");
+            Debug.Write($"Building semantic model for {sourceFile.FileUri}");
 
             this.SourceFile = sourceFile;
 

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Azure.Deployments.Core.Definitions.Schema;
 using Azure.Deployments.Core.Entities;
@@ -24,6 +25,8 @@ namespace Bicep.Core.Semantics
 
         public ArmTemplateSemanticModel(ArmTemplateFile sourceFile)
         {
+            Trace.Write($"Building semantic model for {sourceFile.FileUri}");
+
             this.SourceFile = sourceFile;
 
             this.targetScopeLazy = new(() =>

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Semantics
 
         public SemanticModel(Compilation compilation, BicepFile sourceFile, IFileResolver fileResolver)
         {
-            Debug.Write($"Building semantic model for {sourceFile.FileUri}");
+            Trace.Write($"Building semantic model for {sourceFile.FileUri}");
 
             Compilation = compilation;
             SourceFile = sourceFile;

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Bicep.Core.Analyzers.Linter;
 using Bicep.Core.Configuration;
@@ -29,6 +30,8 @@ namespace Bicep.Core.Semantics
 
         public SemanticModel(Compilation compilation, BicepFile sourceFile, IFileResolver fileResolver)
         {
+            Trace.Write($"Reloading {sourceFile.FileUri}");
+
             Compilation = compilation;
             SourceFile = sourceFile;
             FileResolver = fileResolver;

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Semantics
 
         public SemanticModel(Compilation compilation, BicepFile sourceFile, IFileResolver fileResolver)
         {
-            Trace.Write($"Building semantic model for {sourceFile.FileUri}");
+            Trace.WriteLine($"Building semantic model for {sourceFile.FileUri}");
 
             Compilation = compilation;
             SourceFile = sourceFile;

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Semantics
 
         public SemanticModel(Compilation compilation, BicepFile sourceFile, IFileResolver fileResolver)
         {
-            Trace.Write($"Building semantic model for {sourceFile.FileUri}");
+            Debug.Write($"Building semantic model for {sourceFile.FileUri}");
 
             Compilation = compilation;
             SourceFile = sourceFile;

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Semantics
 
         public SemanticModel(Compilation compilation, BicepFile sourceFile, IFileResolver fileResolver)
         {
-            Trace.Write($"Reloading {sourceFile.FileUri}");
+            Trace.Write($"Building semantic model for {sourceFile.FileUri}");
 
             Compilation = compilation;
             SourceFile = sourceFile;

--- a/src/Bicep.Core/Workspaces/SourceFileGrouping.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGrouping.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Syntax;
+using System.Linq;
 using static Bicep.Core.Diagnostics.DiagnosticBuilder;
 
 namespace Bicep.Core.Workspaces
@@ -12,15 +14,23 @@ namespace Bicep.Core.Workspaces
     public class SourceFileGrouping
     {
         private readonly ImmutableDictionary<ModuleDeclarationSyntax, ISourceFile> sourceFilesByModuleDeclaration;
+        private readonly ImmutableDictionary<ISourceFile, ImmutableHashSet<ISourceFile>> sourceFileParentLookup;
 
         private readonly ImmutableDictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate> errorBuildersByModuleDeclaration;
 
-        public SourceFileGrouping(IFileResolver fileResolver, BicepFile entryPoint, ImmutableHashSet<ISourceFile> sourceFiles, ImmutableDictionary<ModuleDeclarationSyntax, ISourceFile> sourceFilesByModuleDeclaration, ImmutableDictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate> errorBuildersByModuleDeclaration)
+        public SourceFileGrouping(
+            IFileResolver fileResolver,
+            BicepFile entryPoint,
+            ImmutableHashSet<ISourceFile> sourceFiles,
+            ImmutableDictionary<ModuleDeclarationSyntax, ISourceFile> sourceFilesByModuleDeclaration,
+            ImmutableDictionary<ISourceFile, ImmutableHashSet<ISourceFile>> sourceFileParentLookup,
+            ImmutableDictionary<ModuleDeclarationSyntax, ErrorBuilderDelegate> errorBuildersByModuleDeclaration)
         {
             this.FileResolver = fileResolver;
             this.EntryPoint = entryPoint;
             this.SourceFiles = sourceFiles;
             this.sourceFilesByModuleDeclaration = sourceFilesByModuleDeclaration;
+            this.sourceFileParentLookup = sourceFileParentLookup;
             this.errorBuildersByModuleDeclaration = errorBuildersByModuleDeclaration;
         }
         public IFileResolver FileResolver { get; }
@@ -31,6 +41,28 @@ namespace Bicep.Core.Workspaces
 
         public ISourceFile LookUpModuleSourceFile(ModuleDeclarationSyntax moduleDeclaration) =>
             this.sourceFilesByModuleDeclaration[moduleDeclaration];
+
+        public ImmutableHashSet<ISourceFile> GetFilesDependingOn(ISourceFile sourceFile)
+        {
+            var filesToCheck = new Queue<ISourceFile>(new [] { sourceFile });
+            var knownFiles = new HashSet<ISourceFile>();
+
+            while (filesToCheck.TryDequeue(out var current))
+            {
+                knownFiles.Add(current);
+
+                if (sourceFileParentLookup.TryGetValue(current, out var parents))
+                {
+                    foreach (var parent in parents.Where(x => !knownFiles.Contains(x)))
+                    {
+                        knownFiles.Add(parent);
+                        filesToCheck.Enqueue(parent);
+                    }
+                }
+            }
+
+            return knownFiles.ToImmutableHashSet();
+        }
 
         public bool TryLookUpModuleErrorDiagnostic(ModuleDeclarationSyntax moduleDeclaration, [NotNullWhen(true)] out ErrorDiagnostic? errorDiagnostic)
         {

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
@@ -26,7 +26,7 @@ namespace Bicep.LangServer.UnitTests
 
             var document = CreateMockDocument(p => receivedParams = p);
             var server = CreateMockServer(document);
-            BicepCompilationManager bicepCompilationManager = new BicepCompilationManager(server.Object, CreateEmptyCompilationProvider(), new Workspace());
+            BicepCompilationManager bicepCompilationManager = new BicepCompilationManager(server.Object, CreateEmptyCompilationProvider(), new Workspace(), new FileResolver());
 
             if (upsertCompilation)
             {

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Bicep.Core.Configuration;
 using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Samples;
+using Bicep.Core.Semantics;
 using Bicep.Core.UnitTests.Configuration;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
@@ -20,25 +22,30 @@ namespace Bicep.LangServer.UnitTests
     [TestClass]
     public class BicepCompilationProviderTests
     {
-        private static IFileResolver CreateEmptyFileResolver()
-            => new InMemoryFileResolver(new Dictionary<Uri, string>());
+        private static IFileResolver CreateFileResolver(Uri fileUri, string contents)
+            => new InMemoryFileResolver(new Dictionary<Uri, string>
+            {
+                [fileUri] = contents,
+            });
 
         [TestMethod]
         public void Create_ShouldReturnValidCompilation()
         {
-            var provider = new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), CreateEmptyFileResolver());
-
             var fileUri = DocumentUri.Parse($"/{DataSets.Parameters_LF.Name}.bicep");
+            var fileResolver = CreateFileResolver(fileUri.ToUri(), DataSets.Parameters_LF.Bicep);
+
+            var provider = new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), fileResolver);
+
+            var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, new Workspace(), fileUri.ToUri());
+
             var sourceFile = SourceFileFactory.CreateSourceFile(fileUri.ToUri(), DataSets.Parameters_LF.Bicep);
             var workspace = new Workspace();
             workspace.UpsertSourceFile(sourceFile);
-            var context = provider.Create(workspace, fileUri);
+            var context = provider.Create(sourceFileGrouping, fileUri, ImmutableDictionary<ISourceFile, ISemanticModel>.Empty);
 
             context.Compilation.Should().NotBeNull();
             // TODO: remove Where when the support of modifiers is dropped.
-            context.Compilation.GetEntrypointSemanticModel()
-                   .GetAllDiagnostics(new ConfigHelper().GetDisabledLinterConfig())
-                   .Where(d => d.Code != "BCP161").Should().BeEmpty();
+            context.Compilation.GetEntrypointSemanticModel().GetAllDiagnostics(new ConfigHelper().GetDisabledLinterConfig()).Should().BeEmpty();
             context.LineStarts.Should().NotBeEmpty();
             context.LineStarts[0].Should().Be(0);
         }

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -7,6 +7,8 @@ using System.Collections.Immutable;
 using System.Linq;
 using Bicep.Core;
 using Bicep.Core.Extensions;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Semantics;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Extensions;
@@ -24,15 +26,17 @@ namespace Bicep.LanguageServer
         private readonly IWorkspace workspace;
         private readonly ILanguageServerFacade server;
         private readonly ICompilationProvider provider;
+        private readonly IFileResolver fileResolver;
 
         // represents compilations of open bicep files
         private readonly ConcurrentDictionary<DocumentUri, CompilationContext> activeContexts = new ConcurrentDictionary<DocumentUri, CompilationContext>();
 
-        public BicepCompilationManager(ILanguageServerFacade server, ICompilationProvider provider, IWorkspace workspace)
+        public BicepCompilationManager(ILanguageServerFacade server, ICompilationProvider provider, IWorkspace workspace, IFileResolver fileResolver)
         {
             this.server = server;
             this.provider = provider;
             this.workspace = workspace;
+            this.fileResolver = fileResolver;
         }
 
         public void UpsertCompilation(DocumentUri documentUri, int? version, string fileContents, string? languageId = null)
@@ -43,18 +47,18 @@ namespace Bicep.LanguageServer
                 var firstChanges = workspace.UpsertSourceFile(newFile);
                 var removedFiles = firstChanges.removed;
 
+                var modelLookup = new Dictionary<ISourceFile, ISemanticModel>();
                 if (newFile is BicepFile)
                 {
                     // Do not update compilation if it is an ARM template file, since it cannot be an entrypoint.
-                    var secondChanges = UpdateCompilationInternal(documentUri, version);
-                    removedFiles = removedFiles.Concat(secondChanges.removed).ToImmutableArray();
+                    UpdateCompilationInternal(documentUri, version, modelLookup, removedFiles);
                 }
 
                 foreach (var (entrypointUri, context) in activeContexts)
                 {
                     if (removedFiles.Any(x => context.Compilation.SourceFileGrouping.SourceFiles.Contains(x)))
                     {
-                        UpdateCompilationInternal(entrypointUri, null);
+                        UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles);
                     }
                 }
             }
@@ -94,11 +98,13 @@ namespace Bicep.LanguageServer
             }
 
             workspace.RemoveSourceFiles(removedFiles);
+
+            var modelLookup = new Dictionary<ISourceFile, ISemanticModel>();
             foreach (var (entrypointUri, context) in activeContexts)
             {
                 if (removedFiles.Any(x => context.Compilation.SourceFileGrouping.SourceFiles.Contains(x)))
                 {
-                    UpdateCompilationInternal(entrypointUri, null);
+                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles);
                 }
             }
         }
@@ -140,24 +146,46 @@ namespace Bicep.LanguageServer
             return closedFiles.ToImmutableArray();
         }
 
-        private (ImmutableArray<ISourceFile> added, ImmutableArray<ISourceFile> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version)
+        private void UpdateCompilationInternal(DocumentUri documentUri, int? version, IDictionary<ISourceFile, ISemanticModel> modelLookup, IEnumerable<ISourceFile> removedFiles)
         {
             try
             {
-                var context = this.provider.Create(workspace, documentUri);
+                var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, workspace, documentUri.ToUri());
 
-                var output = workspace.UpsertSourceFiles(context.Compilation.SourceFileGrouping.SourceFiles);
+                var context = this.activeContexts.AddOrUpdate(
+                    documentUri, 
+                    (documentUri) => this.provider.Create(sourceFileGrouping, documentUri, modelLookup.ToImmutableDictionary()),
+                    (documentUri, prevContext) => {
+                        var sourceDependencies = removedFiles
+                            .SelectMany(x => prevContext.Compilation.SourceFileGrouping.GetFilesDependingOn(x))
+                            .ToImmutableHashSet();
 
-                // there shouldn't be concurrent upsert requests (famous last words...), so a simple overwrite should be sufficient
-                this.activeContexts[documentUri] = context;
+                        // check for semantic models that we can safely reuse from the previous compilation
+                        foreach (var sourceFile in prevContext.Compilation.SourceFileGrouping.SourceFiles)
+                        {
+                            if (!modelLookup.ContainsKey(sourceFile) && !sourceDependencies.Contains(sourceFile))
+                            {
+                                // if we have a file with no dependencies on the modified file(s), we can reuse the previous model
+                                modelLookup[sourceFile] = prevContext.Compilation.GetSemanticModel(sourceFile);
+                            }
+                        }
+
+                        return this.provider.Create(sourceFileGrouping, documentUri, modelLookup.ToImmutableDictionary());
+                    });
+
+                foreach (var sourceFile in context.Compilation.SourceFileGrouping.SourceFiles)
+                {
+                    // store all the updated models as other compilations may be able to reuse them
+                    modelLookup[sourceFile] = context.Compilation.GetSemanticModel(sourceFile);
+                }
+
+                workspace.UpsertSourceFiles(context.Compilation.SourceFileGrouping.SourceFiles);
 
                 // convert all the diagnostics to LSP diagnostics
                 var diagnostics = GetDiagnosticsFromContext(context).ToDiagnostics(context.LineStarts);
 
                 // publish all the diagnostics
                 this.PublishDocumentDiagnostics(documentUri, version, diagnostics);
-
-                return output;
             }
             catch (Exception exception)
             {
@@ -180,8 +208,6 @@ namespace Bicep.LanguageServer
                 // the file is no longer in a state that can be parsed
                 // clear all info to prevent cascading failures elsewhere
                 var closedFiles = CloseCompilationInternal(documentUri, version, fatalError.AsEnumerable());
-
-                return (ImmutableArray<ISourceFile>.Empty, closedFiles);
             }
         }
 

--- a/src/Bicep.LangServer/CompilationManager/CompilationContext.cs
+++ b/src/Bicep.LangServer/CompilationManager/CompilationContext.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
+using Bicep.Core.Workspaces;
 
 namespace Bicep.LanguageServer.CompilationManager
 {

--- a/src/Bicep.LangServer/Providers/BicepCompilationProvider.cs
+++ b/src/Bicep.LangServer/Providers/BicepCompilationProvider.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Collections.Immutable;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem;
@@ -24,10 +25,9 @@ namespace Bicep.LanguageServer.Providers
             this.fileResolver = fileResolver;
         }
 
-        public CompilationContext Create(IReadOnlyWorkspace workspace, DocumentUri documentUri)
+        public CompilationContext Create(SourceFileGrouping sourceFileGrouping, DocumentUri documentUri, ImmutableDictionary<ISourceFile, ISemanticModel> modelLookup)
         {
-            var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, workspace, documentUri.ToUri());
-            var compilation = new Compilation(resourceTypeProvider, sourceFileGrouping);
+            var compilation = new Compilation(resourceTypeProvider, sourceFileGrouping, modelLookup);
 
             return new CompilationContext(compilation);
         }

--- a/src/Bicep.LangServer/Providers/ICompilationProvider.cs
+++ b/src/Bicep.LangServer/Providers/ICompilationProvider.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Collections.Immutable;
+using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
@@ -9,6 +11,6 @@ namespace Bicep.LanguageServer.Providers
 {
     public interface ICompilationProvider
     {
-        CompilationContext Create(IReadOnlyWorkspace workspace, DocumentUri documentUri);
+        CompilationContext Create(SourceFileGrouping sourceFileGrouping, DocumentUri documentUri, ImmutableDictionary<ISourceFile, ISemanticModel> modelLookup);
     }
 }

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -78,8 +78,6 @@ namespace Bicep.LanguageServer
 
                 onOptionsFunc(options);
             });
-
-            Trace.Listeners.Add(new ServerLogTraceListener(server));
         }
 
         public async Task RunAsync(CancellationToken cancellationToken)
@@ -87,6 +85,11 @@ namespace Bicep.LanguageServer
             await server.Initialize(cancellationToken);
 
             server.LogInfo($"Running on processId {Environment.ProcessId}");
+
+            if (bool.TryParse(Environment.GetEnvironmentVariable("BICEP_TRACING_ENABLED"), out var enableTracing) && enableTracing)
+            {
+                Trace.Listeners.Add(new ServerLogTraceListener(server));
+            }
 
             var scheduler = server.GetService<IModuleRestoreScheduler>();
             scheduler.Start();

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Diagnostics;
 using Bicep.Core.Emit;
 using Bicep.Core.FileSystem;
 using Bicep.Core.TypeSystem;
@@ -17,8 +18,11 @@ using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Snippets;
 using Bicep.LanguageServer.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 using OmniSharp.Extensions.LanguageServer.Server;
 using OmnisharpLanguageServer = OmniSharp.Extensions.LanguageServer.Server.LanguageServer;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Bicep.LanguageServer.Utils;
 
 namespace Bicep.LanguageServer
 {
@@ -71,11 +75,15 @@ namespace Bicep.LanguageServer
 
                 onOptionsFunc(options);
             });
+
+            Trace.Listeners.Add(new ServerLogTraceListener(server));
         }
 
         public async Task RunAsync(CancellationToken cancellationToken)
         {
             await server.Initialize(cancellationToken);
+
+            server.LogInfo($"Running on processId {Environment.ProcessId}");
 
             await server.WaitForExit;
         }

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -212,6 +212,7 @@ namespace Bicep.LanguageServer.Snippets
                 bicepFile,
                 ImmutableHashSet.Create<ISourceFile>(bicepFile),
                 ImmutableDictionary.Create<ModuleDeclarationSyntax, ISourceFile>(),
+                ImmutableDictionary.Create<ISourceFile, ImmutableHashSet<ISourceFile>>(),
                 ImmutableDictionary.Create<ModuleDeclarationSyntax, DiagnosticBuilder.ErrorBuilderDelegate>());
 
             Compilation compilation = new Compilation(AzResourceTypeProvider.CreateWithAzTypes(), sourceFileGrouping);

--- a/src/Bicep.LangServer/Utils/ServerLogTraceListener.cs
+++ b/src/Bicep.LangServer/Utils/ServerLogTraceListener.cs
@@ -18,18 +18,12 @@ namespace Bicep.LanguageServer.Utils
 
         public override void Write(string? message)
         {
-            if (message is not null)
-            {
-                server.Log(new LogMessageParams { Type = MessageType.Log, Message = message});
-            }
+            server.Log(new LogMessageParams { Type = MessageType.Log, Message = $"TRACE: {message}" });
         }
 
         public override void WriteLine(string? message)
         {
-            if (message is not null)
-            {
-                server.Log(new LogMessageParams { Type = MessageType.Log, Message = message});
-            }
+            server.Log(new LogMessageParams { Type = MessageType.Log, Message = $"TRACE: {message}" });
         }
     }
 }

--- a/src/Bicep.LangServer/Utils/ServerLogTraceListener.cs
+++ b/src/Bicep.LangServer/Utils/ServerLogTraceListener.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Diagnostics;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace Bicep.LanguageServer.Utils
+{
+    class ServerLogTraceListener : TraceListener
+    {
+        private readonly ILanguageServer server;
+
+        public ServerLogTraceListener(ILanguageServer server)
+        {
+            this.server = server;
+        }
+
+        public override void Write(string? message)
+        {
+            if (message is not null)
+            {
+                server.Log(new LogMessageParams { Type = MessageType.Log, Message = message});
+            }
+        }
+
+        public override void WriteLine(string? message)
+        {
+            if (message is not null)
+            {
+                server.Log(new LogMessageParams { Type = MessageType.Log, Message = message});
+            }
+        }
+    }
+}

--- a/src/Bicep.MSBuild/Bicep.cs
+++ b/src/Bicep.MSBuild/Bicep.cs
@@ -38,6 +38,13 @@ namespace Azure.Bicep.MSBuild
 
         protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
         {
+            if (singleLine.StartsWith("TRACE: "))
+            {
+                // trace messages (see TextWriterTraceListener)
+                this.Log.LogMessage(singleLine);
+                return;
+            }
+
             // diagnostics emitted during compilation follow the canonical msbuild format and don't require re-parsing
             // however startup errors simply write a message to StdErr
             if (singleLine.Contains(") : "))

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -46,7 +46,7 @@ async function launchLanguageService(
     args: [languageServerPath],
     options: {
       env: process.env,
-    }
+    },
   };
 
   const serverOptions: lsp.ServerOptions = {

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -44,6 +44,9 @@ async function launchLanguageService(
   const serverExecutable: lsp.Executable = {
     command: dotnetCommandPath,
     args: [languageServerPath],
+    options: {
+      env: process.env,
+    }
   };
 
   const serverOptions: lsp.ServerOptions = {


### PR DESCRIPTION
Closes #3785 

Changes:
* Allow semantic models to be reused between compilations if the source file has not been modified and contains no dependencies on a source file which has been modified. This avoids constant re-running of linters (and other semantic analysis) across multiple module dependencies on every keypress.
* De-duplicate semantic models between active compilation contexts if multiple files part of the same compilation are open. This minimizes the number of times the linters (and other semantic analysis) must be run.
* Avoid processing resource type strings & module paths in the `no-hardcoded-env-urls` linter.
* Add debug tracing framework for language server and CLI.