### PR TITLE
Fail tests when no tests are discovered

### DIFF
--- a/.github/workflows/codecov.runsettings
+++ b/.github/workflows/codecov.runsettings
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <RunSettings>
+  <RunConfiguration>
+    <!-- Break builds when no tests are discovered. -->
+    <TreatNoTestsAsError>true</TreatNoTestsAsError>
+  </RunConfiguration>
   <DataCollectionRunSettings>
     <DataCollectors>
       <!-- Settings are documented at https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings -->


### PR DESCRIPTION
Set `TreatNoTestsAsError` to `true` in run settings to prevent test regressions caused by issues during test discovery. Validated locally and via GitHub actions. The setting keeps the test discovery message as a warning but the exit code from `dotnet test` is 1 instead of 0, which breaks our CI jobs as we'd expect.