### PR TITLE
Sort required properties first in completion

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAParams.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAParams.json
@@ -9,7 +9,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_arrayParam",
+    "sortText": "1_arrayParam",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27,7 +27,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_objParam",
+    "sortText": "1_objParam",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63,7 +63,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_stringParamB",
+    "sortText": "1_stringParamB",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAParams.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAParams.json
@@ -8,7 +8,7 @@
       "value": "Type: `array`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_arrayParam",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -26,7 +26,7 @@
       "value": "Type: `object`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_objParam",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -62,7 +62,7 @@
       "value": "Type: `string`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_stringParamB",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelProperties.json
@@ -26,7 +26,7 @@
       "value": "Type: `string`  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -44,7 +44,7 @@
       "value": "Type: `params`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_params",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelProperties.json
@@ -27,7 +27,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_name",
+    "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45,7 +45,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_params",
+    "sortText": "1_params",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelPropertiesMinusName.json
@@ -26,7 +26,7 @@
       "value": "Type: `params`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_params",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelPropertiesMinusName.json
@@ -27,7 +27,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_params",
+    "sortText": "1_params",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionParams.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionParams.json
@@ -9,7 +9,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_arrayParam",
+    "sortText": "1_arrayParam",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27,7 +27,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_objParam",
+    "sortText": "1_objParam",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63,7 +63,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_stringParamB",
+    "sortText": "1_stringParamB",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionParams.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionParams.json
@@ -8,7 +8,7 @@
       "value": "Type: `array`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_arrayParam",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -26,7 +26,7 @@
       "value": "Type: `object`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_objParam",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -62,7 +62,7 @@
       "value": "Type: `string`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_stringParamB",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelProperties.json
@@ -26,7 +26,7 @@
       "value": "Type: `string`  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -44,7 +44,7 @@
       "value": "Type: `params`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_params",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelProperties.json
@@ -27,7 +27,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_name",
+    "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45,7 +45,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_params",
+    "sortText": "1_params",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelPropertiesMinusName.json
@@ -26,7 +26,7 @@
       "value": "Type: `params`  \nWrite-only property  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_params",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelPropertiesMinusName.json
@@ -27,7 +27,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_params",
+    "sortText": "1_params",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptCliProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptCliProperties.json
@@ -26,7 +26,7 @@
       "value": "Type: `string`  \nAzure CLI module version to be used.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_azCliVersion",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -134,7 +134,7 @@
       "value": "Type: `string`  \nInterval for which the service retains the script resource after it reaches a terminal state. Resource will be deleted when this duration expires. Duration is based on ISO 8601 pattern (for example P1D means one day).  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_retentionInterval",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptCliProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptCliProperties.json
@@ -27,7 +27,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_azCliVersion",
+    "sortText": "1_azCliVersion",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -135,7 +135,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_retentionInterval",
+    "sortText": "1_retentionInterval",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptPSProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptPSProperties.json
@@ -27,7 +27,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_azPowerShellVersion",
+    "sortText": "1_azPowerShellVersion",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -135,7 +135,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_retentionInterval",
+    "sortText": "1_retentionInterval",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptPSProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptPSProperties.json
@@ -26,7 +26,7 @@
       "value": "Type: `string`  \nAzure PowerShell module version to be used.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_azPowerShellVersion",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -134,7 +134,7 @@
       "value": "Type: `string`  \nInterval for which the service retains the script resource after it reaches a terminal state. Resource will be deleted when this duration expires. Duration is based on ISO 8601 pattern (for example P1D means one day).  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_retentionInterval",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
@@ -45,7 +45,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_location",
+    "sortText": "1_location",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63,7 +63,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_name",
+    "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
@@ -44,7 +44,7 @@
       "value": "Type: `string`  \nThe location of the ACI and the storage account for the deployment script.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_location",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -62,7 +62,7 @@
       "value": "Type: `string`  \nThe resource name  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
@@ -9,7 +9,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_kind",
+    "sortText": "1_kind",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
@@ -8,7 +8,7 @@
       "value": "Type: `'AzureCLI' | 'AzurePowerShell'`  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_kind",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/environmentVariableProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/environmentVariableProperties.json
@@ -8,7 +8,7 @@
       "value": "Type: `string`  \nThe name of the environment variable.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/environmentVariableProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/environmentVariableProperties.json
@@ -9,7 +9,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_name",
+    "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
@@ -63,7 +63,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_kind",
+    "sortText": "1_kind",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -81,7 +81,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_location",
+    "sortText": "1_location",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -99,7 +99,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_name",
+    "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -207,7 +207,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_sku",
+    "sortText": "1_sku",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
@@ -62,7 +62,7 @@
       "value": "Type: `'BlobStorage' | 'BlockBlobStorage' | 'FileStorage' | 'Storage' | 'StorageV2'`  \nIndicates the type of storage account.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_kind",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -80,7 +80,7 @@
       "value": "Type: `string`  \nThe geo-location where the resource lives  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_location",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -98,7 +98,7 @@
       "value": "Type: `string`  \nThe resource name  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_name",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -206,7 +206,7 @@
       "value": "Type: `Sku`  \nThe SKU of the storage account.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_sku",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
@@ -63,7 +63,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_kind",
+    "sortText": "1_kind",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -81,7 +81,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_location",
+    "sortText": "1_location",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -189,7 +189,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_sku",
+    "sortText": "1_sku",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
@@ -62,7 +62,7 @@
       "value": "Type: `'BlobStorage' | 'BlockBlobStorage' | 'FileStorage' | 'Storage' | 'StorageV2'`  \nIndicates the type of storage account.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_kind",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -80,7 +80,7 @@
       "value": "Type: `string`  \nThe geo-location where the resource lives  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_location",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -188,7 +188,7 @@
       "value": "Type: `Sku`  \nThe SKU of the storage account.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_sku",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
@@ -62,7 +62,7 @@
       "value": "Type: `'BlobStorage' | 'BlockBlobStorage' | 'FileStorage' | 'Storage' | 'StorageV2'`  \nIndicates the type of storage account.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_kind",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -80,7 +80,7 @@
       "value": "Type: `string`  \nThe geo-location where the resource lives  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_location",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
@@ -116,7 +116,7 @@
       "value": "Type: `Sku`  \nThe SKU of the storage account.  \n"
     },
     "deprecated": false,
-    "preselect": false,
+    "preselect": true,
     "sortText": "1_sku",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
@@ -63,7 +63,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_kind",
+    "sortText": "1_kind",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -81,7 +81,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_location",
+    "sortText": "1_location",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -117,7 +117,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_sku",
+    "sortText": "1_sku",
     "insertTextFormat": "plainText",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -563,7 +563,7 @@ output string test2 = testRes.properties.|
         }
 
         [TestMethod]
-        public async Task Property_completions_required_first()
+        public async Task Property_completions_required_first_and_selected()
         {
             var fileWithCursors = @"
 resource testRes 'Test.Rp/readWriteTests@2020-01-01' = {
@@ -579,7 +579,11 @@ output string test2 = testRes.properties.|
             await RunCompletionScenarioTest(this.TestContext, fileWithCursors, completions =>
                 completions.Should().SatisfyRespectively(
                     x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
-                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which is required."),
+                        d =>
+                        {
+                            d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which is required.");
+                            d.Preselect.Should().BeTrue();
+                        },
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which only supports writing.")),
                     x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -547,8 +547,8 @@ output string test2 = testRes.properties.|
             await RunCompletionScenarioTest(this.TestContext, fileWithCursors, completions =>
                 completions.Should().SatisfyRespectively(
                     x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
-                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which is required."),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which only supports writing.")),
                     x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("apiVersion property"),
@@ -556,6 +556,32 @@ output string test2 = testRes.properties.|
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("name property"),
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("properties property"),
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("type property")),
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which only supports reading."),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which is required."))));
+        }
+
+        [TestMethod]
+        public async Task Property_completions_required_first()
+        {
+            var fileWithCursors = @"
+resource testRes 'Test.Rp/readWriteTests@2020-01-01' = {
+  name: 'testRes'
+  properties: {
+    |
+  }
+}
+
+output string test2 = testRes.properties.|
+";
+
+            await RunCompletionScenarioTest(this.TestContext, fileWithCursors, completions =>
+                completions.Should().SatisfyRespectively(
+                    x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which is required."),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),
+                        d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which only supports writing.")),
                     x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which only supports reading."),
                         d => d.Documentation!.MarkupContent!.Value.Should().Contain("This is a property which supports reading AND writing!"),

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -896,7 +896,7 @@ namespace Bicep.LanguageServer.Completions
             }
         }
 
-        private static CompletionItem CreatePropertyNameCompletion(TypeProperty property, bool includeColon, Range replacementRange, CompletionPriority priority = CompletionPriority.Medium)
+        private static CompletionItem CreatePropertyNameCompletion(TypeProperty property, bool includeColon, Range replacementRange)
         {
             var escapedPropertyName = IsPropertyNameEscapingRequired(property) ? StringUtils.EscapeBicepString(property.Name) : property.Name;
             var suffix = includeColon ? ":" : string.Empty;
@@ -905,7 +905,7 @@ namespace Bicep.LanguageServer.Completions
                 .WithPlainTextEdit(replacementRange, $"{escapedPropertyName}{suffix}")
                 .WithDetail(FormatPropertyDetail(property))
                 .WithDocumentation(FormatPropertyDocumentation(property))
-                .WithSortText(GetSortText(property.Name, priority))
+                .WithSortText(GetSortText(property.Name, GetPropertyPriority(property)))
                 .Build();
         }
 
@@ -1140,6 +1140,11 @@ namespace Bicep.LanguageServer.Completions
             property.Flags.HasFlag(TypePropertyFlags.Required)
                 ? $"{property.Name} (Required)"
                 : property.Name;
+
+        private static CompletionPriority GetPropertyPriority(TypeProperty property) =>
+            property.Flags.HasFlag(TypePropertyFlags.Required)
+                ? CompletionPriority.High
+                : CompletionPriority.Medium;
 
         private static string FormatPropertyDocumentation(TypeProperty property)
         {

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -898,6 +898,8 @@ namespace Bicep.LanguageServer.Completions
 
         private static CompletionItem CreatePropertyNameCompletion(TypeProperty property, bool includeColon, Range replacementRange)
         {
+            var required = property.Flags.HasFlag(TypePropertyFlags.Required);
+
             var escapedPropertyName = IsPropertyNameEscapingRequired(property) ? StringUtils.EscapeBicepString(property.Name) : property.Name;
             var suffix = includeColon ? ":" : string.Empty;
             return CompletionItemBuilder.Create(CompletionItemKind.Property, property.Name)
@@ -905,7 +907,8 @@ namespace Bicep.LanguageServer.Completions
                 .WithPlainTextEdit(replacementRange, $"{escapedPropertyName}{suffix}")
                 .WithDetail(FormatPropertyDetail(property))
                 .WithDocumentation(FormatPropertyDocumentation(property))
-                .WithSortText(GetSortText(property.Name, GetPropertyPriority(property)))
+                .WithSortText(GetSortText(property.Name, required ? CompletionPriority.High : CompletionPriority.Medium))
+                .Preselect(required)
                 .Build();
         }
 
@@ -1140,11 +1143,6 @@ namespace Bicep.LanguageServer.Completions
             property.Flags.HasFlag(TypePropertyFlags.Required)
                 ? $"{property.Name} (Required)"
                 : property.Name;
-
-        private static CompletionPriority GetPropertyPriority(TypeProperty property) =>
-            property.Flags.HasFlag(TypePropertyFlags.Required)
-                ? CompletionPriority.High
-                : CompletionPriority.Medium;
 
         private static string FormatPropertyDocumentation(TypeProperty property)
         {


### PR DESCRIPTION
Fixes https://github.com/Azure/bicep/issues/4561

![image](https://user-images.githubusercontent.com/1697911/134546418-204365be-e4d2-4362-93d2-a070f75b9716.png)

When all required properties are set we are back to the original behavior:
![image](https://user-images.githubusercontent.com/1697911/134546847-4455f835-10d0-4934-a28a-549b24982fd8.png)
