### PR TITLE
Add build command to tab context menu

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -167,7 +167,7 @@
         },
         {
           "command": "bicep.build",
-          "when": "resourceLangId == bicep",
+          "when": "resourceLangId == bicep && commandsRegistered",
           "group": "navigation"
         }
       ],
@@ -176,6 +176,11 @@
           "command": "bicep.showVisualizer",
           "when": "resourceLangId == bicep && commandsRegistered",
           "group": "1_open"
+        },
+        {
+          "command": "bicep.build",
+          "when": "resourceLangId == bicep && commandsRegistered",
+          "group": "1_build"
         }
       ],
       "commandPalette": [


### PR DESCRIPTION
Fixes #4058

Adds build command to tab context menu

![AddBuildCommandTabContextMenu](https://user-images.githubusercontent.com/30270536/130857176-fbdafade-a055-45b5-bff6-121519d6ff7d.gif)
