### PR TITLE
Added logic to fail build from context menu only if file has errors

### DIFF
--- a/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bicep.Core.UnitTests.Utils
@@ -23,10 +24,18 @@ namespace Bicep.Core.UnitTests.Utils
             return filePath;
         }
 
-        public static string SaveResultFile(TestContext testContext, string fileName, string contents, string? testOutputPath = null)
+        public static string SaveResultFile(TestContext testContext, string fileName, string contents, string? testOutputPath = null, Encoding? encoding = null)
         {
             var filePath = GetResultFilePath(testContext, fileName, testOutputPath);
-            File.WriteAllText(filePath, contents);
+
+            if (encoding is not null)
+            {
+                File.WriteAllText(filePath, contents, encoding);
+            }
+            else
+            {
+                File.WriteAllText(filePath, contents);
+            }
 
             return filePath;
         }
@@ -36,7 +45,7 @@ namespace Bicep.Core.UnitTests.Utils
             var outputDirectory = GetUniqueTestOutputPath(testContext);
 
             var filesSaved = false;
-            foreach (var embeddedResourceName in containingAssembly.GetManifestResourceNames().Where(file => file.StartsWith(manifestFilePrefix,  StringComparison.Ordinal)))
+            foreach (var embeddedResourceName in containingAssembly.GetManifestResourceNames().Where(file => file.StartsWith(manifestFilePrefix, StringComparison.Ordinal)))
             {
                 var relativePath = embeddedResourceName.Substring(manifestFilePrefix.Length).TrimStart('/');
                 var manifestStream = containingAssembly.GetManifestResourceStream(embeddedResourceName);
@@ -55,7 +64,7 @@ namespace Bicep.Core.UnitTests.Utils
                 testContext.WriteLine($"Bytes written to {filePath}: {fileStream.Position}");
 
                 fileStream.Close();
-                
+
                 testContext.AddResultFile(filePath);
                 filesSaved = true;
             }

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
@@ -22,6 +22,7 @@ namespace Bicep.LangServer.UnitTests
 {
     public class BicepCompilationManagerHelper
     {
+        private static readonly FileResolver FileResolver = new();
         private static readonly MockRepository Repository = new(MockBehavior.Strict);
 
         public static BicepCompilationManager CreateCompilationManager(DocumentUri documentUri, string fileContents, bool upsertCompilation = false)
@@ -30,7 +31,7 @@ namespace Bicep.LangServer.UnitTests
 
             var document = CreateMockDocument(p => receivedParams = p);
             var server = CreateMockServer(document);
-            BicepCompilationManager bicepCompilationManager = new BicepCompilationManager(server.Object, CreateEmptyCompilationProvider(), new Workspace(), new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object);
+            BicepCompilationManager bicepCompilationManager = new BicepCompilationManager(server.Object, CreateEmptyCompilationProvider(), new Workspace(), FileResolver, BicepCompilationManagerHelper.CreateMockScheduler().Object);
 
             if (upsertCompilation)
             {
@@ -71,8 +72,7 @@ namespace Bicep.LangServer.UnitTests
 
         public static ICompilationProvider CreateEmptyCompilationProvider()
         {
-            var fileResolver = new InMemoryFileResolver(new Dictionary<Uri, string>());
-            return new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), fileResolver, new ModuleDispatcher(new DefaultModuleRegistryProvider(fileResolver)));
+            return new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), FileResolver, new ModuleDispatcher(new DefaultModuleRegistryProvider(FileResolver)));
         }
 
         public static Mock<IModuleRestoreScheduler> CreateMockScheduler()

--- a/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
@@ -75,7 +75,7 @@ namespace Bicep.LanguageServer.Handlers
             KeyValuePair<BicepFile, IEnumerable<IDiagnostic>> diagnosticsByFile = context.Compilation.GetAllDiagnosticsByBicepFile()
                 .FirstOrDefault(x => x.Key.FileUri == documentUri.ToUri());
 
-            if (diagnosticsByFile.Value.Any())
+            if (diagnosticsByFile.Value.Any(x => x.Level == DiagnosticLevel.Error))
             {
                 return GetDiagnosticsMessage(diagnosticsByFile);
             }


### PR DESCRIPTION
Fixes #3933 

Added logic to fail build command invoked from context menu only if file has errors

![Bicep_Build_3933](https://user-images.githubusercontent.com/30270536/128787695-811029a0-c698-4164-98ec-1f17dc2a9c85.gif)
