### PR TITLE
added tracing for `br`, `ts` and auth requests

### DIFF
--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -12,7 +12,7 @@ using Bicep.Core.Exceptions;
 using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
-using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Tracing;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Utils;
 using Bicep.Decompiler;
@@ -35,7 +35,7 @@ namespace Bicep.Cli
             this.invocationContext = invocationContext;
         }
 
-        public static Task<int> Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
             string profilePath = DirHelper.GetTempPath();
             ProfileOptimization.SetProfileRoot(profilePath);
@@ -49,15 +49,21 @@ namespace Bicep.Cli
                 Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
             }
 
-            var program = new Program(new InvocationContext(
-                new AzResourceTypeLoader(),
-                Console.Out,
-                Console.Error,
-                ThisAssembly.AssemblyFileVersion,
-                features: null,
-                clientFactory: null));
+            // this event listener picks up SDK events and writes them to Trace.WriteLine()
+            using(FeatureProvider.TracingEnabled ? AzureEventSourceListenerFactory.Create(FeatureProvider.TracingVerbosity) : null)
+            {
+                var program = new Program(new InvocationContext(
+                    new AzResourceTypeLoader(),
+                    Console.Out,
+                    Console.Error,
+                    ThisAssembly.AssemblyFileVersion,
+                    features: null,
+                    clientFactory: null));
 
-            return program.RunAsync(args);
+                // this must be awaited so dispose of the listener occurs in the continuation
+                // rather than the sync part at the beginning of RunAsync()
+                return await program.RunAsync(args);
+            }
         }
 
         public async Task<int> RunAsync(string[] args)

--- a/src/Bicep.Core.UnitTests/Tracing/AzureEventSourceListenerFactoryTests.cs
+++ b/src/Bicep.Core.UnitTests/Tracing/AzureEventSourceListenerFactoryTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Tracing;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Bicep.Core.UnitTests.Tracing
+{
+    [TestClass]
+    public class AzureEventSourceListenerFactoryTests
+    {
+        private static readonly ReadOnlyCollection<string> SampleNamesWithHeaders = new List<string>
+        {
+            "one",
+            "headers",
+            "two"
+        }.AsReadOnly();
+
+        private static readonly ReadOnlyCollection<object> SampleValuesWithHeaders = new List<object>
+        {
+            1,
+            "one: two\r\nthree: four",
+            "two"
+        }.AsReadOnly();
+
+        private static readonly ReadOnlyCollection<string> SampleNamesWithoutHeaders = new List<string>
+        {
+            "one",
+            "notHeaders",
+            "two"
+        }.AsReadOnly();
+
+        private static readonly ReadOnlyCollection<object> SampleValuesWithoutHeaders = new List<object>
+        {
+            1,
+            "something",
+            "two"
+        }.AsReadOnly();
+
+        private const string FormatString = "{0}-->{1}<--{2}";
+
+
+        private static readonly string AzureCoreEventSource = "Azure-Core";
+
+        [TestMethod]
+        public void FullVerbosityShouldReturnNull()
+        {
+            AzureEventSourceListenerFactory.GetFormattedMessageWithoutHeaders(
+                Features.TraceVerbosity.Full,
+                AzureCoreEventSource,
+                FormatString,
+                SampleNamesWithHeaders,
+                SampleValuesWithHeaders).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void NonAzureCoreShouldReturnNull()
+        {
+            AzureEventSourceListenerFactory.GetFormattedMessageWithoutHeaders(
+                Features.TraceVerbosity.Basic,
+                "not-azure-core",
+                FormatString,
+                SampleNamesWithHeaders,
+                SampleValuesWithHeaders).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void NonHeaderEventShouldReturnNull()
+        {
+            AzureEventSourceListenerFactory.GetFormattedMessageWithoutHeaders(
+                Features.TraceVerbosity.Basic,
+                AzureCoreEventSource,
+                FormatString,
+                SampleNamesWithoutHeaders,
+                SampleValuesWithoutHeaders).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void HeadersShouldBeRemoved()
+        {
+            AzureEventSourceListenerFactory.GetFormattedMessageWithoutHeaders(
+                Features.TraceVerbosity.Basic,
+                AzureCoreEventSource,
+                FormatString,
+                SampleNamesWithHeaders,
+                SampleValuesWithHeaders).Should().Be("1--><--two");
+        }
+    }
+}

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -23,8 +23,16 @@ namespace Bicep.Core.Features
 
         public static bool TracingEnabled => ReadBooleanEnvVar("BICEP_TRACING_ENABLED", defaultValue: false);
 
+        public static TraceVerbosity TracingVerbosity => ReadEnumEnvvar<TraceVerbosity>("BICEP_TRACING_VERBOSITY", TraceVerbosity.Basic);
+
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)
             => bool.TryParse(Environment.GetEnvironmentVariable(envVar), out var value) ? value : defaultValue;
+
+        private static T ReadEnumEnvvar<T>(string envVar, T defaultValue) where T : struct
+        {
+            var str = Environment.GetEnvironmentVariable(envVar);
+            return Enum.TryParse<T>(str, true, out var value) ? value : defaultValue;
+        }
 
         private static string GetDefaultCachePath()
         {

--- a/src/Bicep.Core/Features/TraceVerbosity.cs
+++ b/src/Bicep.Core/Features/TraceVerbosity.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Features
+{
+    public enum TraceVerbosity
+    {
+        Basic,
+        Full
+    }
+}

--- a/src/Bicep.Core/Registry/ContainerRegistryClientFactory.cs
+++ b/src/Bicep.Core/Registry/ContainerRegistryClientFactory.cs
@@ -3,6 +3,7 @@
 
 using Azure.Core;
 using Bicep.Core.RegistryClient;
+using Bicep.Core.Tracing;
 using System;
 
 namespace Bicep.Core.Registry
@@ -12,9 +13,7 @@ namespace Bicep.Core.Registry
         public BicepRegistryBlobClient CreateBlobClient(Uri registryUri, string repository, TokenCredential credential)
         {
             var options = new ContainerRegistryClientOptions();
-
-            // ensure User-Agent mentions us
-            options.Diagnostics.ApplicationId = $"{LanguageConstants.LanguageId}/{ThisAssembly.AssemblyFileVersion}";
+            options.Diagnostics.ApplySharedContainerRegistrySettings();
 
             return new(registryUri, credential, repository, options);
         }

--- a/src/Bicep.Core/Registry/TemplateSpecRepositoryFactory.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecRepositoryFactory.cs
@@ -5,6 +5,7 @@ using System;
 using Azure.Core;
 using Azure.Identity;
 using Azure.ResourceManager;
+using Bicep.Core.Tracing;
 
 namespace Bicep.Core.Registry
 {
@@ -15,7 +16,7 @@ namespace Bicep.Core.Registry
             tokenCredential ??= new DefaultAzureCredential();
 
             var options = new ArmClientOptions();
-            options.Diagnostics.ApplicationId = $"{LanguageConstants.LanguageId}/{ThisAssembly.AssemblyFileVersion}";
+            options.Diagnostics.ApplySharedResourceManagerSettings();
             options.ApiVersions.SetApiVersion("templateSpecs", "2021-05-01");
 
             var armClient = new ArmClient(subscriptionId, endpointUri, tokenCredential, options);

--- a/src/Bicep.Core/Tracing/AzureEventSourceListenerFactory.cs
+++ b/src/Bicep.Core/Tracing/AzureEventSourceListenerFactory.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core.Diagnostics;
+using Bicep.Core.Features;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Linq;
+
+namespace Bicep.Core.Tracing
+{
+    /// <summary>
+    /// Listens to SDK events and redirects them to Trace.WriteLine(). In certain cases, we will strip HTTP headers out from the events that are written out.
+    /// </summary>
+    public static class AzureEventSourceListenerFactory
+    {
+        public static AzureEventSourceListener Create(TraceVerbosity verbosity) => new((eventArgs, formattedMessage) => WriteTraceLine(eventArgs, formattedMessage, verbosity), EventLevel.LogAlways);
+
+        private static void WriteTraceLine(EventWrittenEventArgs eventArgs, string formattedMessage, TraceVerbosity verbosity)
+        {
+            var updatedMessage = GetFormattedMessageWithoutHeaders(
+                verbosity,
+                eventArgs.EventSource.Name,
+                eventArgs.Message,
+                eventArgs.PayloadNames,
+                eventArgs.Payload) ?? formattedMessage;
+
+            Trace.WriteLine(string.Format(CultureInfo.InvariantCulture, "[{0}] {1}", eventArgs.Level, updatedMessage), eventArgs.EventSource.Name);
+        }
+
+        // EventWrittenEventArgs does not appear mockable, so we will expose this method with deconstructed parameters
+        public static string? GetFormattedMessageWithoutHeaders(TraceVerbosity verbosity, string eventSourceName, string formatString, ReadOnlyCollection<string> parameterNames, ReadOnlyCollection<object> parameterValues)
+        {
+            if (verbosity == TraceVerbosity.Full || !string.Equals(eventSourceName, "Azure-Core"))
+            {
+                // we have full verbosity enabled or the event came from non Azure-Core source
+                // (non Azure-Core sources do not appear to produce large traces)
+                return null;
+            }
+
+            var headerIndex = IndexOfHeaders(parameterNames);
+            if (headerIndex < 0)
+            {
+                // no headers on Azure-Core event
+                return null;
+            }
+
+            // Azure-Core insists on logging a fairly large dump of headers and there's no way to opt out
+            var parameters = parameterValues.ToArray();
+
+            // remove headers
+            parameters[headerIndex] = string.Empty;
+
+            // reformat the message
+            return string.Format(CultureInfo.InvariantCulture, formatString, parameters);
+        }
+
+        private static int IndexOfHeaders(ReadOnlyCollection<string> payloadNames)
+        {
+            // Most common events from Azure-Core have "headers"
+            // and those events have it as the 2nd to last payload
+            for (var i = payloadNames.Count - 1; i >= 0; i--)
+            {
+                var current = payloadNames[i];
+                if (string.Equals(current, "headers"))
+                {
+                    return i;
+                }
+            }
+
+            // headers parameter is not present
+            return -1;
+        }
+    }
+}

--- a/src/Bicep.Core/Tracing/DiagnosticOptionsExtensions.cs
+++ b/src/Bicep.Core/Tracing/DiagnosticOptionsExtensions.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Tracing
+{
+    public static class DiagnosticOptionsExtensions
+    {
+        private static readonly ImmutableArray<string> ArmClientAdditionalLoggedHeaders = new[]
+        {
+            "x-ms-ratelimit-remaining-subscription-reads",
+            "x-ms-correlation-request-id",
+            "x-ms-routing-request-id"
+        }.ToImmutableArray();
+
+        private static readonly ImmutableArray<string> ArmClientAdditionalLoggedQueryParams = new[]
+        {
+            "api-version"
+        }.ToImmutableArray();
+
+        private static readonly ImmutableArray<string> AcrClientAdditionalLoggedHeaders = new[]
+        {
+            "Accept-Ranges",
+            "x-ms-version",
+            "Docker-Content-Digest",
+            "Docker-Distribution-Api-Version",
+            "X-Content-Type-Options",
+            "X-Ms-Correlation-Request-Id",
+            "x-ms-ratelimit-remaining-calls-per-second"
+        }.ToImmutableArray();
+
+        private static readonly ImmutableArray<string> AcrClientAdditionalLoggedQueryParams = ImmutableArray<string>.Empty;
+
+        public static void ApplySharedResourceManagerSettings(this DiagnosticsOptions options) =>
+            options.ApplySharedDiagnosticsSettings(ArmClientAdditionalLoggedHeaders, ArmClientAdditionalLoggedQueryParams);
+
+        public static void ApplySharedContainerRegistrySettings(this DiagnosticsOptions options) =>
+            options.ApplySharedDiagnosticsSettings(AcrClientAdditionalLoggedHeaders, AcrClientAdditionalLoggedQueryParams);
+
+        private static void ApplySharedDiagnosticsSettings(this DiagnosticsOptions options, ImmutableArray<string> additionalHeaders, ImmutableArray<string> additionalQueryParameters)
+        {
+            // ensure User-Agent mentions us
+            options.ApplicationId = $"{LanguageConstants.LanguageId}/{ThisAssembly.AssemblyFileVersion}";
+
+            options.IsLoggingContentEnabled = false;
+            options.IsDistributedTracingEnabled = false;
+            options.IsTelemetryEnabled = false;
+
+            foreach(var header in additionalHeaders)
+            {
+                options.LoggedHeaderNames.Add(header);
+            }
+
+            foreach(var queryParam in additionalQueryParameters)
+            {
+                options.LoggedQueryParameters.Add(queryParam);
+            }
+        }
+    }
+}

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -7,6 +7,7 @@ using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Tracing;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
@@ -94,10 +95,13 @@ namespace Bicep.LanguageServer
                 Trace.Listeners.Add(new ServerLogTraceListener(server));
             }
 
-            var scheduler = server.GetRequiredService<IModuleRestoreScheduler>();
-            scheduler.Start();
+            using (FeatureProvider.TracingEnabled ? AzureEventSourceListenerFactory.Create(FeatureProvider.TracingVerbosity) : null)
+            {
+                var scheduler = server.GetRequiredService<IModuleRestoreScheduler>();
+                scheduler.Start();
 
-            await server.WaitForExit;
+                await server.WaitForExit;
+            }
         }
 
         private static void RegisterServices(CreationOptions creationOptions, IServiceCollection services)

--- a/src/Bicep.Wasm/Program.cs
+++ b/src/Bicep.Wasm/Program.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 
 namespace Bicep.Wasm


### PR DESCRIPTION
Added tracing for REST calls made via the ARM or ACR SDKs. The traces also cover credential logic. This fixes #4211.