### PR TITLE
Simplification of expressions on decompile

### DIFF
--- a/docs/decompiling.md
+++ b/docs/decompiling.md
@@ -1,7 +1,7 @@
 # Decompiling an ARM Template
- 
+
 > Requires Bicep CLI v0.2.59 or later
- 
+
 The Bicep CLI provides the ability to decompile any existing ARM Template to a `.bicep` file, using the `decompile` command:
 ```sh
 bicep decompile "path/to/file.json"
@@ -35,3 +35,4 @@ See [Export Template](https://aka.ms/armexport) for guidance. Use `bicep decompi
 The following are temporary limitations on the `bicep decompile` command:
 * Templates using copy loops cannot be decompiled.
 * Nested templates can only be decompiled if they are using ['inner' expression evaluation scope](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/linked-templates#expression-evaluation-scope-in-nested-templates).
+* Only comparisions using `toLower` function will result in case-insensitive comparision in bicep. For example `equals(toLower(variables('a')),tolower(variables('b')))` will result in `a =~ b` but using `toUpper` will not.

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -204,7 +204,9 @@ namespace Bicep.Core.IntegrationTests
         [DataRow("greater(variables('a'), variables('b'))", "boolean", "a > b")]
         [DataRow("greaterOrEquals(variables('a'), variables('b'))", "boolean", "a >= b")]
         [DataRow("equals(variables('a'), variables('b'))", "boolean", "a == b")]
+        [DataRow("equals(toLower(variables('a')),toLower(variables('b')))", "boolean", "a =~ b")]
         [DataRow("not(equals(variables('a'),variables('b')))","boolean", "a != b")]
+        [DataRow("not(equals(toLower(variables('a')),toLower(variables('b'))))", "boolean", "a !~ b")]
         public void Decompiler_handles_banned_function_replacement(string expression, string type, string expectedValue)
         {
             var template = @"{

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -205,10 +205,8 @@ namespace Bicep.Core.IntegrationTests
         [DataRow("greaterOrEquals(variables('a'), variables('b'))", "boolean", "a >= b")]
         [DataRow("equals(variables('a'), variables('b'))", "boolean", "a == b")]
         [DataRow("equals(toLower(variables('a')),toLower(variables('b')))", "boolean", "a =~ b")]
-        [DataRow("equals(toUpper(variables('a')),toUpper(variables('b')))", "boolean", "a =~ b")]
         [DataRow("not(equals(variables('a'),variables('b')))","boolean", "a != b")]
         [DataRow("not(equals(toLower(variables('a')),toLower(variables('b'))))", "boolean", "a !~ b")]
-        [DataRow("not(equals(toUpper(variables('a')),toUpper(variables('b'))))", "boolean", "a !~ b")]
         public void Decompiler_handles_banned_function_replacement(string expression, string type, string expectedValue)
         {
             var template = @"{

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -205,8 +205,10 @@ namespace Bicep.Core.IntegrationTests
         [DataRow("greaterOrEquals(variables('a'), variables('b'))", "boolean", "a >= b")]
         [DataRow("equals(variables('a'), variables('b'))", "boolean", "a == b")]
         [DataRow("equals(toLower(variables('a')),toLower(variables('b')))", "boolean", "a =~ b")]
+        [DataRow("equals(toUpper(variables('a')),toUpper(variables('b')))", "boolean", "a =~ b")]
         [DataRow("not(equals(variables('a'),variables('b')))","boolean", "a != b")]
         [DataRow("not(equals(toLower(variables('a')),toLower(variables('b'))))", "boolean", "a !~ b")]
+        [DataRow("not(equals(toUpper(variables('a')),toUpper(variables('b'))))", "boolean", "a !~ b")]
         public void Decompiler_handles_banned_function_replacement(string expression, string type, string expectedValue)
         {
             var template = @"{

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -204,6 +204,7 @@ namespace Bicep.Core.IntegrationTests
         [DataRow("greater(variables('a'), variables('b'))", "boolean", "a > b")]
         [DataRow("greaterOrEquals(variables('a'), variables('b'))", "boolean", "a >= b")]
         [DataRow("equals(variables('a'), variables('b'))", "boolean", "a == b")]
+        [DataRow("not(equals(variables('a'),variables('b')))","boolean", "a != b")]
         public void Decompiler_handles_banned_function_replacement(string expression, string type, string expectedValue)
         {
             var template = @"{

--- a/src/Bicep.Decompiler.IntegrationTests/Working/expressions/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/expressions/main.bicep
@@ -27,7 +27,5 @@ output coalesceArrayOutput array = ((coalesceObjectToTest.null1 ?? coalesceObjec
 output coalesceEmptyOutput bool = empty((coalesceObjectToTest.null1 ?? coalesceObjectToTest.null2))
 output emptyFunctionsOutput bool = ((null == json('null')) ? true : false)
 output equalsInsensitiveWithLower bool = (insensitiveToTest.leftInsensitive =~ insensitiveToTest.rightInsensitive)
-output equalsInsensitiveWithUpper bool = (insensitiveToTest.leftInsensitive =~ insensitiveToTest.rightInsensitive)
 output notEqualsInsensitiveWithLower bool = (insensitiveToTest.leftInsensitive !~ insensitiveToTest.rightInsensitive)
-output notEqualsInsensitiveWithUpper bool = (insensitiveToTest.leftInsensitive !~ insensitiveToTest.rightInsensitive)
 output notEquals bool = (insensitiveToTest.left != insensitiveToTest.right)

--- a/src/Bicep.Decompiler.IntegrationTests/Working/expressions/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/expressions/main.bicep
@@ -10,6 +10,12 @@ param coalesceObjectToTest object = {
     1
   ]
 }
+param insensitiveToTest object = {
+  left: 'value'
+  right: 'value'
+  leftInsensitive: 'valuE'
+  rightInsensitive: 'Value'
+}
 
 output andExampleOutput bool = (bool('true') && bool('false'))
 output orExampleOutput bool = (bool('true') || bool('false'))
@@ -20,3 +26,8 @@ output coalesceObjectOutput object = ((coalesceObjectToTest.null1 ?? coalesceObj
 output coalesceArrayOutput array = ((coalesceObjectToTest.null1 ?? coalesceObjectToTest.null2) ?? coalesceObjectToTest.array)
 output coalesceEmptyOutput bool = empty((coalesceObjectToTest.null1 ?? coalesceObjectToTest.null2))
 output emptyFunctionsOutput bool = ((null == json('null')) ? true : false)
+output equalsInsensitiveWithLower bool = (insensitiveToTest.leftInsensitive =~ insensitiveToTest.rightInsensitive)
+output equalsInsensitiveWithUpper bool = (insensitiveToTest.leftInsensitive =~ insensitiveToTest.rightInsensitive)
+output notEqualsInsensitiveWithLower bool = (insensitiveToTest.leftInsensitive !~ insensitiveToTest.rightInsensitive)
+output notEqualsInsensitiveWithUpper bool = (insensitiveToTest.leftInsensitive !~ insensitiveToTest.rightInsensitive)
+output notEquals bool = (insensitiveToTest.left != insensitiveToTest.right)

--- a/src/Bicep.Decompiler.IntegrationTests/Working/expressions/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/expressions/main.json
@@ -66,17 +66,9 @@
       "type": "bool",
       "value": "[equals(toLower(parameters('insensitiveToTest').leftInsensitive),toLower(parameters('insensitiveToTest').rightInsensitive))]"
     },
-    "equalsInsensitiveWithUpper": {
-      "type": "bool",
-      "value": "[equals(toUpper(parameters('insensitiveToTest').leftInsensitive),toUpper(parameters('insensitiveToTest').rightInsensitive))]"
-    },
     "notEqualsInsensitiveWithLower": {
       "type": "bool",
       "value": "[not(equals(toLower(parameters('insensitiveToTest').leftInsensitive),toLower(parameters('insensitiveToTest').rightInsensitive)))]"
-    },
-    "notEqualsInsensitiveWithUpper": {
-      "type": "bool",
-      "value": "[not(equals(toUpper(parameters('insensitiveToTest').leftInsensitive),toUpper(parameters('insensitiveToTest').rightInsensitive)))]"
     },
     "notEquals": {
       "type": "bool",

--- a/src/Bicep.Decompiler.IntegrationTests/Working/expressions/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/expressions/main.json
@@ -12,6 +12,15 @@
         "object": { "first": "default" },
         "array": [ 1 ]
       }
+    },
+    "insensitiveToTest": {
+      "type": "object",
+      "defaultValue": {
+        "left": "value",
+        "right": "value",
+        "leftInsensitive": "valuE",
+        "rightInsensitive": "Value"
+      }
     }
   },
   "resources": [
@@ -52,6 +61,26 @@
     "emptyFunctionsOutput": {
       "type": "bool",
       "value": "[if(equals(null(), json('null')), true(), false())]"
+    },
+    "equalsInsensitiveWithLower": {
+      "type": "bool",
+      "value": "[equals(toLower(parameters('insensitiveToTest').leftInsensitive),toLower(parameters('insensitiveToTest').rightInsensitive))]"
+    },
+    "equalsInsensitiveWithUpper": {
+      "type": "bool",
+      "value": "[equals(toUpper(parameters('insensitiveToTest').leftInsensitive),toUpper(parameters('insensitiveToTest').rightInsensitive))]"
+    },
+    "notEqualsInsensitiveWithLower": {
+      "type": "bool",
+      "value": "[not(equals(toLower(parameters('insensitiveToTest').leftInsensitive),toLower(parameters('insensitiveToTest').rightInsensitive)))]"
+    },
+    "notEqualsInsensitiveWithUpper": {
+      "type": "bool",
+      "value": "[not(equals(toUpper(parameters('insensitiveToTest').leftInsensitive),toUpper(parameters('insensitiveToTest').rightInsensitive)))]"
+    },
+    "notEquals": {
+      "type": "bool",
+      "value": "[not(equals(parameters('insensitiveToTest').left,parameters('insensitiveToTest').right))]"
     }
   }
 }

--- a/src/Bicep.Decompiler/BicepHelpers/SyntaxHelpers.cs
+++ b/src/Bicep.Decompiler/BicepHelpers/SyntaxHelpers.cs
@@ -98,10 +98,11 @@ namespace Bicep.Decompiler.BicepHelpers
             ["greater"] = TokenType.GreaterThan,
             ["greaterOrEquals"] = TokenType.GreaterThanOrEqual,
             ["equals"] = TokenType.Equals,
-            ["notEquals"] = TokenType.NotEquals,
             ["and"] = TokenType.LogicalAnd,
             ["or"] = TokenType.LogicalOr,
             ["coalesce"] = TokenType.DoubleQuestion,
+            // not an actual ARM template function but is used by Bicep to simplify the expression when decompiling
+            ["notEquals"] = TokenType.NotEquals,
         };
 
         private static IReadOnlyDictionary<string, TokenType> EmptyFunctionKeywordReplacements = new Dictionary<string, TokenType>(StringComparer.OrdinalIgnoreCase)

--- a/src/Bicep.Decompiler/BicepHelpers/SyntaxHelpers.cs
+++ b/src/Bicep.Decompiler/BicepHelpers/SyntaxHelpers.cs
@@ -98,6 +98,7 @@ namespace Bicep.Decompiler.BicepHelpers
             ["greater"] = TokenType.GreaterThan,
             ["greaterOrEquals"] = TokenType.GreaterThanOrEqual,
             ["equals"] = TokenType.Equals,
+            ["notEquals"] = TokenType.NotEquals,
             ["and"] = TokenType.LogicalAnd,
             ["or"] = TokenType.LogicalOr,
             ["coalesce"] = TokenType.DoubleQuestion,

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -222,10 +222,27 @@ namespace Bicep.Decompiler
                     throw new ArgumentException($"Expected 0 properties for binary function {expression.Function}");
                 }
 
+                var leftParameter = expression.Parameters[0];
+                var rightParameter = expression.Parameters[1];
+                // if token is = or != check to see if they are insensitive conditions i.e =~ or !~
+                if (binaryTokenType is TokenType.Equals || binaryTokenType is TokenType.NotEquals)
+                {
+                    if(leftParameter is FunctionExpression leftFunctionExpression &&
+                    rightParameter is FunctionExpression rightFunctionExpression &&
+                    leftFunctionExpression.Function == "toLower" &&
+                    rightFunctionExpression.Function == "toLower")
+                    {
+                        leftParameter = leftFunctionExpression.Parameters[0];
+                        rightParameter = rightFunctionExpression.Parameters[0];
+                        binaryTokenType = binaryTokenType == TokenType.Equals ? TokenType.EqualsInsensitive : TokenType.NotEqualsInsensitive;
+                        binaryOperator = Operators.TokenTypeToBinaryOperator[binaryTokenType];
+                    }
+                }
+
                 var binaryOperation = new BinaryOperationSyntax(
-                    ParseLanguageExpression(expression.Parameters[0]),
+                    ParseLanguageExpression(leftParameter),
                     SyntaxFactory.CreateToken(binaryTokenType, Operators.BinaryOperatorToText[binaryOperator]),
-                    ParseLanguageExpression(expression.Parameters[1]));
+                    ParseLanguageExpression(rightParameter));
 
                 foreach (var parameter in expression.Parameters.Skip(2))
                 {

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -289,8 +289,7 @@ namespace Bicep.Decompiler
 
                 // Check to see if the inner expression is also a function and if it is equals we can
                 // simplify the expression from (!(a == b)) to (a != b)
-                if (expression.Parameters[0].GetType() == typeof(FunctionExpression)){
-                    FunctionExpression functionExpression = (FunctionExpression)expression.Parameters[0];
+                if (expression.Parameters[0] is FunctionExpression functionExpression){
                     if (StringComparer.OrdinalIgnoreCase.Equals(functionExpression.Function, "equals")){
                         return TryReplaceBannedFunction(
                             new FunctionExpression("notEquals", functionExpression.Parameters, functionExpression.Properties),

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -270,6 +270,17 @@ namespace Bicep.Decompiler
                     throw new ArgumentException($"Expected 0 properties for unary function {expression.Function}");
                 }
 
+                // Check to see if the inner expression is also a function and if it is equals we can
+                // simplify the expression from (!(a == b)) to (a != b)
+                if (expression.Parameters[0].GetType() == typeof(FunctionExpression)){
+                    FunctionExpression functionExpression = (FunctionExpression)expression.Parameters[0];
+                    if (StringComparer.OrdinalIgnoreCase.Equals(functionExpression.Function, "equals")){
+                        return TryReplaceBannedFunction(
+                            new FunctionExpression("notEquals", functionExpression.Parameters, functionExpression.Properties),
+                        out syntax);
+                    }
+                }
+
                 syntax = new ParenthesizedExpressionSyntax(
                     SyntaxFactory.LeftParenToken,
                     new UnaryOperationSyntax(

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -228,9 +228,8 @@ namespace Bicep.Decompiler
                 if (binaryTokenType is TokenType.Equals || binaryTokenType is TokenType.NotEquals)
                 {
                     if(leftParameter is FunctionExpression leftFunctionExpression &&
-                    rightParameter is FunctionExpression rightFunctionExpression &&
-                    leftFunctionExpression.Function == "toLower" &&
-                    rightFunctionExpression.Function == "toLower")
+                        rightParameter is FunctionExpression rightFunctionExpression &&
+                        IsCaseInsensitiveCondition(leftFunctionExpression, rightFunctionExpression))
                     {
                         leftParameter = leftFunctionExpression.Parameters[0];
                         rightParameter = rightFunctionExpression.Parameters[0];
@@ -332,6 +331,12 @@ namespace Bicep.Decompiler
 
             syntax = null;
             return false;
+        }
+
+        private bool IsCaseInsensitiveCondition(FunctionExpression left, FunctionExpression right)
+        {
+            return (left.Function == "toLower" && right.Function == "toLower")
+                || (left.Function == "toUpper" && right.Function == "toUpper");
         }
 
         private SyntaxBase? TryParseStringExpression(LanguageExpression expression)

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -229,7 +229,8 @@ namespace Bicep.Decompiler
                 {
                     if(leftParameter is FunctionExpression leftFunctionExpression &&
                         rightParameter is FunctionExpression rightFunctionExpression &&
-                        IsCaseInsensitiveCondition(leftFunctionExpression, rightFunctionExpression))
+                        leftFunctionExpression.Function == "toLower" &&
+                        rightFunctionExpression.Function == "toLower")
                     {
                         leftParameter = leftFunctionExpression.Parameters[0];
                         rightParameter = rightFunctionExpression.Parameters[0];
@@ -331,12 +332,6 @@ namespace Bicep.Decompiler
 
             syntax = null;
             return false;
-        }
-
-        private bool IsCaseInsensitiveCondition(FunctionExpression left, FunctionExpression right)
-        {
-            return (left.Function == "toLower" && right.Function == "toLower")
-                || (left.Function == "toUpper" && right.Function == "toUpper");
         }
 
         private SyntaxBase? TryParseStringExpression(LanguageExpression expression)


### PR DESCRIPTION
Closes #3988 

- [X] Integration tests passing
- [X] Unit tests passing
- [X] Additional tests added

I have made the change to simplify the decompiling of the following nested function expressions

- `not(equals(variables('a'),variables('b'))` to `a != b`
- `not(equals(toLower(variables('a')),toLower(variables('b'))))` to `a !~ b`
- `equals(toLower(variables('a')),toLower(variables('b')))` to `a =~ b`

The idea behind the approach was to first validate if the expression contained a child `FunctionExpression` and if it did create a new expression without the nesting of the `not` and `equals` expressions.

The second change was to add support for comparison with case insensitive. For this I simply inspect the left and right parameter to see if they are both function expressions of type `toLower` and if they are remove the nesting and update the binary operator from either == != to =~ !~.

Once the nesting is removed we continue to evaluate the paramater and property expressions as before to ensure things like variables are handled accordingly.

# Update

Also includes additional simplifications

- ~`not(equals(toUpper(variables('a')),toUpper(variables('b'))))` to `a !~ b`~
- ~`equals(toUpper(variables('a')),toUpper(variables('b')))` to `a =~ b`~

- [X] Additional e2e tests added