### PR TITLE
Remove non-working pipeline config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Update Baselines"]
-    types:
-      - completed
 
 jobs:
   build-bicep:


### PR DESCRIPTION
I added this config to try and invoke build automatically after the "Update Baselines" pipeline completes, but it doesn't work. 