### PR TITLE
Fixed bug in `res-container-registry` snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -772,7 +772,7 @@
     "detail": "Container Registry",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  sku: {\n    name: 'Classic'\n  }\n  properties: {\n    adminUserEnabled: true\n  }\n}\n\n```"
+      "value": "```bicep\nresource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {\n  name: 'name'\n  location: resourceGroup().location\n  sku: {\n    name: 'Basic'\n  }\n  properties: {\n    adminUserEnabled: true\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -781,7 +781,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:containerRegistry} 'Microsoft.ContainerRegistry/registries@2019-05-01' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  sku: {\n    name: ${3|'Classic','Basic','Standard','Premium'|}\n  }\n  properties: {\n    adminUserEnabled: ${4|true,false|}\n  }\n}\n"
+      "newText": "resource ${1:containerRegistry} 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  sku: {\n    name: ${3|'Basic','Standard','Premium'|}\n  }\n  properties: {\n    adminUserEnabled: ${4|true,false|}\n  }\n}\n"
     },
     "command": {
       "command": "bicep.Telemetry",

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.bicep
@@ -1,6 +1,6 @@
 ﻿// $1 = containerRegistry
 // $2 = 'name'
 // $3 = 'Basic'
-// $4 = true
+// $4 = false
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.bicep
@@ -1,6 +1,6 @@
 ﻿// $1 = containerRegistry
 // $2 = 'name'
-// $3 = 'Classic'
+// $3 = 'Basic'
 // $4 = true
 
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.combined.bicep
@@ -3,14 +3,14 @@
 // $3 = 'Classic'
 // $4 = true
 
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {
   name: 'name'
   location: resourceGroup().location
   sku: {
-    name: 'Classic'
+    name: 'Basic'
   }
   properties: {
-    adminUserEnabled: true
+    adminUserEnabled: false
   }
 }
 // Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-container-registry/main.combined.bicep
@@ -1,7 +1,7 @@
 // $1 = containerRegistry
 // $2 = 'name'
-// $3 = 'Classic'
-// $4 = true
+// $3 = 'Basic'
+// $4 = false
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {
   name: 'name'

--- a/src/Bicep.LangServer/Snippets/Templates/res-container-registry.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-container-registry.bicep
@@ -1,11 +1,11 @@
 ﻿// Container Registry
-resource /*${1:containerRegistry}*/containerRegistry 'Microsoft.ContainerRegistry/registries@2019-05-01' = {
+resource /*${1:containerRegistry}*/containerRegistry 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = {
   name: /*${2:'name'}*/'name'
   location: resourceGroup().location
   sku: {
-    name: /*${3|'Classic','Basic','Standard','Premium'|}*/'Classic'
+    name: /*${3|'Basic','Standard','Premium'|}*/'Basic'
   }
   properties: {
-    adminUserEnabled: /*${4|true,false|}*/true
+    adminUserEnabled: /*${4|true,false|}*/false
   }
 }


### PR DESCRIPTION
Closes #4577.

- Removed deprecated SKU `Classic` from snippet. 
- Updated the API Version
- Changed `adminUserEnabled` default from `true` to `false` 

## Contributing a snippet

* [x] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
