### PR TITLE
Update reference to tmlanguage package

### DIFF
--- a/src/textmate/package-lock.json
+++ b/src/textmate/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "version": "1.0.0",
       "devDependencies": {
-        "@azure-tools/tmlanguage-generator": "^0.1.4",
         "@types/html-escaper": "^3.0.0",
         "@types/jest": "^27.0.0",
         "@types/node": "^16.4.13",
@@ -21,24 +20,12 @@
         "jest": "^27.0.6",
         "onigasm": "^2.2.5",
         "plist": "^3.0.3",
+        "tmlanguage-generator": "^0.2.0",
         "ts-jest": "^27.0.4",
         "ts-node": "^10.2.0",
         "typescript": "^4.3.5",
         "vscode-oniguruma": "^1.5.1",
         "vscode-textmate": "^5.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure-tools/tmlanguage-generator": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@azure-tools/tmlanguage-generator/-/tmlanguage-generator-0.1.4.tgz",
-      "integrity": "sha512-JZ+PmgqvQoppgACth9CGX/gjzxfEwU/b1c5hs8o70tXSqdEnXlaORrM0sUsBm2AiaS+Ael5rajTGz8a0zScooQ==",
-      "dev": true,
-      "dependencies": {
-        "onigasm": "~2.2.5",
-        "plist": "~3.0.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -6209,6 +6196,19 @@
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
     },
+    "node_modules/tmlanguage-generator": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tmlanguage-generator/-/tmlanguage-generator-0.2.0.tgz",
+      "integrity": "sha512-GXZsY8rTveR2OTxlUcRjD4YYI0FZp5aS9OXFVfla6Er6Eu2vtv37BE6yBxjDLHxijcp08hI6CZk49jTAhcd4Gw==",
+      "dev": true,
+      "dependencies": {
+        "onigasm": "~2.2.5",
+        "plist": "~3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -6756,16 +6756,6 @@
     }
   },
   "dependencies": {
-    "@azure-tools/tmlanguage-generator": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@azure-tools/tmlanguage-generator/-/tmlanguage-generator-0.1.4.tgz",
-      "integrity": "sha512-JZ+PmgqvQoppgACth9CGX/gjzxfEwU/b1c5hs8o70tXSqdEnXlaORrM0sUsBm2AiaS+Ael5rajTGz8a0zScooQ==",
-      "dev": true,
-      "requires": {
-        "onigasm": "~2.2.5",
-        "plist": "~3.0.2"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -11557,6 +11547,16 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "tmlanguage-generator": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tmlanguage-generator/-/tmlanguage-generator-0.2.0.tgz",
+      "integrity": "sha512-GXZsY8rTveR2OTxlUcRjD4YYI0FZp5aS9OXFVfla6Er6Eu2vtv37BE6yBxjDLHxijcp08hI6CZk49jTAhcd4Gw==",
+      "dev": true,
+      "requires": {
+        "onigasm": "~2.2.5",
+        "plist": "~3.0.2"
+      }
     },
     "tmpl": {
       "version": "1.0.4",

--- a/src/textmate/package.json
+++ b/src/textmate/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "private": true,
   "devDependencies": {
-    "@azure-tools/tmlanguage-generator": "^0.1.4",
+    "tmlanguage-generator": "^0.2.0",
     "@types/html-escaper": "^3.0.0",
     "@types/jest": "^27.0.0",
     "@types/node": "^16.4.13",

--- a/src/textmate/src/bicep.ts
+++ b/src/textmate/src/bicep.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as tm from "@azure-tools/tmlanguage-generator";
+import * as tm from "tmlanguage-generator";
 import path from "path";
 import plist from "plist";
 


### PR DESCRIPTION
@nguerrera let me know that he's moved this package from `@azure-tools/tmlanguage-generator` to `tmlanguage-generator`. This PR just updates our reference to the new package.