### PR TITLE
Removed the `BICEP_REGISTRY_ENABLED_EXPERIMENTAL` environment variable

### DIFF
--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -12,8 +12,7 @@ namespace Bicep.Core.Features
         private Lazy<string> cacheRootDirectoryLazy = new(() => GetCacheRootDirectory(Environment.GetEnvironmentVariable("BICEP_CACHE_DIRECTORY")), LazyThreadSafetyMode.PublicationOnly);
         public string CacheRootDirectory => cacheRootDirectoryLazy.Value;
 
-        private Lazy<bool> registryEnabledLazy = new(() => ReadBooleanEnvVar("BICEP_REGISTRY_ENABLED_EXPERIMENTAL", defaultValue: false), LazyThreadSafetyMode.PublicationOnly);
-        public bool RegistryEnabled => registryEnabledLazy.Value;
+        public bool RegistryEnabled => true;
 
         private Lazy<bool> symbolicNameCodegenEnabledLazy = new(() => ReadBooleanEnvVar("BICEP_SYMBOLIC_NAME_CODEGEN_EXPERIMENTAL", defaultValue: false), LazyThreadSafetyMode.PublicationOnly);
         public bool SymbolicNameCodegenEnabled => symbolicNameCodegenEnabledLazy.Value;


### PR DESCRIPTION
Removed the `BICEP_REGISTRY_ENABLED_EXPERIMENTAL` environment variable and permanently enabled `ts` and `br` module registry support.

I did not remove the property from `IFeatureProvider` because it requires a refactoring of our tests. It turns out that many of our tests do not provide all the dependencies that an enabled registry requires (mainly the module cache root path).

This fixes #4763.