### PR TITLE
Reverted dependency updates

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/Bicep.Cli.IntegrationTests.csproj
+++ b/src/Bicep.Cli.IntegrationTests/Bicep.Cli.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 

--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.6, )",
-        "resolved": "2.2.6",
-        "contentHash": "2z5XVBednseou2LXUgtnbkE9PNz0eFZaYyaJfI6VAHaeAx79gk3BE/Sjv6x3AnrzySzhHrVsS9Jr3z7sI7w0XA==",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"
@@ -463,8 +463,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -1507,12 +1507,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -2221,7 +2221,7 @@
         "type": "Project",
         "dependencies": {
           "FluentAssertions": "5.10.3",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "bicep": "1.0.0"
@@ -2256,7 +2256,7 @@
           "Bicep.Core": "1.0.0",
           "Bicep.Core.UnitTests": "1.0.0",
           "FluentAssertions": "5.10.3",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "bicep": "1.0.0"
@@ -2270,13 +2270,13 @@
           "DiffPlex": "1.7.0",
           "FluentAssertions": "5.10.3",
           "JsonDiffPatch.Net": "2.3.0",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "Microsoft.PowerShell.SDK": "7.1.3",
           "Moq": "4.16.1",
           "Newtonsoft.Json": "13.0.1",
-          "System.Management.Automation": "7.1.4"
+          "System.Management.Automation": "7.1.3"
         }
       },
       "bicep.decompiler": {
@@ -2355,8 +2355,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -3055,12 +3055,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -3582,8 +3582,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -4282,12 +4282,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -4809,8 +4809,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -5509,12 +5509,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -6036,8 +6036,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -6718,12 +6718,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",

--- a/src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj
+++ b/src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.6, )",
-        "resolved": "2.2.6",
-        "contentHash": "2z5XVBednseou2LXUgtnbkE9PNz0eFZaYyaJfI6VAHaeAx79gk3BE/Sjv6x3AnrzySzhHrVsS9Jr3z7sI7w0XA==",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"

--- a/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
+++ b/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Azure.Deployments.Templates" Version="1.0.207" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -46,9 +46,9 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.6, )",
-        "resolved": "2.2.6",
-        "contentHash": "2z5XVBednseou2LXUgtnbkE9PNz0eFZaYyaJfI6VAHaeAx79gk3BE/Sjv6x3AnrzySzhHrVsS9Jr3z7sI7w0XA==",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"
@@ -464,8 +464,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -1508,12 +1508,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -2247,7 +2247,7 @@
           "Bicep.Core": "1.0.0",
           "Bicep.Core.UnitTests": "1.0.0",
           "FluentAssertions": "5.10.3",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "bicep": "1.0.0"
@@ -2261,13 +2261,13 @@
           "DiffPlex": "1.7.0",
           "FluentAssertions": "5.10.3",
           "JsonDiffPatch.Net": "2.3.0",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "Microsoft.PowerShell.SDK": "7.1.3",
           "Moq": "4.16.1",
           "Newtonsoft.Json": "13.0.1",
-          "System.Management.Automation": "7.1.4"
+          "System.Management.Automation": "7.1.3"
         }
       },
       "bicep.decompiler": {
@@ -2346,8 +2346,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -3046,12 +3046,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -3573,8 +3573,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -4273,12 +4273,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -4800,8 +4800,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -5500,12 +5500,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -6027,8 +6027,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -6709,12 +6709,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",

--- a/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
+++ b/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.6, )",
-        "resolved": "2.2.6",
-        "contentHash": "2z5XVBednseou2LXUgtnbkE9PNz0eFZaYyaJfI6VAHaeAx79gk3BE/Sjv6x3AnrzySzhHrVsS9Jr3z7sI7w0XA==",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"
@@ -463,8 +463,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -1507,12 +1507,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -2248,13 +2248,13 @@
           "DiffPlex": "1.7.0",
           "FluentAssertions": "5.10.3",
           "JsonDiffPatch.Net": "2.3.0",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "Microsoft.PowerShell.SDK": "7.1.3",
           "Moq": "4.16.1",
           "Newtonsoft.Json": "13.0.1",
-          "System.Management.Automation": "7.1.4"
+          "System.Management.Automation": "7.1.3"
         }
       },
       "bicep.decompiler": {
@@ -2333,8 +2333,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -3033,12 +3033,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -3560,8 +3560,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -4260,12 +4260,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -4787,8 +4787,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -5487,12 +5487,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -6014,8 +6014,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -6696,12 +6696,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",

--- a/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
+++ b/src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj
@@ -13,14 +13,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.3" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Management.Automation" Version="7.1.4" />
+    <PackageReference Include="System.Management.Automation" Version="7.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -88,9 +88,9 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.6, )",
-        "resolved": "2.2.6",
-        "contentHash": "2z5XVBednseou2LXUgtnbkE9PNz0eFZaYyaJfI6VAHaeAx79gk3BE/Sjv6x3AnrzySzhHrVsS9Jr3z7sI7w0XA==",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"
@@ -120,13 +120,13 @@
       },
       "System.Management.Automation": {
         "type": "Direct",
-        "requested": "[7.1.4, )",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -531,8 +531,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -2275,13 +2275,13 @@
       },
       "System.Management.Automation": {
         "type": "Direct",
-        "requested": "[7.1.4, )",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -2354,8 +2354,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -3504,13 +3504,13 @@
       },
       "System.Management.Automation": {
         "type": "Direct",
-        "requested": "[7.1.4, )",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -3583,8 +3583,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -4733,13 +4733,13 @@
       },
       "System.Management.Automation": {
         "type": "Direct",
-        "requested": "[7.1.4, )",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -4812,8 +4812,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -5962,13 +5962,13 @@
       },
       "System.Management.Automation": {
         "type": "Direct",
-        "requested": "[7.1.4, )",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -6041,8 +6041,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }

--- a/src/Bicep.Decompiler.IntegrationTests/Bicep.Decompiler.IntegrationTests.csproj
+++ b/src/Bicep.Decompiler.IntegrationTests/Bicep.Decompiler.IntegrationTests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.6, )",
-        "resolved": "2.2.6",
-        "contentHash": "2z5XVBednseou2LXUgtnbkE9PNz0eFZaYyaJfI6VAHaeAx79gk3BE/Sjv6x3AnrzySzhHrVsS9Jr3z7sI7w0XA==",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"
@@ -462,8 +462,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -1506,12 +1506,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -2238,13 +2238,13 @@
           "DiffPlex": "1.7.0",
           "FluentAssertions": "5.10.3",
           "JsonDiffPatch.Net": "2.3.0",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "Microsoft.PowerShell.SDK": "7.1.3",
           "Moq": "4.16.1",
           "Newtonsoft.Json": "13.0.1",
-          "System.Management.Automation": "7.1.4"
+          "System.Management.Automation": "7.1.3"
         }
       },
       "bicep.decompiler": {
@@ -2323,8 +2323,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -3023,12 +3023,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -3550,8 +3550,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -4250,12 +4250,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -4777,8 +4777,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -5477,12 +5477,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -6004,8 +6004,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -6686,12 +6686,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",

--- a/src/Bicep.Decompiler.UnitTests/Bicep.Decompiler.UnitTests.csproj
+++ b/src/Bicep.Decompiler.UnitTests/Bicep.Decompiler.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.6, )",
-        "resolved": "2.2.6",
-        "contentHash": "2z5XVBednseou2LXUgtnbkE9PNz0eFZaYyaJfI6VAHaeAx79gk3BE/Sjv6x3AnrzySzhHrVsS9Jr3z7sI7w0XA==",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"
@@ -462,8 +462,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -1506,12 +1506,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -2238,13 +2238,13 @@
           "DiffPlex": "1.7.0",
           "FluentAssertions": "5.10.3",
           "JsonDiffPatch.Net": "2.3.0",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "Microsoft.PowerShell.SDK": "7.1.3",
           "Moq": "4.16.1",
           "Newtonsoft.Json": "13.0.1",
-          "System.Management.Automation": "7.1.4"
+          "System.Management.Automation": "7.1.3"
         }
       },
       "bicep.decompiler": {
@@ -2323,8 +2323,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -3023,12 +3023,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -3550,8 +3550,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -4250,12 +4250,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -4777,8 +4777,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -5477,12 +5477,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -6004,8 +6004,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -6686,12 +6686,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",

--- a/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
+++ b/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.2" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-expressroute-gateway/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-expressroute-gateway/main.combined.bicep
@@ -20,3 +20,4 @@ resource expressRouteGateways 'Microsoft.Network/expressRouteGateways@2021-02-01
   }
 }
 // Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-route-server/main.combined.bicep
@@ -21,3 +21,4 @@ resource ipConfiguration 'Microsoft.Network/virtualHubs/ipConfigurations@2021-02
   }
 }
 // Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -45,9 +45,9 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.6, )",
-        "resolved": "2.2.6",
-        "contentHash": "2z5XVBednseou2LXUgtnbkE9PNz0eFZaYyaJfI6VAHaeAx79gk3BE/Sjv6x3AnrzySzhHrVsS9Jr3z7sI7w0XA==",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"
@@ -485,8 +485,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -1520,12 +1520,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -2259,7 +2259,7 @@
           "Bicep.Core": "1.0.0",
           "Bicep.Core.UnitTests": "1.0.0",
           "FluentAssertions": "5.10.3",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "bicep": "1.0.0"
@@ -2273,13 +2273,13 @@
           "DiffPlex": "1.7.0",
           "FluentAssertions": "5.10.3",
           "JsonDiffPatch.Net": "2.3.0",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "Microsoft.PowerShell.SDK": "7.1.3",
           "Moq": "4.16.1",
           "Newtonsoft.Json": "13.0.1",
-          "System.Management.Automation": "7.1.4"
+          "System.Management.Automation": "7.1.3"
         }
       },
       "bicep.decompiler": {
@@ -2358,8 +2358,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -3058,12 +3058,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -3585,8 +3585,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -4285,12 +4285,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -4812,8 +4812,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -5512,12 +5512,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -6039,8 +6039,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -6721,12 +6721,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",

--- a/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
+++ b/src/Bicep.LangServer.UnitTests/Bicep.LangServer.UnitTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.6" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.2" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -45,9 +45,9 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[2.2.6, )",
-        "resolved": "2.2.6",
-        "contentHash": "2z5XVBednseou2LXUgtnbkE9PNz0eFZaYyaJfI6VAHaeAx79gk3BE/Sjv6x3AnrzySzhHrVsS9Jr3z7sI7w0XA==",
+        "requested": "[2.2.3, )",
+        "resolved": "2.2.3",
+        "contentHash": "Xxc6+JyELKOmM46CYrHxL9f2LMZGnx1Neh0dr52THZbmVTwlJM1tj0U5RQ50G+wxsfsU8ZfR1HAUugc+64b6TA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1",
           "System.Diagnostics.TextWriterTraceListener": "4.3.0"
@@ -485,8 +485,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -1520,12 +1520,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -2259,7 +2259,7 @@
           "Bicep.Core": "1.0.0",
           "Bicep.Core.UnitTests": "1.0.0",
           "FluentAssertions": "5.10.3",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "bicep": "1.0.0"
@@ -2273,13 +2273,13 @@
           "DiffPlex": "1.7.0",
           "FluentAssertions": "5.10.3",
           "JsonDiffPatch.Net": "2.3.0",
-          "MSTest.TestAdapter": "2.2.6",
+          "MSTest.TestAdapter": "2.2.3",
           "MSTest.TestFramework": "2.2.5",
           "Microsoft.NET.Test.Sdk": "16.10.0",
           "Microsoft.PowerShell.SDK": "7.1.3",
           "Moq": "4.16.1",
           "Newtonsoft.Json": "13.0.1",
-          "System.Management.Automation": "7.1.4"
+          "System.Management.Automation": "7.1.3"
         }
       },
       "bicep.decompiler": {
@@ -2358,8 +2358,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -3058,12 +3058,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -3585,8 +3585,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -4285,12 +4285,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -4812,8 +4812,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -5512,12 +5512,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",
@@ -6039,8 +6039,8 @@
       },
       "Microsoft.PowerShell.CoreCLR.Eventing": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "0YaMEm1qYTlCfWJxePBQiQd5bGsBTsU6LZP3nOafBfZNHyp+qLztqJ25nVDsEadPKaYs2SsQNQHycwFLOZK+0w==",
+        "resolved": "7.1.3",
+        "contentHash": "gsshJYIbjJjlTDGlDntENxMkRd+KWZo0CXF1jLJrpqtF51nmP5AHMKysFXRTPBWTNFmFTZ0tqgazkzF5S92/VA==",
         "dependencies": {
           "System.Diagnostics.EventLog": "5.0.1"
         }
@@ -6721,12 +6721,12 @@
       },
       "System.Management.Automation": {
         "type": "Transitive",
-        "resolved": "7.1.4",
-        "contentHash": "Ivc6HO9rv+eVlE1mGji35N7S4XwbStWhEKcwUvDc7hGKa1O4bKdVev2JDnpSj2eaM8Evcde8ZYa2uEuMSkHmTg==",
+        "resolved": "7.1.3",
+        "contentHash": "rXPo+ujbsrraKk7F0VYQLM5oTXUo8bOmd+lnALCNPXaeZZ7pcGLqAfayuGX/Y6sXd4zoOE0jDtF572u4vCR5fg==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.15.0",
           "Microsoft.Management.Infrastructure": "2.0.0",
-          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.4",
+          "Microsoft.PowerShell.CoreCLR.Eventing": "7.1.3",
           "Microsoft.PowerShell.Native": "7.1.0",
           "Microsoft.Win32.Registry.AccessControl": "5.0.0",
           "Newtonsoft.Json": "12.0.3",


### PR DESCRIPTION
Currently in `main` all the .net tests are completely skipped due to a bug in mstest test discovery. Reverting `MSTest.TestAdapter` down to 2.2.3 brings back the correct behavior.

At the same time `System.Management.Automation` had to be reverted back to 7.1.3 due to come breaking changes in the package that were missed because of the test regression.