### PR TITLE
[Snippet] Added Route Server snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -2014,6 +2014,35 @@
     }
   },
   {
+    "label": "res-route-server",
+    "kind": "snippet",
+    "detail": "Route Server",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource virtualHub 'Microsoft.Network/virtualHubs@2021-02-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  properties: {\n    sku: 'Standard'\n  }\n}\n\nresource ipConfiguration 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02-01' = {\n  name: 'name'\n  parent: virtualHub\n  properties: {\n    subnet: {\n      id: 'subnet.id'\n    }\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-route-server",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource virtualHub 'Microsoft.Network/virtualHubs@2021-02-01' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n  properties: {\n    sku: 'Standard'\n  }\n}\n\nresource ${2:ipConfiguration} 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02-01' = {\n  name: ${3:'name'}\n  parent: virtualHub\n  properties: {\n    subnet: {\n      id: ${4:'subnet.id'}\n    }\n  }\n}\n"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "TopLevelDeclarationSnippetInsertion",
+          "Properties": {
+            "name": "res-route-server"
+          }
+        }
+      ]
+    }
+  },
+  {
     "label": "res-route-table",
     "kind": "snippet",
     "detail": "Route Table",

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.bicep
@@ -1,0 +1,6 @@
+// $1 = 'name'
+// $2 = 'ipConfiguration'
+// $3 = 'name'
+// $4 = 'subnet.id'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.bicep
@@ -1,5 +1,5 @@
 // $1 = 'name'
-// $2 = 'ipConfiguration'
+// $2 = ipConfiguration
 // $3 = 'name'
 // $4 = 'subnet.id'
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.combined.bicep
@@ -1,0 +1,24 @@
+// $1 = 'name'
+// $2 = ipConfiguration
+// $3 = 'name'
+// $4 = 'subnet.id'
+
+resource virtualHub 'Microsoft.Network/virtualHubs@2021-02-01' = {
+  name: 'name'
+  location: resourceGroup().location
+  properties: {
+    sku: 'Standard'
+  }
+}
+
+resource ipConfiguration 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02-01' = {
+  name: 'name'
+  parent: virtualHub
+  properties: {
+    subnet: {
+      id: 'subnet.id'
+    }
+  }
+}
+// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.combined.bicep
@@ -21,4 +21,3 @@ resource ipConfiguration 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02
   }
 }
 // Insert snippet here
-

--- a/src/Bicep.LangServer/Snippets/Templates/res-route-server.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-route-server.bicep
@@ -1,0 +1,18 @@
+// Route Server
+resource virtualHub 'Microsoft.Network/virtualHubs@2021-02-01' = {
+  name: /*${1:'name'}*/'name'
+  location: resourceGroup().location
+  properties: {
+    sku: 'Standard'
+  }
+}
+
+resource /*${2:'ipConfiguration'}*/ipConfiguration 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02-01' = {
+  name: /*${3:'name'}*/'name'
+  parent: virtualHub
+  properties: {
+    subnet: {
+      id: /*${4:'subnet.id'}*/'subnet.id'
+    }
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-route-server.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-route-server.bicep
@@ -7,7 +7,7 @@ resource virtualHub 'Microsoft.Network/virtualHubs@2021-02-01' = {
   }
 }
 
-resource /*${2:'ipConfiguration'}*/ipConfiguration 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02-01' = {
+resource /*${2:ipConfiguration}*/ipConfiguration 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02-01' = {
   name: /*${3:'name'}*/'name'
   parent: virtualHub
   properties: {


### PR DESCRIPTION
Added a new snippet for Azure Route Server

## Contributing a snippet

* [x] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
