### PR TITLE
Add NamespaceType to ResourceType definition

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -1080,13 +1080,13 @@ resource eventGridSubscription 'Microsoft.EventGrid/eventSubscriptions@2020-06-0
         public void Test_Issue657_discriminators()
         {
             var customTypes = new[] {
-                new ResourceType(
+                new ResourceTypeComponents(
                     ResourceTypeReference.Parse("Rp.A/parent@2020-10-01"),
                     ResourceScope.ResourceGroup,
                     TestTypeHelper.CreateObjectType(
                         "Rp.A/parent@2020-10-01",
                         ("name", LanguageConstants.String))),
-                new ResourceType(
+                new ResourceTypeComponents(
                     ResourceTypeReference.Parse("Rp.A/parent/child@2020-10-01"),
                     ResourceScope.ResourceGroup,
                     TestTypeHelper.CreateDiscriminatedObjectType(
@@ -1178,13 +1178,13 @@ resource test5 'Rp.A/parent/child@2020-10-01' existing = {
         public void Test_Issue657_enum()
         {
             var customTypes = new[] {
-                new ResourceType(
+                new ResourceTypeComponents(
                     ResourceTypeReference.Parse("Rp.A/parent@2020-10-01"),
                     ResourceScope.ResourceGroup,
                     TestTypeHelper.CreateObjectType(
                         "Rp.A/parent@2020-10-01",
                         ("name", LanguageConstants.String))),
-                new ResourceType(
+                new ResourceTypeComponents(
                     ResourceTypeReference.Parse("Rp.A/parent/child@2020-10-01"),
                     ResourceScope.ResourceGroup,
                     TestTypeHelper.CreateObjectType(

--- a/src/Bicep.Core.IntegrationTests/ScopeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScopeTests.cs
@@ -180,7 +180,7 @@ output resourceARef string = resourceA.properties.myProp
         {
             var typeReference = ResourceTypeReference.Parse("My.Rp/myResource@2020-01-01");
             var typeLoader = TestTypeHelper.CreateAzResourceTypeLoaderWithTypes(new [] {
-                new ResourceType(typeReference, ResourceScope.ResourceGroup, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
+                new ResourceTypeComponents(typeReference, ResourceScope.ResourceGroup, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
                     new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.DeployTimeConstant, "name property"),
                     new TypeProperty("kind", LanguageConstants.String, TypePropertyFlags.ReadOnly, "kind property"),
                 }, null))
@@ -223,7 +223,7 @@ output resourceARef string = resourceA.kind
         {
             var typeReference = ResourceTypeReference.Parse("My.Rp/myResource@2020-01-01");
             var typeLoader = TestTypeHelper.CreateAzResourceTypeLoaderWithTypes(new [] {
-                new ResourceType(typeReference, ResourceScope.ResourceGroup, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
+                new ResourceTypeComponents(typeReference, ResourceScope.ResourceGroup, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
                     new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.DeployTimeConstant, "name property"),
                 }, null))
             });
@@ -259,7 +259,7 @@ resource resourceA 'My.Rp/myResource@2020-01-01' existing = {
         {
             var typeReference = ResourceTypeReference.Parse("My.Rp/myResource@2020-01-01");
             var typeLoader = TestTypeHelper.CreateAzResourceTypeLoaderWithTypes(new [] {
-                new ResourceType(typeReference, ResourceScope.ResourceGroup | ResourceScope.Resource, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
+                new ResourceTypeComponents(typeReference, ResourceScope.ResourceGroup | ResourceScope.Resource, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
                     new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.DeployTimeConstant, "name property"),
                 }, null))
             });
@@ -287,7 +287,7 @@ resource resourceB 'My.Rp/myResource@2020-01-01' = {
         {
             var typeReference = ResourceTypeReference.Parse("My.Rp/myResource@2020-01-01");
             var typeLoader = TestTypeHelper.CreateAzResourceTypeLoaderWithTypes(new [] {
-                new ResourceType(typeReference, ResourceScope.ResourceGroup | ResourceScope.Resource, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
+                new ResourceTypeComponents(typeReference, ResourceScope.ResourceGroup | ResourceScope.Resource, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
                     new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.DeployTimeConstant, "name property"),
                 }, null))
             });
@@ -321,7 +321,7 @@ resource resourceB 'My.Rp/myResource@2020-01-01' = {
         {
             var typeReference = ResourceTypeReference.Parse("My.Rp/myResource@2020-01-01");
             var typeLoader = TestTypeHelper.CreateAzResourceTypeLoaderWithTypes(new[] {
-                new ResourceType(typeReference, ResourceScope.Tenant, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
+                new ResourceTypeComponents(typeReference, ResourceScope.Tenant, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
                     new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.DeployTimeConstant, "name property"),
                 }, null))
             });

--- a/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
@@ -17,7 +17,7 @@ namespace Bicep.Core.IntegrationTests
     [TestClass]
     public class TypeValidationTests
     {
-        private static SemanticModel GetSemanticModelForTest(string programText, IEnumerable<ResourceType> definedTypes)
+        private static SemanticModel GetSemanticModelForTest(string programText, IEnumerable<ResourceTypeComponents> definedTypes)
         {
             var typeProvider = TestTypeHelper.CreateProviderWithTypes(definedTypes);
             var configuration = BicepTestConstants.BuiltInConfigurationWithAnalyzersDisabled;
@@ -368,7 +368,7 @@ var commentsPropAccess = jsonWithComments.key
 var invalidPropAccess = objectJson.invalidProp
 ";
 
-            var model = GetSemanticModelForTest(program, Enumerable.Empty<ResourceType>());
+            var model = GetSemanticModelForTest(program, Enumerable.Empty<ResourceTypeComponents>());
 
             GetTypeForNamedSymbol(model, "objectJson").Name.Should().Be("object");
             GetTypeForNamedSymbol(model, "propAccess").Name.Should().Be("'validValue'");
@@ -393,7 +393,7 @@ var invalidPropAccess = objectJson.invalidProp
 var invalidJson = json('{""prop"": ""value')
 ";
 
-            var model = GetSemanticModelForTest(program, Enumerable.Empty<ResourceType>());
+            var model = GetSemanticModelForTest(program, Enumerable.Empty<ResourceTypeComponents>());
 
             GetTypeForNamedSymbol(model, "invalidJson").Name.Should().Be("error");
 

--- a/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
@@ -38,7 +38,10 @@ namespace Bicep.Core.UnitTests.TypeSystem.Az
         [DataRow(ResourceTypeGenerationFlags.ExistingResource | ResourceTypeGenerationFlags.PermitLiteralNameProperty)]
         public void AzResourceTypeProvider_can_deserialize_all_types_without_throwing(ResourceTypeGenerationFlags flags)
         {
-            var resourceTypeProvider = new AzResourceTypeProvider(new AzResourceTypeLoader());
+            var typeProvider = TestTypeHelper.CreateWithAzTypes();
+            var namespaceType = typeProvider.TryGetNamespace("az", "az", ResourceScope.ResourceGroup)!;
+
+            var resourceTypeProvider = namespaceType.ResourceTypeProvider;
             var availableTypes = resourceTypeProvider.GetAvailableTypes();
 
             // sanity check - we know there should be a lot of types available
@@ -48,7 +51,7 @@ namespace Bicep.Core.UnitTests.TypeSystem.Az
             foreach (var availableType in availableTypes)
             {
                 resourceTypeProvider.HasDefinedType(availableType).Should().BeTrue();
-                var resourceType = resourceTypeProvider.TryGetDefinedType(availableType, flags)!;
+                var resourceType = resourceTypeProvider.TryGetDefinedType(namespaceType, availableType, flags)!;
 
                 try
                 {

--- a/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
@@ -606,8 +606,9 @@ namespace Bicep.Core.UnitTests.TypeSystem
         {
             var typeProvider = TestTypeHelper.CreateEmptyProvider();
             var typeReference = ResourceTypeReference.Parse("Mock.Rp/mockType@2020-01-01");
+            var azNamespaceType = typeProvider.TryGetNamespace("az", "az", ResourceScope.ResourceGroup)!;
 
-            return typeProvider.TryGetNamespace("az", "az", ResourceScope.ResourceGroup)!.ResourceTypeProvider.TryGenerateDefaultType(typeReference, ResourceTypeGenerationFlags.None)!;
+            return azNamespaceType.ResourceTypeProvider.TryGenerateDefaultType(azNamespaceType, typeReference, ResourceTypeGenerationFlags.None)!;
         }
 
         private static (TypeSymbol result, IReadOnlyList<IDiagnostic> diagnostics) NarrowTypeAndCollectDiagnostics(SyntaxHierarchy hierarchy, SyntaxBase expression, TypeSymbol targetType)

--- a/src/Bicep.Core.UnitTests/Utils/BuiltInTestTypes.cs
+++ b/src/Bicep.Core.UnitTests/Utils/BuiltInTestTypes.cs
@@ -21,17 +21,17 @@ namespace Bicep.Core.UnitTests.Utils
             yield return new TypeProperty(LanguageConstants.ResourceApiVersionPropertyName, new StringLiteralType(reference.ApiVersion), TypePropertyFlags.ReadOnly | TypePropertyFlags.DeployTimeConstant, "apiVersion property");
         }
 
-        private static ResourceType BasicTestsType()
+        private static ResourceTypeComponents BasicTestsType()
         {
             var resourceType = ResourceTypeReference.Parse("Test.Rp/basicTests@2020-01-01");
 
-            return new ResourceType(resourceType, ResourceScope.ResourceGroup, new ObjectType(resourceType.FormatName(), TypeSymbolValidationFlags.Default,
+            return new ResourceTypeComponents(resourceType, ResourceScope.ResourceGroup, new ObjectType(resourceType.FormatName(), TypeSymbolValidationFlags.Default,
                 GetCommonResourceProperties(resourceType).Concat(new[] {
                     new TypeProperty("kind", LanguageConstants.String, TypePropertyFlags.ReadOnly, "kind property"),
                 }), null));
         }
 
-        private static ResourceType ReadWriteTestsType()
+        private static ResourceTypeComponents ReadWriteTestsType()
         {
             var resourceType = ResourceTypeReference.Parse("Test.Rp/readWriteTests@2020-01-01");
 
@@ -42,13 +42,13 @@ namespace Bicep.Core.UnitTests.Utils
                 new TypeProperty("required", LanguageConstants.String, TypePropertyFlags.Required, "This is a property which is required."),
             }, null);
 
-            return new ResourceType(resourceType, ResourceScope.ResourceGroup, new ObjectType(resourceType.FormatName(), TypeSymbolValidationFlags.Default,
+            return new ResourceTypeComponents(resourceType, ResourceScope.ResourceGroup, new ObjectType(resourceType.FormatName(), TypeSymbolValidationFlags.Default,
                 GetCommonResourceProperties(resourceType).Concat(new[] {
                     new TypeProperty("properties", propertiesType, TypePropertyFlags.Required, "properties property"),
                 }), null));
         }
 
-        private static ResourceType DiscriminatorTestsType()
+        private static ResourceTypeComponents DiscriminatorTestsType()
         {
             var resourceType = ResourceTypeReference.Parse("Test.Rp/discriminatorTests@2020-01-01");
 
@@ -83,10 +83,10 @@ namespace Bicep.Core.UnitTests.Utils
                     }), null),
                 });
 
-            return new ResourceType(resourceType, ResourceScope.ResourceGroup, bodyType);
+            return new ResourceTypeComponents(resourceType, ResourceScope.ResourceGroup, bodyType);
         }
 
-        private static ResourceType FallbackPropertyTestsType()
+        private static ResourceTypeComponents FallbackPropertyTestsType()
         {
             var resourceType = ResourceTypeReference.Parse("Test.Rp/fallbackProperties@2020-01-01");
 
@@ -94,7 +94,7 @@ namespace Bicep.Core.UnitTests.Utils
                 new TypeProperty("required", LanguageConstants.String, TypePropertyFlags.Required, "This is a property which is required."),
             }, null);
 
-            return new ResourceType(resourceType, ResourceScope.ResourceGroup, new ObjectType(resourceType.FormatName(), TypeSymbolValidationFlags.Default,
+            return new ResourceTypeComponents(resourceType, ResourceScope.ResourceGroup, new ObjectType(resourceType.FormatName(), TypeSymbolValidationFlags.Default,
                 GetCommonResourceProperties(resourceType).Concat(new[] {
                     new TypeProperty("properties", propertiesType, TypePropertyFlags.Required, "properties property"),
                 }).Concat(

--- a/src/Bicep.Core.UnitTests/Utils/TestTypeHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestTypeHelper.cs
@@ -21,9 +21,9 @@ namespace Bicep.Core.UnitTests.Utils
     {
         private class TestResourceTypeLoader : IAzResourceTypeLoader
         {
-            private readonly ImmutableDictionary<ResourceTypeReference, ResourceType> resourceTypes;
+            private readonly ImmutableDictionary<ResourceTypeReference, ResourceTypeComponents> resourceTypes;
 
-            public TestResourceTypeLoader(IEnumerable<ResourceType> resourceTypes)
+            public TestResourceTypeLoader(IEnumerable<ResourceTypeComponents> resourceTypes)
             {
                 this.resourceTypes = resourceTypes.ToImmutableDictionary(
                     x => x.TypeReference,
@@ -31,7 +31,7 @@ namespace Bicep.Core.UnitTests.Utils
                     ResourceTypeReferenceComparer.Instance);
             }
 
-            public ResourceType LoadType(ResourceTypeReference reference)
+            public ResourceTypeComponents LoadType(ResourceTypeReference reference)
                 => resourceTypes[reference];
 
             public IEnumerable<ResourceTypeReference> GetAvailableTypes()
@@ -39,21 +39,21 @@ namespace Bicep.Core.UnitTests.Utils
         }
 
         public static IAzResourceTypeLoader CreateEmptyAzResourceTypeLoader()
-            => new TestResourceTypeLoader(Enumerable.Empty<ResourceType>());
+            => new TestResourceTypeLoader(Enumerable.Empty<ResourceTypeComponents>());
 
-        public static IAzResourceTypeLoader CreateAzResourceTypeLoaderWithTypes(IEnumerable<ResourceType> resourceTypes)
+        public static IAzResourceTypeLoader CreateAzResourceTypeLoaderWithTypes(IEnumerable<ResourceTypeComponents> resourceTypes)
             => new TestResourceTypeLoader(resourceTypes);
 
-        public static INamespaceProvider CreateProviderWithTypes(IEnumerable<ResourceType> resourceTypes)
+        public static INamespaceProvider CreateProviderWithTypes(IEnumerable<ResourceTypeComponents> resourceTypes)
             => new DefaultNamespaceProvider(CreateAzResourceTypeLoaderWithTypes(resourceTypes), BicepTestConstants.Features);
 
         public static INamespaceProvider CreateEmptyProvider()
-            => CreateProviderWithTypes(Enumerable.Empty<ResourceType>());
+            => CreateProviderWithTypes(Enumerable.Empty<ResourceTypeComponents>());
 
         public static INamespaceProvider CreateWithAzTypes()
             => new DefaultNamespaceProvider(new AzResourceTypeLoader(), BicepTestConstants.Features);
 
-        public static ResourceType CreateCustomResourceType(string fullyQualifiedType, string apiVersion, TypeSymbolValidationFlags validationFlags, params TypeProperty[] customProperties)
+        public static ResourceTypeComponents CreateCustomResourceType(string fullyQualifiedType, string apiVersion, TypeSymbolValidationFlags validationFlags, params TypeProperty[] customProperties)
         {
             var reference = ResourceTypeReference.Parse($"{fullyQualifiedType}@{apiVersion}");
 
@@ -61,7 +61,7 @@ namespace Bicep.Core.UnitTests.Utils
                 .Concat(new TypeProperty("properties", new ObjectType("properties", validationFlags, customProperties, null), TypePropertyFlags.Required));
 
             var bodyType = new ObjectType(reference.FormatName(), validationFlags, resourceProperties, null);
-            return new ResourceType(reference, ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup | ResourceScope.Resource, bodyType);
+            return new ResourceTypeComponents(reference, ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup | ResourceScope.Resource, bodyType);
         }
 
         public static ObjectType CreateObjectType(string name, params (string name, ITypeReference type)[] properties)

--- a/src/Bicep.Core/Semantics/Namespaces/NamespaceResolver.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/NamespaceResolver.cs
@@ -96,7 +96,7 @@ namespace Bicep.Core.Semantics.Namespaces
         public ResourceType GetResourceType(ResourceTypeReference reference, ResourceTypeGenerationFlags flags)
         {
             var definedTypes = namespaceTypes.Values
-                .Select(type => type.ResourceTypeProvider.TryGetDefinedType(reference, flags))
+                .Select(type => type.ResourceTypeProvider.TryGetDefinedType(type, reference, flags))
                 .WhereNotNull();
 
             if (definedTypes.FirstOrDefault() is {} definedType)
@@ -105,7 +105,7 @@ namespace Bicep.Core.Semantics.Namespaces
             }
 
             var generatedTypes = namespaceTypes.Values
-                .Select(type => type.ResourceTypeProvider.TryGenerateDefaultType(reference, flags))
+                .Select(type => type.ResourceTypeProvider.TryGenerateDefaultType(type, reference, flags))
                 .WhereNotNull();
 
             // Here we are assuming that one of the namespaces will always return at least one result with TryGenerateDefaultType.

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeFactory.cs
@@ -17,11 +17,12 @@ namespace Bicep.Core.TypeSystem.Az
             typeCache = new();
         }
 
-        public ResourceType GetResourceType(Azure.Bicep.Types.Concrete.ResourceType resourceType)
+        public ResourceTypeComponents GetResourceType(Azure.Bicep.Types.Concrete.ResourceType resourceType)
         {
-            var output = GetTypeSymbol(resourceType, false) as ResourceType;
+            var resourceTypeReference = ResourceTypeReference.Parse(resourceType.Name);
+            var bodyType = GetTypeSymbol(resourceType.Body.Type, true);
 
-            return output ?? throw new ArgumentException("Unable to deserialize resource type", nameof(resourceType));
+            return new ResourceTypeComponents(resourceTypeReference, ToResourceScope(resourceType.ScopeType), bodyType);
         }
 
         private TypeSymbol GetTypeSymbol(Azure.Bicep.Types.Concrete.TypeBase serializedType, bool isResourceBodyType)
@@ -90,12 +91,6 @@ namespace Bicep.Core.TypeSystem.Az
                 case Azure.Bicep.Types.Concrete.ArrayType arrayType:
                 {
                     return new TypedArrayType(GetTypeReference(arrayType.ItemType), GetValidationFlags(isResourceBodyType));
-                }
-                case Azure.Bicep.Types.Concrete.ResourceType resourceType:
-                {
-                    var resourceTypeReference = ResourceTypeReference.Parse(resourceType.Name);
-                    var bodyType = GetTypeSymbol(resourceType.Body.Type, true);
-                    return new ResourceType(resourceTypeReference, ToResourceScope(resourceType.ScopeType), bodyType);
                 }
                 case Azure.Bicep.Types.Concrete.UnionType unionType:
                 {

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeLoader.cs
@@ -27,7 +27,7 @@ namespace Bicep.Core.TypeSystem.Az
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => availableTypes.Keys;
 
-        public ResourceType LoadType(ResourceTypeReference reference)
+        public ResourceTypeComponents LoadType(ResourceTypeReference reference)
         {
             var typeLocation = availableTypes[reference];
 

--- a/src/Bicep.Core/TypeSystem/Az/IAzResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Az/IAzResourceTypeLoader.cs
@@ -7,7 +7,7 @@ namespace Bicep.Core.TypeSystem.Az
 {
     public interface IAzResourceTypeLoader
     {
-        ResourceType LoadType(ResourceTypeReference reference);
+        ResourceTypeComponents LoadType(ResourceTypeReference reference);
 
         IEnumerable<ResourceTypeReference> GetAvailableTypes();
     }

--- a/src/Bicep.Core/TypeSystem/EmptyResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/EmptyResourceTypeProvider.cs
@@ -12,10 +12,10 @@ namespace Bicep.Core.TypeSystem
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => Enumerable.Empty<ResourceTypeReference>();
 
-        public ResourceType? TryGetDefinedType(ResourceTypeReference reference, ResourceTypeGenerationFlags flags)
+        public ResourceType? TryGetDefinedType(NamespaceType declaringNamespace, ResourceTypeReference reference, ResourceTypeGenerationFlags flags)
             => null;
 
-        public ResourceType? TryGenerateDefaultType(ResourceTypeReference reference, ResourceTypeGenerationFlags flags)
+        public ResourceType? TryGenerateDefaultType(NamespaceType declaringNamespace, ResourceTypeReference reference, ResourceTypeGenerationFlags flags)
             => null;
 
         public bool HasDefinedType(ResourceTypeReference typeReference)

--- a/src/Bicep.Core/TypeSystem/IResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/IResourceTypeProvider.cs
@@ -10,12 +10,12 @@ namespace Bicep.Core.TypeSystem
         /// <summary>
         /// Tries to get a resource type from the set of well known resource types. Returns null if none is available.
         /// </summary>
-        ResourceType? TryGetDefinedType(ResourceTypeReference reference, ResourceTypeGenerationFlags flags);
+        ResourceType? TryGetDefinedType(NamespaceType declaringNamespace, ResourceTypeReference reference, ResourceTypeGenerationFlags flags);
 
         /// <summary>
         /// Tries to generate a default resource type definition, if possible. Returns null if this is not possible.
         /// </summary>
-        ResourceType? TryGenerateDefaultType(ResourceTypeReference reference, ResourceTypeGenerationFlags flags);
+        ResourceType? TryGenerateDefaultType(NamespaceType declaringNamespace, ResourceTypeReference reference, ResourceTypeGenerationFlags flags);
 
         /// <summary>
         /// Checks whether the type exists in the set of well known resource types.

--- a/src/Bicep.Core/TypeSystem/ResourceType.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceType.cs
@@ -4,11 +4,17 @@ using Bicep.Core.Resources;
 
 namespace Bicep.Core.TypeSystem
 {
+    public record ResourceTypeComponents(
+        ResourceTypeReference TypeReference,
+        ResourceScope ValidParentScopes,
+        ITypeReference Body);
+
     public class ResourceType : TypeSymbol, IScopeReference
     {
-        public ResourceType(ResourceTypeReference typeReference, ResourceScope validParentScopes, ITypeReference body)
+        public ResourceType(NamespaceType declaringNamespace, ResourceTypeReference typeReference, ResourceScope validParentScopes, ITypeReference body)
             : base(typeReference.FormatName())
         {
+            DeclaringNamespace = declaringNamespace;
             TypeReference = typeReference;
             ValidParentScopes = validParentScopes;
             Body = body;
@@ -16,6 +22,7 @@ namespace Bicep.Core.TypeSystem
 
         public override TypeKind TypeKind => TypeKind.Resource;
 
+        public NamespaceType DeclaringNamespace { get; }
         public ResourceTypeReference TypeReference { get; }
 
         /// <summary>

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -214,7 +214,7 @@ namespace Bicep.Core.TypeSystem
                     {
                         var narrowedBody = NarrowType(config, expression, targetResourceType.Body.Type);
 
-                        return new ResourceType(targetResourceType.TypeReference, targetResourceType.ValidParentScopes, narrowedBody);
+                        return new ResourceType(targetResourceType.DeclaringNamespace, targetResourceType.TypeReference, targetResourceType.ValidParentScopes, narrowedBody);
                     }
                 case ModuleType targetModuleType:
                     {

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -21,6 +21,7 @@ namespace Bicep.LangServer.UnitTests.Snippets
     public class SnippetsProviderTests
     {
         private readonly SnippetsProvider snippetsProvider = new(BicepTestConstants.NamespaceProvider, BicepTestConstants.FileResolver, BicepTestConstants.ConfigurationManager);
+        private readonly NamespaceType azNamespaceType = BicepTestConstants.NamespaceProvider.TryGetNamespace("az", "az", ResourceScope.ResourceGroup)!;
 
         [TestMethod]
         public void GetDescriptionAndText_WithEmptyInput_ReturnsEmptyDescriptionAndText()
@@ -140,6 +141,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
         public void GetResourceBodyCompletionSnippets_WithStaticTemplateAndNoResourceDependencies_ShouldReturnSnippets()
         {
             ResourceType resourceType = new ResourceType(
+                azNamespaceType,
                 ResourceTypeReference.Parse("Microsoft.DataLakeStore/accounts@2016-11-01"),
                 ResourceScope.ResourceGroup,
                 CreateObjectType("Microsoft.DataLakeStore/accounts@2016-11-01",
@@ -187,6 +189,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
         public void GetResourceBodyCompletionSnippets_WithStaticTemplateAndResourceDependencies_ShouldReturnSnippets()
         {
             ResourceType resourceType = new ResourceType(
+                azNamespaceType,
                 ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/modules@2015-10-31"),
                 ResourceScope.ResourceGroup,
                 CreateObjectType("Microsoft.Automation/automationAccounts/modules@2015-10-31",
@@ -238,6 +241,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         public void GetResourceBodyCompletionSnippets_WithNestedResource_ShouldReturnSnippets()
         {
             ResourceType resourceType = new ResourceType(
+                azNamespaceType,
                 ResourceTypeReference.Parse("Microsoft.Automation/automationAccounts/certificates@2019-06-01"),
                 ResourceScope.ResourceGroup,
                 CreateObjectType("Microsoft.Automation/automationAccounts/certificates@2019-06-01",
@@ -285,6 +289,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         public void GetResourceBodyCompletionSnippets_WithNoStaticTemplate_ShouldReturnSnippets()
         {
             ResourceType resourceType = new ResourceType(
+                azNamespaceType,
                 ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
                 ResourceScope.ResourceGroup,
                 CreateObjectType("microsoft.aadiam/azureADMetrics@2020-07-01-preview",
@@ -336,6 +341,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         public void GetResourceBodyCompletionSnippets_WithNoRequiredProperties_ShouldReturnEmptySnippet()
         {
             ResourceType resourceType = new ResourceType(
+                azNamespaceType,
                 ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
                 ResourceScope.ResourceGroup,
                 CreateObjectType("microsoft.aadiam/azureADMetrics@2020-07-01-preview"));
@@ -430,6 +436,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
             var discriminatedObjectType = new DiscriminatedObjectType("discObj", TypeSymbolValidationFlags.Default, "discKey", new[] { objectTypeA, objectTypeB });
 
             ResourceType resourceType = new ResourceType(
+                azNamespaceType,
                 ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
                 ResourceScope.ResourceGroup,
                 discriminatedObjectType);
@@ -468,6 +475,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
             var discriminatedObjectType = new DiscriminatedObjectType("discObj", TypeSymbolValidationFlags.Default, "discKey", new[] { objectTypeA, objectTypeB });
 
             ResourceType resourceType = new ResourceType(
+                azNamespaceType,
                 ResourceTypeReference.Parse("microsoft.aadiam/azureADMetrics@2020-07-01-preview"),
                 ResourceScope.ResourceGroup,
                 discriminatedObjectType);


### PR DESCRIPTION
This refactor attaches namespace information to `ResourceType` classes, so that it's possible to determine which namespace generated a particular resource type. Certain classes (such as `AzResourceTypeProvider`) require the ability to cache resource type internally, so I've introduced a `ResourceTypeComponents` record to store this information mins the namespace (to avoid invalidating the cache every time a namespacetype is reconstructed).