### PR TITLE
Fixed error message for I/O exceptions with local module cache

### DIFF
--- a/src/Bicep.Core.IntegrationTests/RegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/RegistryTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Features;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
+using Bicep.Core.Samples;
+using Bicep.Core.Semantics;
+using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.IntegrationTests
+{
+    [TestClass]
+    public class RegistryTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        [TestMethod]
+        public async Task InvalidRootCachePathShouldProduceReasonableErrors()
+        {
+            var dataSet = DataSets.Registry_LF;
+
+            var outputDirectory = dataSet.SaveFilesToTestDirectory(TestContext);
+            var clientFactory = dataSet.CreateMockRegistryClients(TestContext);
+            await dataSet.PublishModulesToRegistryAsync(clientFactory, TestContext);
+
+            var fileUri = PathHelper.FilePathToFileUrl(Path.Combine(outputDirectory, DataSet.TestFileMain));
+
+            var badCacheDirectory = FileHelper.GetCacheRootPath(TestContext);
+            Directory.CreateDirectory(badCacheDirectory);
+
+            var badCachePath = Path.Combine(badCacheDirectory, "file.txt");
+            File.Create(badCachePath);
+            File.Exists(badCachePath).Should().BeTrue();
+
+            // cache root points to a file
+            var features = new Mock<IFeatureProvider>(MockBehavior.Strict);
+            features.Setup(m => m.RegistryEnabled).Returns(true);
+            features.SetupGet(m => m.CacheRootDirectory).Returns(badCachePath);
+
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver, clientFactory, features.Object));
+
+            var workspace = new Workspace();
+            var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, workspace, fileUri);
+            if (await dispatcher.RestoreModules(dispatcher.GetValidModuleReferences(sourceFileGrouping.ModulesToRestore)))
+            {
+                sourceFileGrouping = SourceFileGroupingBuilder.Rebuild(dispatcher, workspace, sourceFileGrouping);
+            }
+
+            var compilation = new Compilation(AzResourceTypeProvider.CreateWithAzTypes(), sourceFileGrouping);
+            var diagnostics = compilation.GetAllDiagnosticsByBicepFile();
+            diagnostics.Should().HaveCount(1);
+
+            diagnostics.Single().Value.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Level.Should().Be(DiagnosticLevel.Error);
+                    x.Code.Should().Be("BCP192");
+                    x.Message.Should().StartWith("Unable to restore the module with reference \"oci:mock-registry-one.invalid/demo/plan:v2\": Unable to create the local module directory \"");
+                },
+                x =>
+                {
+                    x.Level.Should().Be(DiagnosticLevel.Error);
+                    x.Code.Should().Be("BCP192");
+                    x.Message.Should().StartWith("Unable to restore the module with reference \"oci:mock-registry-two.invalid/demo/site:v3\": Unable to create the local module directory \"");
+                },
+                x =>
+                {
+                    x.Level.Should().Be(DiagnosticLevel.Error);
+                    x.Code.Should().Be("BCP062");
+                    x.Message.Should().Be("The referenced declaration with name \"siteDeploy\" is not valid.");
+                });
+        }
+    }
+}

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -26,7 +26,6 @@ namespace Bicep.Core.Features
 
         private static string GetDefaultCachePath()
         {
-            // TODO: Will NOT work if user profile is not loaded on Windows! (Az functions load executables like that)
             string basePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
             return Path.Combine(basePath, ".bicep", "artifacts");

--- a/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
+++ b/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
@@ -119,7 +119,7 @@ namespace Bicep.Core.Registry
             }
             catch (Exception exception)
             {
-                throw new AcrManagerException($"Unable to create the local module directory \"{modulePath}\".", exception);
+                throw new AcrManagerException($"Unable to create the local module directory \"{modulePath}\". {exception.Message}", exception);
             }
         }
 


### PR DESCRIPTION
Fixes #4169.

Changes:
- Tweaked the error message for I/O exceptions with local module cache and added test.
- Investigated behavior when Bicep process is loaded without user profile loaded on Windows. No changes were needed.

