### PR TITLE
Update Azure.ResourceManager.Resources to version 1.0.0-beta.1

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -133,12 +133,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2245,7 +2255,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -133,12 +133,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -1280,7 +1290,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -50,8 +50,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -106,12 +106,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -305,7 +315,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -88,8 +88,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -134,12 +134,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2236,7 +2246,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -133,12 +133,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2235,7 +2245,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.Core.UnitTests/Registry/TemplateSpecTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/TemplateSpecTests.cs
@@ -1,13 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Azure.Deployments.Core.Uri;
-using Azure.ResourceManager.Resources.Models;
+using Azure.ResourceManager.Resources;
 using Bicep.Core.Registry;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -20,9 +15,9 @@ namespace Bicep.Core.UnitTests.Registry
     {
         [DataTestMethod]
         [DynamicData(nameof(GetInvalidData), DynamicDataSourceType.Method)]
-        public void FromGenericResource_InvalidTemplateSpecResource_ThrowsTemplateSpecException(GenericResource resource)
+        public void FromGenericResource_InvalidTemplateSpecResource_ThrowsTemplateSpecException(GenericResourceData data)
         {
-            Invoking(() => TemplateSpec.FromGenericResource(resource))
+            Invoking(() => TemplateSpec.FromGenericResourceData(data))
                 .Should()
                 .Throw<TemplateSpecException>()
                 .WithMessage("The referenced Template Spec is malformed.");
@@ -31,7 +26,7 @@ namespace Bicep.Core.UnitTests.Registry
         [TestMethod]
         public void FromGenericResource_ValidTemplateSpecResource_ReturnsTemplateSpec()
         {
-            var resource = new GenericResource
+            var data = new GenericResourceData("westus")
             {
                 Properties = new Dictionary<string, string>
                 {
@@ -39,7 +34,7 @@ namespace Bicep.Core.UnitTests.Registry
                 },
             };
 
-            var templateSpec = TemplateSpec.FromGenericResource(resource);
+            var templateSpec = TemplateSpec.FromGenericResourceData(data);
 
             templateSpec.MainTemplateContents.Should().Be("contents");
         }
@@ -48,7 +43,7 @@ namespace Bicep.Core.UnitTests.Registry
         {
             yield return new object[]
             {
-                new GenericResource
+                new GenericResourceData("westus")
                 {
                     Properties = 123,
                 },
@@ -56,7 +51,7 @@ namespace Bicep.Core.UnitTests.Registry
 
             yield return new object[]
             {
-                new GenericResource
+                new GenericResourceData("westus")
                 {
                     Properties = new Dictionary<string, string>
                     {

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -159,8 +159,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -215,12 +215,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2231,7 +2241,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Identity" Version="1.4.0" />
-		<PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-preview.2" />
+		<PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-beta.1" />
 		<PackageReference Include="JetBrains.Annotations" Version="2021.2.0">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/Bicep.Core/Registry/TemplateSpec.cs
+++ b/src/Bicep.Core/Registry/TemplateSpec.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.ResourceManager.Resources.Models;
+using Azure.ResourceManager.Resources;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -18,11 +18,11 @@ namespace Bicep.Core.Registry
 
         public string MainTemplateContents { get; }
 
-        public static TemplateSpec FromGenericResource(GenericResource resource)
+        public static TemplateSpec FromGenericResourceData(GenericResourceData data)
         {
             try
             {
-                var templateSpecProperties = JObject.FromObject(resource.Properties);
+                var templateSpecProperties = JObject.FromObject(data.Properties);
 
                 if (!templateSpecProperties.TryGetValue("mainTemplate", out var mainTemplate))
                 {

--- a/src/Bicep.Core/Registry/TemplateSpecRepository.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecRepository.cs
@@ -6,31 +6,26 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
-using Azure.ResourceManager.Resources;
+using Azure.ResourceManager;
 
 namespace Bicep.Core.Registry
 {
     public class TemplateSpecRepository : ITemplateSpecRepository
     {
-        public readonly ResourcesManagementClient client;
+        public readonly ArmClient client;
 
-        public TemplateSpecRepository(ResourcesManagementClient client)
+        public TemplateSpecRepository(ArmClient client)
         {
             this.client =client;
-        }
-
-        public TemplateSpecRepository(Uri? endpoint, string subscriptionId, TokenCredential tokenCredential, ResourcesManagementClientOptions options)
-            : this(new(endpoint, subscriptionId, tokenCredential, options))
-        {
         }
 
         public async Task<TemplateSpec> FindTemplateSpecByIdAsync(string templateSpecId, CancellationToken cancellationToken = default)
         {
             try
             {
-                var response = await this.client.Resources.GetByIdAsync(templateSpecId, "2021-05-01", cancellationToken);
+                var response = await this.client.GetGenericResource(templateSpecId).GetAsync(cancellationToken);
 
-                return TemplateSpec.FromGenericResource(response.Value);
+                return TemplateSpec.FromGenericResourceData(response.Value.Data);
             }
             catch (RequestFailedException exception)
             {

--- a/src/Bicep.Core/Registry/TemplateSpecRepositoryFactory.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecRepositoryFactory.cs
@@ -4,20 +4,23 @@
 using System;
 using Azure.Core;
 using Azure.Identity;
-using Azure.ResourceManager.Resources;
+using Azure.ResourceManager;
 
 namespace Bicep.Core.Registry
 {
     public class TemplateSpecRepositoryFactory : ITemplateSpecRepositoryFactory
     {
-        public ITemplateSpecRepository CreateRepository(Uri? endpoint, string subscriptionId, TokenCredential? tokenCredential = null)
+        public ITemplateSpecRepository CreateRepository(Uri? endpointUri, string subscriptionId, TokenCredential? tokenCredential = null)
         {
             tokenCredential ??= new DefaultAzureCredential();
 
-            var options = new ResourcesManagementClientOptions();
+            var options = new ArmClientOptions();
             options.Diagnostics.ApplicationId = $"{LanguageConstants.LanguageId}/{ThisAssembly.AssemblyFileVersion}";
+            options.ApiVersions.SetApiVersion("templateSpecs", "2021-05-01");
 
-            return new TemplateSpecRepository(endpoint, subscriptionId, tokenCredential, options);
+            var armClient = new ArmClient(subscriptionId, endpointUri, tokenCredential, options);
+
+            return new TemplateSpecRepository(armClient);
         }
     }
 }

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -68,11 +68,12 @@
       },
       "Azure.ResourceManager.Resources": {
         "type": "Direct",
-        "requested": "[1.0.0-preview.2, )",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "requested": "[1.0.0-beta.1, )",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -143,8 +144,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -155,6 +156,15 @@
           "System.Text.Encodings.Web": "4.7.2",
           "System.Text.Json": "4.6.0",
           "System.Threading.Tasks.Extensions": "4.5.2"
+        }
+      },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -133,12 +133,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2225,7 +2235,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -133,12 +133,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2225,7 +2235,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -57,8 +57,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -104,12 +104,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -1459,7 +1469,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -99,8 +99,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -155,12 +155,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2248,7 +2258,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -99,8 +99,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -155,12 +155,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2248,7 +2258,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -44,8 +44,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -100,12 +100,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -566,7 +576,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -51,8 +51,8 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.14.0",
-        "contentHash": "kUMUOZX4FcmfHmy7OjyP5LovO5FMXco9uUYB76l77mtqMVbZ0cLobv+XCy/j6LpStc8cZo2sI1+dMXhk0YROEQ==",
+        "resolved": "1.18.0",
+        "contentHash": "h0DQLyIKvowm6n9XV2njDiiI5Et0QecpE2VcGfhps9J4m9MJ6tBD4Qxl+fbL8k/41sD7UXP4nAWgxC81oV11oQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -107,12 +107,22 @@
           "System.Threading.Tasks.Extensions": "4.5.2"
         }
       },
+      "Azure.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.2",
+        "contentHash": "y0EMHnpvzCFODGquSGu7oD51qaxOLgqjVVLXw0nzf+dyuVdFL0UYkdcDg2EHABW+LEowYbTw/Ji6PlU1XlrKWA==",
+        "dependencies": {
+          "Azure.Core": "1.18.0",
+          "System.Text.Json": "4.6.0"
+        }
+      },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-preview.2",
-        "contentHash": "dCFubyUeVaVGVn8+/gOAZ/Zt3YASDwOrs5eJMJNC3/N4AgDZqlF5LQ5a5gR19L6ZEQcIO/ZkMO1NdOrZzQ3SkQ==",
+        "resolved": "1.0.0-beta.1",
+        "contentHash": "Ym9FwOScPl2sb+jUV7cxyYGX/qttevm8lWOCtK/+CCTEz41qwx0Q2wi99M28MtccOYREiL1XyeMeNUy9TknzRw==",
         "dependencies": {
-          "Azure.Core": "1.5.0",
+          "Azure.Core": "1.18.0",
+          "Azure.ResourceManager": "1.0.0-beta.2",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -389,7 +399,7 @@
           "Azure.Deployments.Expression": "1.0.247",
           "Azure.Deployments.Templates": "1.0.247",
           "Azure.Identity": "1.4.0",
-          "Azure.ResourceManager.Resources": "1.0.0-preview.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.1",
           "Bicep.Core.RegistryClient": "1.0.0",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",


### PR DESCRIPTION
The Azure .NET SDK team just refactored the management SDK for resources and published `Azure.ResourceManager.Resources` 
 1.0.0-beta.1 (which contains some breaking changes). The PR updates the package to that version.