### PR TITLE
better version example; only reinforce identity for extension

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -2541,7 +2541,7 @@
     "detail": "Guest configuration extension for Linux virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource windowsVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforLinux'\n  location: resourceGroup().location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforLinux'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource windowsVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforLinux'\n  location: resourceGroup().location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforLinux'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    enableAutomaticUpgrade: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -2550,7 +2550,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource ${2:windowsVMGuestConfigExtension} 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforLinux'\n  location: resourceGroup().location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforLinux'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n"
+      "newText": "resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource ${2:windowsVMGuestConfigExtension} 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforLinux'\n  location: resourceGroup().location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforLinux'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    enableAutomaticUpgrade: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n"
     },
     "command": {
       "command": "bicep.Telemetry",
@@ -2715,7 +2715,7 @@
     "detail": "Guest configuration assignment for Windows virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource windowsVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforWindows'\n  location: resourceGroup().location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforWindows'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource windowsVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforWindows'\n  location: resourceGroup().location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforWindows'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    enableAutomaticUpgrade: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -2724,7 +2724,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource ${2:windowsVMGuestConfigExtension} 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforWindows'\n  location: resourceGroup().location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforWindows'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n"
+      "newText": "resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource ${2:windowsVMGuestConfigExtension} 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {\n  parent: virtualMachine\n  name: 'AzurePolicyforWindows'\n  location: resourceGroup().location\n  properties: {\n    publisher: 'Microsoft.GuestConfiguration'\n    type: 'ConfigurationforWindows'\n    typeHandlerVersion: '1.0'\n    autoUpgradeMinorVersion: true\n    enableAutomaticUpgrade: true\n    settings: {}\n    protectedSettings: {}\n  }\n}\n"
     },
     "command": {
       "command": "bicep.Telemetry",

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -1961,7 +1961,7 @@
     "detail": "Guest configuration assignment for virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: 'name'\n  scope: virtualMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'Audit'\n      version: 'version'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: resourceGroup().location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: 'name'\n  scope: virtualMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'ApplyAndMonitor'\n      version: '1.*'\n    }\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -1970,7 +1970,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource ${2:guestConfigAssignment} 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: ${3:'name'}\n  scope: virtualMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: ${4:'configurationName'}\n      assignmentType: ${5|'Audit','ApplyAndMonitor','ApplyAndAutoCorrect'|}\n      version: ${6:'version'}\n    }\n  }\n}\n"
+      "newText": "resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n}\n\nresource ${2:guestConfigAssignment} 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: ${3:'name'}\n  scope: virtualMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: ${4:'configurationName'}\n      assignmentType: ${5|'ApplyAndMonitor','ApplyAndAutoCorrect','Audit'|}\n      version: ${6:'1.*'}\n    }\n  }\n}\n"
     },
     "command": {
       "command": "bicep.Telemetry",
@@ -1990,7 +1990,7 @@
     "detail": "Guest configuration assignment for virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource arcEnabledMachine 'Microsoft.HybridCompute/machines@2021-05-20' = {\n  name: 'name'\n  location: resourceGroup().location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: 'name'\n  scope: arcEnabledMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'Audit'\n      version: 'version'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource arcEnabledMachine 'Microsoft.HybridCompute/machines@2021-05-20' = {\n  name: 'name'\n  location: resourceGroup().location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: 'name'\n  scope: arcEnabledMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'ApplyAndMonitor'\n      version: '1.*'\n    }\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -1999,7 +1999,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource arcEnabledMachine 'Microsoft.HybridCompute/machines@2021-05-20' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n}\n\nresource ${2:guestConfigAssignment} 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: ${3:'name'}\n  scope: arcEnabledMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: ${4:'configurationName'}\n      assignmentType: ${5|'Audit','ApplyAndMonitor','ApplyAndAutoCorrect'|}\n      version: ${6:'version'}\n    }\n  }\n}\n"
+      "newText": "resource arcEnabledMachine 'Microsoft.HybridCompute/machines@2021-05-20' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n}\n\nresource ${2:guestConfigAssignment} 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: ${3:'name'}\n  scope: arcEnabledMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: ${4:'configurationName'}\n      assignmentType: ${5|'ApplyAndMonitor','ApplyAndAutoCorrect','Audit'|}\n      version: ${6:'1.*'}\n    }\n  }\n}\n"
     },
     "command": {
       "command": "bicep.Telemetry",
@@ -2019,7 +2019,7 @@
     "detail": "Guest configuration assignment with parameters, for virtual machine",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: 'name'\n  scope: virtualMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'Audit'\n      version: 'version'\n      configurationParameter: [\n        {\n          name: 'parameter1[dscResourceType]dscResourceName;propertyName'\n          value: 'parameter1Value'\n        }\n        {\n          name: 'parameter2[dscResourceType]dscResourceName;propertyName'\n          value: 'parameter2Value'\n        }\n      ]\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: 'name'\n  location: resourceGroup().location\n}\n\nresource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: 'name'\n  scope: virtualMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: 'configurationName'\n      assignmentType: 'ApplyAndMonitor'\n      version: '1.*'\n      configurationParameter: [\n        {\n          name: 'parameter1[dscResourceType]dscResourceName;propertyName'\n          value: 'parameter1Value'\n        }\n        {\n          name: 'parameter2[dscResourceType]dscResourceName;propertyName'\n          value: 'parameter2Value'\n        }\n      ]\n    }\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -2028,7 +2028,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n  identity: {\n    type:'SystemAssigned'\n  }\n}\n\nresource ${2:guestConfigAssignment} 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: ${3:'name'}\n  scope: virtualMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: ${4:'configurationName'}\n      assignmentType: ${5|'Audit','ApplyAndMonitor','ApplyAndAutoCorrect'|}\n      version: ${6:'version'}\n      configurationParameter: [\n        {\n          name: ${7:'parameter1[dscResourceType]dscResourceName;propertyName'}\n          value: ${8:'parameter1Value'}\n        }\n        {\n          name: ${9:'parameter2[dscResourceType]dscResourceName;propertyName'}\n          value: ${10:'parameter2Value'}\n        }\n      ]\n    }\n  }\n}\n"
+      "newText": "resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {\n  name: ${1:'name'}\n  location: resourceGroup().location\n}\n\nresource ${2:guestConfigAssignment} 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {\n  name: ${3:'name'}\n  scope: virtualMachine\n  location: resourceGroup().location\n  properties: {\n    guestConfiguration: {\n      name: ${4:'configurationName'}\n      assignmentType: ${5|'ApplyAndMonitor','ApplyAndAutoCorrect','Audit'|}\n      version: ${6:'1.*'}\n      configurationParameter: [\n        {\n          name: ${7:'parameter1[dscResourceType]dscResourceName;propertyName'}\n          value: ${8:'parameter1Value'}\n        }\n        {\n          name: ${9:'parameter2[dscResourceType]dscResourceName;propertyName'}\n          value: ${10:'parameter2Value'}\n        }\n      ]\n    }\n  }\n}\n"
     },
     "command": {
       "command": "bicep.Telemetry",

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-guestconfig-params/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-guestconfig-params/main.combined.bicep
@@ -12,9 +12,6 @@
 resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
-  identity: {
-    type:'SystemAssigned'
-  }
 }
 
 resource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-guestconfig/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-policy-guestconfig/main.combined.bicep
@@ -8,9 +8,6 @@
 resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: 'name'
   location: resourceGroup().location
-  identity: {
-    type:'SystemAssigned'
-  }
 }
 
 resource guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-linux-guestconfig-ext/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-linux-guestconfig-ext/main.combined.bicep
@@ -18,6 +18,7 @@ resource linuxVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extensio
     type: 'ConfigurationforLinux'
     typeHandlerVersion: '1.0'
     autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
     settings: {}
     protectedSettings: {}
   }

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows-guestconfig-ext/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-vm-windows-guestconfig-ext/main.combined.bicep
@@ -18,6 +18,7 @@ resource windowsVMGuestConfigExtension 'Microsoft.Compute/virtualMachines/extens
     type: 'ConfigurationforWindows'
     typeHandlerVersion: '1.0'
     autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
     settings: {}
     protectedSettings: {}
   }

--- a/src/Bicep.LangServer/Snippets/Templates/res-policy-guestconfig-hybrid.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-policy-guestconfig-hybrid.bicep
@@ -11,8 +11,8 @@ resource /*${2:guestConfigAssignment}*/guestConfigAssignment 'Microsoft.GuestCon
   properties: {
     guestConfiguration: {
       name: /*${4:'configurationName'}*/'configurationName'
-      assignmentType: /*${5|'Audit','ApplyAndMonitor','ApplyAndAutoCorrect'|}*/'ApplyAndMonitor'
-      version: /*${6:'version'}*/'1.*'
+      assignmentType: /*${5|'ApplyAndMonitor','ApplyAndAutoCorrect','Audit'|}*/'ApplyAndMonitor'
+      version: /*${6:'1.*'}*/'1.*'
     }
   }
 }

--- a/src/Bicep.LangServer/Snippets/Templates/res-policy-guestconfig-params.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-policy-guestconfig-params.bicep
@@ -2,9 +2,6 @@
 resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: /*${1:'name'}*/'name'
   location: resourceGroup().location
-  identity: {
-    type:'SystemAssigned'
-  }
 }
 
 resource /*${2:guestConfigAssignment}*/guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {
@@ -14,8 +11,8 @@ resource /*${2:guestConfigAssignment}*/guestConfigAssignment 'Microsoft.GuestCon
   properties: {
     guestConfiguration: {
       name: /*${4:'configurationName'}*/'configurationName'
-      assignmentType: /*${5|'Audit','ApplyAndMonitor','ApplyAndAutoCorrect'|}*/'ApplyAndMonitor'
-      version: /*${6:'version'}*/'1.*'
+      assignmentType: /*${5|'ApplyAndMonitor','ApplyAndAutoCorrect','Audit'|}*/'ApplyAndMonitor'
+      version: /*${6:'1.*'}*/'1.*'
       configurationParameter: [
         {
           name: /*${7:'parameter1[dscResourceType]dscResourceName;propertyName'}*/'parameter1[dscResourceType]dscResourceName;propertyName'

--- a/src/Bicep.LangServer/Snippets/Templates/res-policy-guestconfig.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-policy-guestconfig.bicep
@@ -2,9 +2,6 @@
 resource virtualMachine 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: /*${1:'name'}*/'name'
   location: resourceGroup().location
-  identity: {
-    type:'SystemAssigned'
-  }
 }
 
 resource /*${2:guestConfigAssignment}*/guestConfigAssignment 'Microsoft.GuestConfiguration/guestConfigurationAssignments@2020-06-25' = {
@@ -14,8 +11,8 @@ resource /*${2:guestConfigAssignment}*/guestConfigAssignment 'Microsoft.GuestCon
   properties: {
     guestConfiguration: {
       name: /*${4:'configurationName'}*/'configurationName'
-      assignmentType: /*${5|'Audit','ApplyAndMonitor','ApplyAndAutoCorrect'|}*/'ApplyAndMonitor'
-      version: /*${6:'version'}*/'1.*'
+      assignmentType: /*${5|'ApplyAndMonitor','ApplyAndAutoCorrect','Audit'|}*/'ApplyAndMonitor'
+      version: /*${6:'1.*'}*/'1.*'
     }
   }
 }

--- a/src/Bicep.LangServer/Snippets/Templates/res-vm-linux-guestconfig-ext.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-vm-linux-guestconfig-ext.bicep
@@ -16,6 +16,7 @@ resource /*${2:windowsVMGuestConfigExtension}*/windowsVMGuestConfigExtension 'Mi
     type: 'ConfigurationforLinux'
     typeHandlerVersion: '1.0'
     autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
     settings: {}
     protectedSettings: {}
   }

--- a/src/Bicep.LangServer/Snippets/Templates/res-vm-windows-guestconfig-ext.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-vm-windows-guestconfig-ext.bicep
@@ -16,6 +16,7 @@ resource /*${2:windowsVMGuestConfigExtension}*/windowsVMGuestConfigExtension 'Mi
     type: 'ConfigurationforWindows'
     typeHandlerVersion: '1.0'
     autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
     settings: {}
     protectedSettings: {}
   }


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [x] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [x] This is a bug fix for an existing example
* [x] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [x] I have checked that all tests are passing by running `dotnet test`
* [x] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [x] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
