### PR TITLE
TemplateEmitter.Emit(TextWriter) no longer disposes the text writer

### DIFF
--- a/src/Bicep.Core/Emit/TemplateEmitter.cs
+++ b/src/Bicep.Core/Emit/TemplateEmitter.cs
@@ -36,7 +36,7 @@ namespace Bicep.Core.Emit
         /// <param name="stream">The stream to write the template</param>
         public EmitResult Emit(Stream stream) => EmitOrFail(() =>
         {
-            using var writer = new JsonTextWriter(new StreamWriter(stream, UTF8EncodingWithoutBom, 4096, true))
+            using var writer = new JsonTextWriter(new StreamWriter(stream, UTF8EncodingWithoutBom, 4096, leaveOpen: true))
             {
                 Formatting = Formatting.Indented
             };
@@ -52,10 +52,13 @@ namespace Bicep.Core.Emit
         {
             using var writer = new JsonTextWriter(textWriter)
             {
+                // don't close the textWriter when writer is disposed
+                CloseOutput = false,
                 Formatting = Formatting.Indented
             };
 
             new TemplateWriter(this.model, this.assemblyFileVersion).Write(writer);
+            writer.Flush();
         });
 
         /// <summary>


### PR DESCRIPTION
This fixes #4115.