### PR TITLE
Updated link to Bicep PS module repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ We are here to help you be successful with Bicep, please do not hesitate to reac
 
 * [Bicep GitHub Action](https://github.com/marketplace/actions/bicep-build)
 * [Bicep Language Service support in Neovim](https://github.com/Azure/bicep/issues/1141#issuecomment-749372637)
-* [Bicep PowerShell Module](https://github.com/StefanIvemo/BicepPowerShell)
+* [Bicep PowerShell Module](https://github.com/PSBicep/PSBicep)
 * [Bicep Tasks extension for Azure Pipelines](https://marketplace.visualstudio.com/items?itemName=piraces.bicep-tasks)
 
 ## Alternatives


### PR DESCRIPTION
The Bicep PowerShell module has been moved to an organization, updated the link with the new URL.

## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)
