### PR TITLE
fixing examples in the decompiling.md page

### DIFF
--- a/docs/decompiling.md
+++ b/docs/decompiling.md
@@ -4,7 +4,7 @@
  
 The Bicep CLI provides the ability to decompile any existing ARM Template to a `.bicep` file, using the `decompile` command:
 ```sh
-bicep decompile "path/to/file.json"
+az bicep decompile "path/to/file.json"
 ```
 
 You can use this command to get to a starting point for Bicep authoring. Note that because there is no guaranteed conversion from JSON to Bicep, decompilation may fail, or you may be left with errors/warnings in the generated Bicep file to fix up. See [Limitations](#current-limitations) for some details of what is not currently possible. Also note that because there is not an exact 1:1 conversion from ARM Template to Bicep, it's possible (and likely) to wind up with different ARM Template code if you go decompile then rebuild(ARM Template --`bicep decompile`--> Bicep --`bicep build`--> ARM Template).
@@ -18,17 +18,17 @@ You can pass an exported template directly to the `bicep decompile` command to e
 The following will create a file named `main.bicep` in the current directory:
 ```sh
 az group export --name "your_resource_group_name" > main.json
-bicep decompile main.json
+az bicep decompile main.json
 ```
 ### Azure PowerShell
 The following will create a file named `main.bicep` in the current directory:
 ```powershell
 Export-AzResourceGroup -ResourceGroupName "your_resource_group_name" -Path ./main.json
-bicep decompile main.json
+az bicep decompile main.json
 ```
 
 ### Azure Portal
-See [Export Template](https://aka.ms/armexport) for guidance. Use `bicep decompile <filename>` on the downloaded file.
+See [Export Template](https://aka.ms/armexport) for guidance. Use `az bicep decompile <filename>` on the downloaded file.
 
 
 ## Current Limitations


### PR DESCRIPTION
fixing examples: bicep commands should start with `az bicep` rather than just `bicep`.

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
