### PR TITLE
Add resource types in outputs and parameters

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -16,7 +16,9 @@ targetScopeDecl -> "targetScope" "=" expression
 
 importDecl -> decorator* "import" IDENTIFIER(providerName) "as" IDENTIFIER(aliasName) object? NL
 
-parameterDecl -> decorator* "parameter" IDENTIFIER(name) IDENTIFIER(type) parameterDefaultValue? NL
+parameterDecl -> 
+  decorator* "parameter" IDENTIFIER(name) IDENTIFIER(type) parameterDefaultValue? NL |
+  decorator* "parameter" IDENTIFIER(name) "resource" interpString(type) parameterDefaultValue? NL |
 parameterDefaultValue -> "=" expression
 
 variableDecl -> decorator* "variable" IDENTIFIER(name) "=" expression NL
@@ -25,8 +27,9 @@ resourceDecl -> decorator* "resource" IDENTIFIER(name) interpString(type) "exist
 
 moduleDecl -> decorator* "module" IDENTIFIER(name) interpString(type) "=" (ifCondition | object | forExpression) NL
 
-outputDecl -> decorator* "output" IDENTIFIER(name) IDENTIFIER(type) "=" expression NL
-
+outputDecl -> 
+  decorator* "output" IDENTIFIER(name) IDENTIFIER(type) "=" expression NL
+  decorator* "output" IDENTIFIER(name) "resource" interpString(type) "=" expression NL
 NL -> ("\n" | "\r")+
 
 decorator -> "@" decoratorExpression NL

--- a/src/Bicep.Cli.IntegrationTests/TestBase.cs
+++ b/src/Bicep.Cli.IntegrationTests/TestBase.cs
@@ -59,7 +59,7 @@ namespace Bicep.Cli.IntegrationTests
             var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver, clientFactory, templateSpecRepositoryFactory, BicepTestConstants.Features));
             var configuration = BicepTestConstants.BuiltInConfiguration;
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath), configuration);
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), sourceFileGrouping, configuration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), sourceFileGrouping, configuration, BicepTestConstants.LinterAnalyzer);
 
             var output = new List<string>();
             foreach (var (bicepFile, diagnostics) in compilation.GetAllDiagnosticsByBicepFile())

--- a/src/Bicep.Cli/CliResources.Designer.cs
+++ b/src/Bicep.Cli/CliResources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Bicep.Cli {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace Bicep.Cli {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CliResources {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal CliResources() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Bicep.Cli {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Bicep.Cli {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0}: Decompilation failed with fatal error &quot;{1}&quot;.
         /// </summary>
@@ -68,7 +68,7 @@ namespace Bicep.Cli {
                 return ResourceManager.GetString("DecompilationFailedFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to WARNING: Decompilation is a best-effort process, as there is no guaranteed mapping from ARM JSON to Bicep.
         ///You may need to fix warnings and errors in the generated bicep file(s), or decompilation may fail entirely if an accurate conversion is not possible.
@@ -79,7 +79,7 @@ namespace Bicep.Cli {
                 return ResourceManager.GetString("DecompilerDisclaimerMessage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The specified output directory &quot;{0}&quot; does not exist..
         /// </summary>
@@ -88,7 +88,7 @@ namespace Bicep.Cli {
                 return ResourceManager.GetString("DirectoryDoesNotExistFormat", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to WARNING: Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!.
         /// </summary>
@@ -97,7 +97,13 @@ namespace Bicep.Cli {
                 return ResourceManager.GetString("SymbolicNamesDisclaimerMessage", resourceCulture);
             }
         }
-        
+
+        internal static string ResourceTypesDisclaimerMessage {
+            get {
+                return ResourceManager.GetString("ResourceTypesDisclaimerMessage", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Unrecognized arguments &quot;{0}&quot; specified. Use &quot;{1} --help&quot; to view available options..
         /// </summary>

--- a/src/Bicep.Cli/CliResources.resx
+++ b/src/Bicep.Cli/CliResources.resx
@@ -125,6 +125,9 @@ If you would like to report any issues or inaccurate conversions, please see htt
   <data name="SymbolicNamesDisclaimerMessage" xml:space="preserve">
     <value>WARNING: Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!</value>
   </data>
+  <data name="ResourceTypesDisclaimerMessage" xml:space="preserve">
+    <value>WARNING: Resource-typed parameters and outputs in ARM are experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!</value>
+  </data>
   <data name="DecompilationFailedFormat" xml:space="preserve">
     <value>{0}: Decompilation failed with fatal error "{1}"</value>
     <comment>{0} json path      {1} message string</comment>

--- a/src/Bicep.Cli/Commands/BuildCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildCommand.cs
@@ -41,6 +41,11 @@ namespace Bicep.Cli.Commands
                 logger.LogWarning(CliResources.SymbolicNamesDisclaimerMessage);
             }
 
+            if (invocationContext.Features.ResourceTypedParamsAndOutputsEnabled)
+            {
+                logger.LogWarning(CliResources.ResourceTypesDisclaimerMessage);
+            }
+
             var compilation = await compilationService.CompileAsync(inputPath, args.NoRestore);
 
             if (diagnosticLogger.ErrorCount < 1)

--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -82,7 +82,7 @@ namespace Bicep.Cli.Services
                 }
             }
 
-            var compilation = new Compilation(this.invocationContext.NamespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
+            var compilation = new Compilation(this.invocationContext.Features, this.invocationContext.NamespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
             LogDiagnostics(compilation);
 
             return compilation;

--- a/src/Bicep.Core.IntegrationTests/DecoratorTests.cs
+++ b/src/Bicep.Core.IntegrationTests/DecoratorTests.cs
@@ -81,7 +81,7 @@ param inputb string
 ",
             };
 
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.FileUri, kvp => kvp.Value);
             var success = diagnosticsByFile.Values.SelectMany(x => x).All(d => d.Level != DiagnosticLevel.Error);
 
@@ -161,7 +161,7 @@ param inputb string
 ",
             };
 
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.FileUri, kvp => kvp.Value);
             var success = diagnosticsByFile.Values.SelectMany(x => x).All(d => d.Level != DiagnosticLevel.Error);
 

--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -220,7 +220,7 @@ this
 
         private EmitResult EmitTemplate(SourceFileGrouping sourceFileGrouping, EmitterSettings emitterSettings, string filePath)
         {
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), sourceFileGrouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), sourceFileGrouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), emitterSettings);
 
             using var stream = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
@@ -229,7 +229,7 @@ this
 
         private EmitResult EmitTemplate(SourceFileGrouping sourceFileGrouping, EmitterSettings emitterSettings, MemoryStream memoryStream)
         {
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), sourceFileGrouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), sourceFileGrouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), emitterSettings);
 
             TextWriter tw = new StreamWriter(memoryStream);

--- a/src/Bicep.Core.IntegrationTests/OutputsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/OutputsTests.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Diagnostics.CodeAnalysis;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Features;
+using Bicep.Core.IntegrationTests.Extensibility;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.IntegrationTests
+{
+    [TestClass]
+    public class OutputsTests
+    {
+        private IFeatureProvider ResourceTypedFeatures => BicepTestConstants.CreateFeaturesProvider(TestContext, resourceTypedParamsAndOutputsEnabled: true);
+
+        private CompilationHelper.CompilationHelperContext ResourceTypedFeatureContext => new CompilationHelper.CompilationHelperContext(Features: ResourceTypedFeatures);
+
+
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        private CompilationHelper.CompilationHelperContext GetExtensibilityCompilationContext()
+        {
+            var features = BicepTestConstants.CreateFeaturesProvider(TestContext, importsEnabled: true, resourceTypedParamsAndOutputsEnabled: true);
+            var resourceTypeLoader = BicepTestConstants.AzResourceTypeLoader;
+            var namespaceProvider = new ExtensibilityNamespaceProvider(resourceTypeLoader, features);
+
+            return new(
+                AzResourceTypeLoader: resourceTypeLoader,
+                Features: features,
+                NamespaceProvider: namespaceProvider);
+        }
+
+        [TestMethod]
+        public void Output_can_have_inferred_resource_type()
+        {
+            var result = CompilationHelper.Compile(ResourceTypedFeatureContext, @"
+resource resource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'test'
+  location: 'eastus'
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties:{
+    accessTier: 'Cool'
+  }
+}
+output out resource = resource
+");
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+            var model = result.Compilation.GetEntrypointSemanticModel();
+            var @out = model.Root.OutputDeclarations.Should().ContainSingle().Subject;
+            var typeInfo = model.GetTypeInfo(@out.DeclaringSyntax);
+            typeInfo.Should().BeOfType<ResourceType>().Which.TypeReference.FormatName().Should().BeEquivalentTo("Microsoft.Storage/storageAccounts@2019-06-01");
+
+            result.Template.Should().HaveValueAtPath("$.outputs.out", new JObject()
+            {
+                ["type"] = "string",
+                ["value"] = "[resourceId('Microsoft.Storage/storageAccounts', 'test')]",
+                ["metadata"] = new JObject()
+                {
+                    ["resourceType"] = new JValue("Microsoft.Storage/storageAccounts@2019-06-01"),
+                },
+            });
+        }
+
+        [TestMethod]
+        public void Output_can_have_specified_resource_type()
+        {
+            var result = CompilationHelper.Compile(ResourceTypedFeatureContext, @"
+resource resource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'test'
+  location: 'eastus'
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties:{
+    accessTier: 'Cool'
+  }
+}
+output out resource 'Microsoft.Storage/storageAccounts@2019-06-01' = resource
+");
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+            var model = result.Compilation.GetEntrypointSemanticModel();
+            var @out = model.Root.OutputDeclarations.Should().ContainSingle().Subject;
+            var typeInfo = model.GetTypeInfo(@out.DeclaringSyntax);
+            typeInfo.Should().BeOfType<ResourceType>().Which.TypeReference.FormatName().Should().BeEquivalentTo("Microsoft.Storage/storageAccounts@2019-06-01");
+
+            result.Template.Should().HaveValueAtPath("$.outputs.out", new JObject()
+            {
+                ["type"] = "string",
+                ["value"] = "[resourceId('Microsoft.Storage/storageAccounts', 'test')]",
+                ["metadata"] = new JObject()
+                {
+                    ["resourceType"] = new JValue("Microsoft.Storage/storageAccounts@2019-06-01"),
+                },
+            });
+        }
+
+        [TestMethod]
+        public void Output_can_have_decorators()
+        {
+            var result = CompilationHelper.Compile(ResourceTypedFeatureContext, @"
+resource resource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'test'
+  location: 'eastus'
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties:{
+    accessTier: 'Cool'
+  }
+}
+
+@description('cool beans')
+output out resource 'Microsoft.Storage/storageAccounts@2019-06-01' = resource
+");
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+            result.Template.Should().HaveValueAtPath("$.outputs.out", new JObject()
+            {
+                ["type"] = "string",
+                ["value"] = "[resourceId('Microsoft.Storage/storageAccounts', 'test')]",
+                ["metadata"] = new JObject()
+                {
+                    ["resourceType"] = new JValue("Microsoft.Storage/storageAccounts@2019-06-01"),
+                    ["description"] = new JValue("cool beans"),
+                },
+            });
+        }
+
+        [TestMethod]
+        public void Output_can_have_warnings_for_missing_type()
+        {
+            var result = CompilationHelper.Compile(ResourceTypedFeatureContext, @"
+resource resource 'Some.Fake/Type@2019-06-01' = {
+  name: 'test'
+}
+output out resource 'Some.Fake/Type@2019-06-01' = resource
+");
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new []
+            {
+                // There are two warnings because there are two places in code to correct the missing type.
+                ("BCP081", DiagnosticLevel.Warning, "Resource type \"Some.Fake/Type@2019-06-01\" does not have types available."),
+                ("BCP081", DiagnosticLevel.Warning, "Resource type \"Some.Fake/Type@2019-06-01\" does not have types available."),
+            });
+        }
+
+        [TestMethod]
+        public void Output_can_have_warnings_for_missing_type_but_we_dont_duplicate_them_when_type_is_inferred()
+        {
+            // As a special case we don't show a warning on the output when the type is inferred
+            // the user only has one location in code to correct.
+            var result = CompilationHelper.Compile(ResourceTypedFeatureContext, @"
+resource resource 'Some.Fake/Type@2019-06-01' = {
+  name: 'test'
+}
+output out resource = resource
+");
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new []
+            {
+                ("BCP081", DiagnosticLevel.Warning, "Resource type \"Some.Fake/Type@2019-06-01\" does not have types available."),
+            });
+        }
+
+        [TestMethod]
+        public void Output_cannot_use_extensibility_resource_type()
+        {
+            var result = CompilationHelper.Compile(GetExtensibilityCompilationContext(), @"
+import storage as stg {
+  connectionString: 'asdf'
+}
+
+resource container 'stg:container' = {
+  name: 'myblob'
+}
+output out resource = container
+");
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new []
+            {
+                ("BCP228", DiagnosticLevel.Error, "The type \"container\" cannot be used as an output type. Extensibility types are currently not supported as parameters or outputs."),
+            });
+        }
+    }
+}

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Features;
+using Bicep.Core.IntegrationTests.Extensibility;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.IntegrationTests
+{
+    [TestClass]
+    public class ParameterTests
+    {
+        private IFeatureProvider ResourceTypedFeatures => BicepTestConstants.CreateFeaturesProvider(TestContext, resourceTypedParamsAndOutputsEnabled: true);
+
+        private CompilationHelper.CompilationHelperContext ResourceTypedFeatureContext => new CompilationHelper.CompilationHelperContext(Features: ResourceTypedFeatures);
+
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        private CompilationHelper.CompilationHelperContext GetExtensibilityCompilationContext()
+        {
+            var features = BicepTestConstants.CreateFeaturesProvider(TestContext, importsEnabled: true, resourceTypedParamsAndOutputsEnabled: true);
+            var resourceTypeLoader = BicepTestConstants.AzResourceTypeLoader;
+            var namespaceProvider = new ExtensibilityNamespaceProvider(resourceTypeLoader, features);
+
+            return new(
+                AzResourceTypeLoader: resourceTypeLoader,
+                Features: features,
+                NamespaceProvider: namespaceProvider);
+        }
+
+        [TestMethod]
+        public void Parameter_can_have_resource_type()
+        {
+            var result = CompilationHelper.Compile(
+                ResourceTypedFeatureContext, @"
+param p resource 'Microsoft.Storage/storageAccounts@2019-06-01'
+
+resource resource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'test'
+  location: 'eastus'
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties:{
+    accessTier: p.properties.accessTier
+  }
+}
+");
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+            var model = result.Compilation.GetEntrypointSemanticModel();
+            var parameterSymbol = model.Root.ParameterDeclarations.Should().ContainSingle().Subject;
+            var typeInfo = model.GetTypeInfo(parameterSymbol.DeclaringSyntax);
+            typeInfo.Should().BeOfType<ResourceType>().Which.TypeReference.FormatName().Should().BeEquivalentTo("Microsoft.Storage/storageAccounts@2019-06-01");
+
+            var reference = model.FindReferences(parameterSymbol).OfType<VariableAccessSyntax>().Should().ContainSingle().Subject;
+            model.GetDeclaredType(reference).Should().NotBeNull();
+            model.GetTypeInfo(reference).Should().NotBeNull();
+
+            result.Template.Should().HaveValueAtPath("$.resources[0].properties.accessTier", "[reference(parameters('p'), '2019-06-01').accessTier]");
+            result.Template.Should().HaveValueAtPath("$.parameters.p", new JObject()
+            {
+                ["type"] = new JValue("string"),
+                ["metadata"] = new JObject()
+                {
+                    ["resourceType"] = new JValue("Microsoft.Storage/storageAccounts@2019-06-01"),
+                },
+            });
+        }
+
+        [TestMethod]
+        public void Parameter_with_resource_type_can_have_decorators()
+        {
+            var result = CompilationHelper.Compile(
+                ResourceTypedFeatureContext, @"
+@description('cool')
+param p resource 'Microsoft.Storage/storageAccounts@2019-06-01'
+
+resource resource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'test'
+  location: 'eastus'
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties:{
+    accessTier: p.properties.accessTier
+  }
+}
+");
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+            result.Template.Should().HaveValueAtPath("$.parameters.p", new JObject()
+            {
+                ["type"] = new JValue("string"),
+                ["metadata"] = new JObject()
+                {
+                    ["resourceType"] = new JValue("Microsoft.Storage/storageAccounts@2019-06-01"),
+                    ["description"] = new JValue("cool"),
+                },
+            });
+        }
+
+        [TestMethod]
+        public void Parameter_with_resource_type_can_have_properties_evaluated()
+        {
+            var result = CompilationHelper.Compile(
+                ResourceTypedFeatureContext, @"
+param p resource 'Microsoft.Storage/storageAccounts@2019-06-01'
+
+output id string = p.id
+output name string = p.name
+output type string = p.type
+output apiVersion string = p.apiVersion
+output accessTier string = p.properties.accessTier
+");
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+            result.Template.Should().HaveValueAtPath("$.outputs.id", new JObject()
+            {
+                ["type"] = new JValue("string"),
+                ["value"] = new JValue("[parameters('p')]"),
+            });
+            result.Template.Should().HaveValueAtPath("$.outputs.name", new JObject()
+            {
+                ["type"] = new JValue("string"),
+                ["value"] = new JValue("[last(split(parameters('p'), '/'))]"),
+            });
+            result.Template.Should().HaveValueAtPath("$.outputs.type", new JObject()
+            {
+                ["type"] = new JValue("string"),
+                ["value"] = new JValue("Microsoft.Storage/storageAccounts"),
+            });
+            result.Template.Should().HaveValueAtPath("$.outputs.apiVersion", new JObject()
+            {
+                ["type"] = new JValue("string"),
+                ["value"] = new JValue("2019-06-01"),
+            });
+            result.Template.Should().HaveValueAtPath("$.outputs.accessTier", new JObject()
+            {
+                ["type"] = new JValue("string"),
+                ["value"] = new JValue("[reference(parameters('p'), '2019-06-01').accessTier]"),
+            });
+        }
+
+        [TestMethod]
+        public void Parameter_can_have_warnings_for_missing_type()
+        {
+            var result = CompilationHelper.Compile(
+                ResourceTypedFeatureContext, @"
+param p resource 'Some.Fake/Type@2019-06-01'
+
+output id string = p.id
+");
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new []
+            {
+                ("BCP081", DiagnosticLevel.Warning, "Resource type \"Some.Fake/Type@2019-06-01\" does not have types available."),
+            });
+        }
+
+        [TestMethod]
+        public void Parameter_cannot_use_extensibility_resource_type()
+        {
+            var result = CompilationHelper.Compile(GetExtensibilityCompilationContext(), @"
+import storage as stg {
+  connectionString: 'asdf'
+}
+
+param container resource 'stg:container'
+output name string = container.name // silence unused params warning
+");
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new []
+            {
+                ("BCP227", DiagnosticLevel.Error, "The type \"container\" cannot be used as a parameter type. Extensibility types are currently not supported as parameters or outputs."),
+                ("BCP062", DiagnosticLevel.Error, "The referenced declaration with name \"container\" is not valid."),
+            });
+        }
+
+        [TestMethod]
+        public void Parameter_with_resource_type_cannot_be_used_as_extension_scope()
+        {
+            var result = CompilationHelper.Compile(ResourceTypedFeatureContext, @"
+param p resource 'Microsoft.Storage/storageAccounts@2019-06-01'
+
+resource resource 'My.Rp/myResource@2020-01-01' = {
+  scope: p
+  name: 'resource'
+}");
+
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new []
+            {
+                ("BCP081", DiagnosticLevel.Warning, "Resource type \"My.Rp/myResource@2020-01-01\" does not have types available."),
+                ("BCP229", DiagnosticLevel.Error, "The parameter \"p\" cannot be used as a resource scope or parent. Resources passed as parameters cannot be used as a scope or parent of a resource."),
+            });
+        }
+
+        [TestMethod]
+        public void Parameter_with_resource_type_cannot_be_used_as_parent()
+        {
+            var result = CompilationHelper.Compile(ResourceTypedFeatureContext, @"
+param p resource 'Microsoft.Storage/storageAccounts@2019-06-01'
+
+resource resource 'Microsoft.Storage/storageAccounts/tableServices@2020-06-01' = {
+  parent: p
+  name: 'child1'
+  properties: {
+    cors: {
+      corsRules: []
+    }
+  }
+}");
+
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new []
+            {
+                ("BCP081", DiagnosticLevel.Warning, "Resource type \"Microsoft.Storage/storageAccounts/tableServices@2020-06-01\" does not have types available."),
+                ("BCP229", DiagnosticLevel.Error, "The parameter \"p\" cannot be used as a resource scope or parent. Resources passed as parameters cannot be used as a scope or parent of a resource."),
+                ("BCP169", DiagnosticLevel.Error, "Expected resource name to contain 1 \"/\" character(s). The number of name segments must match the number of segments in the resource type."),
+            });
+        }
+    }
+}

--- a/src/Bicep.Core.IntegrationTests/RegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/RegistryTests.cs
@@ -67,7 +67,7 @@ namespace Bicep.Core.IntegrationTests
                 sourceFileGrouping = SourceFileGroupingBuilder.Rebuild(dispatcher, workspace, sourceFileGrouping, configuration);
             }
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, sourceFileGrouping, configuration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, sourceFileGrouping, configuration, BicepTestConstants.LinterAnalyzer);
             var diagnostics = compilation.GetAllDiagnosticsByBicepFile();
             diagnostics.Should().HaveCount(1);
 

--- a/src/Bicep.Core.IntegrationTests/Scenarios/FallbackTopLevelResourcePropertiesTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/FallbackTopLevelResourcePropertiesTests.cs
@@ -26,6 +26,7 @@ namespace Bicep.Core.IntegrationTests.Scenarios
         private static readonly LinterAnalyzer LinterAnalyzer = new LinterAnalyzer(Configuration);
 
         private static Compilation CreateCompilation(string program) => new(
+            BicepTestConstants.Features,
             BuiltInTestTypes.Create(),
             SourceFileGroupingFactory.CreateFromText(program, new Mock<IFileResolver>(MockBehavior.Strict).Object),
             Configuration,
@@ -78,7 +79,7 @@ resource fallbackProperty 'Test.Rp/readWriteTests@2020-01-01' = {
 resource fallbackProperty 'Test.Rp/readWriteTests@2020-01-01' = {
   name: 'fallbackProperty'
   properties: {
-    required: 'required'  
+    required: 'required'
   " + $"{property}: {value}" + @"
   }
 }
@@ -96,7 +97,7 @@ resource fallbackProperty 'Test.Rp/readWriteTests@2020-01-01' = {
             // Missing top-level properties - should be an error
             var compilation = CreateCompilation(@"
 var props = {
-  required: 'required'  
+  required: 'required'
   " + $"{property}: {value}" + @"
 }
 
@@ -120,7 +121,7 @@ resource fallbackProperty 'Test.Rp/readWriteTests@2020-01-01' = {
 resource fallbackProperty 'Test.Rp/readWriteTests@2020-01-01' = {
   name: 'fallbackProperty'
   properties: {
-    required: 'required'    
+    required: 'required'
   }
 }
 
@@ -182,7 +183,7 @@ output outputa string = '${inputa}-${inputb}'
 ",
             };
 
-            var compilation = new Compilation(BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, Configuration), Configuration, LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, Configuration), Configuration, LinterAnalyzer);
 
             compilation.Should().HaveDiagnostics(new[] {
                 ("BCP037", DiagnosticLevel.Error, $"The property \"{property}\" is not allowed on objects of type \"module\". Permissible properties include \"dependsOn\", \"scope\".")
@@ -223,7 +224,7 @@ output outputa string = '${inputa}-${inputb}'
 ",
             };
 
-            var compilation = new Compilation(BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, Configuration), Configuration, LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, Configuration), Configuration, LinterAnalyzer);
 
             compilation.Should().HaveDiagnostics(new[] {
                 ("BCP037", DiagnosticLevel.Error, $"The property \"{property}\" is not allowed on objects of type \"params\". Permissible properties include \"inputc\".")
@@ -266,7 +267,7 @@ output outputa string = '${inputa}-${inputb}'
 ",
             };
 
-            var compilation = new Compilation(BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, Configuration), Configuration, LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, Configuration), Configuration, LinterAnalyzer);
 
             compilation.Should().HaveDiagnostics(new[] {
                 ("BCP037", DiagnosticLevel.Error, $"The property \"{property}\" from source declaration \"inputs\" is not allowed on objects of type \"params\". Permissible properties include \"inputc\"."),
@@ -292,7 +293,7 @@ module modulea 'modulea.bicep' = {
   params: {
     inputa: inputa
     inputb: inputb
-  }  
+  }
 }
 
 var check = modulea." + property + @"
@@ -305,7 +306,7 @@ output outputa string = '${inputa}-${inputb}'
 ",
             };
 
-            var compilation = new Compilation(BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, Configuration), Configuration, LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, Configuration), Configuration, LinterAnalyzer);
 
             compilation.Should().HaveDiagnostics(new[] {
                 ("BCP053", DiagnosticLevel.Error, $"The type \"module\" does not contain property \"{property}\". Available properties include \"name\", \"outputs\".")

--- a/src/Bicep.Core.IntegrationTests/Semantics/CompilationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/CompilationTests.cs
@@ -18,7 +18,7 @@ namespace Bicep.Core.IntegrationTests.Semantics
         {
             var fileResolver = new FileResolver();
             var program = SourceFileGroupingFactory.CreateFromText(DataSets.Empty.Bicep, fileResolver);
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), program, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), program, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             compilation.SourceFileGrouping.Should().BeSameAs(program);
             compilation.GetEntrypointSemanticModel().Should().NotBeNull();

--- a/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
@@ -57,7 +57,7 @@ namespace Bicep.Core.IntegrationTests.Semantics
         [TestMethod]
         public void EndOfFileFollowingSpaceAfterParameterKeyWordShouldNotThrow()
         {
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText("parameter ", BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText("parameter ", BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             compilation.GetEntrypointSemanticModel().GetParseDiagnostics();
         }
 
@@ -187,7 +187,7 @@ resource test";
                 [uri] = bicepFileContents,
             };
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
             diagnostics.Count().Should().Be(2);
@@ -233,7 +233,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
                 [uri] = bicepFileContents,
             };
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             compilation.GetEntrypointSemanticModel().GetAllDiagnostics().Should().BeEmpty();
         }
@@ -252,7 +252,7 @@ param storageAccount string = 'testStorageAccount'";
                 [uri] = bicepFileContents,
             };
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             compilation.GetEntrypointSemanticModel().GetAllDiagnostics().Should().BeEmpty();
         }
@@ -272,7 +272,7 @@ param storageAccount string = 'testStorageAccount'";
                 [uri] = bicepFileContents,
             };
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             compilation.GetEntrypointSemanticModel().GetAllDiagnostics().Count().Should().Be(1);
         }

--- a/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
@@ -21,7 +21,7 @@ namespace Bicep.Core.IntegrationTests
         private static SemanticModel GetSemanticModelForTest(string programText, INamespaceProvider nsProvider)
         {
             var configuration = BicepTestConstants.BuiltInConfigurationWithAnalyzersDisabled;
-            var compilation = new Compilation(nsProvider, SourceFileGroupingFactory.CreateFromText(programText, BicepTestConstants.FileResolver), configuration, new LinterAnalyzer(configuration));
+            var compilation = new Compilation(BicepTestConstants.Features, nsProvider, SourceFileGroupingFactory.CreateFromText(programText, BicepTestConstants.FileResolver), configuration, new LinterAnalyzer(configuration));
 
             return compilation.GetEntrypointSemanticModel();
         }

--- a/src/Bicep.Core.Samples/DataSetsExtensions.cs
+++ b/src/Bicep.Core.Samples/DataSetsExtensions.cs
@@ -57,7 +57,7 @@ namespace Bicep.Core.Samples
                 sourceFileGrouping = SourceFileGroupingBuilder.Rebuild(dispatcher, workspace, sourceFileGrouping, configuration);
             }
 
-            return (new Compilation(namespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration)), outputDirectory, fileUri);
+            return (new Compilation(BicepTestConstants.Features, namespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration)), outputDirectory, fileUri);
         }
 
         public static IContainerRegistryClientFactory CreateMockRegistryClients(this DataSet dataSet, TestContext testContext, params (Uri registryUri, string repository)[] additionalClients)

--- a/src/Bicep.Core.Samples/ExamplesTests.cs
+++ b/src/Bicep.Core.Samples/ExamplesTests.cs
@@ -127,7 +127,7 @@ namespace Bicep.Core.Samples
             var dispatcher = new ModuleDispatcher(BicepTestConstants.RegistryProvider);
             var configuration = BicepTestConstants.BuiltInConfigurationWithAnalyzersDisabled;
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFileName), configuration);
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), BicepTestConstants.EmitterSettings);
 
             foreach (var (bicepFile, diagnostics) in compilation.GetAllDiagnosticsByBicepFile())
@@ -192,7 +192,7 @@ namespace Bicep.Core.Samples
             var dispatcher = new ModuleDispatcher(BicepTestConstants.RegistryProvider);
             var configuration = BicepTestConstants.BuiltInConfigurationWithAnalyzersDisabled;
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFileName), configuration);
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), BicepTestConstants.EmitterSettingsWithSymbolicNames);
 
             foreach (var (bicepFile, diagnostics) in compilation.GetAllDiagnosticsByBicepFile())
@@ -253,7 +253,7 @@ namespace Bicep.Core.Samples
             var dispatcher = new ModuleDispatcher(BicepTestConstants.RegistryProvider);
             var configuration = BicepTestConstants.BuiltInConfigurationWithAnalyzersDisabled;
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFileName), configuration);
-            var compilation = new Compilation(new DefaultNamespaceProvider(BicepTestConstants.AzResourceTypeLoader, features), sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
+            var compilation = new Compilation(BicepTestConstants.Features, new DefaultNamespaceProvider(BicepTestConstants.AzResourceTypeLoader, features), sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), new EmitterSettings(features));
 
             foreach (var (bicepFile, diagnostics) in compilation.GetAllDiagnosticsByBicepFile())

--- a/src/Bicep.Core.Samples/Files/AKS_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/AKS_LF/main.syntax.bicep
@@ -5,7 +5,7 @@ param dnsPrefix string
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |dnsPrefix|
-//@[16:22)  TypeSyntax
+//@[16:22)  SimpleTypeSyntax
 //@[16:22)   Identifier |string|
 //@[22:23) NewLine |\n|
 param linuxAdminUsername string
@@ -13,7 +13,7 @@ param linuxAdminUsername string
 //@[0:5)  Identifier |param|
 //@[6:24)  IdentifierSyntax
 //@[6:24)   Identifier |linuxAdminUsername|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |string|
 //@[31:32) NewLine |\n|
 param sshRSAPublicKey string
@@ -21,7 +21,7 @@ param sshRSAPublicKey string
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |sshRSAPublicKey|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[28:30) NewLine |\n\n|
 
@@ -39,7 +39,7 @@ param servcePrincipalClientId string
 //@[0:5)  Identifier |param|
 //@[6:29)  IdentifierSyntax
 //@[6:29)   Identifier |servcePrincipalClientId|
-//@[30:36)  TypeSyntax
+//@[30:36)  SimpleTypeSyntax
 //@[30:36)   Identifier |string|
 //@[36:38) NewLine |\n\n|
 
@@ -57,7 +57,7 @@ param servicePrincipalClientSecret string
 //@[0:5)  Identifier |param|
 //@[6:34)  IdentifierSyntax
 //@[6:34)   Identifier |servicePrincipalClientSecret|
-//@[35:41)  TypeSyntax
+//@[35:41)  SimpleTypeSyntax
 //@[35:41)   Identifier |string|
 //@[41:43) NewLine |\n\n|
 
@@ -68,7 +68,7 @@ param clusterName string = 'aks101cluster'
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |clusterName|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |string|
 //@[25:42)  ParameterDefaultValueSyntax
 //@[25:26)   Assignment |=|
@@ -80,7 +80,7 @@ param location string = resourceGroup().location
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |location|
-//@[15:21)  TypeSyntax
+//@[15:21)  SimpleTypeSyntax
 //@[15:21)   Identifier |string|
 //@[22:48)  ParameterDefaultValueSyntax
 //@[22:23)   Assignment |=|
@@ -124,7 +124,7 @@ param osDiskSizeGB int = 0
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |osDiskSizeGB|
-//@[19:22)  TypeSyntax
+//@[19:22)  SimpleTypeSyntax
 //@[19:22)   Identifier |int|
 //@[23:26)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -161,7 +161,7 @@ param agentCount int = 3
 //@[0:5)  Identifier |param|
 //@[6:16)  IdentifierSyntax
 //@[6:16)   Identifier |agentCount|
-//@[17:20)  TypeSyntax
+//@[17:20)  SimpleTypeSyntax
 //@[17:20)   Identifier |int|
 //@[21:24)  ParameterDefaultValueSyntax
 //@[21:22)   Assignment |=|
@@ -174,7 +174,7 @@ param agentVMSize string = 'Standard_DS2_v2'
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |agentVMSize|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |string|
 //@[25:44)  ParameterDefaultValueSyntax
 //@[25:26)   Assignment |=|

--- a/src/Bicep.Core.Samples/Files/Dependencies_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Dependencies_LF/main.syntax.bicep
@@ -3,7 +3,7 @@ param deployTimeParam string = 'steve'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |deployTimeParam|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:38)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -142,7 +142,7 @@ output resourceAType string = resA.type
 //@[0:6)  Identifier |output|
 //@[7:20)  IdentifierSyntax
 //@[7:20)   Identifier |resourceAType|
-//@[21:27)  TypeSyntax
+//@[21:27)  SimpleTypeSyntax
 //@[21:27)   Identifier |string|
 //@[28:29)  Assignment |=|
 //@[30:39)  PropertyAccessSyntax
@@ -209,7 +209,7 @@ output resourceBId string = resB.id
 //@[0:6)  Identifier |output|
 //@[7:18)  IdentifierSyntax
 //@[7:18)   Identifier |resourceBId|
-//@[19:25)  TypeSyntax
+//@[19:25)  SimpleTypeSyntax
 //@[19:25)   Identifier |string|
 //@[26:27)  Assignment |=|
 //@[28:35)  PropertyAccessSyntax
@@ -439,7 +439,7 @@ output resourceCProperties object = resC.properties
 //@[0:6)  Identifier |output|
 //@[7:26)  IdentifierSyntax
 //@[7:26)   Identifier |resourceCProperties|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |object|
 //@[34:35)  Assignment |=|
 //@[36:51)  PropertyAccessSyntax

--- a/src/Bicep.Core.Samples/Files/DisableNextLineDiagnosticsDirective_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/DisableNextLineDiagnosticsDirective_CRLF/main.syntax.bicep
@@ -112,7 +112,7 @@ param storageAccount1 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount1|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -126,7 +126,7 @@ param storageAccount2 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount2|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -140,7 +140,7 @@ param storageAccount3 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount3|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -154,7 +154,7 @@ param storageAccount5 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount5|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|

--- a/src/Bicep.Core.Samples/Files/InvalidDisableNextLineDiagnosticsDirective_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidDisableNextLineDiagnosticsDirective_CRLF/main.syntax.bicep
@@ -5,7 +5,7 @@ param storageAccount1 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount1|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -32,7 +32,7 @@ param storageAccount2 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount2|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -59,7 +59,7 @@ param storageAccount3 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount3|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -81,7 +81,7 @@ param storageAccount4 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount4|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -96,7 +96,7 @@ param storageAccount5 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount5|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -119,7 +119,7 @@ param storageAccount6 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount6|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -139,7 +139,7 @@ param storageAccount7 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount7|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -173,7 +173,7 @@ param storageAccount8 string = 'testStorageAccount'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |storageAccount8|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:51)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
@@ -1143,7 +1143,7 @@ param funcvarparam bool = concat
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |funcvarparam|
-//@[19:23)  TypeSyntax
+//@[19:23)  SimpleTypeSyntax
 //@[19:23)   Identifier |bool|
 //@[24:32)  ParameterDefaultValueSyntax
 //@[24:25)   Assignment |=|
@@ -1156,7 +1156,7 @@ output funcvarout array = padLeft
 //@[0:6)  Identifier |output|
 //@[7:17)  IdentifierSyntax
 //@[7:17)   Identifier |funcvarout|
-//@[18:23)  TypeSyntax
+//@[18:23)  SimpleTypeSyntax
 //@[18:23)   Identifier |array|
 //@[24:25)  Assignment |=|
 //@[26:33)  VariableAccessSyntax
@@ -1197,7 +1197,7 @@ param fakeFuncP string = blue()
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |fakeFuncP|
-//@[16:22)  TypeSyntax
+//@[16:22)  SimpleTypeSyntax
 //@[16:22)   Identifier |string|
 //@[23:31)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
@@ -3172,7 +3172,7 @@ output directRefToCollectionViaOutput array = nonexistentArrays
 //@[0:6)  Identifier |output|
 //@[7:37)  IdentifierSyntax
 //@[7:37)   Identifier |directRefToCollectionViaOutput|
-//@[38:43)  TypeSyntax
+//@[38:43)  SimpleTypeSyntax
 //@[38:43)   Identifier |array|
 //@[44:45)  Assignment |=|
 //@[46:63)  VariableAccessSyntax

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.syntax.bicep
@@ -48,7 +48,7 @@ output missingValue string =
 //@[0:6)  Identifier |output|
 //@[7:19)  IdentifierSyntax
 //@[7:19)   Identifier |missingValue|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[27:28)  Assignment |=|
 //@[29:29)  SkippedTriviaSyntax
@@ -61,7 +61,7 @@ output arrayCompletions array =
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |arrayCompletions|
-//@[24:29)  TypeSyntax
+//@[24:29)  SimpleTypeSyntax
 //@[24:29)   Identifier |array|
 //@[30:31)  Assignment |=|
 //@[32:32)  SkippedTriviaSyntax
@@ -74,7 +74,7 @@ output objectCompletions object =
 //@[0:6)  Identifier |output|
 //@[7:24)  IdentifierSyntax
 //@[7:24)   Identifier |objectCompletions|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |object|
 //@[32:33)  Assignment |=|
 //@[34:34)  SkippedTriviaSyntax
@@ -87,7 +87,7 @@ output boolCompletions bool =
 //@[0:6)  Identifier |output|
 //@[7:22)  IdentifierSyntax
 //@[7:22)   Identifier |boolCompletions|
-//@[23:27)  TypeSyntax
+//@[23:27)  SimpleTypeSyntax
 //@[23:27)   Identifier |bool|
 //@[28:29)  Assignment |=|
 //@[30:30)  SkippedTriviaSyntax
@@ -134,7 +134,7 @@ output partialType obj
 //@[0:6)  Identifier |output|
 //@[7:18)  IdentifierSyntax
 //@[7:18)   Identifier |partialType|
-//@[19:22)  TypeSyntax
+//@[19:22)  SimpleTypeSyntax
 //@[19:22)   Identifier |obj|
 //@[22:22)  SkippedTriviaSyntax
 //@[22:22)  SkippedTriviaSyntax
@@ -219,7 +219,7 @@ output foo fluffy
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |foo|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |fluffy|
 //@[17:17)  SkippedTriviaSyntax
 //@[17:17)  SkippedTriviaSyntax
@@ -232,7 +232,7 @@ output foo string
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |foo|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[17:17)  SkippedTriviaSyntax
 //@[17:17)  SkippedTriviaSyntax
@@ -245,7 +245,7 @@ output foo string =
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |foo|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[18:19)  Assignment |=|
 //@[19:19)  SkippedTriviaSyntax
@@ -258,7 +258,7 @@ output str string = true
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |str|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[18:19)  Assignment |=|
 //@[20:24)  BooleanLiteralSyntax
@@ -269,7 +269,7 @@ output str string = false
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |str|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[18:19)  Assignment |=|
 //@[20:25)  BooleanLiteralSyntax
@@ -280,7 +280,7 @@ output str string = [
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |str|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[18:19)  Assignment |=|
 //@[20:24)  ArraySyntax
@@ -294,7 +294,7 @@ output str string = {
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |str|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[18:19)  Assignment |=|
 //@[20:24)  ObjectSyntax
@@ -308,7 +308,7 @@ output str string = 52
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |str|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[18:19)  Assignment |=|
 //@[20:22)  IntegerLiteralSyntax
@@ -322,7 +322,7 @@ output i int = true
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |i|
-//@[9:12)  TypeSyntax
+//@[9:12)  SimpleTypeSyntax
 //@[9:12)   Identifier |int|
 //@[13:14)  Assignment |=|
 //@[15:19)  BooleanLiteralSyntax
@@ -333,7 +333,7 @@ output i int = false
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |i|
-//@[9:12)  TypeSyntax
+//@[9:12)  SimpleTypeSyntax
 //@[9:12)   Identifier |int|
 //@[13:14)  Assignment |=|
 //@[15:20)  BooleanLiteralSyntax
@@ -344,7 +344,7 @@ output i int = [
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |i|
-//@[9:12)  TypeSyntax
+//@[9:12)  SimpleTypeSyntax
 //@[9:12)   Identifier |int|
 //@[13:14)  Assignment |=|
 //@[15:19)  ArraySyntax
@@ -358,7 +358,7 @@ output i int = }
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |i|
-//@[9:12)  TypeSyntax
+//@[9:12)  SimpleTypeSyntax
 //@[9:12)   Identifier |int|
 //@[13:14)  Assignment |=|
 //@[15:16)  SkippedTriviaSyntax
@@ -373,7 +373,7 @@ output i int = 'test'
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |i|
-//@[9:12)  TypeSyntax
+//@[9:12)  SimpleTypeSyntax
 //@[9:12)   Identifier |int|
 //@[13:14)  Assignment |=|
 //@[15:21)  StringSyntax
@@ -387,7 +387,7 @@ output b bool = [
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |b|
-//@[9:13)  TypeSyntax
+//@[9:13)  SimpleTypeSyntax
 //@[9:13)   Identifier |bool|
 //@[14:15)  Assignment |=|
 //@[16:20)  ArraySyntax
@@ -401,7 +401,7 @@ output b bool = {
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |b|
-//@[9:13)  TypeSyntax
+//@[9:13)  SimpleTypeSyntax
 //@[9:13)   Identifier |bool|
 //@[14:15)  Assignment |=|
 //@[16:20)  ObjectSyntax
@@ -415,7 +415,7 @@ output b bool = 32
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |b|
-//@[9:13)  TypeSyntax
+//@[9:13)  SimpleTypeSyntax
 //@[9:13)   Identifier |bool|
 //@[14:15)  Assignment |=|
 //@[16:18)  IntegerLiteralSyntax
@@ -426,7 +426,7 @@ output b bool = 'str'
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |b|
-//@[9:13)  TypeSyntax
+//@[9:13)  SimpleTypeSyntax
 //@[9:13)   Identifier |bool|
 //@[14:15)  Assignment |=|
 //@[16:21)  StringSyntax
@@ -440,7 +440,7 @@ output arr array = 32
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |arr|
-//@[11:16)  TypeSyntax
+//@[11:16)  SimpleTypeSyntax
 //@[11:16)   Identifier |array|
 //@[17:18)  Assignment |=|
 //@[19:21)  IntegerLiteralSyntax
@@ -451,7 +451,7 @@ output arr array = true
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |arr|
-//@[11:16)  TypeSyntax
+//@[11:16)  SimpleTypeSyntax
 //@[11:16)   Identifier |array|
 //@[17:18)  Assignment |=|
 //@[19:23)  BooleanLiteralSyntax
@@ -462,7 +462,7 @@ output arr array = false
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |arr|
-//@[11:16)  TypeSyntax
+//@[11:16)  SimpleTypeSyntax
 //@[11:16)   Identifier |array|
 //@[17:18)  Assignment |=|
 //@[19:24)  BooleanLiteralSyntax
@@ -473,7 +473,7 @@ output arr array = {
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |arr|
-//@[11:16)  TypeSyntax
+//@[11:16)  SimpleTypeSyntax
 //@[11:16)   Identifier |array|
 //@[17:18)  Assignment |=|
 //@[19:23)  ObjectSyntax
@@ -487,7 +487,7 @@ output arr array = 'str'
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |arr|
-//@[11:16)  TypeSyntax
+//@[11:16)  SimpleTypeSyntax
 //@[11:16)   Identifier |array|
 //@[17:18)  Assignment |=|
 //@[19:24)  StringSyntax
@@ -501,7 +501,7 @@ output o object = 32
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |o|
-//@[9:15)  TypeSyntax
+//@[9:15)  SimpleTypeSyntax
 //@[9:15)   Identifier |object|
 //@[16:17)  Assignment |=|
 //@[18:20)  IntegerLiteralSyntax
@@ -512,7 +512,7 @@ output o object = true
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |o|
-//@[9:15)  TypeSyntax
+//@[9:15)  SimpleTypeSyntax
 //@[9:15)   Identifier |object|
 //@[16:17)  Assignment |=|
 //@[18:22)  BooleanLiteralSyntax
@@ -523,7 +523,7 @@ output o object = false
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |o|
-//@[9:15)  TypeSyntax
+//@[9:15)  SimpleTypeSyntax
 //@[9:15)   Identifier |object|
 //@[16:17)  Assignment |=|
 //@[18:23)  BooleanLiteralSyntax
@@ -534,7 +534,7 @@ output o object = [
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |o|
-//@[9:15)  TypeSyntax
+//@[9:15)  SimpleTypeSyntax
 //@[9:15)   Identifier |object|
 //@[16:17)  Assignment |=|
 //@[18:22)  ArraySyntax
@@ -548,7 +548,7 @@ output o object = 'str'
 //@[0:6)  Identifier |output|
 //@[7:8)  IdentifierSyntax
 //@[7:8)   Identifier |o|
-//@[9:15)  TypeSyntax
+//@[9:15)  SimpleTypeSyntax
 //@[9:15)   Identifier |object|
 //@[16:17)  Assignment |=|
 //@[18:23)  StringSyntax
@@ -562,7 +562,7 @@ output exp string = 2 + 3
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |exp|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[18:19)  Assignment |=|
 //@[20:25)  BinaryOperationSyntax
@@ -577,7 +577,7 @@ output union string = true ? 's' : 1
 //@[0:6)  Identifier |output|
 //@[7:12)  IdentifierSyntax
 //@[7:12)   Identifier |union|
-//@[13:19)  TypeSyntax
+//@[13:19)  SimpleTypeSyntax
 //@[13:19)   Identifier |string|
 //@[20:21)  Assignment |=|
 //@[22:36)  TernaryOperationSyntax
@@ -595,7 +595,7 @@ output bad int = true && !4
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |bad|
-//@[11:14)  TypeSyntax
+//@[11:14)  SimpleTypeSyntax
 //@[11:14)   Identifier |int|
 //@[15:16)  Assignment |=|
 //@[17:27)  BinaryOperationSyntax
@@ -612,7 +612,7 @@ output deeper bool = true ? -true : (14 && 's') + 10
 //@[0:6)  Identifier |output|
 //@[7:13)  IdentifierSyntax
 //@[7:13)   Identifier |deeper|
-//@[14:18)  TypeSyntax
+//@[14:18)  SimpleTypeSyntax
 //@[14:18)   Identifier |bool|
 //@[19:20)  Assignment |=|
 //@[21:52)  TernaryOperationSyntax
@@ -644,7 +644,7 @@ output myOutput string = 'hello'
 //@[0:6)  Identifier |output|
 //@[7:15)  IdentifierSyntax
 //@[7:15)   Identifier |myOutput|
-//@[16:22)  TypeSyntax
+//@[16:22)  SimpleTypeSyntax
 //@[16:22)   Identifier |string|
 //@[23:24)  Assignment |=|
 //@[25:32)  StringSyntax
@@ -694,7 +694,7 @@ output notAttachableDecorators int = 32
 //@[0:6)  Identifier |output|
 //@[7:30)  IdentifierSyntax
 //@[7:30)   Identifier |notAttachableDecorators|
-//@[31:34)  TypeSyntax
+//@[31:34)  SimpleTypeSyntax
 //@[31:34)   Identifier |int|
 //@[35:36)  Assignment |=|
 //@[37:39)  IntegerLiteralSyntax
@@ -708,7 +708,7 @@ output noNestedLoops array = [for thing in things: {
 //@[0:6)  Identifier |output|
 //@[7:20)  IdentifierSyntax
 //@[7:20)   Identifier |noNestedLoops|
-//@[21:26)  TypeSyntax
+//@[21:26)  SimpleTypeSyntax
 //@[21:26)   Identifier |array|
 //@[27:28)  Assignment |=|
 //@[29:110)  ForSyntax
@@ -765,7 +765,7 @@ output noInnerLoopsInOutputs object = {
 //@[0:6)  Identifier |output|
 //@[7:28)  IdentifierSyntax
 //@[7:28)   Identifier |noInnerLoopsInOutputs|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |object|
 //@[36:37)  Assignment |=|
 //@[38:74)  ObjectSyntax
@@ -809,7 +809,7 @@ output noInnerLoopsInOutputs2 object = {
 //@[0:6)  Identifier |output|
 //@[7:29)  IdentifierSyntax
 //@[7:29)   Identifier |noInnerLoopsInOutputs2|
-//@[30:36)  TypeSyntax
+//@[30:36)  SimpleTypeSyntax
 //@[30:36)   Identifier |object|
 //@[37:38)  Assignment |=|
 //@[39:116)  ObjectSyntax
@@ -917,7 +917,7 @@ output keyVaultSecretOutput string = kv.getSecret('mySecret')
 //@[0:6)  Identifier |output|
 //@[7:27)  IdentifierSyntax
 //@[7:27)   Identifier |keyVaultSecretOutput|
-//@[28:34)  TypeSyntax
+//@[28:34)  SimpleTypeSyntax
 //@[28:34)   Identifier |string|
 //@[35:36)  Assignment |=|
 //@[37:61)  InstanceFunctionCallSyntax
@@ -938,7 +938,7 @@ output keyVaultSecretInterpolatedOutput string = '${kv.getSecret('mySecret')}'
 //@[0:6)  Identifier |output|
 //@[7:39)  IdentifierSyntax
 //@[7:39)   Identifier |keyVaultSecretInterpolatedOutput|
-//@[40:46)  TypeSyntax
+//@[40:46)  SimpleTypeSyntax
 //@[40:46)   Identifier |string|
 //@[47:48)  Assignment |=|
 //@[49:78)  StringSyntax
@@ -962,7 +962,7 @@ output keyVaultSecretObjectOutput object = {
 //@[0:6)  Identifier |output|
 //@[7:33)  IdentifierSyntax
 //@[7:33)   Identifier |keyVaultSecretObjectOutput|
-//@[34:40)  TypeSyntax
+//@[34:40)  SimpleTypeSyntax
 //@[34:40)   Identifier |object|
 //@[41:42)  Assignment |=|
 //@[43:83)  ObjectSyntax
@@ -994,7 +994,7 @@ output keyVaultSecretArrayOutput array = [
 //@[0:6)  Identifier |output|
 //@[7:32)  IdentifierSyntax
 //@[7:32)   Identifier |keyVaultSecretArrayOutput|
-//@[33:38)  TypeSyntax
+//@[33:38)  SimpleTypeSyntax
 //@[33:38)   Identifier |array|
 //@[39:40)  Assignment |=|
 //@[41:73)  ArraySyntax
@@ -1023,7 +1023,7 @@ output keyVaultSecretArrayInterpolatedOutput array = [
 //@[0:6)  Identifier |output|
 //@[7:44)  IdentifierSyntax
 //@[7:44)   Identifier |keyVaultSecretArrayInterpolatedOutput|
-//@[45:50)  TypeSyntax
+//@[45:50)  SimpleTypeSyntax
 //@[45:50)   Identifier |array|
 //@[51:52)  Assignment |=|
 //@[53:90)  ArraySyntax

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
@@ -8,7 +8,7 @@ param myString string
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |myString|
-//@[15:21)  TypeSyntax
+//@[15:21)  SimpleTypeSyntax
 //@[15:21)   Identifier |string|
 //@[21:22) NewLine |\n|
 wrong
@@ -21,7 +21,7 @@ param myInt int
 //@[0:5)  Identifier |param|
 //@[6:11)  IdentifierSyntax
 //@[6:11)   Identifier |myInt|
-//@[12:15)  TypeSyntax
+//@[12:15)  SimpleTypeSyntax
 //@[12:15)   Identifier |int|
 //@[15:16) NewLine |\n|
 param
@@ -46,7 +46,7 @@ param % string
 //@[6:7)  IdentifierSyntax
 //@[6:7)   SkippedTriviaSyntax
 //@[6:7)    Modulo |%|
-//@[8:14)  TypeSyntax
+//@[8:14)  SimpleTypeSyntax
 //@[8:14)   Identifier |string|
 //@[14:15) NewLine |\n|
 param % string 3 = 's'
@@ -55,7 +55,7 @@ param % string 3 = 's'
 //@[6:7)  IdentifierSyntax
 //@[6:7)   SkippedTriviaSyntax
 //@[6:7)    Modulo |%|
-//@[8:14)  TypeSyntax
+//@[8:14)  SimpleTypeSyntax
 //@[8:14)   Identifier |string|
 //@[15:22)  SkippedTriviaSyntax
 //@[15:16)   Integer |3|
@@ -68,7 +68,7 @@ param myBool bool
 //@[0:5)  Identifier |param|
 //@[6:12)  IdentifierSyntax
 //@[6:12)   Identifier |myBool|
-//@[13:17)  TypeSyntax
+//@[13:17)  SimpleTypeSyntax
 //@[13:17)   Identifier |bool|
 //@[17:19) NewLine |\n\n|
 
@@ -117,7 +117,7 @@ param partialType str
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |partialType|
-//@[18:21)  TypeSyntax
+//@[18:21)  SimpleTypeSyntax
 //@[18:21)   Identifier |str|
 //@[21:23) NewLine |\n\n|
 
@@ -174,7 +174,7 @@ param myString2 string = 'string value'
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |myString2|
-//@[16:22)  TypeSyntax
+//@[16:22)  SimpleTypeSyntax
 //@[16:22)   Identifier |string|
 //@[23:39)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -187,7 +187,7 @@ param wrongDefaultValue string = 42
 //@[0:5)  Identifier |param|
 //@[6:23)  IdentifierSyntax
 //@[6:23)   Identifier |wrongDefaultValue|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:35)  ParameterDefaultValueSyntax
 //@[31:32)   Assignment |=|
@@ -200,7 +200,7 @@ param myInt2 int = 42
 //@[0:5)  Identifier |param|
 //@[6:12)  IdentifierSyntax
 //@[6:12)   Identifier |myInt2|
-//@[13:16)  TypeSyntax
+//@[13:16)  SimpleTypeSyntax
 //@[13:16)   Identifier |int|
 //@[17:21)  ParameterDefaultValueSyntax
 //@[17:18)   Assignment |=|
@@ -212,7 +212,7 @@ param noValueAfterColon int =
 //@[0:5)  Identifier |param|
 //@[6:23)  IdentifierSyntax
 //@[6:23)   Identifier |noValueAfterColon|
-//@[24:27)  TypeSyntax
+//@[24:27)  SimpleTypeSyntax
 //@[24:27)   Identifier |int|
 //@[28:32)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -224,7 +224,7 @@ param myTruth bool = 'not a boolean'
 //@[0:5)  Identifier |param|
 //@[6:13)  IdentifierSyntax
 //@[6:13)   Identifier |myTruth|
-//@[14:18)  TypeSyntax
+//@[14:18)  SimpleTypeSyntax
 //@[14:18)   Identifier |bool|
 //@[19:36)  ParameterDefaultValueSyntax
 //@[19:20)   Assignment |=|
@@ -236,7 +236,7 @@ param myFalsehood bool = 'false'
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |myFalsehood|
-//@[18:22)  TypeSyntax
+//@[18:22)  SimpleTypeSyntax
 //@[18:22)   Identifier |bool|
 //@[23:32)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -249,7 +249,7 @@ param wrongAssignmentToken string: 'hello'
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |wrongAssignmentToken|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[33:42)  SkippedTriviaSyntax
 //@[33:34)   Colon |:|
@@ -261,7 +261,7 @@ param WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWh
 //@[0:5)  Identifier |param|
 //@[6:267)  IdentifierSyntax
 //@[6:267)   Identifier |WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong|
-//@[268:274)  TypeSyntax
+//@[268:274)  SimpleTypeSyntax
 //@[268:274)   Identifier |string|
 //@[275:287)  ParameterDefaultValueSyntax
 //@[275:276)   Assignment |=|
@@ -276,7 +276,7 @@ param boolCompletions bool =
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |boolCompletions|
-//@[22:26)  TypeSyntax
+//@[22:26)  SimpleTypeSyntax
 //@[22:26)   Identifier |bool|
 //@[27:29)  ParameterDefaultValueSyntax
 //@[27:28)   Assignment |=|
@@ -290,7 +290,7 @@ param arrayCompletions array =
 //@[0:5)  Identifier |param|
 //@[6:22)  IdentifierSyntax
 //@[6:22)   Identifier |arrayCompletions|
-//@[23:28)  TypeSyntax
+//@[23:28)  SimpleTypeSyntax
 //@[23:28)   Identifier |array|
 //@[29:31)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -304,7 +304,7 @@ param objectCompletions object =
 //@[0:5)  Identifier |param|
 //@[6:23)  IdentifierSyntax
 //@[6:23)   Identifier |objectCompletions|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |object|
 //@[31:33)  ParameterDefaultValueSyntax
 //@[31:32)   Assignment |=|
@@ -318,7 +318,7 @@ param wrongType fluffyBunny = 'what's up doc?'
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:36)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -339,7 +339,7 @@ param wrongType fluffyBunny = 'what\s up doc?'
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:46)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -354,7 +354,7 @@ param wrongType fluffyBunny = 'what\'s up doc?
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:46)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -369,7 +369,7 @@ param wrongType fluffyBunny = 'what\'s ${
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:41)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -383,7 +383,7 @@ param wrongType fluffyBunny = 'what\'s ${up
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:43)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -399,7 +399,7 @@ param wrongType fluffyBunny = 'what\'s ${up}
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:44)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -415,7 +415,7 @@ param wrongType fluffyBunny = 'what\'s ${'up
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:44)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -433,7 +433,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:46)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -449,7 +449,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:46)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -465,7 +465,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${doc
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:49)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -483,7 +483,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${doc}
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:50)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -502,7 +502,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${doc}'
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:51)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -521,7 +521,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${doc}'}?
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:53)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -543,7 +543,7 @@ param wrongType fluffyBunny = '${{this: doesnt}.work}'
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:54)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -569,7 +569,7 @@ param badInterpolatedString string = 'hello ${}!'
 //@[0:5)  Identifier |param|
 //@[6:27)  IdentifierSyntax
 //@[6:27)   Identifier |badInterpolatedString|
-//@[28:34)  TypeSyntax
+//@[28:34)  SimpleTypeSyntax
 //@[28:34)   Identifier |string|
 //@[35:49)  ParameterDefaultValueSyntax
 //@[35:36)   Assignment |=|
@@ -583,7 +583,7 @@ param badInterpolatedString2 string = 'hello ${a b c}!'
 //@[0:5)  Identifier |param|
 //@[6:28)  IdentifierSyntax
 //@[6:28)   Identifier |badInterpolatedString2|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |string|
 //@[36:55)  ParameterDefaultValueSyntax
 //@[36:37)   Assignment |=|
@@ -604,7 +604,7 @@ param wrongType fluffyBunny = 'what\'s up doc?'
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |wrongType|
-//@[16:27)  TypeSyntax
+//@[16:27)  SimpleTypeSyntax
 //@[16:27)   Identifier |fluffyBunny|
 //@[28:47)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -643,7 +643,7 @@ param someArray arra
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |someArray|
-//@[16:20)  TypeSyntax
+//@[16:20)  SimpleTypeSyntax
 //@[16:20)   Identifier |arra|
 //@[20:22) NewLine |\n\n|
 
@@ -685,7 +685,7 @@ param secureInt int
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |secureInt|
-//@[16:19)  TypeSyntax
+//@[16:19)  SimpleTypeSyntax
 //@[16:19)   Identifier |int|
 //@[19:21) NewLine |\n\n|
 
@@ -763,7 +763,7 @@ param wrongIntModifier int = true
 //@[0:5)  Identifier |param|
 //@[6:22)  IdentifierSyntax
 //@[6:22)   Identifier |wrongIntModifier|
-//@[23:26)  TypeSyntax
+//@[23:26)  SimpleTypeSyntax
 //@[23:26)   Identifier |int|
 //@[27:33)  ParameterDefaultValueSyntax
 //@[27:28)   Assignment |=|
@@ -846,7 +846,7 @@ param wrongMetadataSchema string
 //@[0:5)  Identifier |param|
 //@[6:25)  IdentifierSyntax
 //@[6:25)   Identifier |wrongMetadataSchema|
-//@[26:32)  TypeSyntax
+//@[26:32)  SimpleTypeSyntax
 //@[26:32)   Identifier |string|
 //@[32:34) NewLine |\n\n|
 
@@ -910,7 +910,7 @@ param expressionInModifier string = 2 + 3
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |expressionInModifier|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[34:41)  ParameterDefaultValueSyntax
 //@[34:35)   Assignment |=|
@@ -989,7 +989,7 @@ param nonCompileTimeConstant string
 //@[0:5)  Identifier |param|
 //@[6:28)  IdentifierSyntax
 //@[6:28)   Identifier |nonCompileTimeConstant|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |string|
 //@[35:38) NewLine |\n\n\n|
 
@@ -1012,7 +1012,7 @@ param emptyAllowedString string
 //@[0:5)  Identifier |param|
 //@[6:24)  IdentifierSyntax
 //@[6:24)   Identifier |emptyAllowedString|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |string|
 //@[31:33) NewLine |\n\n|
 
@@ -1034,7 +1034,7 @@ param emptyAllowedInt int
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |emptyAllowedInt|
-//@[22:25)  TypeSyntax
+//@[22:25)  SimpleTypeSyntax
 //@[22:25)   Identifier |int|
 //@[25:27) NewLine |\n\n|
 
@@ -1045,7 +1045,7 @@ param paramDefaultOneCycle string = paramDefaultOneCycle
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |paramDefaultOneCycle|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[34:56)  ParameterDefaultValueSyntax
 //@[34:35)   Assignment |=|
@@ -1061,7 +1061,7 @@ param paramDefaultTwoCycle1 string = paramDefaultTwoCycle2
 //@[0:5)  Identifier |param|
 //@[6:27)  IdentifierSyntax
 //@[6:27)   Identifier |paramDefaultTwoCycle1|
-//@[28:34)  TypeSyntax
+//@[28:34)  SimpleTypeSyntax
 //@[28:34)   Identifier |string|
 //@[35:58)  ParameterDefaultValueSyntax
 //@[35:36)   Assignment |=|
@@ -1074,7 +1074,7 @@ param paramDefaultTwoCycle2 string = paramDefaultTwoCycle1
 //@[0:5)  Identifier |param|
 //@[6:27)  IdentifierSyntax
 //@[6:27)   Identifier |paramDefaultTwoCycle2|
-//@[28:34)  TypeSyntax
+//@[28:34)  SimpleTypeSyntax
 //@[28:34)   Identifier |string|
 //@[35:58)  ParameterDefaultValueSyntax
 //@[35:36)   Assignment |=|
@@ -1109,7 +1109,7 @@ param paramModifierSelfCycle string
 //@[0:5)  Identifier |param|
 //@[6:28)  IdentifierSyntax
 //@[6:28)   Identifier |paramModifierSelfCycle|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |string|
 //@[35:37) NewLine |\n\n|
 
@@ -1151,7 +1151,7 @@ output sampleOutput string = 'hello'
 //@[0:6)  Identifier |output|
 //@[7:19)  IdentifierSyntax
 //@[7:19)   Identifier |sampleOutput|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[27:28)  Assignment |=|
 //@[29:36)  StringSyntax
@@ -1163,7 +1163,7 @@ param paramAccessingVar string = concat(sampleVar, 's')
 //@[0:5)  Identifier |param|
 //@[6:23)  IdentifierSyntax
 //@[6:23)   Identifier |paramAccessingVar|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:55)  ParameterDefaultValueSyntax
 //@[31:32)   Assignment |=|
@@ -1187,7 +1187,7 @@ param paramAccessingResource string = sampleResource
 //@[0:5)  Identifier |param|
 //@[6:28)  IdentifierSyntax
 //@[6:28)   Identifier |paramAccessingResource|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |string|
 //@[36:52)  ParameterDefaultValueSyntax
 //@[36:37)   Assignment |=|
@@ -1201,7 +1201,7 @@ param paramAccessingOutput string = sampleOutput
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |paramAccessingOutput|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[34:48)  ParameterDefaultValueSyntax
 //@[34:35)   Assignment |=|
@@ -1227,7 +1227,7 @@ param defaultValueOneLinerCompletions string =
 //@[0:5)  Identifier |param|
 //@[6:37)  IdentifierSyntax
 //@[6:37)   Identifier |defaultValueOneLinerCompletions|
-//@[38:44)  TypeSyntax
+//@[38:44)  SimpleTypeSyntax
 //@[38:44)   Identifier |string|
 //@[45:47)  ParameterDefaultValueSyntax
 //@[45:46)   Assignment |=|
@@ -1291,7 +1291,7 @@ param commaOne string
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |commaOne|
-//@[15:21)  TypeSyntax
+//@[15:21)  SimpleTypeSyntax
 //@[15:21)   Identifier |string|
 //@[21:23) NewLine |\n\n|
 
@@ -1333,7 +1333,7 @@ param incompleteDecorators string
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |incompleteDecorators|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[33:35) NewLine |\n\n|
 
@@ -1401,7 +1401,7 @@ param someString string
 //@[0:5)  Identifier |param|
 //@[6:16)  IdentifierSyntax
 //@[6:16)   Identifier |someString|
-//@[17:23)  TypeSyntax
+//@[17:23)  SimpleTypeSyntax
 //@[17:23)   Identifier |string|
 //@[23:25) NewLine |\n\n|
 
@@ -1469,7 +1469,7 @@ param someInteger int = 20
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |someInteger|
-//@[18:21)  TypeSyntax
+//@[18:21)  SimpleTypeSyntax
 //@[18:21)   Identifier |int|
 //@[22:26)  ParameterDefaultValueSyntax
 //@[22:23)   Assignment |=|
@@ -1517,7 +1517,7 @@ param tooManyArguments1 int = 20
 //@[0:5)  Identifier |param|
 //@[6:23)  IdentifierSyntax
 //@[6:23)   Identifier |tooManyArguments1|
-//@[24:27)  TypeSyntax
+//@[24:27)  SimpleTypeSyntax
 //@[24:27)   Identifier |int|
 //@[28:32)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -1581,7 +1581,7 @@ param tooManyArguments2 string
 //@[0:5)  Identifier |param|
 //@[6:23)  IdentifierSyntax
 //@[6:23)   Identifier |tooManyArguments2|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[30:32) NewLine |\n\n|
 
@@ -1636,7 +1636,7 @@ param nonConstantInDecorator string
 //@[0:5)  Identifier |param|
 //@[6:28)  IdentifierSyntax
 //@[6:28)   Identifier |nonConstantInDecorator|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |string|
 //@[35:37) NewLine |\n\n|
 
@@ -1690,7 +1690,7 @@ param unaryMinusOnFunction int
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |unaryMinusOnFunction|
-//@[27:30)  TypeSyntax
+//@[27:30)  SimpleTypeSyntax
 //@[27:30)   Identifier |int|
 //@[30:32) NewLine |\n\n|
 
@@ -1756,7 +1756,7 @@ param duplicateDecorators string
 //@[0:5)  Identifier |param|
 //@[6:25)  IdentifierSyntax
 //@[6:25)   Identifier |duplicateDecorators|
-//@[26:32)  TypeSyntax
+//@[26:32)  SimpleTypeSyntax
 //@[26:32)   Identifier |string|
 //@[32:34) NewLine |\n\n|
 
@@ -1793,7 +1793,7 @@ param invalidLength string
 //@[0:5)  Identifier |param|
 //@[6:19)  IdentifierSyntax
 //@[6:19)   Identifier |invalidLength|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[26:28) NewLine |\n\n|
 
@@ -1852,7 +1852,7 @@ param invalidPermutation array = [
 //@[0:5)  Identifier |param|
 //@[6:24)  IdentifierSyntax
 //@[6:24)   Identifier |invalidPermutation|
-//@[25:30)  TypeSyntax
+//@[25:30)  SimpleTypeSyntax
 //@[25:30)   Identifier |array|
 //@[31:60)  ParameterDefaultValueSyntax
 //@[31:32)   Assignment |=|
@@ -1934,7 +1934,7 @@ param invalidDefaultWithAllowedArrayDecorator array = true
 //@[0:5)  Identifier |param|
 //@[6:45)  IdentifierSyntax
 //@[6:45)   Identifier |invalidDefaultWithAllowedArrayDecorator|
-//@[46:51)  TypeSyntax
+//@[46:51)  SimpleTypeSyntax
 //@[46:51)   Identifier |array|
 //@[52:58)  ParameterDefaultValueSyntax
 //@[52:53)   Assignment |=|

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -953,7 +953,7 @@ param resrefpar string = foo.id
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |resrefpar|
-//@[16:22)  TypeSyntax
+//@[16:22)  SimpleTypeSyntax
 //@[16:22)   Identifier |string|
 //@[23:31)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -971,7 +971,7 @@ output resrefout bool = bar.id
 //@[0:6)  Identifier |output|
 //@[7:16)  IdentifierSyntax
 //@[7:16)   Identifier |resrefout|
-//@[17:21)  TypeSyntax
+//@[17:21)  SimpleTypeSyntax
 //@[17:21)   Identifier |bool|
 //@[22:23)  Assignment |=|
 //@[24:30)  PropertyAccessSyntax
@@ -9063,7 +9063,7 @@ output directRefViaOutput array = union(premiumStorages, stuffs)
 //@[0:6)  Identifier |output|
 //@[7:25)  IdentifierSyntax
 //@[7:25)   Identifier |directRefViaOutput|
-//@[26:31)  TypeSyntax
+//@[26:31)  SimpleTypeSyntax
 //@[26:31)   Identifier |array|
 //@[32:33)  Assignment |=|
 //@[34:64)  FunctionCallSyntax
@@ -11375,7 +11375,7 @@ param dataCollectionRule object
 //@[0:5)  Identifier |param|
 //@[6:24)  IdentifierSyntax
 //@[6:24)   Identifier |dataCollectionRule|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |object|
 //@[31:33) NewLine |\r\n|
 param tags object
@@ -11383,7 +11383,7 @@ param tags object
 //@[0:5)  Identifier |param|
 //@[6:10)  IdentifierSyntax
 //@[6:10)   Identifier |tags|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |object|
 //@[17:21) NewLine |\r\n\r\n|
 
@@ -11972,7 +11972,7 @@ param issue4668_kind string = 'AzureCLI'
 //@[0:5)  Identifier |param|
 //@[6:20)  IdentifierSyntax
 //@[6:20)   Identifier |issue4668_kind|
-//@[21:27)  TypeSyntax
+//@[21:27)  SimpleTypeSyntax
 //@[21:27)   Identifier |string|
 //@[28:40)  ParameterDefaultValueSyntax
 //@[28:29)   Assignment |=|
@@ -11996,7 +11996,7 @@ param issue4668_identity object
 //@[0:5)  Identifier |param|
 //@[6:24)  IdentifierSyntax
 //@[6:24)   Identifier |issue4668_identity|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |object|
 //@[31:33) NewLine |\r\n|
 @description('The properties of the Deployment Script.')
@@ -12016,7 +12016,7 @@ param issue4668_properties object
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |issue4668_properties|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |object|
 //@[33:35) NewLine |\r\n|
 resource issue4668_mainResource 'Microsoft.Resources/deploymentScripts@2020-10-01' = {

--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.syntax.bicep
@@ -3,7 +3,7 @@ param name string
 //@[0:5)  Identifier |param|
 //@[6:10)  IdentifierSyntax
 //@[6:10)   Identifier |name|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[17:18) NewLine |\n|
 param accounts array
@@ -11,7 +11,7 @@ param accounts array
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |accounts|
-//@[15:20)  TypeSyntax
+//@[15:20)  SimpleTypeSyntax
 //@[15:20)   Identifier |array|
 //@[20:21) NewLine |\n|
 param index int
@@ -19,7 +19,7 @@ param index int
 //@[0:5)  Identifier |param|
 //@[6:11)  IdentifierSyntax
 //@[6:11)   Identifier |index|
-//@[12:15)  TypeSyntax
+//@[12:15)  SimpleTypeSyntax
 //@[12:15)   Identifier |int|
 //@[15:17) NewLine |\n\n|
 
@@ -637,7 +637,7 @@ output indexedCollectionBlobEndpoint string = storageAccounts[index].properties.
 //@[0:6)  Identifier |output|
 //@[7:36)  IdentifierSyntax
 //@[7:36)   Identifier |indexedCollectionBlobEndpoint|
-//@[37:43)  TypeSyntax
+//@[37:43)  SimpleTypeSyntax
 //@[37:43)   Identifier |string|
 //@[44:45)  Assignment |=|
 //@[46:101)  PropertyAccessSyntax
@@ -667,7 +667,7 @@ output indexedCollectionName string = storageAccounts[index].name
 //@[0:6)  Identifier |output|
 //@[7:28)  IdentifierSyntax
 //@[7:28)   Identifier |indexedCollectionName|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |string|
 //@[36:37)  Assignment |=|
 //@[38:65)  PropertyAccessSyntax
@@ -689,7 +689,7 @@ output indexedCollectionId string = storageAccounts[index].id
 //@[0:6)  Identifier |output|
 //@[7:26)  IdentifierSyntax
 //@[7:26)   Identifier |indexedCollectionId|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[34:35)  Assignment |=|
 //@[36:61)  PropertyAccessSyntax
@@ -711,7 +711,7 @@ output indexedCollectionType string = storageAccounts[index].type
 //@[0:6)  Identifier |output|
 //@[7:28)  IdentifierSyntax
 //@[7:28)   Identifier |indexedCollectionType|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |string|
 //@[36:37)  Assignment |=|
 //@[38:65)  PropertyAccessSyntax
@@ -733,7 +733,7 @@ output indexedCollectionVersion string = storageAccounts[index].apiVersion
 //@[0:6)  Identifier |output|
 //@[7:31)  IdentifierSyntax
 //@[7:31)   Identifier |indexedCollectionVersion|
-//@[32:38)  TypeSyntax
+//@[32:38)  SimpleTypeSyntax
 //@[32:38)   Identifier |string|
 //@[39:40)  Assignment |=|
 //@[41:74)  PropertyAccessSyntax
@@ -758,7 +758,7 @@ output indexedCollectionIdentity object = storageAccounts[index].identity
 //@[0:6)  Identifier |output|
 //@[7:32)  IdentifierSyntax
 //@[7:32)   Identifier |indexedCollectionIdentity|
-//@[33:39)  TypeSyntax
+//@[33:39)  SimpleTypeSyntax
 //@[33:39)   Identifier |object|
 //@[40:41)  Assignment |=|
 //@[42:73)  PropertyAccessSyntax
@@ -783,7 +783,7 @@ output indexedEndpointPair object = {
 //@[0:6)  Identifier |output|
 //@[7:26)  IdentifierSyntax
 //@[7:26)   Identifier |indexedEndpointPair|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |object|
 //@[34:35)  Assignment |=|
 //@[36:181)  ObjectSyntax
@@ -858,7 +858,7 @@ output indexViaReference string = storageAccounts[int(storageAccounts[index].pro
 //@[0:6)  Identifier |output|
 //@[7:24)  IdentifierSyntax
 //@[7:24)   Identifier |indexViaReference|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |string|
 //@[32:33)  Assignment |=|
 //@[34:124)  PropertyAccessSyntax
@@ -2288,7 +2288,7 @@ output indexedModulesName string = moduleCollectionWithSingleDependency[index].n
 //@[0:6)  Identifier |output|
 //@[7:25)  IdentifierSyntax
 //@[7:25)   Identifier |indexedModulesName|
-//@[26:32)  TypeSyntax
+//@[26:32)  SimpleTypeSyntax
 //@[26:32)   Identifier |string|
 //@[33:34)  Assignment |=|
 //@[35:83)  PropertyAccessSyntax
@@ -2310,7 +2310,7 @@ output indexedModuleOutput string = moduleCollectionWithSingleDependency[index *
 //@[0:6)  Identifier |output|
 //@[7:26)  IdentifierSyntax
 //@[7:26)   Identifier |indexedModuleOutput|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[34:35)  Assignment |=|
 //@[36:100)  PropertyAccessSyntax
@@ -2402,7 +2402,7 @@ output existingIndexedResourceName string = existingStorageAccounts[index * 0].n
 //@[0:6)  Identifier |output|
 //@[7:34)  IdentifierSyntax
 //@[7:34)   Identifier |existingIndexedResourceName|
-//@[35:41)  TypeSyntax
+//@[35:41)  SimpleTypeSyntax
 //@[35:41)   Identifier |string|
 //@[42:43)  Assignment |=|
 //@[44:83)  PropertyAccessSyntax
@@ -2428,7 +2428,7 @@ output existingIndexedResourceId string = existingStorageAccounts[index * 1].id
 //@[0:6)  Identifier |output|
 //@[7:32)  IdentifierSyntax
 //@[7:32)   Identifier |existingIndexedResourceId|
-//@[33:39)  TypeSyntax
+//@[33:39)  SimpleTypeSyntax
 //@[33:39)   Identifier |string|
 //@[40:41)  Assignment |=|
 //@[42:79)  PropertyAccessSyntax
@@ -2454,7 +2454,7 @@ output existingIndexedResourceType string = existingStorageAccounts[index+2].typ
 //@[0:6)  Identifier |output|
 //@[7:34)  IdentifierSyntax
 //@[7:34)   Identifier |existingIndexedResourceType|
-//@[35:41)  TypeSyntax
+//@[35:41)  SimpleTypeSyntax
 //@[35:41)   Identifier |string|
 //@[42:43)  Assignment |=|
 //@[44:81)  PropertyAccessSyntax
@@ -2480,7 +2480,7 @@ output existingIndexedResourceApiVersion string = existingStorageAccounts[index-
 //@[0:6)  Identifier |output|
 //@[7:40)  IdentifierSyntax
 //@[7:40)   Identifier |existingIndexedResourceApiVersion|
-//@[41:47)  TypeSyntax
+//@[41:47)  SimpleTypeSyntax
 //@[41:47)   Identifier |string|
 //@[48:49)  Assignment |=|
 //@[50:93)  PropertyAccessSyntax
@@ -2506,7 +2506,7 @@ output existingIndexedResourceLocation string = existingStorageAccounts[index/2]
 //@[0:6)  Identifier |output|
 //@[7:38)  IdentifierSyntax
 //@[7:38)   Identifier |existingIndexedResourceLocation|
-//@[39:45)  TypeSyntax
+//@[39:45)  SimpleTypeSyntax
 //@[39:45)   Identifier |string|
 //@[46:47)  Assignment |=|
 //@[48:89)  PropertyAccessSyntax
@@ -2532,7 +2532,7 @@ output existingIndexedResourceAccessTier string = existingStorageAccounts[index%
 //@[0:6)  Identifier |output|
 //@[7:40)  IdentifierSyntax
 //@[7:40)   Identifier |existingIndexedResourceAccessTier|
-//@[41:47)  TypeSyntax
+//@[41:47)  SimpleTypeSyntax
 //@[41:47)   Identifier |string|
 //@[48:49)  Assignment |=|
 //@[50:104)  PropertyAccessSyntax

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.syntax.bicep
@@ -3,7 +3,7 @@ param name string
 //@[0:5)  Identifier |param|
 //@[6:10)  IdentifierSyntax
 //@[6:10)   Identifier |name|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |string|
 //@[17:18) NewLine |\n|
 param accounts array
@@ -11,7 +11,7 @@ param accounts array
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |accounts|
-//@[15:20)  TypeSyntax
+//@[15:20)  SimpleTypeSyntax
 //@[15:20)   Identifier |array|
 //@[20:21) NewLine |\n|
 param index int
@@ -19,7 +19,7 @@ param index int
 //@[0:5)  Identifier |param|
 //@[6:11)  IdentifierSyntax
 //@[6:11)   Identifier |index|
-//@[12:15)  TypeSyntax
+//@[12:15)  SimpleTypeSyntax
 //@[12:15)   Identifier |int|
 //@[15:17) NewLine |\n\n|
 
@@ -586,7 +586,7 @@ output indexedCollectionBlobEndpoint string = storageAccounts[index].properties.
 //@[0:6)  Identifier |output|
 //@[7:36)  IdentifierSyntax
 //@[7:36)   Identifier |indexedCollectionBlobEndpoint|
-//@[37:43)  TypeSyntax
+//@[37:43)  SimpleTypeSyntax
 //@[37:43)   Identifier |string|
 //@[44:45)  Assignment |=|
 //@[46:101)  PropertyAccessSyntax
@@ -616,7 +616,7 @@ output indexedCollectionName string = storageAccounts[index].name
 //@[0:6)  Identifier |output|
 //@[7:28)  IdentifierSyntax
 //@[7:28)   Identifier |indexedCollectionName|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |string|
 //@[36:37)  Assignment |=|
 //@[38:65)  PropertyAccessSyntax
@@ -638,7 +638,7 @@ output indexedCollectionId string = storageAccounts[index].id
 //@[0:6)  Identifier |output|
 //@[7:26)  IdentifierSyntax
 //@[7:26)   Identifier |indexedCollectionId|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[34:35)  Assignment |=|
 //@[36:61)  PropertyAccessSyntax
@@ -660,7 +660,7 @@ output indexedCollectionType string = storageAccounts[index].type
 //@[0:6)  Identifier |output|
 //@[7:28)  IdentifierSyntax
 //@[7:28)   Identifier |indexedCollectionType|
-//@[29:35)  TypeSyntax
+//@[29:35)  SimpleTypeSyntax
 //@[29:35)   Identifier |string|
 //@[36:37)  Assignment |=|
 //@[38:65)  PropertyAccessSyntax
@@ -682,7 +682,7 @@ output indexedCollectionVersion string = storageAccounts[index].apiVersion
 //@[0:6)  Identifier |output|
 //@[7:31)  IdentifierSyntax
 //@[7:31)   Identifier |indexedCollectionVersion|
-//@[32:38)  TypeSyntax
+//@[32:38)  SimpleTypeSyntax
 //@[32:38)   Identifier |string|
 //@[39:40)  Assignment |=|
 //@[41:74)  PropertyAccessSyntax
@@ -707,7 +707,7 @@ output indexedCollectionIdentity object = storageAccounts[index].identity
 //@[0:6)  Identifier |output|
 //@[7:32)  IdentifierSyntax
 //@[7:32)   Identifier |indexedCollectionIdentity|
-//@[33:39)  TypeSyntax
+//@[33:39)  SimpleTypeSyntax
 //@[33:39)   Identifier |object|
 //@[40:41)  Assignment |=|
 //@[42:73)  PropertyAccessSyntax
@@ -732,7 +732,7 @@ output indexedEndpointPair object = {
 //@[0:6)  Identifier |output|
 //@[7:26)  IdentifierSyntax
 //@[7:26)   Identifier |indexedEndpointPair|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |object|
 //@[34:35)  Assignment |=|
 //@[36:181)  ObjectSyntax
@@ -807,7 +807,7 @@ output indexViaReference string = storageAccounts[int(storageAccounts[index].pro
 //@[0:6)  Identifier |output|
 //@[7:24)  IdentifierSyntax
 //@[7:24)   Identifier |indexViaReference|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |string|
 //@[32:33)  Assignment |=|
 //@[34:124)  PropertyAccessSyntax
@@ -2124,7 +2124,7 @@ output indexedModulesName string = moduleCollectionWithSingleDependency[index].n
 //@[0:6)  Identifier |output|
 //@[7:25)  IdentifierSyntax
 //@[7:25)   Identifier |indexedModulesName|
-//@[26:32)  TypeSyntax
+//@[26:32)  SimpleTypeSyntax
 //@[26:32)   Identifier |string|
 //@[33:34)  Assignment |=|
 //@[35:83)  PropertyAccessSyntax
@@ -2146,7 +2146,7 @@ output indexedModuleOutput string = moduleCollectionWithSingleDependency[index *
 //@[0:6)  Identifier |output|
 //@[7:26)  IdentifierSyntax
 //@[7:26)   Identifier |indexedModuleOutput|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[34:35)  Assignment |=|
 //@[36:100)  PropertyAccessSyntax
@@ -2227,7 +2227,7 @@ output existingIndexedResourceName string = existingStorageAccounts[index * 0].n
 //@[0:6)  Identifier |output|
 //@[7:34)  IdentifierSyntax
 //@[7:34)   Identifier |existingIndexedResourceName|
-//@[35:41)  TypeSyntax
+//@[35:41)  SimpleTypeSyntax
 //@[35:41)   Identifier |string|
 //@[42:43)  Assignment |=|
 //@[44:83)  PropertyAccessSyntax
@@ -2253,7 +2253,7 @@ output existingIndexedResourceId string = existingStorageAccounts[index * 1].id
 //@[0:6)  Identifier |output|
 //@[7:32)  IdentifierSyntax
 //@[7:32)   Identifier |existingIndexedResourceId|
-//@[33:39)  TypeSyntax
+//@[33:39)  SimpleTypeSyntax
 //@[33:39)   Identifier |string|
 //@[40:41)  Assignment |=|
 //@[42:79)  PropertyAccessSyntax
@@ -2279,7 +2279,7 @@ output existingIndexedResourceType string = existingStorageAccounts[index+2].typ
 //@[0:6)  Identifier |output|
 //@[7:34)  IdentifierSyntax
 //@[7:34)   Identifier |existingIndexedResourceType|
-//@[35:41)  TypeSyntax
+//@[35:41)  SimpleTypeSyntax
 //@[35:41)   Identifier |string|
 //@[42:43)  Assignment |=|
 //@[44:81)  PropertyAccessSyntax
@@ -2305,7 +2305,7 @@ output existingIndexedResourceApiVersion string = existingStorageAccounts[index-
 //@[0:6)  Identifier |output|
 //@[7:40)  IdentifierSyntax
 //@[7:40)   Identifier |existingIndexedResourceApiVersion|
-//@[41:47)  TypeSyntax
+//@[41:47)  SimpleTypeSyntax
 //@[41:47)   Identifier |string|
 //@[48:49)  Assignment |=|
 //@[50:93)  PropertyAccessSyntax
@@ -2331,7 +2331,7 @@ output existingIndexedResourceLocation string = existingStorageAccounts[index/2]
 //@[0:6)  Identifier |output|
 //@[7:38)  IdentifierSyntax
 //@[7:38)   Identifier |existingIndexedResourceLocation|
-//@[39:45)  TypeSyntax
+//@[39:45)  SimpleTypeSyntax
 //@[39:45)   Identifier |string|
 //@[46:47)  Assignment |=|
 //@[48:89)  PropertyAccessSyntax
@@ -2357,7 +2357,7 @@ output existingIndexedResourceAccessTier string = existingStorageAccounts[index%
 //@[0:6)  Identifier |output|
 //@[7:40)  IdentifierSyntax
 //@[7:40)   Identifier |existingIndexedResourceAccessTier|
-//@[41:47)  TypeSyntax
+//@[41:47)  SimpleTypeSyntax
 //@[41:47)   Identifier |string|
 //@[48:49)  Assignment |=|
 //@[50:104)  PropertyAccessSyntax
@@ -3704,7 +3704,7 @@ output lastNameServers array = filteredIndexedZones[length(accounts) - 1].proper
 //@[0:6)  Identifier |output|
 //@[7:22)  IdentifierSyntax
 //@[7:22)   Identifier |lastNameServers|
-//@[23:28)  TypeSyntax
+//@[23:28)  SimpleTypeSyntax
 //@[23:28)   Identifier |array|
 //@[29:30)  Assignment |=|
 //@[31:96)  PropertyAccessSyntax
@@ -3830,7 +3830,7 @@ output lastModuleOutput string = filteredIndexedModules[length(accounts) - 1].ou
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |lastModuleOutput|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:94)  PropertyAccessSyntax

--- a/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.syntax.bicep
@@ -11,7 +11,7 @@ param prefix string = 'majastrz'
 //@[0:5)  Identifier |param|
 //@[6:12)  IdentifierSyntax
 //@[6:12)   Identifier |prefix|
-//@[13:19)  TypeSyntax
+//@[13:19)  SimpleTypeSyntax
 //@[13:19)   Identifier |string|
 //@[20:32)  ParameterDefaultValueSyntax
 //@[20:21)   Assignment |=|

--- a/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.syntax.bicep
@@ -212,7 +212,7 @@ output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
 //@[0:6)  Identifier |output|
 //@[7:30)  IdentifierSyntax
 //@[7:30)   Identifier |myManagementGroupOutput|
-//@[31:37)  TypeSyntax
+//@[31:37)  SimpleTypeSyntax
 //@[31:37)   Identifier |string|
 //@[38:39)  Assignment |=|
 //@[40:77)  PropertyAccessSyntax
@@ -232,7 +232,7 @@ output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
 //@[0:6)  Identifier |output|
 //@[7:27)  IdentifierSyntax
 //@[7:27)   Identifier |mySubscriptionOutput|
-//@[28:34)  TypeSyntax
+//@[28:34)  SimpleTypeSyntax
 //@[28:34)   Identifier |string|
 //@[35:36)  Assignment |=|
 //@[37:71)  PropertyAccessSyntax

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.syntax.bicep
@@ -21,7 +21,7 @@ param deployTimeSuffix string = newGuid()
 //@[0:5)  Identifier |param|
 //@[6:22)  IdentifierSyntax
 //@[6:22)   Identifier |deployTimeSuffix|
-//@[23:29)  TypeSyntax
+//@[23:29)  SimpleTypeSyntax
 //@[23:29)   Identifier |string|
 //@[30:41)  ParameterDefaultValueSyntax
 //@[30:31)   Assignment |=|
@@ -929,7 +929,7 @@ output stringOutputA string = modATest.outputs.stringOutputA
 //@[0:6)  Identifier |output|
 //@[7:20)  IdentifierSyntax
 //@[7:20)   Identifier |stringOutputA|
-//@[21:27)  TypeSyntax
+//@[21:27)  SimpleTypeSyntax
 //@[21:27)   Identifier |string|
 //@[28:29)  Assignment |=|
 //@[30:60)  PropertyAccessSyntax
@@ -949,7 +949,7 @@ output stringOutputB string = modATest.outputs.stringOutputB
 //@[0:6)  Identifier |output|
 //@[7:20)  IdentifierSyntax
 //@[7:20)   Identifier |stringOutputB|
-//@[21:27)  TypeSyntax
+//@[21:27)  SimpleTypeSyntax
 //@[21:27)   Identifier |string|
 //@[28:29)  Assignment |=|
 //@[30:60)  PropertyAccessSyntax
@@ -969,7 +969,7 @@ output objOutput object = modATest.outputs.objOutput
 //@[0:6)  Identifier |output|
 //@[7:16)  IdentifierSyntax
 //@[7:16)   Identifier |objOutput|
-//@[17:23)  TypeSyntax
+//@[17:23)  SimpleTypeSyntax
 //@[17:23)   Identifier |object|
 //@[24:25)  Assignment |=|
 //@[26:52)  PropertyAccessSyntax
@@ -989,7 +989,7 @@ output arrayOutput array = modATest.outputs.arrayOutput
 //@[0:6)  Identifier |output|
 //@[7:18)  IdentifierSyntax
 //@[7:18)   Identifier |arrayOutput|
-//@[19:24)  TypeSyntax
+//@[19:24)  SimpleTypeSyntax
 //@[19:24)   Identifier |array|
 //@[25:26)  Assignment |=|
 //@[27:55)  PropertyAccessSyntax
@@ -1009,7 +1009,7 @@ output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputO
 //@[0:6)  Identifier |output|
 //@[7:30)  IdentifierSyntax
 //@[7:30)   Identifier |modCalculatedNameOutput|
-//@[31:37)  TypeSyntax
+//@[31:37)  SimpleTypeSyntax
 //@[31:37)   Identifier |object|
 //@[38:39)  Assignment |=|
 //@[40:82)  PropertyAccessSyntax

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.syntax.bicep
@@ -245,7 +245,7 @@ output referenceBasicChild string = basicParent::basicChild.properties.size
 //@[0:6)  Identifier |output|
 //@[7:26)  IdentifierSyntax
 //@[7:26)   Identifier |referenceBasicChild|
-//@[27:33)  TypeSyntax
+//@[27:33)  SimpleTypeSyntax
 //@[27:33)   Identifier |string|
 //@[34:35)  Assignment |=|
 //@[36:75)  PropertyAccessSyntax
@@ -271,7 +271,7 @@ output referenceBasicGrandchild string = basicParent::basicChild::basicGrandchil
 //@[0:6)  Identifier |output|
 //@[7:31)  IdentifierSyntax
 //@[7:31)   Identifier |referenceBasicGrandchild|
-//@[32:38)  TypeSyntax
+//@[32:38)  SimpleTypeSyntax
 //@[32:38)   Identifier |string|
 //@[39:40)  Assignment |=|
 //@[41:98)  PropertyAccessSyntax
@@ -416,7 +416,7 @@ param createParent bool
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |createParent|
-//@[19:23)  TypeSyntax
+//@[19:23)  SimpleTypeSyntax
 //@[19:23)   Identifier |bool|
 //@[23:24) NewLine |\n|
 param createChild bool
@@ -424,7 +424,7 @@ param createChild bool
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |createChild|
-//@[18:22)  TypeSyntax
+//@[18:22)  SimpleTypeSyntax
 //@[18:22)   Identifier |bool|
 //@[22:23) NewLine |\n|
 param createGrandchild bool
@@ -432,7 +432,7 @@ param createGrandchild bool
 //@[0:5)  Identifier |param|
 //@[6:22)  IdentifierSyntax
 //@[6:22)   Identifier |createGrandchild|
-//@[23:27)  TypeSyntax
+//@[23:27)  SimpleTypeSyntax
 //@[23:27)   Identifier |bool|
 //@[27:28) NewLine |\n|
 resource conditionParent 'My.Rp/parentType@2020-12-01' = if (createParent) {
@@ -658,7 +658,7 @@ output loopChildOutput string = loopParent::loopChild[0].name
 //@[0:6)  Identifier |output|
 //@[7:22)  IdentifierSyntax
 //@[7:22)   Identifier |loopChildOutput|
-//@[23:29)  TypeSyntax
+//@[23:29)  SimpleTypeSyntax
 //@[23:29)   Identifier |string|
 //@[30:31)  Assignment |=|
 //@[32:61)  PropertyAccessSyntax

--- a/src/Bicep.Core.Samples/Files/Outputs_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Outputs_CRLF/main.syntax.bicep
@@ -21,7 +21,7 @@ output myStr string = 'hello'
 //@[0:6)  Identifier |output|
 //@[7:12)  IdentifierSyntax
 //@[7:12)   Identifier |myStr|
-//@[13:19)  TypeSyntax
+//@[13:19)  SimpleTypeSyntax
 //@[13:19)   Identifier |string|
 //@[20:21)  Assignment |=|
 //@[22:29)  StringSyntax
@@ -49,7 +49,7 @@ output myInt int = 7
 //@[0:6)  Identifier |output|
 //@[7:12)  IdentifierSyntax
 //@[7:12)   Identifier |myInt|
-//@[13:16)  TypeSyntax
+//@[13:16)  SimpleTypeSyntax
 //@[13:16)   Identifier |int|
 //@[17:18)  Assignment |=|
 //@[19:20)  IntegerLiteralSyntax
@@ -60,7 +60,7 @@ output myOtherInt int = 20 / 13 + 80 % -4
 //@[0:6)  Identifier |output|
 //@[7:17)  IdentifierSyntax
 //@[7:17)   Identifier |myOtherInt|
-//@[18:21)  TypeSyntax
+//@[18:21)  SimpleTypeSyntax
 //@[18:21)   Identifier |int|
 //@[22:23)  Assignment |=|
 //@[24:41)  BinaryOperationSyntax
@@ -102,7 +102,7 @@ output myBool bool = !false
 //@[0:6)  Identifier |output|
 //@[7:13)  IdentifierSyntax
 //@[7:13)   Identifier |myBool|
-//@[14:18)  TypeSyntax
+//@[14:18)  SimpleTypeSyntax
 //@[14:18)   Identifier |bool|
 //@[19:20)  Assignment |=|
 //@[21:27)  UnaryOperationSyntax
@@ -115,7 +115,7 @@ output myOtherBool bool = true
 //@[0:6)  Identifier |output|
 //@[7:18)  IdentifierSyntax
 //@[7:18)   Identifier |myOtherBool|
-//@[19:23)  TypeSyntax
+//@[19:23)  SimpleTypeSyntax
 //@[19:23)   Identifier |bool|
 //@[24:25)  Assignment |=|
 //@[26:30)  BooleanLiteralSyntax
@@ -143,7 +143,7 @@ output suchEmpty array = [
 //@[0:6)  Identifier |output|
 //@[7:16)  IdentifierSyntax
 //@[7:16)   Identifier |suchEmpty|
-//@[17:22)  TypeSyntax
+//@[17:22)  SimpleTypeSyntax
 //@[17:22)   Identifier |array|
 //@[23:24)  Assignment |=|
 //@[25:29)  ArraySyntax
@@ -158,7 +158,7 @@ output suchEmpty2 object = {
 //@[0:6)  Identifier |output|
 //@[7:17)  IdentifierSyntax
 //@[7:17)   Identifier |suchEmpty2|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |object|
 //@[25:26)  Assignment |=|
 //@[27:31)  ObjectSyntax
@@ -189,7 +189,7 @@ output obj object = {
 //@[0:6)  Identifier |output|
 //@[7:10)  IdentifierSyntax
 //@[7:10)   Identifier |obj|
-//@[11:17)  TypeSyntax
+//@[11:17)  SimpleTypeSyntax
 //@[11:17)   Identifier |object|
 //@[18:19)  Assignment |=|
 //@[20:178)  ObjectSyntax
@@ -302,7 +302,7 @@ output myArr array = [
 //@[0:6)  Identifier |output|
 //@[7:12)  IdentifierSyntax
 //@[7:12)   Identifier |myArr|
-//@[13:18)  TypeSyntax
+//@[13:18)  SimpleTypeSyntax
 //@[13:18)   Identifier |array|
 //@[19:20)  Assignment |=|
 //@[21:74)  ArraySyntax
@@ -339,7 +339,7 @@ output rgLocation string = resourceGroup().location
 //@[0:6)  Identifier |output|
 //@[7:17)  IdentifierSyntax
 //@[7:17)   Identifier |rgLocation|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |string|
 //@[25:26)  Assignment |=|
 //@[27:51)  PropertyAccessSyntax
@@ -358,7 +358,7 @@ output isWestUs bool = resourceGroup().location != 'westus' ? false : true
 //@[0:6)  Identifier |output|
 //@[7:15)  IdentifierSyntax
 //@[7:15)   Identifier |isWestUs|
-//@[16:20)  TypeSyntax
+//@[16:20)  SimpleTypeSyntax
 //@[16:20)   Identifier |bool|
 //@[21:22)  Assignment |=|
 //@[23:74)  TernaryOperationSyntax
@@ -388,7 +388,7 @@ output expressionBasedIndexer string = {
 //@[0:6)  Identifier |output|
 //@[7:29)  IdentifierSyntax
 //@[7:29)   Identifier |expressionBasedIndexer|
-//@[30:36)  TypeSyntax
+//@[30:36)  SimpleTypeSyntax
 //@[30:36)   Identifier |string|
 //@[37:38)  Assignment |=|
 //@[39:140)  PropertyAccessSyntax
@@ -491,7 +491,7 @@ output primaryKey string = listKeys(resourceId('Mock.RP/type', 'nigel'), '2020-0
 //@[0:6)  Identifier |output|
 //@[7:17)  IdentifierSyntax
 //@[7:17)   Identifier |primaryKey|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |string|
 //@[25:26)  Assignment |=|
 //@[27:97)  PropertyAccessSyntax
@@ -526,7 +526,7 @@ output secondaryKey string = secondaryKeyIntermediateVar
 //@[0:6)  Identifier |output|
 //@[7:19)  IdentifierSyntax
 //@[7:19)   Identifier |secondaryKey|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[27:28)  Assignment |=|
 //@[29:56)  VariableAccessSyntax
@@ -548,7 +548,7 @@ param paramWithOverlappingOutput string
 //@[0:5)  Identifier |param|
 //@[6:32)  IdentifierSyntax
 //@[6:32)   Identifier |paramWithOverlappingOutput|
-//@[33:39)  TypeSyntax
+//@[33:39)  SimpleTypeSyntax
 //@[33:39)   Identifier |string|
 //@[39:43) NewLine |\r\n\r\n|
 
@@ -557,7 +557,7 @@ output varWithOverlappingOutput string = varWithOverlappingOutput
 //@[0:6)  Identifier |output|
 //@[7:31)  IdentifierSyntax
 //@[7:31)   Identifier |varWithOverlappingOutput|
-//@[32:38)  TypeSyntax
+//@[32:38)  SimpleTypeSyntax
 //@[32:38)   Identifier |string|
 //@[39:40)  Assignment |=|
 //@[41:65)  VariableAccessSyntax
@@ -569,7 +569,7 @@ output paramWithOverlappingOutput string = paramWithOverlappingOutput
 //@[0:6)  Identifier |output|
 //@[7:33)  IdentifierSyntax
 //@[7:33)   Identifier |paramWithOverlappingOutput|
-//@[34:40)  TypeSyntax
+//@[34:40)  SimpleTypeSyntax
 //@[34:40)   Identifier |string|
 //@[41:42)  Assignment |=|
 //@[43:69)  VariableAccessSyntax
@@ -584,7 +584,7 @@ output generatedArray array = [for i in range(0,10): i]
 //@[0:6)  Identifier |output|
 //@[7:21)  IdentifierSyntax
 //@[7:21)   Identifier |generatedArray|
-//@[22:27)  TypeSyntax
+//@[22:27)  SimpleTypeSyntax
 //@[22:27)   Identifier |array|
 //@[28:29)  Assignment |=|
 //@[30:55)  ForSyntax

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.syntax.bicep
@@ -10,7 +10,7 @@ param myString string
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |myString|
-//@[15:21)  TypeSyntax
+//@[15:21)  SimpleTypeSyntax
 //@[15:21)   Identifier |string|
 //@[21:23) NewLine |\r\n|
 param myInt int
@@ -18,7 +18,7 @@ param myInt int
 //@[0:5)  Identifier |param|
 //@[6:11)  IdentifierSyntax
 //@[6:11)   Identifier |myInt|
-//@[12:15)  TypeSyntax
+//@[12:15)  SimpleTypeSyntax
 //@[12:15)   Identifier |int|
 //@[15:17) NewLine |\r\n|
 param myBool bool
@@ -26,7 +26,7 @@ param myBool bool
 //@[0:5)  Identifier |param|
 //@[6:12)  IdentifierSyntax
 //@[6:12)   Identifier |myBool|
-//@[13:17)  TypeSyntax
+//@[13:17)  SimpleTypeSyntax
 //@[13:17)   Identifier |bool|
 //@[17:21) NewLine |\r\n\r\n|
 
@@ -37,7 +37,7 @@ param myString2 string = 'string value'
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |myString2|
-//@[16:22)  TypeSyntax
+//@[16:22)  SimpleTypeSyntax
 //@[16:22)   Identifier |string|
 //@[23:39)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -49,7 +49,7 @@ param myInt2 int = 42
 //@[0:5)  Identifier |param|
 //@[6:12)  IdentifierSyntax
 //@[6:12)   Identifier |myInt2|
-//@[13:16)  TypeSyntax
+//@[13:16)  SimpleTypeSyntax
 //@[13:16)   Identifier |int|
 //@[17:21)  ParameterDefaultValueSyntax
 //@[17:18)   Assignment |=|
@@ -61,7 +61,7 @@ param myTruth bool = true
 //@[0:5)  Identifier |param|
 //@[6:13)  IdentifierSyntax
 //@[6:13)   Identifier |myTruth|
-//@[14:18)  TypeSyntax
+//@[14:18)  SimpleTypeSyntax
 //@[14:18)   Identifier |bool|
 //@[19:25)  ParameterDefaultValueSyntax
 //@[19:20)   Assignment |=|
@@ -73,7 +73,7 @@ param myFalsehood bool = false
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |myFalsehood|
-//@[18:22)  TypeSyntax
+//@[18:22)  SimpleTypeSyntax
 //@[18:22)   Identifier |bool|
 //@[23:30)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -85,7 +85,7 @@ param myEscapedString string = 'First line\r\nSecond\ttabbed\tline'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |myEscapedString|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:67)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -100,7 +100,7 @@ param foo object = {
 //@[0:5)  Identifier |param|
 //@[6:9)  IdentifierSyntax
 //@[6:9)   Identifier |foo|
-//@[10:16)  TypeSyntax
+//@[10:16)  SimpleTypeSyntax
 //@[10:16)   Identifier |object|
 //@[17:253)  ParameterDefaultValueSyntax
 //@[17:18)   Assignment |=|
@@ -232,7 +232,7 @@ param myArrayParam array = [
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |myArrayParam|
-//@[19:24)  TypeSyntax
+//@[19:24)  SimpleTypeSyntax
 //@[19:24)   Identifier |array|
 //@[25:52)  ParameterDefaultValueSyntax
 //@[25:26)   Assignment |=|
@@ -274,7 +274,7 @@ param password string
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |password|
-//@[15:21)  TypeSyntax
+//@[15:21)  SimpleTypeSyntax
 //@[15:21)   Identifier |string|
 //@[21:25) NewLine |\r\n\r\n|
 
@@ -294,7 +294,7 @@ param secretObject object
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |secretObject|
-//@[19:25)  TypeSyntax
+//@[19:25)  SimpleTypeSyntax
 //@[19:25)   Identifier |object|
 //@[25:29) NewLine |\r\n\r\n|
 
@@ -330,7 +330,7 @@ param storageSku string
 //@[0:5)  Identifier |param|
 //@[6:16)  IdentifierSyntax
 //@[6:16)   Identifier |storageSku|
-//@[17:23)  TypeSyntax
+//@[17:23)  SimpleTypeSyntax
 //@[17:23)   Identifier |string|
 //@[23:27) NewLine |\r\n\r\n|
 
@@ -365,7 +365,7 @@ param storageName string
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |storageName|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |string|
 //@[24:28) NewLine |\r\n\r\n|
 
@@ -400,7 +400,7 @@ param someArray array
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |someArray|
-//@[16:21)  TypeSyntax
+//@[16:21)  SimpleTypeSyntax
 //@[16:21)   Identifier |array|
 //@[21:25) NewLine |\r\n\r\n|
 
@@ -424,7 +424,7 @@ param emptyMetadata string
 //@[0:5)  Identifier |param|
 //@[6:19)  IdentifierSyntax
 //@[6:19)   Identifier |emptyMetadata|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[26:30) NewLine |\r\n\r\n|
 
@@ -458,7 +458,7 @@ param description string
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |description|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |string|
 //@[24:28) NewLine |\r\n\r\n|
 
@@ -483,7 +483,7 @@ param description2 string
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |description2|
-//@[19:25)  TypeSyntax
+//@[19:25)  SimpleTypeSyntax
 //@[19:25)   Identifier |string|
 //@[25:29) NewLine |\r\n\r\n|
 
@@ -563,7 +563,7 @@ param additionalMetadata string
 //@[0:5)  Identifier |param|
 //@[6:24)  IdentifierSyntax
 //@[6:24)   Identifier |additionalMetadata|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |string|
 //@[31:35) NewLine |\r\n\r\n|
 
@@ -660,7 +660,7 @@ param someParameter string
 //@[0:5)  Identifier |param|
 //@[6:19)  IdentifierSyntax
 //@[6:19)   Identifier |someParameter|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[26:30) NewLine |\r\n\r\n|
 
@@ -669,7 +669,7 @@ param defaultExpression bool = 18 != (true || false)
 //@[0:5)  Identifier |param|
 //@[6:23)  IdentifierSyntax
 //@[6:23)   Identifier |defaultExpression|
-//@[24:28)  TypeSyntax
+//@[24:28)  SimpleTypeSyntax
 //@[24:28)   Identifier |bool|
 //@[29:52)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -718,7 +718,7 @@ param stringLiteral string
 //@[0:5)  Identifier |param|
 //@[6:19)  IdentifierSyntax
 //@[6:19)   Identifier |stringLiteral|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[26:30) NewLine |\r\n\r\n|
 
@@ -757,7 +757,7 @@ param stringLiteralWithAllowedValuesSuperset string = stringLiteral
 //@[0:5)  Identifier |param|
 //@[6:44)  IdentifierSyntax
 //@[6:44)   Identifier |stringLiteralWithAllowedValuesSuperset|
-//@[45:51)  TypeSyntax
+//@[45:51)  SimpleTypeSyntax
 //@[45:51)   Identifier |string|
 //@[52:67)  ParameterDefaultValueSyntax
 //@[52:53)   Assignment |=|
@@ -829,7 +829,7 @@ param decoratedString string
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |decoratedString|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[28:32) NewLine |\r\n\r\n|
 
@@ -850,7 +850,7 @@ param decoratedInt int = 123
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |decoratedInt|
-//@[19:22)  TypeSyntax
+//@[19:22)  SimpleTypeSyntax
 //@[19:22)   Identifier |int|
 //@[23:28)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -893,7 +893,7 @@ param negativeValues int
 //@[0:5)  Identifier |param|
 //@[6:20)  IdentifierSyntax
 //@[6:20)   Identifier |negativeValues|
-//@[21:24)  TypeSyntax
+//@[21:24)  SimpleTypeSyntax
 //@[21:24)   Identifier |int|
 //@[24:28) NewLine |\r\n\r\n|
 
@@ -976,7 +976,7 @@ param decoratedBool bool = (true && false) != true
 //@[0:5)  Identifier |param|
 //@[6:19)  IdentifierSyntax
 //@[6:19)   Identifier |decoratedBool|
-//@[20:24)  TypeSyntax
+//@[20:24)  SimpleTypeSyntax
 //@[20:24)   Identifier |bool|
 //@[25:50)  ParameterDefaultValueSyntax
 //@[25:26)   Assignment |=|
@@ -1009,7 +1009,7 @@ param decoratedObject object = {
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |decoratedObject|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |object|
 //@[29:265)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -1198,7 +1198,7 @@ param decoratedArray array = [
 //@[0:5)  Identifier |param|
 //@[6:20)  IdentifierSyntax
 //@[6:20)   Identifier |decoratedArray|
-//@[21:26)  TypeSyntax
+//@[21:26)  SimpleTypeSyntax
 //@[21:26)   Identifier |array|
 //@[27:62)  ParameterDefaultValueSyntax
 //@[27:28)   Assignment |=|

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.syntax.bicep
@@ -29,7 +29,7 @@ param myString string
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |myString|
-//@[15:21)  TypeSyntax
+//@[15:21)  SimpleTypeSyntax
 //@[15:21)   Identifier |string|
 //@[21:22) NewLine |\n|
 param myInt int
@@ -37,7 +37,7 @@ param myInt int
 //@[0:5)  Identifier |param|
 //@[6:11)  IdentifierSyntax
 //@[6:11)   Identifier |myInt|
-//@[12:15)  TypeSyntax
+//@[12:15)  SimpleTypeSyntax
 //@[12:15)   Identifier |int|
 //@[15:16) NewLine |\n|
 param myBool bool
@@ -45,7 +45,7 @@ param myBool bool
 //@[0:5)  Identifier |param|
 //@[6:12)  IdentifierSyntax
 //@[6:12)   Identifier |myBool|
-//@[13:17)  TypeSyntax
+//@[13:17)  SimpleTypeSyntax
 //@[13:17)   Identifier |bool|
 //@[17:19) NewLine |\n\n|
 
@@ -95,7 +95,7 @@ param myString2 string = 'string value'
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |myString2|
-//@[16:22)  TypeSyntax
+//@[16:22)  SimpleTypeSyntax
 //@[16:22)   Identifier |string|
 //@[23:39)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -107,7 +107,7 @@ param myInt2 int = 42
 //@[0:5)  Identifier |param|
 //@[6:12)  IdentifierSyntax
 //@[6:12)   Identifier |myInt2|
-//@[13:16)  TypeSyntax
+//@[13:16)  SimpleTypeSyntax
 //@[13:16)   Identifier |int|
 //@[17:21)  ParameterDefaultValueSyntax
 //@[17:18)   Assignment |=|
@@ -119,7 +119,7 @@ param myTruth bool = true
 //@[0:5)  Identifier |param|
 //@[6:13)  IdentifierSyntax
 //@[6:13)   Identifier |myTruth|
-//@[14:18)  TypeSyntax
+//@[14:18)  SimpleTypeSyntax
 //@[14:18)   Identifier |bool|
 //@[19:25)  ParameterDefaultValueSyntax
 //@[19:20)   Assignment |=|
@@ -131,7 +131,7 @@ param myFalsehood bool = false
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |myFalsehood|
-//@[18:22)  TypeSyntax
+//@[18:22)  SimpleTypeSyntax
 //@[18:22)   Identifier |bool|
 //@[23:30)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -143,7 +143,7 @@ param myEscapedString string = 'First line\r\nSecond\ttabbed\tline'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |myEscapedString|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:67)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -205,7 +205,7 @@ param foo object = {
 //@[0:5)  Identifier |param|
 //@[6:9)  IdentifierSyntax
 //@[6:9)   Identifier |foo|
-//@[10:16)  TypeSyntax
+//@[10:16)  SimpleTypeSyntax
 //@[10:16)   Identifier |object|
 //@[17:232)  ParameterDefaultValueSyntax
 //@[17:18)   Assignment |=|
@@ -337,7 +337,7 @@ param myArrayParam array = [
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |myArrayParam|
-//@[19:24)  TypeSyntax
+//@[19:24)  SimpleTypeSyntax
 //@[19:24)   Identifier |array|
 //@[25:48)  ParameterDefaultValueSyntax
 //@[25:26)   Assignment |=|
@@ -379,7 +379,7 @@ param password string
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |password|
-//@[15:21)  TypeSyntax
+//@[15:21)  SimpleTypeSyntax
 //@[15:21)   Identifier |string|
 //@[21:23) NewLine |\n\n|
 
@@ -399,7 +399,7 @@ param secretObject object
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |secretObject|
-//@[19:25)  TypeSyntax
+//@[19:25)  SimpleTypeSyntax
 //@[19:25)   Identifier |object|
 //@[25:27) NewLine |\n\n|
 
@@ -435,7 +435,7 @@ param storageSku string
 //@[0:5)  Identifier |param|
 //@[6:16)  IdentifierSyntax
 //@[6:16)   Identifier |storageSku|
-//@[17:23)  TypeSyntax
+//@[17:23)  SimpleTypeSyntax
 //@[17:23)   Identifier |string|
 //@[23:25) NewLine |\n\n|
 
@@ -470,7 +470,7 @@ param storageName string
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |storageName|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |string|
 //@[24:26) NewLine |\n\n|
 
@@ -505,7 +505,7 @@ param someArray array
 //@[0:5)  Identifier |param|
 //@[6:15)  IdentifierSyntax
 //@[6:15)   Identifier |someArray|
-//@[16:21)  TypeSyntax
+//@[16:21)  SimpleTypeSyntax
 //@[16:21)   Identifier |array|
 //@[21:23) NewLine |\n\n|
 
@@ -529,7 +529,7 @@ param emptyMetadata string
 //@[0:5)  Identifier |param|
 //@[6:19)  IdentifierSyntax
 //@[6:19)   Identifier |emptyMetadata|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[26:28) NewLine |\n\n|
 
@@ -563,7 +563,7 @@ param description string
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |description|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |string|
 //@[24:26) NewLine |\n\n|
 
@@ -588,7 +588,7 @@ param description2 string
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |description2|
-//@[19:25)  TypeSyntax
+//@[19:25)  SimpleTypeSyntax
 //@[19:25)   Identifier |string|
 //@[25:27) NewLine |\n\n|
 
@@ -668,7 +668,7 @@ param additionalMetadata string
 //@[0:5)  Identifier |param|
 //@[6:24)  IdentifierSyntax
 //@[6:24)   Identifier |additionalMetadata|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |string|
 //@[31:33) NewLine |\n\n|
 
@@ -765,7 +765,7 @@ param someParameter string
 //@[0:5)  Identifier |param|
 //@[6:19)  IdentifierSyntax
 //@[6:19)   Identifier |someParameter|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[26:28) NewLine |\n\n|
 
@@ -774,7 +774,7 @@ param defaultExpression bool = 18 != (true || false)
 //@[0:5)  Identifier |param|
 //@[6:23)  IdentifierSyntax
 //@[6:23)   Identifier |defaultExpression|
-//@[24:28)  TypeSyntax
+//@[24:28)  SimpleTypeSyntax
 //@[24:28)   Identifier |bool|
 //@[29:52)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -823,7 +823,7 @@ param stringLiteral string
 //@[0:5)  Identifier |param|
 //@[6:19)  IdentifierSyntax
 //@[6:19)   Identifier |stringLiteral|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[26:28) NewLine |\n\n|
 
@@ -862,7 +862,7 @@ param stringLiteralWithAllowedValuesSuperset string = stringLiteral
 //@[0:5)  Identifier |param|
 //@[6:44)  IdentifierSyntax
 //@[6:44)   Identifier |stringLiteralWithAllowedValuesSuperset|
-//@[45:51)  TypeSyntax
+//@[45:51)  SimpleTypeSyntax
 //@[45:51)   Identifier |string|
 //@[52:67)  ParameterDefaultValueSyntax
 //@[52:53)   Assignment |=|
@@ -934,7 +934,7 @@ param decoratedString string
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |decoratedString|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[28:30) NewLine |\n\n|
 
@@ -955,7 +955,7 @@ param decoratedInt int = 123
 //@[0:5)  Identifier |param|
 //@[6:18)  IdentifierSyntax
 //@[6:18)   Identifier |decoratedInt|
-//@[19:22)  TypeSyntax
+//@[19:22)  SimpleTypeSyntax
 //@[19:22)   Identifier |int|
 //@[23:28)  ParameterDefaultValueSyntax
 //@[23:24)   Assignment |=|
@@ -998,7 +998,7 @@ param negativeValues int
 //@[0:5)  Identifier |param|
 //@[6:20)  IdentifierSyntax
 //@[6:20)   Identifier |negativeValues|
-//@[21:24)  TypeSyntax
+//@[21:24)  SimpleTypeSyntax
 //@[21:24)   Identifier |int|
 //@[24:26) NewLine |\n\n|
 
@@ -1081,7 +1081,7 @@ param decoratedBool bool = (true && false) != true
 //@[0:5)  Identifier |param|
 //@[6:19)  IdentifierSyntax
 //@[6:19)   Identifier |decoratedBool|
-//@[20:24)  TypeSyntax
+//@[20:24)  SimpleTypeSyntax
 //@[20:24)   Identifier |bool|
 //@[25:50)  ParameterDefaultValueSyntax
 //@[25:26)   Assignment |=|
@@ -1114,7 +1114,7 @@ param decoratedObject object = {
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |decoratedObject|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |object|
 //@[29:244)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -1303,7 +1303,7 @@ param decoratedArray array = [
 //@[0:5)  Identifier |param|
 //@[6:20)  IdentifierSyntax
 //@[6:20)   Identifier |decoratedArray|
-//@[21:26)  TypeSyntax
+//@[21:26)  SimpleTypeSyntax
 //@[21:26)   Identifier |array|
 //@[27:59)  ParameterDefaultValueSyntax
 //@[27:28)   Assignment |=|

--- a/src/Bicep.Core.Samples/Files/Registry_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Registry_LF/main.syntax.bicep
@@ -692,7 +692,7 @@ output siteUrls array = [for (site, i) in websites: siteDeploy[i].outputs.siteUr
 //@[0:6)  Identifier |output|
 //@[7:15)  IdentifierSyntax
 //@[7:15)   Identifier |siteUrls|
-//@[16:21)  TypeSyntax
+//@[16:21)  SimpleTypeSyntax
 //@[16:21)   Identifier |array|
 //@[22:23)  Assignment |=|
 //@[24:82)  ForSyntax

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.syntax.bicep
@@ -11,7 +11,7 @@ param ownerPrincipalId string
 //@[0:5)  Identifier |param|
 //@[6:22)  IdentifierSyntax
 //@[6:22)   Identifier |ownerPrincipalId|
-//@[23:29)  TypeSyntax
+//@[23:29)  SimpleTypeSyntax
 //@[23:29)   Identifier |string|
 //@[29:33) NewLine |\r\n\r\n|
 
@@ -20,7 +20,7 @@ param contributorPrincipals array
 //@[0:5)  Identifier |param|
 //@[6:27)  IdentifierSyntax
 //@[6:27)   Identifier |contributorPrincipals|
-//@[28:33)  TypeSyntax
+//@[28:33)  SimpleTypeSyntax
 //@[28:33)   Identifier |array|
 //@[33:35) NewLine |\r\n|
 param readerPrincipals array
@@ -28,7 +28,7 @@ param readerPrincipals array
 //@[0:5)  Identifier |param|
 //@[6:22)  IdentifierSyntax
 //@[6:22)   Identifier |readerPrincipals|
-//@[23:28)  TypeSyntax
+//@[23:28)  SimpleTypeSyntax
 //@[23:28)   Identifier |array|
 //@[28:32) NewLine |\r\n\r\n|
 

--- a/src/Bicep.Core.Samples/Files/ResourcesSubscription_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesSubscription_CRLF/main.syntax.bicep
@@ -11,7 +11,7 @@ param ownerPrincipalId string
 //@[0:5)  Identifier |param|
 //@[6:22)  IdentifierSyntax
 //@[6:22)   Identifier |ownerPrincipalId|
-//@[23:29)  TypeSyntax
+//@[23:29)  SimpleTypeSyntax
 //@[23:29)   Identifier |string|
 //@[29:33) NewLine |\r\n\r\n|
 
@@ -20,7 +20,7 @@ param contributorPrincipals array
 //@[0:5)  Identifier |param|
 //@[6:27)  IdentifierSyntax
 //@[6:27)   Identifier |contributorPrincipals|
-//@[28:33)  TypeSyntax
+//@[28:33)  SimpleTypeSyntax
 //@[28:33)   Identifier |array|
 //@[33:35) NewLine |\r\n|
 param readerPrincipals array
@@ -28,7 +28,7 @@ param readerPrincipals array
 //@[0:5)  Identifier |param|
 //@[6:22)  IdentifierSyntax
 //@[6:22)   Identifier |readerPrincipals|
-//@[23:28)  TypeSyntax
+//@[23:28)  SimpleTypeSyntax
 //@[23:28)   Identifier |array|
 //@[28:32) NewLine |\r\n\r\n|
 

--- a/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.syntax.bicep
@@ -426,7 +426,7 @@ output managementGroupIds array = [for i in range(0, length(managementGroups)): 
 //@[0:6)  Identifier |output|
 //@[7:25)  IdentifierSyntax
 //@[7:25)   Identifier |managementGroupIds|
-//@[26:31)  TypeSyntax
+//@[26:31)  SimpleTypeSyntax
 //@[26:31)   Identifier |array|
 //@[32:33)  Assignment |=|
 //@[34:172)  ForSyntax

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.syntax.bicep
@@ -462,7 +462,7 @@ param applicationName string = 'to-do-app${uniqueString(resourceGroup().id)}'
 //@[0:5)  Identifier |param|
 //@[6:21)  IdentifierSyntax
 //@[6:21)   Identifier |applicationName|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:77)  ParameterDefaultValueSyntax
 //@[29:30)   Assignment |=|
@@ -501,7 +501,7 @@ param appServicePlanTier string
 //@[0:5)  Identifier |param|
 //@[6:24)  IdentifierSyntax
 //@[6:24)   Identifier |appServicePlanTier|
-//@[25:31)  TypeSyntax
+//@[25:31)  SimpleTypeSyntax
 //@[25:31)   Identifier |string|
 //@[31:33) NewLine |\r\n|
 param appServicePlanInstances int
@@ -509,7 +509,7 @@ param appServicePlanInstances int
 //@[0:5)  Identifier |param|
 //@[6:29)  IdentifierSyntax
 //@[6:29)   Identifier |appServicePlanInstances|
-//@[30:33)  TypeSyntax
+//@[30:33)  SimpleTypeSyntax
 //@[30:33)   Identifier |int|
 //@[33:37) NewLine |\r\n\r\n|
 
@@ -683,7 +683,7 @@ param webSiteName string
 //@[0:5)  Identifier |param|
 //@[6:17)  IdentifierSyntax
 //@[6:17)   Identifier |webSiteName|
-//@[18:24)  TypeSyntax
+//@[18:24)  SimpleTypeSyntax
 //@[18:24)   Identifier |string|
 //@[24:26) NewLine |\r\n|
 param cosmosDb object
@@ -691,7 +691,7 @@ param cosmosDb object
 //@[0:5)  Identifier |param|
 //@[6:14)  IdentifierSyntax
 //@[6:14)   Identifier |cosmosDb|
-//@[15:21)  TypeSyntax
+//@[15:21)  SimpleTypeSyntax
 //@[15:21)   Identifier |object|
 //@[21:23) NewLine |\r\n|
 resource site 'Microsoft.Web/sites@2019-08-01' = {
@@ -928,7 +928,7 @@ output siteApiVersion string = site.apiVersion
 //@[0:6)  Identifier |output|
 //@[7:21)  IdentifierSyntax
 //@[7:21)   Identifier |siteApiVersion|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:30)  Assignment |=|
 //@[31:46)  PropertyAccessSyntax
@@ -944,7 +944,7 @@ output siteType string = site.type
 //@[0:6)  Identifier |output|
 //@[7:15)  IdentifierSyntax
 //@[7:15)   Identifier |siteType|
-//@[16:22)  TypeSyntax
+//@[16:22)  SimpleTypeSyntax
 //@[16:22)   Identifier |string|
 //@[23:24)  Assignment |=|
 //@[25:34)  PropertyAccessSyntax
@@ -1631,7 +1631,7 @@ param shouldDeployVm bool = true
 //@[0:5)  Identifier |param|
 //@[6:20)  IdentifierSyntax
 //@[6:20)   Identifier |shouldDeployVm|
-//@[21:25)  TypeSyntax
+//@[21:25)  SimpleTypeSyntax
 //@[21:25)   Identifier |bool|
 //@[26:32)  ParameterDefaultValueSyntax
 //@[26:27)   Assignment |=|
@@ -3255,7 +3255,7 @@ output p1_subnet1prefix string = p1_subnet1.properties.addressPrefix
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p1_subnet1prefix|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:68)  PropertyAccessSyntax
@@ -3275,7 +3275,7 @@ output p1_subnet1name string = p1_subnet1.name
 //@[0:6)  Identifier |output|
 //@[7:21)  IdentifierSyntax
 //@[7:21)   Identifier |p1_subnet1name|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:30)  Assignment |=|
 //@[31:46)  PropertyAccessSyntax
@@ -3291,7 +3291,7 @@ output p1_subnet1type string = p1_subnet1.type
 //@[0:6)  Identifier |output|
 //@[7:21)  IdentifierSyntax
 //@[7:21)   Identifier |p1_subnet1type|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:30)  Assignment |=|
 //@[31:46)  PropertyAccessSyntax
@@ -3307,7 +3307,7 @@ output p1_subnet1id string = p1_subnet1.id
 //@[0:6)  Identifier |output|
 //@[7:19)  IdentifierSyntax
 //@[7:19)   Identifier |p1_subnet1id|
-//@[20:26)  TypeSyntax
+//@[20:26)  SimpleTypeSyntax
 //@[20:26)   Identifier |string|
 //@[27:28)  Assignment |=|
 //@[29:42)  PropertyAccessSyntax
@@ -3445,7 +3445,7 @@ output p2_res2childprop string = p2_res2child.properties.someProp
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p2_res2childprop|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:65)  PropertyAccessSyntax
@@ -3465,7 +3465,7 @@ output p2_res2childname string = p2_res2child.name
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p2_res2childname|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:50)  PropertyAccessSyntax
@@ -3481,7 +3481,7 @@ output p2_res2childtype string = p2_res2child.type
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p2_res2childtype|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:50)  PropertyAccessSyntax
@@ -3497,7 +3497,7 @@ output p2_res2childid string = p2_res2child.id
 //@[0:6)  Identifier |output|
 //@[7:21)  IdentifierSyntax
 //@[7:21)   Identifier |p2_res2childid|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:30)  Assignment |=|
 //@[31:46)  PropertyAccessSyntax
@@ -3572,7 +3572,7 @@ output p3_res1childprop string = p3_child1.properties.someProp
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p3_res1childprop|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:62)  PropertyAccessSyntax
@@ -3592,7 +3592,7 @@ output p3_res1childname string = p3_child1.name
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p3_res1childname|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:47)  PropertyAccessSyntax
@@ -3608,7 +3608,7 @@ output p3_res1childtype string = p3_child1.type
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p3_res1childtype|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:47)  PropertyAccessSyntax
@@ -3624,7 +3624,7 @@ output p3_res1childid string = p3_child1.id
 //@[0:6)  Identifier |output|
 //@[7:21)  IdentifierSyntax
 //@[7:21)   Identifier |p3_res1childid|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:30)  Assignment |=|
 //@[31:43)  PropertyAccessSyntax
@@ -3711,7 +3711,7 @@ output p4_res1childprop string = p4_child1.properties.someProp
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p4_res1childprop|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:62)  PropertyAccessSyntax
@@ -3731,7 +3731,7 @@ output p4_res1childname string = p4_child1.name
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p4_res1childname|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:47)  PropertyAccessSyntax
@@ -3747,7 +3747,7 @@ output p4_res1childtype string = p4_child1.type
 //@[0:6)  Identifier |output|
 //@[7:23)  IdentifierSyntax
 //@[7:23)   Identifier |p4_res1childtype|
-//@[24:30)  TypeSyntax
+//@[24:30)  SimpleTypeSyntax
 //@[24:30)   Identifier |string|
 //@[31:32)  Assignment |=|
 //@[33:47)  PropertyAccessSyntax
@@ -3763,7 +3763,7 @@ output p4_res1childid string = p4_child1.id
 //@[0:6)  Identifier |output|
 //@[7:21)  IdentifierSyntax
 //@[7:21)   Identifier |p4_res1childid|
-//@[22:28)  TypeSyntax
+//@[22:28)  SimpleTypeSyntax
 //@[22:28)   Identifier |string|
 //@[29:30)  Assignment |=|
 //@[31:43)  PropertyAccessSyntax

--- a/src/Bicep.Core.Samples/Files/Unicode_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Unicode_LF/main.syntax.bicep
@@ -94,7 +94,7 @@ output concatUnicodeStrings string = concat('Θμ', '二头肌', 'α')
 //@[0:6)  Identifier |output|
 //@[7:27)  IdentifierSyntax
 //@[7:27)   Identifier |concatUnicodeStrings|
-//@[28:34)  TypeSyntax
+//@[28:34)  SimpleTypeSyntax
 //@[28:34)   Identifier |string|
 //@[35:36)  Assignment |=|
 //@[37:61)  FunctionCallSyntax
@@ -119,7 +119,7 @@ output interpolateUnicodeStrings string = 'Θμ二${emojis}头肌${ninjaCat}α'
 //@[0:6)  Identifier |output|
 //@[7:32)  IdentifierSyntax
 //@[7:32)   Identifier |interpolateUnicodeStrings|
-//@[33:39)  TypeSyntax
+//@[33:39)  SimpleTypeSyntax
 //@[33:39)   Identifier |string|
 //@[40:41)  Assignment |=|
 //@[42:70)  StringSyntax

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.syntax.bicep
@@ -1663,7 +1663,7 @@ param parameters bool = true
 //@[0:5)  Identifier |param|
 //@[6:16)  IdentifierSyntax
 //@[6:16)   Identifier |parameters|
-//@[17:21)  TypeSyntax
+//@[17:21)  SimpleTypeSyntax
 //@[17:21)   Identifier |bool|
 //@[22:28)  ParameterDefaultValueSyntax
 //@[22:23)   Assignment |=|
@@ -1738,7 +1738,7 @@ param mod bool = true
 //@[0:5)  Identifier |param|
 //@[6:9)  IdentifierSyntax
 //@[6:9)   Identifier |mod|
-//@[10:14)  TypeSyntax
+//@[10:14)  SimpleTypeSyntax
 //@[10:14)   Identifier |bool|
 //@[15:21)  ParameterDefaultValueSyntax
 //@[15:16)   Assignment |=|
@@ -1786,7 +1786,7 @@ param equals bool = true
 //@[0:5)  Identifier |param|
 //@[6:12)  IdentifierSyntax
 //@[6:12)   Identifier |equals|
-//@[13:17)  TypeSyntax
+//@[13:17)  SimpleTypeSyntax
 //@[13:17)   Identifier |bool|
 //@[18:24)  ParameterDefaultValueSyntax
 //@[18:19)   Assignment |=|

--- a/src/Bicep.Core.UnitTests/BicepTestConstants.cs
+++ b/src/Bicep.Core.UnitTests/BicepTestConstants.cs
@@ -30,12 +30,12 @@ namespace Bicep.Core.UnitTests
 
         public static readonly FileResolver FileResolver = new();
 
-        public static readonly IFeatureProvider Features = CreateMockFeaturesProvider(registryEnabled: false, symbolicNameCodegenEnabled: false, importsEnabled: false, assemblyFileVersion: BicepTestConstants.DevAssemblyFileVersion).Object;
+        public static readonly IFeatureProvider Features = CreateMockFeaturesProvider(registryEnabled: false, symbolicNameCodegenEnabled: false, importsEnabled: false, resourceTypedParamsAndOutputsEnabled: false, assemblyFileVersion: BicepTestConstants.DevAssemblyFileVersion).Object;
 
         public static readonly EmitterSettings EmitterSettings = new EmitterSettings(Features);
 
         public static readonly EmitterSettings EmitterSettingsWithSymbolicNames = new EmitterSettings(
-            CreateMockFeaturesProvider(registryEnabled: false, symbolicNameCodegenEnabled: true, importsEnabled: false, assemblyFileVersion: BicepTestConstants.DevAssemblyFileVersion).Object);
+            CreateMockFeaturesProvider(registryEnabled: false, symbolicNameCodegenEnabled: true, importsEnabled: false, resourceTypedParamsAndOutputsEnabled: false, assemblyFileVersion: BicepTestConstants.DevAssemblyFileVersion).Object);
 
         public static readonly IAzResourceTypeLoader AzResourceTypeLoader = new AzResourceTypeLoader();
 
@@ -62,12 +62,14 @@ namespace Bicep.Core.UnitTests
             bool registryEnabled = false,
             bool symbolicNameCodegenEnabled = false,
             bool importsEnabled = false,
+            bool resourceTypedParamsAndOutputsEnabled = false,
             string assemblyFileVersion = DevAssemblyFileVersion)
         {
             var mock = CreateMockFeaturesProvider(
                 registryEnabled: registryEnabled,
                 symbolicNameCodegenEnabled: symbolicNameCodegenEnabled,
                 importsEnabled: importsEnabled,
+                resourceTypedParamsAndOutputsEnabled: resourceTypedParamsAndOutputsEnabled,
                 assemblyFileVersion: assemblyFileVersion);
 
             var testPath = FileHelper.GetCacheRootPath(testContext);
@@ -106,13 +108,19 @@ namespace Bicep.Core.UnitTests
             return RootConfiguration.Bind(element, configurationPath);
         }
 
-        private static Mock<IFeatureProvider> CreateMockFeaturesProvider(bool registryEnabled, bool symbolicNameCodegenEnabled, bool importsEnabled, string assemblyFileVersion)
+        private static Mock<IFeatureProvider> CreateMockFeaturesProvider(
+            bool registryEnabled,
+            bool symbolicNameCodegenEnabled,
+            bool importsEnabled,
+            bool resourceTypedParamsAndOutputsEnabled,
+            string assemblyFileVersion)
         {
             var mock = StrictMock.Of<IFeatureProvider>();
             mock.SetupGet(m => m.RegistryEnabled).Returns(registryEnabled);
             mock.SetupGet(m => m.SymbolicNameCodegenEnabled).Returns(symbolicNameCodegenEnabled);
             mock.SetupGet(m => m.ImportsEnabled).Returns(importsEnabled);
             mock.SetupGet(m => m.AssemblyVersion).Returns(assemblyFileVersion);
+            mock.SetupGet(m => m.ResourceTypedParamsAndOutputsEnabled).Returns(resourceTypedParamsAndOutputsEnabled);
 
             return mock;
         }

--- a/src/Bicep.Core.UnitTests/Emit/ExpressionConverterTests.cs
+++ b/src/Bicep.Core.UnitTests/Emit/ExpressionConverterTests.cs
@@ -60,7 +60,7 @@ namespace Bicep.Core.UnitTests.Emit
         public void ShouldConvertExpressionsCorrectly(string text, string expected)
         {
             var programText = $"var test = {text}";
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(programText, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(programText, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             var programSyntax = compilation.SourceFileGrouping.EntryPoint.ProgramSyntax;
             var variableDeclarationSyntax = programSyntax.Children.OfType<VariableDeclarationSyntax>().First();

--- a/src/Bicep.Core.UnitTests/Emit/InlineDependencyVisitorTests.cs
+++ b/src/Bicep.Core.UnitTests/Emit/InlineDependencyVisitorTests.cs
@@ -26,7 +26,7 @@ var runtimeLoop2 = [for (item, index) in indirection.keys: 's']
         [TestMethod]
         public void VisitorShouldCalculateInliningInBulk()
         {
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateFromText(Text, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateFromText(Text, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             var inlineVariables = InlineDependencyVisitor.GetVariablesToInline(compilation.GetEntrypointSemanticModel());
 
@@ -43,7 +43,7 @@ var runtimeLoop2 = [for (item, index) in indirection.keys: 's']
         [DataTestMethod]
         public void VisitorShouldProduceNoChainForNonInlinedVariables(string variableName)
         {
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateFromText(Text, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateFromText(Text, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             VariableDeclarationSyntax variable = GetVariableByName(compilation, variableName);
 
             InlineDependencyVisitor.ShouldInlineVariable(compilation.GetEntrypointSemanticModel(), variable, out var chain).Should().BeFalse();
@@ -57,7 +57,7 @@ var runtimeLoop2 = [for (item, index) in indirection.keys: 's']
         [DataTestMethod]
         public void VisitorShouldProduceCorrectChainForInlinedVariables(string variableName, string expectedChain)
         {
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateFromText(Text, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateFromText(Text, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             VariableDeclarationSyntax variable = GetVariableByName(compilation, variableName);
 
             InlineDependencyVisitor.ShouldInlineVariable(compilation.GetEntrypointSemanticModel(), variable, out var chain).Should().BeTrue();

--- a/src/Bicep.Core.UnitTests/Semantics/SymbolContextTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/SymbolContextTests.cs
@@ -19,7 +19,7 @@ namespace Bicep.Core.UnitTests.Semantics
         {
             const string expectedMessage = "Properties of the symbol context should not be accessed until name binding is completed.";
 
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText("", BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText("", BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var bindings = new Dictionary<SyntaxBase, Symbol>();
             var cyclesBySymbol = new Dictionary<DeclaredSymbol, ImmutableArray<DeclaredSymbol>>();
             var context = new SymbolContext(compilation, compilation.GetEntrypointSemanticModel());

--- a/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
@@ -112,7 +112,7 @@ namespace Bicep.Core.UnitTests.TypeSystem.Az
         {
             var configuration = BicepTestConstants.BuiltInConfigurationWithAnalyzersDisabled;
             Compilation createCompilation(string program)
-                    => new Compilation(new DefaultNamespaceProvider(new AzResourceTypeLoader(), BicepTestConstants.Features), SourceFileGroupingFactory.CreateFromText(program, new Mock<IFileResolver>(MockBehavior.Strict).Object), configuration, BicepTestConstants.LinterAnalyzer);
+                    => new Compilation(BicepTestConstants.Features, new DefaultNamespaceProvider(new AzResourceTypeLoader(), BicepTestConstants.Features), SourceFileGroupingFactory.CreateFromText(program, new Mock<IFileResolver>(MockBehavior.Strict).Object), configuration, BicepTestConstants.LinterAnalyzer);
 
             // Missing top-level properties - should be an error
             var compilation = createCompilation(@"
@@ -129,7 +129,7 @@ resource missingResource 'Mock.Rp/madeUpResourceType@2020-01-01' = {
         public void AzResourceTypeProvider_should_error_for_top_level_and_warn_for_nested_properties()
         {
             Compilation createCompilation(string program)
-                => new Compilation(BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateFromText(program, new Mock<IFileResolver>(MockBehavior.Strict).Object), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+                => new Compilation(BicepTestConstants.Features, BuiltInTestTypes.Create(), SourceFileGroupingFactory.CreateFromText(program, new Mock<IFileResolver>(MockBehavior.Strict).Object), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             // Missing top-level properties - should be an error
             var compilation = createCompilation(@"
@@ -159,7 +159,7 @@ resource unexpectedTopLevel 'Test.Rp/readWriteTests@2020-01-01' = {
             compilation = createCompilation(@"
 resource missingRequiredProperty 'Test.Rp/readWriteTests@2020-01-01' = {
   name: 'missingRequiredProperty'
-  properties: {    
+  properties: {
   }
 }
 ");

--- a/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
@@ -624,7 +624,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 .Setup(x => x.GetSymbolInfo(It.IsAny<SyntaxBase>()))
                 .Returns<Symbol?>(null);
 
-            var typeManager = new TypeManager(binderMock.Object, fileResolverMock.Object);
+            var typeManager = new TypeManager(BicepTestConstants.Features, binderMock.Object, fileResolverMock.Object);
 
             var diagnosticWriter = ToListDiagnosticWriter.Create();
             var result = TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binderMock.Object, diagnosticWriter, expression, targetType);

--- a/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
@@ -62,7 +62,7 @@ namespace Bicep.Core.UnitTests.Utils
             var configuration = BicepTestConstants.BuiltInConfiguration;
             var sourceFileGrouping = SourceFileGroupingFactory.CreateForFiles(uriDictionary, entryUri, fileResolver, configuration, context.GetFeatures());
 
-            return Compile(context, new Compilation(context.GetNamespaceProvider(), sourceFileGrouping, configuration, BicepTestConstants.LinterAnalyzer));
+            return Compile(context, new Compilation(context.Features ?? BicepTestConstants.Features, context.GetNamespaceProvider(), sourceFileGrouping, configuration, BicepTestConstants.LinterAnalyzer));
         }
 
         public static CompilationResult Compile(IAzResourceTypeLoader resourceTypeLoader, params (string fileName, string fileContents)[] files)

--- a/src/Bicep.Core.UnitTests/Workspaces/BicepFileTests.cs
+++ b/src/Bicep.Core.UnitTests/Workspaces/BicepFileTests.cs
@@ -16,7 +16,7 @@ namespace Bicep.Core.UnitTests.Workspaces
         {
             string bicepFileContents = @"#disable-next-line no-unused-params
 param storageAccount string = 'testStorageAccount'";
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(bicepFileContents, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(bicepFileContents, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var bicepFile = compilation.GetEntrypointSemanticModel().SourceFile;
 
             var disabledDiagnosticsCache = bicepFile.DisabledDiagnosticsCache;
@@ -31,7 +31,7 @@ param storageAccount string = 'testStorageAccount'";
         public void VerifyDisableNextLineDiagnosticDirectivesCache_WithNoDisableNextLineDiagnosticDirectivesInBicepFile()
         {
             string bicepFileContents = @"param storageAccount string = 'testStorageAccount'";
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(bicepFileContents, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(bicepFileContents, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var bicepFile = compilation.GetEntrypointSemanticModel().SourceFile;
 
             var disabledDiagnosticsCache = bicepFile.DisabledDiagnosticsCache;
@@ -64,7 +64,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
 
 
 ";
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(bicepFileContents, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(bicepFileContents, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var bicepFile = compilation.GetEntrypointSemanticModel().SourceFile;
 
             var disabledDiagnosticsCache = bicepFile.DisabledDiagnosticsCache;

--- a/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberResourcesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberResourcesRule.cs
@@ -3,6 +3,7 @@
 
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,9 +30,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
         override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
         {
-            if (model.AllResources.Length > MaxNumber)
+            if (model.DeclaredResources.Length > MaxNumber)
             {
-                var firstItem = model.AllResources.Where(r => r.Parent is null).First();
+                var firstItem = model.DeclaredResources.Where(r => r.Parent is null).First();
                 return new IDiagnostic[] { CreateDiagnosticForSpan(firstItem.Symbol.NameSyntax.Span, MaxNumber) };
             }
             return Enumerable.Empty<IDiagnostic>();

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseProtectedSettingsForCommandToExecuteSecretsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseProtectedSettingsForCommandToExecuteSecretsRule.cs
@@ -47,7 +47,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         {
             List<IDiagnostic> diagnostics = new();
 
-            foreach (ResourceMetadata resource in semanticModel.AllResources.Where(r => r.IsAzResource))
+            foreach (var resource in semanticModel.DeclaredResources.Where(r => r.IsAzResource))
             {
                 // We're looking for this pattern:
                 //

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseStableVMImageRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseStableVMImageRule.cs
@@ -35,7 +35,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         {
             List<IDiagnostic> diagnostics = new();
 
-            foreach (ResourceMetadata resource in model.AllResources)
+            foreach (DeclaredResourceMetadata resource in model.DeclaredResources)
             {
                 ResourceDeclarationSyntax resourceSyntax = resource.Symbol.DeclaringResource;
                 if (resourceSyntax.TryGetBody()?.TryGetPropertyByNameRecursive("properties", "storageProfile", "imageReference") is ObjectPropertySyntax imageReferenceSyntax)

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1343,6 +1343,32 @@ namespace Bicep.Core.Diagnostics
                 "BCP226",
                 "Expected at least one diagnostic code at this location. Valid format is \"#disable-next-line diagnosticCode1 diagnosticCode2 ...\""
             );
+
+            public ErrorDiagnostic UnsupportedResourceTypeParameterType(string resourceType) => new(
+                TextSpan,
+                "BCP227",
+                $"The type \"{resourceType}\" cannot be used as a parameter type. Extensibility types are currently not supported as parameters or outputs.");
+
+            public ErrorDiagnostic UnsupportedResourceTypeOutputType(string resourceType) => new(
+                TextSpan,
+                "BCP228",
+                $"The type \"{resourceType}\" cannot be used as an output type. Extensibility types are currently not supported as parameters or outputs.");
+
+            public ErrorDiagnostic InvalidResourceScopeCannotBeResourceTypeParameter(string parameterName) => new(
+                TextSpan,
+                "BCP229",
+                $"The parameter \"{parameterName}\" cannot be used as a resource scope or parent. Resources passed as parameters cannot be used as a scope or parent of a resource.");
+
+            public Diagnostic ModuleParamOrOutputResourceTypeUnavailable(ResourceTypeReference resourceTypeReference) => new(
+                TextSpan,
+                DiagnosticLevel.Warning,
+                "BCP230",
+                $"The referenced module uses resource type \"{resourceTypeReference.FormatName()}\" which does not have types available.");
+
+            public ErrorDiagnostic ParamOrOutputResourceTypeUnsupported() => new(
+                TextSpan,
+                "BCP231",
+                "Using resource-typed parameters and outputs requires enabling EXPERIMENTAL feature BICEP_RESOURCE_TYPED_PARAMS_AND_OUTPUTS_EXPERIMENTAL.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -39,7 +39,7 @@ namespace Bicep.Core.Emit
             return new EmitLimitationInfo(diagnosticWriter.GetDiagnostics(), moduleScopeData, resourceScopeData);
         }
 
-        private static void DetectDuplicateNames(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter, ImmutableDictionary<ResourceMetadata, ScopeHelper.ScopeData> resourceScopeData, ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> moduleScopeData)
+        private static void DetectDuplicateNames(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter, ImmutableDictionary<DeclaredResourceMetadata, ScopeHelper.ScopeData> resourceScopeData, ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> moduleScopeData)
         {
             // TODO generalize or move into Az extension
 
@@ -94,9 +94,9 @@ namespace Bicep.Core.Emit
             }
         }
 
-        private static IEnumerable<ResourceDefinition> GetResourceDefinitions(SemanticModel semanticModel, ImmutableDictionary<ResourceMetadata, ScopeHelper.ScopeData> resourceScopeData)
+        private static IEnumerable<ResourceDefinition> GetResourceDefinitions(SemanticModel semanticModel, ImmutableDictionary<DeclaredResourceMetadata, ScopeHelper.ScopeData> resourceScopeData)
         {
-            foreach (var resource in semanticModel.AllResources)
+            foreach (var resource in semanticModel.DeclaredResources)
             {
                 if (resource.IsExistingResource)
                 {
@@ -135,7 +135,7 @@ namespace Bicep.Core.Emit
         public static void DetectIncorrectlyFormattedNames(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
             // TODO move into Az extension
-            foreach (var resource in semanticModel.AllResources)
+            foreach (var resource in semanticModel.DeclaredResources)
             {
                 if (!resource.IsAzResource)
                 {
@@ -192,7 +192,7 @@ namespace Bicep.Core.Emit
 
         public static void DetectUnexpectedResourceLoopInvariantProperties(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
-            foreach (var resource in semanticModel.AllResources)
+            foreach (var resource in semanticModel.DeclaredResources)
             {
                 if (resource.IsExistingResource)
                 {

--- a/src/Bicep.Core/Emit/EmitLimitationInfo.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationInfo.cs
@@ -14,9 +14,9 @@ namespace Bicep.Core.Emit
 
         public ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> ModuleScopeData { get; }
 
-        public ImmutableDictionary<ResourceMetadata, ScopeHelper.ScopeData> ResourceScopeData { get; }
+        public ImmutableDictionary<DeclaredResourceMetadata, ScopeHelper.ScopeData> ResourceScopeData { get; }
 
-        public EmitLimitationInfo(IReadOnlyList<IDiagnostic> diagnostics, ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> moduleScopeData, ImmutableDictionary<ResourceMetadata, ScopeHelper.ScopeData> resourceScopeData)
+        public EmitLimitationInfo(IReadOnlyList<IDiagnostic> diagnostics, ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> moduleScopeData, ImmutableDictionary<DeclaredResourceMetadata, ScopeHelper.ScopeData> resourceScopeData)
         {
             Diagnostics = diagnostics;
             ModuleScopeData = moduleScopeData;

--- a/src/Bicep.Core/Emit/EmitterContext.cs
+++ b/src/Bicep.Core/Emit/EmitterContext.cs
@@ -30,6 +30,6 @@ namespace Bicep.Core.Emit
 
         public ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> ModuleScopeData => SemanticModel.EmitLimitationInfo.ModuleScopeData;
 
-        public ImmutableDictionary<ResourceMetadata, ScopeHelper.ScopeData> ResourceScopeData => SemanticModel.EmitLimitationInfo.ResourceScopeData;
+        public ImmutableDictionary<DeclaredResourceMetadata, ScopeHelper.ScopeData> ResourceScopeData => SemanticModel.EmitLimitationInfo.ResourceScopeData;
     }
 }

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -13,6 +13,7 @@ using Bicep.Core.Extensions;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
 using JetBrains.Annotations;
 using Newtonsoft.Json.Linq;
 
@@ -138,7 +139,7 @@ namespace Bicep.Core.Emit
                             return CreateFunction(
                                 instanceFunctionCall.Name.IdentifierName,
                                 instanceFunctionCall.Arguments.Select(a => ConvertExpression(a.Expression)));
-                        case DeclaredSymbol declaredSymbol when context.SemanticModel.ResourceMetadata.TryLookup(declaredSymbol.DeclaringSyntax) is { } resource:
+                        case DeclaredSymbol declaredSymbol when context.SemanticModel.ResourceMetadata.TryLookup(declaredSymbol.DeclaringSyntax) is DeclaredResourceMetadata resource:
                             if (instanceFunctionCall.Name.IdentifierName.StartsWithOrdinalInsensitively("list"))
                             {
                                 var converter = indexExpression is not null ?
@@ -205,7 +206,7 @@ namespace Bicep.Core.Emit
             // variable replaced with <loop array expression>[this array access' index expression]
             if (arrayAccess.BaseExpression is VariableAccessSyntax || arrayAccess.BaseExpression is ResourceAccessSyntax)
             {
-                if (context.SemanticModel.ResourceMetadata.TryLookup(arrayAccess.BaseExpression) is { } resource &&
+                if (context.SemanticModel.ResourceMetadata.TryLookup(arrayAccess.BaseExpression) is DeclaredResourceMetadata resource &&
                     resource.Symbol.IsCollection)
                 {
                     var movedSyntax = context.Settings.EnableSymbolicNames ? resource.Symbol.NameSyntax : resource.NameSyntax;
@@ -240,41 +241,121 @@ namespace Bicep.Core.Emit
                     new JTokenExpression(propertyName));
             }
 
-            // special cases for certain resource property access. if we recurse normally, we'll end up
-            // generating statements like reference(resourceId(...)).id which are not accepted by ARM
-            switch ((propertyName, context.Settings.EnableSymbolicNames))
+            // The cases for a parameter resource are much simpler and can be handled up front. These do not
+            // support symbolic names they are somewhat different from the declared resource case since we just have an
+            // ID and type.
+            if (resource is ParameterResourceMetadata parameter)
             {
-                case ("id", true):
-                case ("name", true):
-                case ("type", true):
-                case ("apiVersion", true):
-                    var symbolExpression = GenerateSymbolicReference(resource.Symbol.Name, indexExpression);
+                switch (propertyName)
+                {
+                    case "id":
+                        return GetFullyQualifiedResourceId(parameter);
+                    case "type":
+                        return new JTokenExpression(resource.TypeReference.FormatType());
+                    case "apiVersion":
+                        return new JTokenExpression(resource.TypeReference.ApiVersion);
+                    case "name":
+                        // create an expression like: `last(split(<resource id>, '/'))`
+                        return new FunctionExpression(
+                                "last",
+                                new LanguageExpression[]
+                                {
+                                    new FunctionExpression(
+                                        "split",
+                                        new LanguageExpression[]
+                                        {
+                                            GetFullyQualifiedResourceId(parameter),
+                                            new JTokenExpression("/"),
+                                        },
+                                        Array.Empty<LanguageExpression>())
+                                },
+                                Array.Empty<LanguageExpression>());
+                    case "properties":
+                        // use the reference() overload without "full" to generate a shorter expression
+                        // this is dependent on the name expression which could involve locals in case of a resource collection
+                        return GetReferenceExpression(resource, indexExpression, false);
+                    default:
+                        return AppendProperties(
+                            GetReferenceExpression(resource, indexExpression, true),
+                            new JTokenExpression(propertyName));
+                }
+            }
+            else if (resource is ModuleOutputResourceMetadata output)
+            {
+                switch (propertyName)
+                {
+                    case "id":
+                        return GetFullyQualifiedResourceId(output);
+                    case "type":
+                        return new JTokenExpression(resource.TypeReference.FormatType());
+                    case "apiVersion":
+                        return new JTokenExpression(resource.TypeReference.ApiVersion);
+                    case "name":
+                        // create an expression like: `last(split(<resource id>, '/'))`
+                        return new FunctionExpression(
+                                "last",
+                                new LanguageExpression[]
+                                {
+                                    new FunctionExpression(
+                                        "split",
+                                        new LanguageExpression[]
+                                        {
+                                            GetFullyQualifiedResourceId(output),
+                                            new JTokenExpression("/"),
+                                        },
+                                        Array.Empty<LanguageExpression>())
+                                },
+                                Array.Empty<LanguageExpression>());
+                    case "properties":
+                        // use the reference() overload without "full" to generate a shorter expression
+                        // this is dependent on the name expression which could involve locals in case of a resource collection
+                        return GetReferenceExpression(resource, indexExpression, false);
+                    default:
+                        // For a module output we have to handle all possible cases here, because otherwise
+                        // this case would be handled like any old property access rather than access to a resource's property.
+                        return AppendProperties(GetReferenceExpression(resource, indexExpression, true), new JTokenExpression(propertyName));
+                }
+            }
+            else if (resource is DeclaredResourceMetadata declaredResource)
+            {
+                switch ((propertyName, context.Settings.EnableSymbolicNames))
+                {
+                    case ("id", true):
+                    case ("name", true):
+                    case ("type", true):
+                    case ("apiVersion", true):
+                        var symbolExpression = GenerateSymbolicReference(declaredResource.Symbol.Name, indexExpression);
 
-                    return AppendProperties(
-                        CreateFunction("resourceInfo", symbolExpression),
-                        new JTokenExpression(propertyName));
-                case ("id", false):
-                    // the ID is dependent on the name expression which could involve locals in case of a resource collection
-                    return GetFullyQualifiedResourceId(resource);
-                case ("name", false):
-                    // the name is dependent on the name expression which could involve locals in case of a resource collection
+                        return AppendProperties(
+                            CreateFunction("resourceInfo", symbolExpression),
+                            new JTokenExpression(propertyName));
+                    case ("id", false):
+                        // the ID is dependent on the name expression which could involve locals in case of a resource collection
+                        return GetFullyQualifiedResourceId(resource);
+                    case ("name", false):
+                        // the name is dependent on the name expression which could involve locals in case of a resource collection
 
-                    // Note that we don't want to return the fully-qualified resource name in the case of name property access.
-                    // we should return whatever the user has set as the value of the 'name' property for a predictable user experience.
-                    return ConvertExpression(resource.NameSyntax);
-                case ("type", false):
-                    return new JTokenExpression(resource.TypeReference.FormatType());
-                case ("apiVersion", false):
-                    var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
-                    return new JTokenExpression(apiVersion);
-                case ("properties", _):
-                    // use the reference() overload without "full" to generate a shorter expression
-                    // this is dependent on the name expression which could involve locals in case of a resource collection
-                    return GetReferenceExpression(resource, indexExpression, false);
-                default:
-                    return AppendProperties(
-                        GetReferenceExpression(resource, indexExpression, true),
-                        new JTokenExpression(propertyName));
+                        // Note that we don't want to return the fully-qualified resource name in the case of name property access.
+                        // we should return whatever the user has set as the value of the 'name' property for a predictable user experience.
+                        return ConvertExpression(declaredResource.NameSyntax);
+                    case ("type", false):
+                        return new JTokenExpression(resource.TypeReference.FormatType());
+                    case ("apiVersion", false):
+                        var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
+                        return new JTokenExpression(apiVersion);
+                    case ("properties", _):
+                        // use the reference() overload without "full" to generate a shorter expression
+                        // this is dependent on the name expression which could involve locals in case of a resource collection
+                        return GetReferenceExpression(resource, indexExpression, false);
+                    default:
+                        return AppendProperties(
+                            GetReferenceExpression(resource, indexExpression, true),
+                            new JTokenExpression(propertyName));
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unsupported resource metadata type: {resource.GetType()}");
             }
         }
 
@@ -292,7 +373,7 @@ namespace Bicep.Core.Emit
 
         private LanguageExpression ConvertPropertyAccess(PropertyAccessSyntax propertyAccess)
         {
-            if (context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is { } resource)
+            if (context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is DeclaredResourceMetadata resource)
             {
                 var movedSyntax = context.Settings.EnableSymbolicNames ? resource.Symbol.NameSyntax : resource.NameSyntax;
 
@@ -301,14 +382,46 @@ namespace Bicep.Core.Emit
                     .ConvertResourcePropertyAccess(resource, null, propertyAccess.PropertyName.IdentifierName);
             }
 
+            if ((propertyAccess.BaseExpression is VariableAccessSyntax || propertyAccess.BaseExpression is ResourceAccessSyntax) &&
+                context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is ParameterResourceMetadata parameter &&
+                    this.ConvertResourcePropertyAccess(parameter, null, propertyAccess.PropertyName.IdentifierName) is { } convertedSingleParameter)
+            {
+                // we are doing property access on a single resource
+                // and we are dealing with special case properties
+                return convertedSingleParameter;
+            }
+
             if (propertyAccess.BaseExpression is ArrayAccessSyntax propArrayAccess &&
-                context.SemanticModel.ResourceMetadata.TryLookup(propArrayAccess.BaseExpression) is { } resourceCollection)
+                context.SemanticModel.ResourceMetadata.TryLookup(propArrayAccess.BaseExpression) is DeclaredResourceMetadata resourceCollection)
             {
                 var movedSyntax = context.Settings.EnableSymbolicNames ? resourceCollection.Symbol.NameSyntax : resourceCollection.NameSyntax;
 
                 // we are doing property access on an array access of a resource collection
                 return CreateConverterForIndexReplacement(movedSyntax, propArrayAccess.IndexExpression, propertyAccess)
                     .ConvertResourcePropertyAccess(resourceCollection, propArrayAccess.IndexExpression, propertyAccess.PropertyName.IdentifierName);
+            }
+
+            if (propertyAccess.BaseExpression is PropertyAccessSyntax &&
+                context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is ModuleOutputResourceMetadata moduleOutput &&
+                !moduleOutput.Module.IsCollection &&
+                this.ConvertResourcePropertyAccess(moduleOutput, null, propertyAccess.PropertyName.IdentifierName) is { } convertedSingleModuleOutput)
+            {
+                // we are doing property access on an output of a non-collection module.
+                // and we are dealing with special case properties
+                return convertedSingleModuleOutput;
+            }
+
+            if (propertyAccess.BaseExpression is PropertyAccessSyntax moduleCollectionOutputProperty &&
+                moduleCollectionOutputProperty.BaseExpression is PropertyAccessSyntax moduleCollectionOutputs &&
+                moduleCollectionOutputs.BaseExpression is ArrayAccessSyntax moduleArrayAccess &&
+                context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is ModuleOutputResourceMetadata moduleCollectionOutputMetadata &&
+                moduleCollectionOutputMetadata.Module.IsCollection &&
+                CreateConverterForIndexReplacement(moduleCollectionOutputMetadata.NameSyntax, moduleArrayAccess.IndexExpression, propertyAccess)
+                    .ConvertResourcePropertyAccess(moduleCollectionOutputMetadata, null, propertyAccess.PropertyName.IdentifierName) is { } convertedCollectionModuleOutput)
+            {
+                // we are doing property access on an output of an array of modules.
+                // and we are dealing with special case properties
+                return convertedCollectionModuleOutput;
             }
 
             if (propertyAccess.BaseExpression is VariableAccessSyntax modulePropVariableAccess &&
@@ -341,7 +454,7 @@ namespace Bicep.Core.Emit
                     // is <child> a variable which points to a variable that requires in-lining?
                     case VariableAccessSyntax grandChildVariableAccess
                         when context.SemanticModel.GetSymbolInfo(grandChildVariableAccess) is VariableSymbol variableSymbol &&
-                             context.VariablesToInline.Contains(variableSymbol):
+                            context.VariablesToInline.Contains(variableSymbol):
                         {
                             //execute variable in-lining
                             if (ConvertVariableAccess(grandChildVariableAccess) is FunctionExpression moduleReferenceExpression)
@@ -384,7 +497,7 @@ namespace Bicep.Core.Emit
                 new JTokenExpression(propertyAccess.PropertyName.IdentifierName));
         }
 
-        public IEnumerable<LanguageExpression> GetResourceNameSegments(ResourceMetadata resource)
+        public IEnumerable<LanguageExpression> GetResourceNameSegments(DeclaredResourceMetadata resource)
         {
             // TODO move this into az extension
             var typeReference = resource.TypeReference;
@@ -427,7 +540,7 @@ namespace Bicep.Core.Emit
                     new JTokenExpression(i)));
         }
 
-        public LanguageExpression GetFullyQualifiedResourceName(ResourceMetadata resource)
+        public LanguageExpression GetFullyQualifiedResourceName(DeclaredResourceMetadata resource)
         {
             var nameValueSyntax = resource.NameSyntax;
 
@@ -464,7 +577,7 @@ namespace Bicep.Core.Emit
             return moduleSymbol.TryGetBodyPropertyValue(LanguageConstants.ModuleNamePropertyName) ?? throw new ArgumentException($"Expected module syntax body to contain property 'name'");
         }
 
-        public LanguageExpression GetUnqualifiedResourceId(ResourceMetadata resource)
+        public LanguageExpression GetUnqualifiedResourceId(DeclaredResourceMetadata resource)
         {
             return ScopeHelper.FormatUnqualifiedResourceId(
                 context,
@@ -476,12 +589,33 @@ namespace Bicep.Core.Emit
 
         public LanguageExpression GetFullyQualifiedResourceId(ResourceMetadata resource)
         {
-            return ScopeHelper.FormatFullyQualifiedResourceId(
-                context,
-                this,
-                context.ResourceScopeData[resource],
-                resource.TypeReference.FormatType(),
-                GetResourceNameSegments(resource));
+            if (resource is ParameterResourceMetadata parameter)
+            {
+                return new FunctionExpression(
+                    "parameters",
+                    new LanguageExpression[] { new JTokenExpression(parameter.Symbol.Name), },
+                    new LanguageExpression[] { });
+            }
+            else if (resource is ModuleOutputResourceMetadata output)
+            {
+                return AppendProperties(
+                    GetModuleOutputsReferenceExpression(output.Module, null),
+                    new JTokenExpression(output.OutputName),
+                    new JTokenExpression("value"));
+            }
+            else if (resource is DeclaredResourceMetadata declared)
+            {
+                return ScopeHelper.FormatFullyQualifiedResourceId(
+                    context,
+                    this,
+                    context.ResourceScopeData[declared],
+                    resource.TypeReference.FormatType(),
+                    GetResourceNameSegments(declared));
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unsupported resource metadata type: {resource}");
+            }
         }
 
         public LanguageExpression GetFullyQualifiedResourceId(ModuleSymbol moduleSymbol)
@@ -514,9 +648,24 @@ namespace Bicep.Core.Emit
 
         public FunctionExpression GetReferenceExpression(ResourceMetadata resource, SyntaxBase? indexExpression, bool full)
         {
-            var referenceExpression = context.Settings.EnableSymbolicNames ?
-                GenerateSymbolicReference(resource.Symbol.Name, indexExpression) :
-                GetFullyQualifiedResourceId(resource);
+            var referenceExpression = resource switch
+            {
+                ParameterResourceMetadata parameter => new FunctionExpression(
+                    "parameters",
+                    new LanguageExpression[] { new JTokenExpression(parameter.Symbol.Name), },
+                    Array.Empty<LanguageExpression>()),
+
+                ModuleOutputResourceMetadata output => AppendProperties(
+                    GetModuleOutputsReferenceExpression(output.Module, null),
+                    new JTokenExpression(output.OutputName),
+                    new JTokenExpression("value")),
+
+                DeclaredResourceMetadata declared when context.Settings.EnableSymbolicNames =>
+                    GenerateSymbolicReference(declared.Symbol.Name, indexExpression),
+                DeclaredResourceMetadata => GetFullyQualifiedResourceId(resource),
+
+                _ => throw new InvalidOperationException($"Unexpected resource metadata type: {resource.GetType()}"),
+            };
 
             if (!resource.IsAzResource)
             {
@@ -647,6 +796,18 @@ namespace Bicep.Core.Emit
 
             switch (symbol)
             {
+                case ParameterSymbol parameterSymbol when parameterSymbol.Type is ResourceType resourceType:
+                    // This is a reference to a pre-existing resource where the resource ID was passed in as a
+                    // string. Generate a call to reference().
+                    return CreateFunction(
+                        "reference",
+                        CreateFunction("parameters", new JTokenExpression(name)),
+                        new JTokenExpression(resourceType.TypeReference.ApiVersion),
+                        new JTokenExpression("full"));
+
+                case ParameterSymbol parameterSymbol when parameterSymbol.Type is ResourceType:
+                    return CreateFunction("parameters", new JTokenExpression(name));
+
                 case ParameterSymbol _:
                     return CreateFunction("parameters", new JTokenExpression(name));
 

--- a/src/Bicep.Core/Emit/ExpressionEmitter.cs
+++ b/src/Bicep.Core/Emit/ExpressionEmitter.cs
@@ -102,7 +102,7 @@ namespace Bicep.Core.Emit
             writer.WriteValue(serialized);
         }
 
-        public void EmitUnqualifiedResourceId(ResourceMetadata resource, SyntaxBase? indexExpression, SyntaxBase newContext)
+        public void EmitUnqualifiedResourceId(DeclaredResourceMetadata resource, SyntaxBase? indexExpression, SyntaxBase newContext)
         {
             var converterForContext = converter.CreateConverterForIndexReplacement(resource.NameSyntax, indexExpression, newContext);
 
@@ -112,7 +112,7 @@ namespace Bicep.Core.Emit
             writer.WriteValue(serialized);
         }
 
-        public void EmitIndexedSymbolReference(ResourceMetadata resource, SyntaxBase indexExpression, SyntaxBase newContext)
+        public void EmitIndexedSymbolReference(DeclaredResourceMetadata resource, SyntaxBase indexExpression, SyntaxBase newContext)
         {
             var expression = converter.CreateConverterForIndexReplacement(resource.Symbol.NameSyntax, indexExpression, newContext)
                 .GenerateSymbolicReference(resource.Symbol.Name, indexExpression);
@@ -128,7 +128,7 @@ namespace Bicep.Core.Emit
             writer.WriteValue(ExpressionSerializer.SerializeExpression(expression));
         }
 
-        public void EmitResourceIdReference(ResourceMetadata resource, SyntaxBase? indexExpression, SyntaxBase newContext)
+        public void EmitResourceIdReference(DeclaredResourceMetadata resource, SyntaxBase? indexExpression, SyntaxBase newContext)
         {
             var converterForContext = this.converter.CreateConverterForIndexReplacement(resource.NameSyntax, indexExpression, newContext);
 
@@ -148,7 +148,7 @@ namespace Bicep.Core.Emit
             writer.WriteValue(serialized);
         }
 
-        public LanguageExpression GetFullyQualifiedResourceName(ResourceMetadata resource)
+        public LanguageExpression GetFullyQualifiedResourceName(DeclaredResourceMetadata resource)
         {
             return converter.GetFullyQualifiedResourceName(resource);
         }
@@ -362,8 +362,9 @@ namespace Bicep.Core.Emit
 
                 var keyVaultId = instanceFunctionCall.BaseExpression switch
                 {
-                    ArrayAccessSyntax arrayAccessSyntax => converter.CreateConverterForIndexReplacement(resource.NameSyntax, arrayAccessSyntax.IndexExpression, instanceFunctionCall)
-                                                                    .GetFullyQualifiedResourceId(resource),
+                    ArrayAccessSyntax arrayAccessSyntax when resource is DeclaredResourceMetadata declared => converter
+                        .CreateConverterForIndexReplacement(declared.NameSyntax, arrayAccessSyntax.IndexExpression, instanceFunctionCall)
+                        .GetFullyQualifiedResourceId(resource),
                     _ => converter.GetFullyQualifiedResourceId(resource)
                 };
 

--- a/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
@@ -9,6 +9,7 @@ using Bicep.Core.DataFlow;
 using Bicep.Core.Extensions;
 using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Emit
@@ -65,7 +66,7 @@ namespace Bicep.Core.Emit
 
         public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
         {
-            if (model.ResourceMetadata.TryLookup(syntax) is not { } resource)
+            if (model.ResourceMetadata.TryLookup(syntax) is not DeclaredResourceMetadata resource)
             {
                 // When invoked by BicepDeploymentGraphHandler, it's possible that the declaration is unbound.
                 return;

--- a/src/Bicep.Core/Emit/ScopeHelper.cs
+++ b/src/Bicep.Core/Emit/ScopeHelper.cs
@@ -42,7 +42,7 @@ namespace Bicep.Core.Emit
             /// <summary>
             /// The symbol of the resource being extended or null.
             /// </summary>
-            public ResourceMetadata? ResourceScope { get; set; }
+            public DeclaredResourceMetadata? ResourceScope { get; set; }
 
             /// <summary>
             /// The expression for the loop index. This is used with loops when indexing into resource collections.
@@ -129,7 +129,7 @@ namespace Bicep.Core.Emit
                         _ => new ScopeData { RequestedScope = ResourceScope.ResourceGroup, SubscriptionIdProperty = type.Arguments[0].Expression, ResourceGroupProperty = type.Arguments[1].Expression, IndexExpression = indexExpression },
                     };
                 case { } when scopeSymbol is ResourceSymbol targetResourceSymbol:
-                    if (semanticModel.ResourceMetadata.TryLookup(targetResourceSymbol.DeclaringSyntax) is not { } targetResource)
+                    if (semanticModel.ResourceMetadata.TryLookup(targetResourceSymbol.DeclaringSyntax) is not DeclaredResourceMetadata targetResource)
                     {
                         return null;
                     }
@@ -317,7 +317,7 @@ namespace Bicep.Core.Emit
 
         public static void EmitResourceScopeProperties(SemanticModel semanticModel, ScopeData scopeData, ExpressionEmitter expressionEmitter, SyntaxBase newContext)
         {
-            if (scopeData.ResourceScope is { } scopeResource)
+            if (scopeData.ResourceScope is DeclaredResourceMetadata scopeResource)
             {
                 // emit the resource id of the resource being extended
                 expressionEmitter.EmitProperty("scope", () => expressionEmitter.EmitUnqualifiedResourceId(scopeResource, scopeData.IndexExpression, newContext));
@@ -389,7 +389,7 @@ namespace Bicep.Core.Emit
             return new(LanguageConstants.ResourceScopePropertyName, scopeReference, scopePropertyFlags);
         }
 
-        private static ResourceMetadata? GetRootResource(IReadOnlyDictionary<ResourceMetadata, ScopeData> scopeInfo, ResourceMetadata resource)
+        private static DeclaredResourceMetadata? GetRootResource(IReadOnlyDictionary<DeclaredResourceMetadata, ScopeData> scopeInfo, DeclaredResourceMetadata resource)
         {
             if (!scopeInfo.TryGetValue(resource, out var scopeData))
             {
@@ -404,7 +404,7 @@ namespace Bicep.Core.Emit
             return resource;
         }
 
-        private static void ValidateResourceScopeRestrictions(SemanticModel semanticModel, IReadOnlyDictionary<ResourceMetadata, ScopeData> scopeInfo, ResourceMetadata resource, Action<DiagnosticBuilder.DiagnosticBuilderDelegate> writeScopeDiagnostic)
+        private static void ValidateResourceScopeRestrictions(SemanticModel semanticModel, IReadOnlyDictionary<DeclaredResourceMetadata, ScopeData> scopeInfo, DeclaredResourceMetadata resource, Action<DiagnosticBuilder.DiagnosticBuilderDelegate> writeScopeDiagnostic)
         {
             if (resource.IsExistingResource)
             {
@@ -449,13 +449,13 @@ namespace Bicep.Core.Emit
             return matchesTargetScope;
         }
 
-        public static ImmutableDictionary<ResourceMetadata, ScopeData> GetResourceScopeInfo(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
+        public static ImmutableDictionary<DeclaredResourceMetadata, ScopeData> GetResourceScopeInfo(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
             void logInvalidScopeDiagnostic(IPositionable positionable, ResourceScope suppliedScope, ResourceScope supportedScopes)
                 => diagnosticWriter.Write(positionable, x => x.UnsupportedResourceScope(suppliedScope, supportedScopes));
 
-            var scopeInfo = new Dictionary<ResourceMetadata, ScopeData>();
-            var ancestorsLookup = semanticModel.AllResources
+            var scopeInfo = new Dictionary<DeclaredResourceMetadata, ScopeData>();
+            var ancestorsLookup = semanticModel.DeclaredResources
                 .ToDictionary(
                     x => x,
                     x => semanticModel.ResourceAncestors.GetAncestors(x));
@@ -502,12 +502,28 @@ namespace Bicep.Core.Emit
                     continue;
                 }
 
-                var validatedScopeData = ScopeHelper.ValidateScope(semanticModel, logInvalidScopeDiagnostic, resource.Type.ValidParentScopes, resource.Symbol.DeclaringResource.Value, resource.TryGetScopeSyntax());
+                // way to validate scope-escaping.
+                if (resource.TryGetScopeSyntax() is SyntaxBase scope &&
+                    semanticModel.ResourceMetadata.TryLookup(scope) is ParameterResourceMetadata scopeMetadata)
+                {
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(scope).InvalidResourceScopeCannotBeResourceTypeParameter(scopeMetadata.Symbol.Name));
+                    scopeInfo[resource] = defaultScopeData;
+                    continue;
+                }
+                // This check has to live here because if here because this case is not handled when building the resource ancestor graph.
+                else if (resource.Symbol.TryGetBodyPropertyValue(LanguageConstants.ResourceParentPropertyName) is {} referenceParentSyntax &&
+                    semanticModel.ResourceMetadata.TryLookup(referenceParentSyntax) is ParameterResourceMetadata parentMetadata)
+                {
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(referenceParentSyntax).InvalidResourceScopeCannotBeResourceTypeParameter(parentMetadata.Symbol.Name));
+                    scopeInfo[resource] = defaultScopeData;
+                    continue;
+                }
 
+                var validatedScopeData = ScopeHelper.ValidateScope(semanticModel, logInvalidScopeDiagnostic, resource.Type.ValidParentScopes, resource.Symbol.DeclaringResource.Value, resource.TryGetScopeSyntax());
                 scopeInfo[resource] = validatedScopeData ?? defaultScopeData;
             }
 
-            foreach (var resourceToValidate in semanticModel.AllResources)
+            foreach (var resourceToValidate in semanticModel.DeclaredResources)
             {
                 ValidateResourceScopeRestrictions(
                     semanticModel,

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -206,7 +206,26 @@ namespace Bicep.Core.Emit
         private void EmitParameter(JsonTextWriter jsonWriter, ParameterSymbol parameterSymbol, ExpressionEmitter emitter)
         {
             var declaringParameter = parameterSymbol.DeclaringParameter;
-            if (SyntaxHelper.TryGetPrimitiveType(declaringParameter) is not TypeSymbol primitiveType)
+
+            var properties = new List<ObjectPropertySyntax>();
+            if (parameterSymbol.Type is ResourceType resourceType)
+            {
+                // Encode a resource type as a string parameter with a metadata for the resource type.
+                properties.Add(SyntaxFactory.CreateObjectProperty("type", SyntaxFactory.CreateStringLiteral(LanguageConstants.String.Name)));
+                properties.Add(SyntaxFactory.CreateObjectProperty(
+                    LanguageConstants.ParameterMetadataPropertyName,
+                    SyntaxFactory.CreateObject(new[]
+                    {
+                        SyntaxFactory.CreateObjectProperty(
+                            LanguageConstants.MetadataResourceTypePropertyName,
+                            SyntaxFactory.CreateStringLiteral(resourceType.TypeReference.FormatName())),
+                    })));
+            }
+            else if (SyntaxHelper.TryGetPrimitiveType(declaringParameter) is TypeSymbol primitiveType)
+            {
+                properties.Add(SyntaxFactory.CreateObjectProperty("type", SyntaxFactory.CreateStringLiteral(primitiveType.Name)));
+            }
+            else
             {
                 // this should have been caught by the type checker long ago
                 throw new ArgumentException($"Unable to find primitive type for parameter {parameterSymbol.Name}");
@@ -214,15 +233,14 @@ namespace Bicep.Core.Emit
 
             jsonWriter.WriteStartObject();
 
-            var parameterType = SyntaxFactory.CreateStringLiteral(primitiveType.Name);
-            var parameterObject = SyntaxFactory.CreateObject(SyntaxFactory.CreateObjectProperty("type", parameterType).AsEnumerable());
+            var parameterObject = SyntaxFactory.CreateObject(properties);
 
             if (declaringParameter.Modifier is ParameterDefaultValueSyntax defaultValueSyntax)
             {
                 parameterObject = parameterObject.MergeProperty("defaultValue", defaultValueSyntax.DefaultValue);
             }
 
-            parameterObject = AddDecoratorsToBody(declaringParameter, parameterObject, primitiveType);
+            parameterObject = AddDecoratorsToBody(declaringParameter, parameterObject, SyntaxHelper.TryGetPrimitiveType(declaringParameter) ?? parameterSymbol.Type);
 
             foreach (var property in parameterObject.Properties)
             {
@@ -323,7 +341,7 @@ namespace Bicep.Core.Emit
                 jsonWriter.WriteStartArray();
             }
 
-            foreach (var resource in this.context.SemanticModel.AllResources)
+            foreach (var resource in this.context.SemanticModel.DeclaredResources)
             {
                 if (resource.IsExistingResource && !context.Settings.EnableSymbolicNames)
                 {
@@ -375,7 +393,7 @@ namespace Bicep.Core.Emit
             return null;
         }
 
-        private void EmitResource(JsonTextWriter jsonWriter, ResourceMetadata resource, ExpressionEmitter emitter)
+        private void EmitResource(JsonTextWriter jsonWriter, DeclaredResourceMetadata resource, ExpressionEmitter emitter)
         {
             jsonWriter.WriteStartObject();
 
@@ -519,7 +537,7 @@ namespace Bicep.Core.Emit
             jsonWriter.WriteEndObject();
         }
 
-        private static void EmitModuleParameters(JsonTextWriter jsonWriter, ModuleSymbol moduleSymbol, ExpressionEmitter emitter)
+        private void EmitModuleParameters(JsonTextWriter jsonWriter, ModuleSymbol moduleSymbol, ExpressionEmitter emitter)
         {
             var paramsValue = moduleSymbol.TryGetBodyPropertyValue(LanguageConstants.ModuleParamsPropertyName);
             if (paramsValue is not ObjectSyntax paramsObjectSyntax)
@@ -554,6 +572,12 @@ namespace Bicep.Core.Emit
                         emitter.EmitCopyObject("value", @for, @for.Body, "value");
                         jsonWriter.WriteEndArray();
                     });
+                }
+                else if (this.context.SemanticModel.ResourceMetadata.TryLookup(propertySyntax.Value) is {} resourceMetadata)
+                {
+                    // This is a resource being passed into a module, we actually want to pass in its id
+                    // rather than the whole resource.
+                    emitter.EmitProperty("value", new PropertyAccessSyntax(propertySyntax.Value, SyntaxFactory.DotToken, SyntaxFactory.CreateIdentifier("id")));
                 }
                 else
                 {
@@ -678,7 +702,7 @@ namespace Bicep.Core.Emit
             switch (dependency.Resource)
             {
                 case ResourceSymbol resourceDependency:
-                    var resource = context.SemanticModel.ResourceMetadata.TryLookup(resourceDependency.DeclaringSyntax) ??
+                    var resource = context.SemanticModel.ResourceMetadata.TryLookup(resourceDependency.DeclaringSyntax) as DeclaredResourceMetadata ??
                         throw new ArgumentException($"Unable to find resource metadata for dependency '{dependency.Resource.Name}'");
 
                     switch ((resourceDependency.IsCollection, dependency.IndexExpression))
@@ -733,7 +757,7 @@ namespace Bicep.Core.Emit
                         break;
                     }
 
-                    var resource = context.SemanticModel.ResourceMetadata.TryLookup(resourceDependency.DeclaringSyntax) ??
+                    var resource = context.SemanticModel.ResourceMetadata.TryLookup(resourceDependency.DeclaringSyntax) as DeclaredResourceMetadata ??
                         throw new ArgumentException($"Unable to find resource metadata for dependency '{dependency.Resource.Name}'");
 
                     emitter.EmitResourceIdReference(resource, dependency.IndexExpression, newContext);
@@ -806,20 +830,49 @@ namespace Bicep.Core.Emit
         {
             jsonWriter.WriteStartObject();
 
-            emitter.EmitProperty("type", outputSymbol.Type.Name);
+            var properties = new List<ObjectPropertySyntax>();
+            if (outputSymbol.Type is ResourceType resourceType)
+            {
+                // Resource-typed outputs are encoded as strings
+                emitter.EmitProperty("type", LanguageConstants.String.Name);
+
+                properties.Add(SyntaxFactory.CreateObjectProperty(
+                    LanguageConstants.ParameterMetadataPropertyName,
+                    SyntaxFactory.CreateObject(new[]
+                    {
+                        SyntaxFactory.CreateObjectProperty(
+                            LanguageConstants.MetadataResourceTypePropertyName,
+                            SyntaxFactory.CreateStringLiteral(resourceType.TypeReference.FormatName())),
+                    })));
+            }
+            else
+            {
+                emitter.EmitProperty("type", outputSymbol.Type.Name);
+            }
+
+
             if (outputSymbol.Value is ForSyntax @for)
             {
                 emitter.EmitProperty("copy", () => emitter.EmitCopyObject(name: null, @for, @for.Body));
             }
             else
             {
-                emitter.EmitProperty("value", outputSymbol.Value);
+                if (outputSymbol.Type is ResourceType)
+                {
+                    // Resource-typed outputs are serialized using the resource id.
+                    var value = new PropertyAccessSyntax(outputSymbol.Value, SyntaxFactory.DotToken, SyntaxFactory.CreateIdentifier("id"));
+                    emitter.EmitProperty("value", value);
+                }
+                else
+                {
+                    emitter.EmitProperty("value", outputSymbol.Value);
+                }
             }
 
             // emit any decorators on this output
             foreach (var (property, val) in AddDecoratorsToBody(
                 outputSymbol.DeclaringOutput,
-                SyntaxFactory.CreateObject(Enumerable.Empty<ObjectPropertySyntax>()),
+                SyntaxFactory.CreateObject(properties),
                 outputSymbol.Type).ToNamedPropertyValueDictionary())
             {
                 emitter.EmitProperty(property, val);

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -20,6 +20,10 @@ namespace Bicep.Core.Features
         private Lazy<bool> importsEnabledLazy = new(() => ReadBooleanEnvVar("BICEP_IMPORTS_ENABLED_EXPERIMENTAL", defaultValue: false), LazyThreadSafetyMode.PublicationOnly);
         public bool ImportsEnabled => importsEnabledLazy.Value;
 
+        private Lazy<bool> resourceTypedParamsAndOutputsEnabledLazy = new(() => ReadBooleanEnvVar("BICEP_RESOURCE_TYPED_PARAMS_AND_OUTPUTS_EXPERIMENTAL", defaultValue: false), LazyThreadSafetyMode.PublicationOnly);
+
+        public bool ResourceTypedParamsAndOutputsEnabled => resourceTypedParamsAndOutputsEnabledLazy.Value;
+
         public string AssemblyVersion => ThisAssembly.AssemblyFileVersion;
 
         public static bool TracingEnabled => ReadBooleanEnvVar("BICEP_TRACING_ENABLED", defaultValue: false);

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -14,5 +14,7 @@ namespace Bicep.Core.Features
         bool SymbolicNameCodegenEnabled { get; }
 
         bool ImportsEnabled { get; }
+
+        bool ResourceTypedParamsAndOutputsEnabled { get; }
     }
 }

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -87,6 +87,7 @@ namespace Bicep.Core
         public const string ParameterMaxLengthPropertyName = "maxLength";
         public const string ParameterMetadataPropertyName = "metadata";
         public const string MetadataDescriptionPropertyName = "description";
+        public const string MetadataResourceTypePropertyName = "resourceType";
         public const string BatchSizePropertyName = "batchSize";
 
         // module properties

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -233,7 +233,7 @@ namespace Bicep.Core.Parsing
         {
             var keyword = ExpectKeyword(LanguageConstants.ParameterKeyword);
             var name = this.IdentifierWithRecovery(b => b.ExpectedParameterIdentifier(), RecoveryFlags.None, TokenType.Identifier, TokenType.NewLine);
-            var type = this.WithRecovery(() => Type(b => b.ExpectedParameterType()), GetSuppressionFlag(name), TokenType.Assignment, TokenType.LeftBrace, TokenType.NewLine);
+            var type = this.WithRecovery(() => Type(b => b.ExpectedParameterType(), allowOptionalResourceType: false), GetSuppressionFlag(name), TokenType.Assignment, TokenType.LeftBrace, TokenType.NewLine);
 
             // TODO: Need a better way to choose the terminating token
             SyntaxBase? modifier = this.WithRecoveryNullable(
@@ -280,7 +280,7 @@ namespace Bicep.Core.Parsing
         {
             var keyword = ExpectKeyword(LanguageConstants.OutputKeyword);
             var name = this.IdentifierWithRecovery(b => b.ExpectedOutputIdentifier(), RecoveryFlags.None, TokenType.Identifier, TokenType.NewLine);
-            var type = this.WithRecovery(() => Type(b => b.ExpectedOutputType()), GetSuppressionFlag(name), TokenType.Assignment, TokenType.NewLine);
+            var type = this.WithRecovery(() => Type(b => b.ExpectedOutputType(), allowOptionalResourceType: true), GetSuppressionFlag(name), TokenType.Assignment, TokenType.NewLine);
             var assignment = this.WithRecovery(this.Assignment, GetSuppressionFlag(type), TokenType.NewLine);
             var value = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), GetSuppressionFlag(assignment), TokenType.NewLine);
 
@@ -800,11 +800,30 @@ namespace Bicep.Core.Parsing
             return new SkippedTriviaSyntax(span, ImmutableArray<SyntaxBase>.Empty, errorFunc(DiagnosticBuilder.ForPosition(span)).AsEnumerable());
         }
 
-        private TypeSyntax Type(DiagnosticBuilder.ErrorBuilderDelegate errorFunc)
+        private TypeSyntax Type(DiagnosticBuilder.ErrorBuilderDelegate errorFunc, bool allowOptionalResourceType)
         {
-            var identifier = Expect(TokenType.Identifier, errorFunc);
+            if (GetOptionalKeyword(LanguageConstants.ResourceKeyword) is {} resourceKeyword)
+            {
+                var type = this.WithRecoveryNullable(
+                    () =>
+                    {
+                        // The resource type is optional for an output
+                        if (allowOptionalResourceType && !this.Check(this.reader.Peek(), TokenType.StringComplete, TokenType.StringLeftPiece))
+                        {
+                            return null;
+                        }
+                        else
+                        {
+                            return ThrowIfSkipped(this.InterpolableString, b => b.ExpectedResourceTypeString());
+                        }
+                    },
+                    RecoveryFlags.None,
+                    TokenType.Assignment, TokenType.NewLine);
+                return new ResourceTypeSyntax(resourceKeyword, type);
+            }
 
-            return new TypeSyntax(identifier);
+            var identifier = Expect(TokenType.Identifier, errorFunc);
+            return new SimpleTypeSyntax(identifier);
         }
 
         private IntegerLiteralSyntax NumericLiteral()

--- a/src/Bicep.Core/Semantics/Compilation.cs
+++ b/src/Bicep.Core/Semantics/Compilation.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Bicep.Core.Analyzers.Interfaces;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Features;
 using Bicep.Core.Extensions;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Workspaces;
@@ -17,8 +18,9 @@ namespace Bicep.Core.Semantics
     {
         private readonly ImmutableDictionary<ISourceFile, Lazy<ISemanticModel>> lazySemanticModelLookup;
 
-        public Compilation(INamespaceProvider namespaceProvider, SourceFileGrouping sourceFileGrouping, RootConfiguration configuration, IBicepAnalyzer linterAnalyzer, ImmutableDictionary<ISourceFile, ISemanticModel>? modelLookup = null)
+        public Compilation(IFeatureProvider features, INamespaceProvider namespaceProvider, SourceFileGrouping sourceFileGrouping, RootConfiguration configuration, IBicepAnalyzer linterAnalyzer, ImmutableDictionary<ISourceFile, ISemanticModel>? modelLookup = null)
         {
+            this.Features = features;
             this.SourceFileGrouping = sourceFileGrouping;
             this.NamespaceProvider = namespaceProvider;
             this.Configuration = configuration;
@@ -39,6 +41,8 @@ namespace Bicep.Core.Semantics
         }
 
         public RootConfiguration Configuration { get; }
+
+        public IFeatureProvider Features { get; }
 
         public SourceFileGrouping SourceFileGrouping { get; }
 

--- a/src/Bicep.Core/Semantics/ISemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ISemanticModel.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Bicep.Core.TypeSystem;
+using Bicep.Core.Semantics.Metadata;
 
 namespace Bicep.Core.Semantics
 {
@@ -10,9 +11,9 @@ namespace Bicep.Core.Semantics
     {
         ResourceScope TargetScope { get; }
 
-        ImmutableArray<TypeProperty> ParameterTypeProperties { get; }
+        ImmutableArray<ParameterMetadata> Parameters { get; }
 
-        ImmutableArray<TypeProperty> OutputTypeProperties { get; }
+        ImmutableArray<OutputMetadata> Outputs { get; }
 
         bool HasErrors();
     }

--- a/src/Bicep.Core/Semantics/Metadata/DeclaredResourceMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/DeclaredResourceMetadata.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Extensions;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.Az;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    // Represents a resource that is declared with Bicep code.
+    public record DeclaredResourceMetadata(
+        ResourceType Type,
+        bool IsExistingResource,
+        ResourceSymbol Symbol,
+        ResourceMetadataParent? Parent)
+        : ResourceMetadata(Type, IsExistingResource)
+    {
+        private readonly ImmutableDictionary<string, SyntaxBase> UniqueIdentifiers = GetUniqueIdentifiers(Type, Symbol);
+
+        public SyntaxBase NameSyntax => TryGetNameSyntax() ??
+            throw new InvalidOperationException($"Failed to find a 'name' property for resource '{Symbol.Name}'");
+
+        public SyntaxBase? TryGetNameSyntax() => UniqueIdentifiers.TryGetValue(AzResourceTypeProvider.ResourceNamePropertyName);
+
+        public SyntaxBase? TryGetScopeSyntax() => UniqueIdentifiers.TryGetValue(LanguageConstants.ResourceScopePropertyName);
+
+        private static ImmutableDictionary<string, SyntaxBase> GetUniqueIdentifiers(ResourceType type, ResourceSymbol symbol)
+        {
+            if (symbol.DeclaringResource.TryGetBody() is not { } bodySyntax)
+            {
+                return ImmutableDictionary<string, SyntaxBase>.Empty;
+            }
+
+            var identifiersBuilder = ImmutableDictionary.CreateBuilder<string, SyntaxBase>(LanguageConstants.IdentifierComparer);
+            foreach (var propertySyntax in bodySyntax.Properties)
+            {
+                if (propertySyntax.TryGetKeyText() is { } propertyKey &&
+                    type.UniqueIdentifierProperties.Contains(propertyKey))
+                {
+                    identifiersBuilder[propertyKey] = propertySyntax.Value;
+                }
+            }
+
+            return identifiersBuilder.ToImmutable();
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/Metadata/ModuleOutputResourceMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ModuleOutputResourceMetadata.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    // Represents a resource that is declared as a parameter in Bicep.
+    public record ModuleOutputResourceMetadata(
+        ResourceType Type,
+        ModuleSymbol Module,
+        SyntaxBase NameSyntax,
+        string OutputName)
+        : ResourceMetadata(Type, IsExistingResource: true)
+    {
+    }
+}

--- a/src/Bicep.Core/Semantics/Metadata/OutputMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/OutputMetadata.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    public record OutputMetadata(string Name, ITypeReference TypeReference, string? Description)
+    {
+    }
+}

--- a/src/Bicep.Core/Semantics/Metadata/ParameterMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ParameterMetadata.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    public record ParameterMetadata(string Name, ITypeReference TypeReference, bool IsRequired, string? Description)
+    {
+    }
+}

--- a/src/Bicep.Core/Semantics/Metadata/ParameterResourceMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ParameterResourceMetadata.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Resources;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    // Represents a resource that is declared as a parameter in Bicep.
+    public record ParameterResourceMetadata(
+        ResourceType Type,
+        ParameterSymbol Symbol)
+        : ResourceMetadata(Type, IsExistingResource: true)
+    {
+    }
+}

--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadata.cs
@@ -1,55 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System;
-using System.Linq;
-using Bicep.Core.Extensions;
 using Bicep.Core.Resources;
-using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.Semantics.Namespaces;
-using Bicep.Core.TypeSystem.Az;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 
 namespace Bicep.Core.Semantics.Metadata
 {
+    // Represents a logical resource, regardless of how it was declared.
     public record ResourceMetadata(
         ResourceType Type,
-        ResourceSymbol Symbol,
-        ResourceMetadataParent? Parent,
         bool IsExistingResource)
     {
-        private readonly ImmutableDictionary<string, SyntaxBase> UniqueIdentifiers = GetUniqueIdentifiers(Type, Symbol);
-
         public ResourceTypeReference TypeReference => Type.TypeReference;
 
-        public SyntaxBase NameSyntax => TryGetNameSyntax() ?? 
-            throw new InvalidOperationException($"Failed to find a 'name' property for resource '{Symbol.Name}'");
-
-        public SyntaxBase? TryGetNameSyntax() => UniqueIdentifiers.TryGetValue(AzResourceTypeProvider.ResourceNamePropertyName);
-
-        public SyntaxBase? TryGetScopeSyntax() => UniqueIdentifiers.TryGetValue(LanguageConstants.ResourceScopePropertyName);
-
         public bool IsAzResource => Type.DeclaringNamespace.ProviderNameEquals(AzNamespaceType.BuiltInName);
-
-        private static ImmutableDictionary<string, SyntaxBase> GetUniqueIdentifiers(ResourceType type, ResourceSymbol symbol)
-        {
-            if (symbol.DeclaringResource.TryGetBody() is not { } bodySyntax)
-            {
-                return ImmutableDictionary<string, SyntaxBase>.Empty;
-            }
-
-            var identifiersBuilder = ImmutableDictionary.CreateBuilder<string, SyntaxBase>(LanguageConstants.IdentifierComparer);
-            foreach (var propertySyntax in bodySyntax.Properties)
-            {
-                if (propertySyntax.TryGetKeyText() is { } propertyKey &&
-                    type.UniqueIdentifierProperties.Contains(propertyKey))
-                {
-                    identifiersBuilder[propertyKey] = propertySyntax.Value;
-                }
-            }
-
-            return identifiersBuilder.ToImmutable();
-        }
     }
 }

--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
@@ -4,9 +4,12 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Bicep.Core.Extensions;
 using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.Az;
 
 namespace Bicep.Core.Semantics.Metadata
 {
@@ -15,6 +18,7 @@ namespace Bicep.Core.Semantics.Metadata
         private readonly SemanticModel semanticModel;
         private readonly ConcurrentDictionary<ResourceSymbol, ResourceMetadata> symbolLookup;
         private readonly Lazy<ImmutableDictionary<ResourceDeclarationSyntax, ResourceSymbol>> resourceSymbols;
+        private readonly ConcurrentDictionary<(ModuleSymbol module, string output), ResourceMetadata> moduleOutputLookup;
 
         public ResourceMetadataCache(SemanticModel semanticModel)
         {
@@ -22,6 +26,30 @@ namespace Bicep.Core.Semantics.Metadata
             this.symbolLookup = new();
             this.resourceSymbols = new(() => ResourceSymbolVisitor.GetAllResources(semanticModel.Root)
                 .ToImmutableDictionary(x => x.DeclaringResource));
+
+            this.moduleOutputLookup = new();
+        }
+
+        // NOTE: modules can declare outputs with resource types. This means one piece of syntax (the module)
+        // can declare multiple ResourceMetadata. We have this separate code path to 'load' these because
+        // the discovery is driven by semantics not syntax.
+        public ResourceMetadata? TryAdd(ModuleSymbol module, string output)
+        {
+            if (module.TryGetBodyPropertyValue(AzResourceTypeProvider.ResourceNamePropertyName) is {} nameSyntax &&
+                module.TryGetBodyObjectType() is ObjectType objectType &&
+                objectType.Properties.TryGetValue(LanguageConstants.ModuleOutputsPropertyName, out var outputsProperty) &&
+                outputsProperty.TypeReference.Type is ObjectType outputsType &&
+                outputsType.Properties.TryGetValue(output, out var property))
+            {
+                if (property.TypeReference.Type is ResourceType resourceType)
+                {
+                    var metadata = new ModuleOutputResourceMetadata(resourceType, module, nameSyntax, output);
+                    moduleOutputLookup.TryAdd((module, output), metadata);
+                    return metadata;
+                }
+            }
+
+            return null;
         }
 
         protected override ResourceMetadata? Calculate(SyntaxBase syntax)
@@ -39,8 +67,27 @@ namespace Bicep.Core.Semantics.Metadata
                             return this.TryLookup(declaredSymbol.DeclaringSyntax);
                         }
 
-                        break;
+                    break;
+                }
+                case ParameterDeclarationSyntax parameterDeclarationSyntax:
+                {
+                    var symbol = semanticModel.GetSymbolInfo(parameterDeclarationSyntax);
+                    if (symbol is ParameterSymbol parameterSymbol && parameterSymbol.Type is ResourceType resourceType)
+                    {
+                        return new ParameterResourceMetadata(resourceType, parameterSymbol);
                     }
+                    break;
+                }
+                case PropertyAccessSyntax propertyAccessSyntax when IsModuleScalarOutputAccess(propertyAccessSyntax, out var module):
+                {
+                    // Access to a module output might be a resource metadata.
+                    return this.TryAdd(module, propertyAccessSyntax.PropertyName.IdentifierName);
+                }
+                case PropertyAccessSyntax propertyAccessSyntax when IsModuleArrayOutputAccess(propertyAccessSyntax, out var module):
+                {
+                    // Access to a module array output might be a resource metadata.
+                    return this.TryAdd(module, propertyAccessSyntax.PropertyName.IdentifierName);
+                }
                 case ResourceDeclarationSyntax resourceDeclarationSyntax:
                     {
                         // Skip analysis for ErrorSymbol and similar cases, these are invalid cases, and won't be emitted.
@@ -60,11 +107,11 @@ namespace Bicep.Core.Semantics.Metadata
                             // nested resource parent syntax
                             if (TryLookup(nestedParentSyntax) is { } parentMetadata)
                             {
-                                return new(
+                                return new DeclaredResourceMetadata(
                                     resourceType,
+                                    symbol.DeclaringResource.IsExistingResource(),
                                     symbol,
-                                    new(parentMetadata, null, true),
-                                    symbol.DeclaringResource.IsExistingResource());
+                                    new(parentMetadata, null, true));
                             }
                         }
                         else if (symbol.TryGetBodyPropertyValue(LanguageConstants.ResourceParentPropertyName) is { } referenceParentSyntax)
@@ -79,20 +126,20 @@ namespace Bicep.Core.Semantics.Metadata
                             // parent property reference syntax
                             if (TryLookup(referenceParentSyntax) is { } parentMetadata)
                             {
-                                return new(
+                                return new DeclaredResourceMetadata(
                                     resourceType,
+                                    symbol.DeclaringResource.IsExistingResource(),
                                     symbol,
-                                    new(parentMetadata, indexExpression, false),
-                                    symbol.DeclaringResource.IsExistingResource());
+                                    new(parentMetadata, indexExpression, false));
                             }
                         }
                         else
                         {
-                            return new(
+                            return new DeclaredResourceMetadata(
                                 resourceType,
+                                symbol.DeclaringResource.IsExistingResource(),
                                 symbol,
-                                null,
-                                symbol.DeclaringResource.IsExistingResource());
+                                null);
                         }
 
                         break;
@@ -102,6 +149,39 @@ namespace Bicep.Core.Semantics.Metadata
             }
 
             return null;
+        }
+
+        private bool IsModuleScalarOutputAccess(PropertyAccessSyntax propertyAccessSyntax, [NotNullWhen(true)] out ModuleSymbol? symbol)
+        {
+            if (propertyAccessSyntax.BaseExpression is PropertyAccessSyntax childPropertyAccess &&
+                childPropertyAccess.PropertyName.IdentifierName == LanguageConstants.ModuleOutputsPropertyName &&
+                childPropertyAccess.BaseExpression is VariableAccessSyntax grandChildAccess &&
+                this.semanticModel.GetSymbolInfo(grandChildAccess) is ModuleSymbol module &&
+                module.TryGetBodyPropertyValue(AzResourceTypeProvider.ResourceNamePropertyName) is {} name)
+            {
+                symbol = module;
+                return true;
+            }
+
+            symbol = null;
+            return false;
+        }
+
+        private bool IsModuleArrayOutputAccess(PropertyAccessSyntax propertyAccessSyntax, [NotNullWhen(true)] out ModuleSymbol? symbol)
+        {
+            if (propertyAccessSyntax.BaseExpression is PropertyAccessSyntax childPropertyAccess &&
+                childPropertyAccess.PropertyName.IdentifierName == LanguageConstants.ModuleOutputsPropertyName &&
+                childPropertyAccess.BaseExpression is ArrayAccessSyntax arrayAccessSyntax &&
+                arrayAccessSyntax.BaseExpression is  VariableAccessSyntax grandChildAccess &&
+                this.semanticModel.GetSymbolInfo(grandChildAccess) is ModuleSymbol module &&
+                module.TryGetBodyPropertyValue(AzResourceTypeProvider.ResourceNamePropertyName) is {} name)
+            {
+                symbol = module;
+                return true;
+            }
+
+            symbol = null;
+            return false;
         }
     }
 }

--- a/src/Bicep.Core/Semantics/ResourceAncestorGraph.cs
+++ b/src/Bicep.Core/Semantics/ResourceAncestorGraph.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
-using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.Semantics
 {
@@ -20,7 +19,7 @@ namespace Bicep.Core.Semantics
 
         public class ResourceAncestor
         {
-            public ResourceAncestor(ResourceAncestorType ancestorType, ResourceMetadata resource, SyntaxBase? indexExpression)
+            public ResourceAncestor(ResourceAncestorType ancestorType, DeclaredResourceMetadata resource, SyntaxBase? indexExpression)
             {
                 AncestorType = ancestorType;
                 Resource = resource;
@@ -29,21 +28,21 @@ namespace Bicep.Core.Semantics
 
             public ResourceAncestorType AncestorType { get; }
 
-            public ResourceMetadata Resource { get; }
+            public DeclaredResourceMetadata Resource { get; }
 
             public SyntaxBase? IndexExpression { get; }
         }
 
-        private readonly ImmutableDictionary<ResourceMetadata, ImmutableArray<ResourceAncestor>> data;
+        private readonly ImmutableDictionary<DeclaredResourceMetadata, ImmutableArray<ResourceAncestor>> data;
 
-        public ResourceAncestorGraph(ImmutableDictionary<ResourceMetadata, ImmutableArray<ResourceAncestor>> data)
+        public ResourceAncestorGraph(ImmutableDictionary<DeclaredResourceMetadata, ImmutableArray<ResourceAncestor>> data)
         {
             this.data = data;
         }
 
         // Gets the ordered list of ancestors of this resource in order from 'oldest' to 'youngest'
         // this is the same order we need to compute the name of a resource using `/` separated segments in a string.
-        public ImmutableArray<ResourceAncestor> GetAncestors(ResourceMetadata resource)
+        public ImmutableArray<ResourceAncestor> GetAncestors(DeclaredResourceMetadata resource)
         {
             if (data.TryGetValue(resource, out var results))
             {
@@ -55,9 +54,9 @@ namespace Bicep.Core.Semantics
             }
         }
 
-        private static IEnumerable<ResourceAncestor> GetAncestorsYoungestToOldest(ImmutableDictionary<ResourceMetadata, ResourceAncestor> hierarchy, ResourceMetadata resource)
+        private static IEnumerable<ResourceAncestor> GetAncestorsYoungestToOldest(ImmutableDictionary<DeclaredResourceMetadata, ResourceAncestor> hierarchy, DeclaredResourceMetadata resource)
         {
-            var visited = new HashSet<ResourceMetadata>();
+            var visited = new HashSet<DeclaredResourceMetadata>();
             while (hierarchy.TryGetValue(resource, out var ancestor) && !visited.Contains(ancestor.Resource))
             {
                 visited.Add(ancestor.Resource);

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -24,10 +24,11 @@ namespace Bicep.Core.Semantics
         private readonly Lazy<EmitLimitationInfo> emitLimitationInfoLazy;
         private readonly Lazy<SymbolHierarchy> symbolHierarchyLazy;
         private readonly Lazy<ResourceAncestorGraph> resourceAncestorsLazy;
-        private readonly Lazy<ImmutableArray<TypeProperty>> parameterTypePropertiesLazy;
-        private readonly Lazy<ImmutableArray<TypeProperty>> outputTypePropertiesLazy;
+        private readonly Lazy<ImmutableArray<ParameterMetadata>> parametersLazy;
+        private readonly Lazy<ImmutableArray<OutputMetadata>> outputsLazy;
 
         private readonly Lazy<ImmutableArray<ResourceMetadata>> allResourcesLazy;
+        private readonly Lazy<ImmutableArray<DeclaredResourceMetadata>> declaredResourcesLazy;
         private readonly Lazy<IEnumerable<IDiagnostic>> allDiagnostics;
 
         public SemanticModel(Compilation compilation, BicepFile sourceFile, IFileResolver fileResolver, IBicepAnalyzer linterAnalyzer)
@@ -45,7 +46,7 @@ namespace Bicep.Core.Semantics
             SymbolContext = symbolContext;
 
             Binder = new Binder(compilation.NamespaceProvider, sourceFile, symbolContext);
-            TypeManager = new TypeManager(Binder, fileResolver);
+            TypeManager = new TypeManager(compilation.Features, Binder, fileResolver);
 
             // name binding is done
             // allow type queries now
@@ -65,41 +66,56 @@ namespace Bicep.Core.Semantics
             LinterAnalyzer = linterAnalyzer;
 
             this.allResourcesLazy = new Lazy<ImmutableArray<ResourceMetadata>>(() => GetAllResourceMetadata());
+            this.declaredResourcesLazy = new Lazy<ImmutableArray<DeclaredResourceMetadata>>(() => this.AllResources.OfType<DeclaredResourceMetadata>().ToImmutableArray());
 
             // lazy load single use diagnostic set
             this.allDiagnostics = new Lazy<IEnumerable<IDiagnostic>>(() => AssembleDiagnostics());
 
-            this.parameterTypePropertiesLazy = new Lazy<ImmutableArray<TypeProperty>>(() =>
+            this.parametersLazy = new Lazy<ImmutableArray<ParameterMetadata>>(() =>
             {
-                var paramTypeProperties = new List<TypeProperty>();
+                var parameters = new List<ParameterMetadata>();
 
                 foreach (var param in this.Root.ParameterDeclarations.DistinctBy(p => p.Name))
                 {
-                    var typePropertyFlags = TypePropertyFlags.WriteOnly;
-                    if (SyntaxHelper.TryGetDefaultValue(param.DeclaringParameter) == null)
-                    {
-                        // if there's no default value, it must be specified
-                        typePropertyFlags |= TypePropertyFlags.Required;
-                    }
-
                     var description = SemanticModelHelper.TryGetDescription(this, param.DeclaringParameter);
-                    paramTypeProperties.Add(new TypeProperty(param.Name, param.Type, typePropertyFlags, description));
+                    var isRequired =  SyntaxHelper.TryGetDefaultValue(param.DeclaringParameter) == null;
+                    if (param.Type is ResourceType resourceType)
+                    {
+                        // Resource type parameters are a special case, we need to convert to a dedicated
+                        // type so we can compare differently for assignment.
+                        var type = new UnboundResourceType(resourceType.TypeReference);
+                        parameters.Add(new ParameterMetadata(param.Name, type, isRequired, description));
+                    }
+                    else
+                    {
+                        parameters.Add(new ParameterMetadata(param.Name, param.Type, isRequired, description));
+                    }
                 }
 
-                return paramTypeProperties.ToImmutableArray();
+                return parameters.ToImmutableArray();
             });
 
-            this.outputTypePropertiesLazy = new Lazy<ImmutableArray<TypeProperty>>(() =>
+            this.outputsLazy = new Lazy<ImmutableArray<OutputMetadata>>(() =>
             {
-                var outputTypeProperties = new List<TypeProperty>();
+                var outputs = new List<OutputMetadata>();
 
                 foreach (var output in this.Root.OutputDeclarations.DistinctBy(o => o.Name))
                 {
                     var description = SemanticModelHelper.TryGetDescription(this, output.DeclaringOutput);
-                    outputTypeProperties.Add(new TypeProperty(output.Name, output.Type, TypePropertyFlags.ReadOnly, description));
+                    if (output.Type is ResourceType resourceType)
+                    {
+                        // Resource type parameters are a special case, we need to convert to a dedicated
+                        // type so we can compare differently for assignment and code generation.
+                        var type = new UnboundResourceType(resourceType.TypeReference);
+                        outputs.Add(new OutputMetadata(output.Name, type, description));
+                    }
+                    else
+                    {
+                        outputs.Add(new OutputMetadata(output.Name, output.Type, description));
+                    }
                 }
 
-                return outputTypeProperties.ToImmutableArray();
+                return outputs.ToImmutableArray();
             });
         }
 
@@ -123,11 +139,20 @@ namespace Bicep.Core.Semantics
 
         public IBicepAnalyzer LinterAnalyzer { get; }
 
-        public ImmutableArray<TypeProperty> ParameterTypeProperties => this.parameterTypePropertiesLazy.Value;
+        public ImmutableArray<ParameterMetadata> Parameters => this.parametersLazy.Value;
 
-        public ImmutableArray<TypeProperty> OutputTypeProperties => this.outputTypePropertiesLazy.Value;
+        public ImmutableArray<OutputMetadata> Outputs => this.outputsLazy.Value;
 
+        /// <summary>
+        /// Gets the metadata of all resources for the semantic model including parameters and outputs of modules.
+        /// </summary>
         public ImmutableArray<ResourceMetadata> AllResources => allResourcesLazy.Value;
+
+        /// <summary>
+        /// Gets the metadata of resources declared for the semantic model (using the resource declaration).
+        /// Does not include parameters and outputs of modules.
+        /// </summary>
+        public ImmutableArray<DeclaredResourceMetadata> DeclaredResources => declaredResourcesLazy.Value;
 
         /// <summary>
         /// Gets all the parser and lexer diagnostics unsorted. Does not include diagnostics from the semantic model.
@@ -259,6 +284,25 @@ namespace Bicep.Core.Semantics
                 if (this.ResourceMetadata.TryLookup(resourceSymbol.DeclaringSyntax) is { } resource)
                 {
                     resources.Add(resource);
+                }
+            }
+
+            foreach (var parameterSymbol in Root.ParameterDeclarations)
+            {
+                if (this.ResourceMetadata.TryLookup(parameterSymbol.DeclaringSyntax) is { } resource)
+                {
+                    resources.Add(resource);
+                }
+            }
+
+            foreach (var moduleSymbol in Root.ModuleDeclarations)
+            {
+                if (moduleSymbol.TryGetSemanticModel(out var model, out _))
+                {
+                    foreach (var output in model.Outputs)
+                    {
+                        this.ResourceMetadata.TryAdd(moduleSymbol, output.Name);
+                    }
                 }
             }
 

--- a/src/Bicep.Core/Semantics/TemplateSpecSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/TemplateSpecSemanticModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
+using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.Workspaces;
 
@@ -21,9 +22,9 @@ namespace Bicep.Core.Semantics
 
         public ResourceScope TargetScope => this.mainTemplateSemanticModel.TargetScope;
 
-        public ImmutableArray<TypeProperty> ParameterTypeProperties => this.mainTemplateSemanticModel.ParameterTypeProperties;
+        public ImmutableArray<ParameterMetadata> Parameters => this.mainTemplateSemanticModel.Parameters;
 
-        public ImmutableArray<TypeProperty> OutputTypeProperties => this.mainTemplateSemanticModel.OutputTypeProperties;
+        public ImmutableArray<OutputMetadata> Outputs => this.mainTemplateSemanticModel.Outputs;
 
         public bool HasErrors() => this.SourceFile.HasErrors() || this.mainTemplateSemanticModel.HasErrors();
     }

--- a/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
@@ -62,7 +62,9 @@ namespace Bicep.Core.Syntax
 
         void VisitToken(Token token);
 
-        void VisitTypeSyntax(TypeSyntax syntax);
+        void VisitSimpleTypeSyntax(SimpleTypeSyntax syntax);
+
+        void VisitResourceTypeSyntax(ResourceTypeSyntax syntax);
 
         void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax);
 

--- a/src/Bicep.Core/Syntax/ModuleDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ModuleDeclarationSyntax.cs
@@ -46,27 +46,6 @@ namespace Bicep.Core.Syntax
 
         public StringSyntax? TryGetPath() => Path as StringSyntax;
 
-        public TypeSymbol GetDeclaredType(IBinder binder)
-        {
-            if (binder.GetSymbolInfo(this) is not ModuleSymbol moduleSymbol)
-            {
-                // TODO: Ideally we'd still be able to return a type here, but we'd need access to the compilation to get it.
-                return ErrorType.Empty();
-            }
-
-            if (!moduleSymbol.TryGetSemanticModel(out var moduleSemanticModel, out var failureDiagnostic))
-            {
-                return ErrorType.Create(failureDiagnostic);
-            }
-
-            return LanguageConstants.CreateModuleType(
-                moduleSemanticModel.ParameterTypeProperties,
-                moduleSemanticModel.OutputTypeProperties,
-                moduleSemanticModel.TargetScope,
-                binder.TargetScope,
-                LanguageConstants.TypeNameModule);
-        }
-
         public ObjectSyntax? TryGetBody() =>
             this.Value switch
             {

--- a/src/Bicep.Core/Syntax/OutputDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/OutputDeclarationSyntax.cs
@@ -17,7 +17,7 @@ namespace Bicep.Core.Syntax
         {
             AssertKeyword(keyword, nameof(keyword), LanguageConstants.OutputKeyword);
             AssertSyntaxType(name, nameof(name), typeof(IdentifierSyntax), typeof(IdentifierSyntax));
-            AssertSyntaxType(type, nameof(type), typeof(TypeSyntax), typeof(SkippedTriviaSyntax));
+            AssertSyntaxType(type, nameof(type), typeof(SimpleTypeSyntax), typeof(ResourceTypeSyntax), typeof(SkippedTriviaSyntax));
             AssertSyntaxType(assignment, nameof(assignment), typeof(Token), typeof(SkippedTriviaSyntax));
             AssertTokenType(assignment as Token, nameof(assignment), TokenType.Assignment);
 
@@ -43,20 +43,5 @@ namespace Bicep.Core.Syntax
         public override TextSpan Span => TextSpan.Between(this.LeadingNodes.FirstOrDefault() ?? this.Keyword, Value);
 
         public TypeSyntax? OutputType => this.Type as TypeSyntax;
-
-        public TypeSymbol GetDeclaredType()
-        {
-            // assume "any" type if the output type has parse errors (either missing or skipped)
-            var declaredType = this.OutputType == null
-                ? LanguageConstants.Any
-                : LanguageConstants.TryGetDeclarationType(this.OutputType.TypeName);
-
-            if (declaredType == null)
-            {
-                return ErrorType.Create(DiagnosticBuilder.ForPosition(this.Type).InvalidOutputType());
-            }
-
-            return declaredType;
-        }
     }
 }

--- a/src/Bicep.Core/Syntax/ResourceTypeSyntax.cs
+++ b/src/Bicep.Core/Syntax/ResourceTypeSyntax.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    public class ResourceTypeSyntax : TypeSyntax
+    {
+        public ResourceTypeSyntax(Token keyword, SyntaxBase? type)
+        {
+            AssertKeyword(keyword, nameof(keyword), LanguageConstants.ResourceKeyword);
+            AssertSyntaxType(type, nameof(type), typeof(StringSyntax), typeof(SkippedTriviaSyntax));
+
+            this.Keyword = keyword;
+            this.Type = type;
+        }
+
+        public Token Keyword { get; }
+
+        public SyntaxBase? Type { get; }
+
+        public StringSyntax? TypeString => Type as StringSyntax;
+
+        public override void Accept(ISyntaxVisitor visitor)
+        {
+            visitor.VisitResourceTypeSyntax(this);
+        }
+
+        public override TextSpan Span => TextSpan.Between(this.Keyword, this.Type ?? this.Keyword);
+    }
+}

--- a/src/Bicep.Core/Syntax/SimpleTypeSyntax.cs
+++ b/src/Bicep.Core/Syntax/SimpleTypeSyntax.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    public class SimpleTypeSyntax : TypeSyntax
+    {
+        public SimpleTypeSyntax(Token identifier)
+        {
+            AssertTokenType(identifier, nameof(identifier), TokenType.Identifier);
+            Assert(string.IsNullOrEmpty(identifier.Text) == false, "Identifier must not be null or empty.");
+
+            this.Identifier = identifier;
+        }
+
+        public Token Identifier { get; }
+
+        public string TypeName => this.Identifier.Text;
+
+        public override void Accept(ISyntaxVisitor visitor)
+        {
+            visitor.VisitSimpleTypeSyntax(this);
+        }
+
+        public override TextSpan Span => this.Identifier.Span;
+    }
+}

--- a/src/Bicep.Core/Syntax/SyntaxHelper.cs
+++ b/src/Bicep.Core/Syntax/SyntaxHelper.cs
@@ -41,7 +41,7 @@ namespace Bicep.Core.Syntax
         }
 
         public static TypeSymbol? TryGetPrimitiveType(ParameterDeclarationSyntax parameterDeclarationSyntax)
-            => LanguageConstants.TryGetDeclarationType(parameterDeclarationSyntax.ParameterType?.TypeName);
+            => LanguageConstants.TryGetDeclarationType((parameterDeclarationSyntax.ParameterType as SimpleTypeSyntax)?.TypeName);
 
         public static ResourceScope GetTargetScope(TargetScopeSyntax targetScopeSyntax)
         {

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -304,7 +304,21 @@ namespace Bicep.Core.Syntax
         }
         void ISyntaxVisitor.VisitIdentifierSyntax(IdentifierSyntax syntax) => ReplaceCurrent(syntax, ReplaceIdentifierSyntax);
 
-        protected virtual SyntaxBase ReplaceTypeSyntax(TypeSyntax syntax)
+        protected virtual SyntaxBase ReplaceResourceTypeSyntax(ResourceTypeSyntax syntax)
+        {
+            var hasChanges = TryRewriteStrict(syntax.Keyword, out var keyword);
+            hasChanges |= TryRewriteStrict(syntax.Type, out var type);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new ResourceTypeSyntax(keyword, type);
+        }
+        void ISyntaxVisitor.VisitResourceTypeSyntax(ResourceTypeSyntax syntax) => ReplaceCurrent(syntax, ReplaceResourceTypeSyntax);
+
+        protected virtual SyntaxBase ReplaceSimpleTypeSyntax(SimpleTypeSyntax syntax)
         {
             var hasChanges = TryRewriteStrict(syntax.Identifier, out var identifier);
 
@@ -313,9 +327,9 @@ namespace Bicep.Core.Syntax
                 return syntax;
             }
 
-            return new TypeSyntax(identifier);
+            return new SimpleTypeSyntax(identifier);
         }
-        void ISyntaxVisitor.VisitTypeSyntax(TypeSyntax syntax) => ReplaceCurrent(syntax, ReplaceTypeSyntax);
+        void ISyntaxVisitor.VisitSimpleTypeSyntax(SimpleTypeSyntax syntax) => ReplaceCurrent(syntax, ReplaceSimpleTypeSyntax);
 
         protected virtual SyntaxBase ReplaceBooleanLiteralSyntax(BooleanLiteralSyntax syntax)
         {

--- a/src/Bicep.Core/Syntax/SyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxVisitor.cs
@@ -126,7 +126,13 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Child);
         }
 
-        public virtual void VisitTypeSyntax(TypeSyntax syntax)
+        public virtual void VisitResourceTypeSyntax(ResourceTypeSyntax syntax)
+        {
+            this.Visit(syntax.Keyword);
+            this.Visit(syntax.Type);
+        }
+
+        public virtual void VisitSimpleTypeSyntax(SimpleTypeSyntax syntax)
         {
             this.Visit(syntax.Identifier);
         }

--- a/src/Bicep.Core/Syntax/TypeSyntax.cs
+++ b/src/Bicep.Core/Syntax/TypeSyntax.cs
@@ -1,28 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax
 {
-    public class TypeSyntax : SyntaxBase
+    public abstract class TypeSyntax : SyntaxBase
     {
-        public TypeSyntax(Token identifier)
-        {
-            AssertTokenType(identifier, nameof(identifier), TokenType.Identifier);
-            Assert(string.IsNullOrEmpty(identifier.Text) == false, "Identifier must not be null or empty.");
-
-            this.Identifier = identifier;
-        }
-
-        public Token Identifier { get; }
-
-        public string TypeName => this.Identifier.Text;
-
-        public override void Accept(ISyntaxVisitor visitor)
-        {
-            visitor.VisitTypeSyntax(this);
-        }
-
-        public override TextSpan Span => TextSpan.Between(this.Identifier, this.Identifier);
     }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -12,6 +12,7 @@ using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
 using Bicep.Core.Resources;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.TypeSystem
@@ -109,9 +110,42 @@ namespace Bicep.Core.TypeSystem
             return null;
         }
 
-        private DeclaredTypeAssignment GetParameterType(ParameterDeclarationSyntax syntax) => new(syntax.GetDeclaredType(), syntax);
+        private DeclaredTypeAssignment GetParameterType(ParameterDeclarationSyntax syntax)
+        {
+            var declaredType = TryGetTypeFromTypeSyntax(syntax.ParameterType);
+            declaredType ??= ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).InvalidParameterType());
 
-        private DeclaredTypeAssignment GetOutputType(OutputDeclarationSyntax syntax) => new(syntax.GetDeclaredType(), syntax);
+            return new(declaredType, syntax);
+        }
+
+        private DeclaredTypeAssignment GetOutputType(OutputDeclarationSyntax syntax)
+        {
+            TypeSymbol declaredType;
+            if (syntax.Type is ResourceTypeSyntax resourceTypeSyntax && resourceTypeSyntax.Type is null)
+            {
+                // The resource type of an output can be inferred.
+                declaredType = this.typeManager.GetTypeInfo(syntax.Value);
+            }
+            else
+            {
+                declaredType = TryGetTypeFromTypeSyntax(syntax.OutputType) ??
+                    ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).InvalidOutputType());
+            }
+
+            return new(declaredType, syntax);
+        }
+
+        private TypeSymbol? TryGetTypeFromTypeSyntax(TypeSyntax? syntax)
+        {
+            // assume "any" type when the parameter has parse errors (either missing or was skipped)
+            return syntax switch
+            {
+                null => LanguageConstants.Any,
+                SimpleTypeSyntax simple => LanguageConstants.TryGetDeclarationType(simple.TypeName),
+                ResourceTypeSyntax resource => GetDeclaredResourceType(this.binder, resource),
+                _ => null
+            };
+        }
 
         private DeclaredTypeAssignment? GetImportType(ImportDeclarationSyntax syntax)
         {
@@ -135,7 +169,7 @@ namespace Bicep.Core.TypeSystem
 
         private DeclaredTypeAssignment GetModuleType(ModuleDeclarationSyntax syntax)
         {
-            var declaredModuleType = syntax.GetDeclaredType(this.binder);
+            var declaredModuleType = GetDeclaredModuleType(syntax);
 
             // if the value is a loop (not a condition or object), the type is an array of the declared module type
             return new DeclaredTypeAssignment(
@@ -183,7 +217,19 @@ namespace Bicep.Core.TypeSystem
 
             var baseExpressionAssignment = GetDeclaredTypeAssignment(syntax.BaseExpression);
 
-            // it's ok to rely on useSyntax=true because those types have already been established
+            // As a special case, a 'resource' parameter or output is a reference to an existing resource
+            // we can't rely on it's syntax because it doesn't declare the resource body.
+            if (baseExpressionAssignment?.DeclaringSyntax is ParameterDeclarationSyntax parameterSyntax &&
+                baseExpressionAssignment.Reference.Type is ResourceType parameterResourceType)
+            {
+                return GetObjectPropertyType(
+                    parameterResourceType.Body.Type,
+                    null,
+                    syntax.PropertyName.IdentifierName,
+                    useSyntax: false);
+            }
+
+            // If we get here, it's ok to rely on useSyntax=true because those types have already been established
 
             var body = baseExpressionAssignment?.DeclaringSyntax switch
             {
@@ -191,6 +237,7 @@ namespace Bicep.Core.TypeSystem
                 ModuleDeclarationSyntax moduleDeclarationSyntax => moduleDeclarationSyntax.TryGetBody(),
                 _ => baseExpressionAssignment?.DeclaringSyntax as ObjectSyntax,
             };
+
             return GetObjectPropertyType(
                 baseExpressionAssignment?.Reference.Type,
                 body,
@@ -592,6 +639,15 @@ namespace Bicep.Core.TypeSystem
                 }
             }
 
+            if (type is ResourceType resourceType)
+            {
+                // We can see a resource type here for an expression like: `mod.outputs.foo.|properties|.bar`
+                // The type of foo is a resource type, but since it's part of the module there's no corresponding declaration.
+                //
+                // For that case resolve the property lookup against the body.
+                type = resourceType.Body.Type;
+            }
+
             // could not get the declared type via syntax
             // let's use the type info instead
             switch (type)
@@ -674,12 +730,39 @@ namespace Bicep.Core.TypeSystem
         private bool IsCycleFree(DeclaredSymbol declaredSymbol) => this.binder.TryGetCycle(declaredSymbol) is null;
 
         /// <summary>
+        /// Returns the declared type of the parameter/output based on a resource type.
+        /// </summary>
+        /// <param name="resourceTypeProvider">resource type provider</param>
+        private TypeSymbol GetDeclaredResourceType(IBinder binder, ResourceTypeSyntax typeSyntax)
+        {
+            // NOTE: this is closely related to the logic in the other overload. Keep them in sync.
+            var stringSyntax = typeSyntax.TypeString;
+            if (stringSyntax != null && stringSyntax.IsInterpolated())
+            {
+                // TODO: in the future, we can relax this check to allow interpolation with compile-time constants.
+                // right now, codegen will still generate a format string however, which will cause problems for the type.
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(typeSyntax.Type!).ResourceTypeInterpolationUnsupported());
+            }
+
+            var stringContent = stringSyntax?.TryGetLiteralValue();
+            if (stringContent == null)
+            {
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(typeSyntax.Type!).InvalidResourceType());
+            }
+
+            // A parameter/output always refers to an 'existing' resource.
+            var typeGenerationFlags = ResourceTypeGenerationFlags.ExistingResource;
+            return GetResourceTypeFromString(typeSyntax.Type!.Span, stringContent, typeGenerationFlags, parentResourceType: null);
+        }
+
+        /// <summary>
         /// Returns the declared type of the resource body (based on the type string).
         /// Returns the same value for single resource or resource loops declarations.
         /// </summary>
         /// <param name="resourceTypeProvider">resource type provider</param>
         private TypeSymbol GetDeclaredResourceType(ResourceDeclarationSyntax resource)
         {
+            // NOTE: this is closely related to the logic in the other overload. Keep them in sync.
             var stringSyntax = resource.TypeString;
 
             if (stringSyntax != null && stringSyntax.IsInterpolated())
@@ -696,7 +779,65 @@ namespace Bicep.Core.TypeSystem
             }
 
             var (typeGenerationFlags, parentResourceType) = GetResourceTypeGenerationFlags(resource);
+            return GetResourceTypeFromString(resource.Type.Span, stringContent, typeGenerationFlags, parentResourceType);
+        }
 
+        private TypeSymbol GetDeclaredModuleType(ModuleDeclarationSyntax module)
+        {
+            if (binder.GetSymbolInfo(module) is not ModuleSymbol moduleSymbol)
+            {
+                // TODO: Ideally we'd still be able to return a type here, but we'd need access to the compilation to get it.
+                return ErrorType.Empty();
+            }
+
+            if (!moduleSymbol.TryGetSemanticModel(out var moduleSemanticModel, out var failureDiagnostic))
+            {
+                return ErrorType.Create(failureDiagnostic);
+            }
+
+            // We need to bind and validate all of the parameters and outputs that declare resource types
+            // within the context of this type manager. This will surface any issues where the type declared by
+            // a module is not understood inside this compilation unit.
+            var parameters = new List<TypeProperty>();
+            foreach (var parameter in moduleSemanticModel.Parameters)
+            {
+                var type = parameter.TypeReference.Type;
+                if (type is UnboundResourceType unboundType)
+                {
+                    var boundType = GetResourceTypeFromString(module.Span, unboundType.TypeReference.FormatName(), ResourceTypeGenerationFlags.ExistingResource, parentResourceType: null);
+                    if (boundType is ResourceType resourceType)
+                    {
+                        // We use a special type for Resource type parameters because they have different assignability rules.
+                        type = new ResourceParameterType(resourceType.DeclaringNamespace, unboundType.TypeReference);
+                    }
+                }
+
+                var flags = parameter.IsRequired ? TypePropertyFlags.Required | TypePropertyFlags.WriteOnly : TypePropertyFlags.WriteOnly;
+                parameters.Add(new TypeProperty(parameter.Name, type, flags, parameter.Description));
+            }
+
+            var outputs = new List<TypeProperty>();
+            foreach (var output in moduleSemanticModel.Outputs)
+            {
+                var type = output.TypeReference.Type;
+                if (type is UnboundResourceType unboundType)
+                {
+                    type = GetResourceTypeFromString(module.Span, unboundType.TypeReference.FormatName(), ResourceTypeGenerationFlags.ExistingResource, parentResourceType: null);
+                }
+
+                outputs.Add(new TypeProperty(output.Name, type, TypePropertyFlags.ReadOnly, output.Description));
+            }
+
+            return LanguageConstants.CreateModuleType(
+                parameters,
+                outputs,
+                moduleSemanticModel.TargetScope,
+                binder.TargetScope,
+                LanguageConstants.TypeNameModule);
+        }
+
+        private TypeSymbol GetResourceTypeFromString(TextSpan span, string stringContent, ResourceTypeGenerationFlags typeGenerationFlags, ResourceType? parentResourceType)
+        {
             var colonIndex = stringContent.IndexOf(':');
             if (colonIndex > 0)
             {
@@ -705,16 +846,16 @@ namespace Bicep.Core.TypeSystem
 
                 if (binder.NamespaceResolver.TryGetNamespace(scheme) is not { } namespaceType)
                 {
-                    return ErrorType.Create(DiagnosticBuilder.ForPosition(resource.Type).UnknownResourceReferenceScheme(scheme, binder.NamespaceResolver.GetNamespaceNames().OrderBy(x => x, StringComparer.OrdinalIgnoreCase)));
+                    return ErrorType.Create(DiagnosticBuilder.ForPosition(span).UnknownResourceReferenceScheme(scheme, binder.NamespaceResolver.GetNamespaceNames().OrderBy(x => x, StringComparer.OrdinalIgnoreCase)));
                 }
 
                 if (parentResourceType is not null &&
                     parentResourceType.DeclaringNamespace != namespaceType)
                 {
-                    return ErrorType.Create(DiagnosticBuilder.ForPosition(resource.Type).ParentResourceInDifferentNamespace(namespaceType.Name, parentResourceType.DeclaringNamespace.Name));
+                    return ErrorType.Create(DiagnosticBuilder.ForPosition(span).ParentResourceInDifferentNamespace(namespaceType.Name, parentResourceType.DeclaringNamespace.Name));
                 }
 
-                var (errorType, typeReference) = GetCombinedTypeReference(typeGenerationFlags, resource, parentResourceType, typeString);
+                var (errorType, typeReference) = GetCombinedTypeReference(span, typeGenerationFlags, parentResourceType, typeString);
                 if (errorType is not null)
                 {
                     return errorType;
@@ -737,11 +878,11 @@ namespace Bicep.Core.TypeSystem
                     return defaultResource;
                 }
 
-                return ErrorType.Create(DiagnosticBuilder.ForPosition(resource.Type).FailedToFindResourceTypeInNamespace(namespaceType.ProviderName, typeReference.FormatName()));
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(span).FailedToFindResourceTypeInNamespace(namespaceType.ProviderName, typeReference.FormatName()));
             }
             else
             {
-                var (errorType, typeReference) = GetCombinedTypeReference(typeGenerationFlags, resource, parentResourceType, stringContent);
+                var (errorType, typeReference) = GetCombinedTypeReference(span, typeGenerationFlags, parentResourceType, stringContent);
                 if (errorType is not null)
                 {
                     return errorType;
@@ -759,7 +900,7 @@ namespace Bicep.Core.TypeSystem
                     return resourceType;
                 }
 
-                return ErrorType.Create(DiagnosticBuilder.ForPosition(resource.Type).InvalidResourceType());
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(span).InvalidResourceType());
             }
         }
 
@@ -802,11 +943,11 @@ namespace Bicep.Core.TypeSystem
             return (flags, parentType as ResourceType);
         }
 
-        private static (ErrorType? error, ResourceTypeReference? typeReference) GetCombinedTypeReference(ResourceTypeGenerationFlags flags, ResourceDeclarationSyntax resource, ResourceType? parentResourceType, string typeString)
+        private static (ErrorType? error, ResourceTypeReference? typeReference) GetCombinedTypeReference(TextSpan span, ResourceTypeGenerationFlags flags, ResourceType? parentResourceType, string typeString)
         {
             if (ResourceTypeReference.TryParse(typeString) is not { } typeReference)
             {
-                return (ErrorType.Create(DiagnosticBuilder.ForPosition(resource.Type).InvalidResourceType()), null);
+                return (ErrorType.Create(DiagnosticBuilder.ForPosition(span).InvalidResourceType()), null);
             }
 
             if (!flags.HasFlag(ResourceTypeGenerationFlags.NestedResource))
@@ -818,13 +959,13 @@ namespace Bicep.Core.TypeSystem
             // we're dealing with a syntactically nested resource here
             if (parentResourceType is null)
             {
-                return (ErrorType.Create(DiagnosticBuilder.ForPosition(resource.Type).InvalidAncestorResourceType()), null);
+                return (ErrorType.Create(DiagnosticBuilder.ForPosition(span).InvalidAncestorResourceType()), null);
             }
 
             if (typeReference.TypeSegments.Length > 1)
             {
                 // OK this resource is the one that's wrong.
-                return (ErrorType.Create(DiagnosticBuilder.ForPosition(resource.Type).InvalidResourceTypeSegment(typeString)), null);
+                return (ErrorType.Create(DiagnosticBuilder.ForPosition(span).InvalidResourceTypeSegment(typeString)), null);
             }
 
             return (null, ResourceTypeReference.Combine(

--- a/src/Bicep.Core/TypeSystem/ResourceParameterType.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceParameterType.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Resources;
+
+namespace Bicep.Core.TypeSystem
+{
+    public class ResourceParameterType : TypeSymbol
+    {
+        public ResourceParameterType(NamespaceType declaringNamespace, ResourceTypeReference typeReference)
+            : base(typeReference.FormatType())
+        {
+            this.DeclaringNamespace = declaringNamespace;
+            this.TypeReference = typeReference;
+        }
+
+        public NamespaceType DeclaringNamespace { get; }
+
+        public ResourceTypeReference TypeReference { get; }
+
+        public override TypeKind TypeKind => TypeKind.Resource;
+    }
+}

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
+using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
@@ -38,15 +39,17 @@ namespace Bicep.Core.TypeSystem
             public IEnumerable<IDiagnostic> Diagnostics { get; }
         }
 
+        private readonly IFeatureProvider features;
         private readonly ITypeManager typeManager;
         private readonly IBinder binder;
         private readonly IFileResolver fileResolver;
         private readonly ConcurrentDictionary<SyntaxBase, TypeAssignment> assignedTypes;
         private readonly ConcurrentDictionary<FunctionCallSyntaxBase, FunctionOverload> matchedFunctionOverloads;
 
-        public TypeAssignmentVisitor(ITypeManager typeManager, IBinder binder, IFileResolver fileResolver)
+        public TypeAssignmentVisitor(ITypeManager typeManager, IFeatureProvider features, IBinder binder, IFileResolver fileResolver)
         {
             this.typeManager = typeManager;
+            this.features = features;
             this.binder = binder;
             this.fileResolver = fileResolver;
             assignedTypes = new();
@@ -284,6 +287,52 @@ namespace Bicep.Core.TypeSystem
                     return singleDeclaredType;
                 }
 
+                // We need to validate all of the parameters and outputs to make sure they are valid types.
+                // This is where we surface errors for 'unknown' resource types.
+                if (singleDeclaredType is ModuleType moduleType &&
+                    moduleType.Body is ObjectType objectType)
+                {
+                    if (objectType.Properties.TryGetValue(LanguageConstants.ModuleParamsPropertyName, out var paramsProperty)
+                        && paramsProperty.TypeReference.Type is ObjectType paramsType)
+                    {
+                        foreach (var property in paramsType.Properties.Values)
+                        {
+                            if (property.TypeReference.Type is ResourceParameterType resourceType)
+                            {
+                                if (!features.ResourceTypedParamsAndOutputsEnabled)
+                                {
+                                    diagnostics.Write(DiagnosticBuilder.ForPosition(syntax.Path).ParamOrOutputResourceTypeUnsupported());
+                                }
+
+                                if (!resourceType.DeclaringNamespace.ResourceTypeProvider.HasDefinedType(resourceType.TypeReference))
+                                {
+                                    diagnostics.Write(DiagnosticBuilder.ForPosition(syntax.Path).ModuleParamOrOutputResourceTypeUnavailable(resourceType.TypeReference));
+                                }
+                            }
+                        }
+                    }
+
+                    if (objectType.Properties.TryGetValue(LanguageConstants.ModuleOutputsPropertyName, out var outputsProperty)
+                        && outputsProperty.TypeReference.Type is ObjectType outputsType)
+                    {
+                        foreach (var property in outputsType.Properties.Values)
+                        {
+                            if (property.TypeReference.Type is ResourceType resourceType)
+                            {
+                                if (!features.ResourceTypedParamsAndOutputsEnabled)
+                                {
+                                    diagnostics.Write(DiagnosticBuilder.ForPosition(syntax.Path).ParamOrOutputResourceTypeUnsupported());
+                                }
+
+                                if (!resourceType.DeclaringNamespace.ResourceTypeProvider.HasDefinedType(resourceType.TypeReference))
+                                {
+                                    diagnostics.Write(DiagnosticBuilder.ForPosition(syntax.Path).ModuleParamOrOutputResourceTypeUnavailable(resourceType.TypeReference));
+                                }
+                            }
+                        }
+                    }
+                }
+
                 if (this.binder.GetSymbolInfo(syntax) is ModuleSymbol moduleSymbol &&
                     moduleSymbol.TryGetSemanticModel(out var moduleSemanticModel, out var _) &&
                     moduleSemanticModel.HasErrors())
@@ -293,13 +342,38 @@ namespace Bicep.Core.TypeSystem
                         : DiagnosticBuilder.ForPosition(syntax.Path).ReferencedModuleHasErrors());
                 }
 
+
                 return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, diagnostics, syntax.Value, declaredType);
             });
 
         public override void VisitParameterDeclarationSyntax(ParameterDeclarationSyntax syntax)
             => AssignTypeWithDiagnostics(syntax, diagnostics =>
             {
-                var declaredType = syntax.GetDeclaredType();
+                var declaredType = typeManager.GetDeclaredType(syntax);
+                if (declaredType is null)
+                {
+                    return ErrorType.Empty();
+                }
+
+                if (declaredType is ResourceType resourceType)
+                {
+                    if (IsExtensibilityType(resourceType))
+                    {
+                        declaredType = ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).UnsupportedResourceTypeParameterType(declaredType.Name));
+                    }
+
+                    if (!features.ResourceTypedParamsAndOutputsEnabled)
+                    {
+                        declaredType = ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Span).ParamOrOutputResourceTypeUnsupported());
+                    }
+
+                    if (syntax.Type is ResourceTypeSyntax resourceTypeSyntax &&
+                        resourceTypeSyntax.Type is {} &&
+                        !resourceType.DeclaringNamespace.ResourceTypeProvider.HasDefinedType(resourceType.TypeReference))
+                    {
+                        diagnostics.Write(DiagnosticBuilder.ForPosition(resourceTypeSyntax.Type!).ResourceTypesUnavailable(resourceType.TypeReference));
+                    }
+                }
 
                 this.ValidateDecorators(syntax.Decorators, declaredType, diagnostics);
 
@@ -470,13 +544,14 @@ namespace Bicep.Core.TypeSystem
         public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
             => AssignTypeWithDiagnostics(syntax, diagnostics =>
             {
-                var declaredType = syntax.GetDeclaredType();
+                var declaredType = this.typeManager.GetDeclaredType(syntax);
+                if (declaredType is null)
+                {
+                    return ErrorType.Empty();
+                }
 
                 this.ValidateDecorators(syntax.Decorators, declaredType, diagnostics);
-
-                var currentDiagnostics = GetOutputDeclarationDiagnostics(declaredType, syntax);
-
-                diagnostics.WriteMultiple(currentDiagnostics);
+                diagnostics.WriteMultiple(GetOutputDeclarationDiagnostics(declaredType, syntax));
 
                 return declaredType;
             });
@@ -1365,17 +1440,39 @@ namespace Bicep.Core.TypeSystem
             var valueType = typeManager.GetTypeInfo(syntax.Value);
 
             // this type is not a property in a symbol so the semantic error visitor won't collect the errors automatically
-            if (valueType is ErrorType)
+            var diagnostics = new List<IDiagnostic>();
+            diagnostics.AddRange(valueType.GetDiagnostics());
+
+            if (assignedType is ResourceType resourceType &&
+                syntax.Type is ResourceTypeSyntax resourceTypeSyntax)
             {
-                return valueType.GetDiagnostics();
+                if (IsExtensibilityType(resourceType))
+                {
+                    diagnostics.Add(DiagnosticBuilder.ForPosition(resourceTypeSyntax).UnsupportedResourceTypeOutputType(assignedType.Name));
+                }
+
+                if (!features.ResourceTypedParamsAndOutputsEnabled)
+                {
+                    diagnostics.Add(DiagnosticBuilder.ForPosition(syntax.Span).ParamOrOutputResourceTypeUnsupported());
+                }
+
+                // As a special case of outputs, we don't want to double-up diagnostics on inferred resource types.
+                // The inference is based on another declaration in the file, and so the user should fix that instead.
+                if (resourceTypeSyntax.Type is {}
+                    && !resourceType.DeclaringNamespace.ResourceTypeProvider.HasDefinedType(resourceType.TypeReference))
+                {
+                    diagnostics.Add(DiagnosticBuilder.ForPosition(resourceTypeSyntax.Type!).ResourceTypesUnavailable(resourceType.TypeReference));
+                }
             }
 
-            if (TypeValidator.AreTypesAssignable(valueType, assignedType) == false)
+            // Avoid reporting an additional error if we failed to bind the output type.
+            if (TypeValidator.AreTypesAssignable(valueType, assignedType) == false &&
+                valueType is not ErrorType)
             {
                 return DiagnosticBuilder.ForPosition(syntax.Value).OutputTypeMismatch(assignedType, valueType).AsEnumerable();
             }
 
-            return Enumerable.Empty<IDiagnostic>();
+            return diagnostics;
         }
 
         private IEnumerable<IDiagnostic> ValidateDefaultValue(ParameterDefaultValueSyntax defaultValueSyntax, TypeSymbol assignedType)
@@ -1397,7 +1494,7 @@ namespace Bicep.Core.TypeSystem
 
                 return diagnosticWriter.GetDiagnostics();
             }
-            else if (TypeValidator.AreTypesAssignable(defaultValueType, assignedType) == false)
+            else if (!TypeValidator.AreTypesAssignable(defaultValueType, assignedType))
             {
                 return DiagnosticBuilder.ForPosition(defaultValueSyntax.DefaultValue).ParameterTypeMismatch(assignedType, defaultValueType).AsEnumerable();
             }
@@ -1464,6 +1561,11 @@ namespace Bicep.Core.TypeSystem
 
                 _ => baseType
             };
+
+        private bool IsExtensibilityType(ResourceType resourceType)
+        {
+            return resourceType.DeclaringNamespace.ProviderName != AzNamespaceType.BuiltInName;
+        }
 
         private DecoratorSyntax? GetNamedDecorator(StatementSyntax syntax, string decoratorName)
         {

--- a/src/Bicep.Core/TypeSystem/TypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/TypeManager.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
@@ -15,12 +15,12 @@ namespace Bicep.Core.TypeSystem
         private readonly TypeAssignmentVisitor typeAssignmentVisitor;
         private readonly DeclaredTypeManager declaredTypeManager;
 
-        public TypeManager(IBinder binder, IFileResolver fileResolver)
+        public TypeManager(IFeatureProvider features, IBinder binder, IFileResolver fileResolver)
         {
             // bindings will be modified by name binding after this object is created
             // so we can't make an immutable copy here
             // (using the IReadOnlyDictionary to prevent accidental mutation)
-            this.typeAssignmentVisitor = new TypeAssignmentVisitor(this, binder, fileResolver);
+            this.typeAssignmentVisitor = new TypeAssignmentVisitor(this, features, binder, fileResolver);
 
             this.declaredTypeManager = new DeclaredTypeManager(this, binder);
         }

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -103,6 +103,10 @@ namespace Bicep.Core.TypeSystem
                     // Assigning a resource to a parent property.
                     return sourceResourceType.TypeReference.IsParentOf(targetResourceParentType.ChildTypeReference);
 
+                case (ResourceType sourceResourceType, ResourceParameterType resourceParameterType):
+                    // Assigning a resource to a parameter ignores the API Version
+                    return sourceResourceType.TypeReference.FormatType().Equals(resourceParameterType.TypeReference.FormatType(), StringComparison.OrdinalIgnoreCase);
+
                 case (ResourceType sourceResourceType, _):
                     // When assigning a resource, we're really assigning the value of the resource body.
                     return AreTypesAssignable(sourceResourceType.Body.Type, targetType);

--- a/src/Bicep.Core/TypeSystem/UnboundResourceType.cs
+++ b/src/Bicep.Core/TypeSystem/UnboundResourceType.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Resources;
+
+namespace Bicep.Core.TypeSystem
+{
+    /// <summary>
+    /// UnboundResourceType represents a resource type that has been specified but not validated.
+    ///
+    /// Generally this means the resource type is used as a parameter or an output of a module. The binding
+    /// of the type has yet to occur because it must take place in the context of the consuming module.
+    /// </summary>
+    public class UnboundResourceType : TypeSymbol
+    {
+        public UnboundResourceType(ResourceTypeReference typeReference)
+            : base(typeReference.FormatType())
+        {
+            this.TypeReference = typeReference;
+        }
+
+        public ResourceTypeReference TypeReference { get; }
+
+        public override TypeKind TypeKind => TypeKind.Resource;
+    }
+}

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -89,7 +89,7 @@ namespace Bicep.Core.IntegrationTests
             var nsProvider = BicepTestConstants.NamespaceProvider;
 
             var jsonUri = PathHelper.FilePathToFileUrl(jsonFileName);
-            var decompiler = new TemplateDecompiler(nsProvider, new FileResolver(), BicepTestConstants.RegistryProvider, BicepTestConstants.ConfigurationManager);
+            var decompiler = new TemplateDecompiler(BicepTestConstants.Features, nsProvider, new FileResolver(), BicepTestConstants.RegistryProvider, BicepTestConstants.ConfigurationManager);
             var (bicepUri, filesToSave) = decompiler.DecompileFileWithModules(jsonUri, PathHelper.ChangeToBicepExtension(jsonUri));
 
             var bicepFiles = filesToSave.Select(kvp => SourceFileFactory.CreateBicepFile(kvp.Key, kvp.Value));
@@ -99,7 +99,7 @@ namespace Bicep.Core.IntegrationTests
             var dispatcher = new ModuleDispatcher(BicepTestConstants.RegistryProvider);
             var configuration = BicepTestConstants.BuiltInConfigurationWithAnalyzersDisabled;
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, workspace, bicepUri, configuration);
-            var compilation = new Compilation(nsProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
+            var compilation = new Compilation(BicepTestConstants.Features, nsProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
             var diagnosticsByBicepFile = compilation.GetAllDiagnosticsByBicepFile();
 
             using (new AssertionScope())
@@ -147,7 +147,7 @@ namespace Bicep.Core.IntegrationTests
             Action onDecompile = () =>
             {
                 var fileResolver = ReadResourceFile(resourcePath);
-                var decompiler = new TemplateDecompiler(TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
+                var decompiler = new TemplateDecompiler(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
                 decompiler.DecompileFileWithModules(new Uri($"file:///{resourcePath}"), new Uri("file:///unused.bicep"));
             };
 
@@ -181,7 +181,7 @@ namespace Bicep.Core.IntegrationTests
                 [fileUri] = template,
             }); ;
 
-            var decompiler = new TemplateDecompiler(TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
+            var decompiler = new TemplateDecompiler(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
             var (entryPointUri, filesToSave) = decompiler.DecompileFileWithModules(fileUri, PathHelper.ChangeToBicepExtension(fileUri));
 
             // this behavior is actually controlled by newtonsoft's deserializer, but we should assert it anyway to avoid regressions.
@@ -232,7 +232,7 @@ namespace Bicep.Core.IntegrationTests
                 [fileUri] = template,
             });
 
-            var decompiler = new TemplateDecompiler(TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
+            var decompiler = new TemplateDecompiler(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
             var (entryPointUri, filesToSave) = decompiler.DecompileFileWithModules(fileUri, PathHelper.ChangeToBicepExtension(fileUri));
 
             filesToSave[entryPointUri].Should().Contain($"output calculated {type} = ({expectedValue})");
@@ -258,7 +258,7 @@ namespace Bicep.Core.IntegrationTests
 
             Action sut = () =>
             {
-                var decompiler = new TemplateDecompiler(TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
+                var decompiler = new TemplateDecompiler(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
                 decompiler.DecompileFileWithModules(fileUri, PathHelper.ChangeToBicepExtension(fileUri));
             };
 
@@ -320,7 +320,7 @@ namespace Bicep.Core.IntegrationTests
                 [fileUri] = template,
             });
 
-            var decompiler = new TemplateDecompiler(TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
+            var decompiler = new TemplateDecompiler(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), fileResolver, new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features), BicepTestConstants.ConfigurationManager);
             var (entryPointUri, filesToSave) = decompiler.DecompileFileWithModules(fileUri, PathHelper.ChangeToBicepExtension(fileUri));
 
             filesToSave[entryPointUri].Should().Contain($"? /* TODO: User defined functions are not supported and have not been decompiled */");

--- a/src/Bicep.Decompiler/Rewriters/ParentChildResourceNameRewriter.cs
+++ b/src/Bicep.Decompiler/Rewriters/ParentChildResourceNameRewriter.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 
@@ -17,7 +18,7 @@ namespace Bicep.Core.Decompiler.Rewriters
     //   resource resA 'My.Rp/resA@2020-01-01' = {
     //     name: parentName
     //   }
-    //   
+    //
     //   resource resB 'My.Rp/resA/childB@2020-01-01' = {
     //     name: '${parentName}/resB'
     //     dependsOn: [
@@ -91,7 +92,7 @@ namespace Bicep.Core.Decompiler.Rewriters
                 return syntax;
             }
 
-            foreach (var otherResource in semanticModel.AllResources)
+            foreach (var otherResource in semanticModel.DeclaredResources)
             {
                 var otherResourceSymbol = otherResource.Symbol;
 

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -152,15 +152,16 @@ namespace Bicep.Decompiler
             return ExpressionHelpers.FlattenStringOperations(inlined);
         }
 
-        private static TypeSyntax? TryParseType(JToken? value)
+        private static SimpleTypeSyntax? TryParseType(JToken? value)
         {
+            // ARM JSON always encodes the type as a simple type (not a resource type).
             var typeString = value?.Value<string>();
             if (typeString == null)
             {
                 return null;
             }
 
-            return new TypeSyntax(SyntaxFactory.CreateToken(TokenType.Identifier, typeString.ToLowerInvariant()));
+            return new SimpleTypeSyntax(SyntaxFactory.CreateToken(TokenType.Identifier, typeString.ToLowerInvariant()));
         }
 
         private string? TryLookupResource(LanguageExpression expression)
@@ -751,18 +752,18 @@ namespace Bicep.Decompiler
             switch (typeSyntax.TypeName)
             {
                 case "securestring":
-                    typeSyntax = new TypeSyntax(SyntaxFactory.CreateToken(TokenType.Identifier, "string"));
+                    typeSyntax = new SimpleTypeSyntax(SyntaxFactory.CreateToken(TokenType.Identifier, "string"));
                     decoratorsAndNewLines.Add(SyntaxFactory.CreateDecorator(LanguageConstants.ParameterSecurePropertyName));
                     decoratorsAndNewLines.Add(SyntaxFactory.NewlineToken);
                     break;
                 case "secureobject":
-                    typeSyntax = new TypeSyntax(SyntaxFactory.CreateToken(TokenType.Identifier, "object"));
+                    typeSyntax = new SimpleTypeSyntax(SyntaxFactory.CreateToken(TokenType.Identifier, "object"));
                     decoratorsAndNewLines.Add(SyntaxFactory.CreateDecorator(LanguageConstants.ParameterSecurePropertyName));
                     decoratorsAndNewLines.Add(SyntaxFactory.NewlineToken);
                     break;
                 case "__bicep_replace":
                     var fixupToken = SyntaxHelpers.CreatePlaceholderToken(TokenType.Identifier, "TODO: fill in correct type");
-                    typeSyntax = new TypeSyntax(fixupToken);
+                    typeSyntax = new SimpleTypeSyntax(fixupToken);
                     break;
             }
 

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -177,7 +177,7 @@ namespace Bicep.LangServer.IntegrationTests
             var bicepConfigUri = DocumentUri.FromFileSystemPath(bicepConfigFilePath);
             fileSystemDict[bicepConfigUri.ToUri()] = bicepConfigFileContents;
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(fileSystemDict, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(fileSystemDict, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
             diagnostics.Should().HaveCount(1);
@@ -220,7 +220,7 @@ resource test";
                 [uri] = bicepFileContents,
             };
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
             diagnostics.Should().HaveCount(2);
@@ -282,7 +282,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
                 [uri] = bicepFileContents,
             };
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
             diagnostics.Should().HaveCount(3);

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -119,7 +119,7 @@ namespace Bicep.LangServer.IntegrationTests
                 {
                     [combinedFileUri] = bicepContentsReplaced,
                 }, combinedFileUri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration);
-                var compilation = new Compilation(NamespaceProvider, sourceFileGrouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+                var compilation = new Compilation(BicepTestConstants.Features, NamespaceProvider, sourceFileGrouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
                 var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
                 var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(bicepContentsReplaced, "\n", diagnostics, diag => OutputHelper.GetDiagLoggingString(bicepContentsReplaced, outputDirectory, diag));
@@ -1870,7 +1870,7 @@ resource test";
             var fileSystemDict = new Dictionary<Uri, string>();
             fileSystemDict[uri] = file;
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(fileSystemDict, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(fileSystemDict, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
             diagnostics.Should().SatisfyRespectively(

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageServerHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageServerHelper.cs
@@ -24,7 +24,7 @@ namespace Bicep.LangServer.IntegrationTests
 {
     public class LanguageServerHelper : IDisposable
     {
-        public static readonly ISnippetsProvider SnippetsProvider = new SnippetsProvider(TestTypeHelper.CreateEmptyProvider(), BicepTestConstants.FileResolver, BicepTestConstants.ConfigurationManager);
+        public static readonly ISnippetsProvider SnippetsProvider = new SnippetsProvider(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), BicepTestConstants.FileResolver, BicepTestConstants.ConfigurationManager);
 
         public Server Server { get; }
         public ILanguageClient Client { get; }

--- a/src/Bicep.LangServer.IntegrationTests/SnippetTemplatesTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/SnippetTemplatesTests.cs
@@ -55,7 +55,7 @@ namespace Bicep.LangServer.IntegrationTests
                     return;
             }
 
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateForFiles(files, mainUri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var semanticModel = compilation.GetEntrypointSemanticModel();
 
             if (semanticModel.HasErrors())

--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -93,7 +93,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             string text = @"resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-03-15' = {
   name: 'name'
-  properties: 
+  properties:
 }";
             IDictionary<string, string> properties = new Dictionary<string, string>
             {
@@ -116,7 +116,7 @@ namespace Bicep.LangServer.IntegrationTests
   properties: {
     managedRules: {
       managedRuleSets: [
-        
+
       ]
     }
   }
@@ -160,7 +160,7 @@ namespace Bicep.LangServer.IntegrationTests
                 [uri] = bicepFileContents,
             };
 
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateForFiles(files, uri, BicepTestConstants.FileResolver, BicepTestConstants.BuiltInConfiguration), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
 
             var telemetryEventsListener = new MultipleMessageListener<BicepTelemetryEvent>();

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
@@ -77,7 +77,7 @@ namespace Bicep.LangServer.UnitTests
 
         public static ICompilationProvider CreateEmptyCompilationProvider()
         {
-            return new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), FileResolver, new ModuleDispatcher(BicepTestConstants.RegistryProvider));
+            return new BicepCompilationProvider(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), FileResolver, new ModuleDispatcher(BicepTestConstants.RegistryProvider));
         }
 
         public static Mock<IModuleRestoreScheduler> CreateMockScheduler()

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -515,7 +515,7 @@ module moduleB './moduleB.bicep' = {
             var server = BicepCompilationManagerHelper.CreateMockServer(document);
 
             var fileResolver = new InMemoryFileResolver(fileDict);
-            var compilationProvider = new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), fileResolver, new ModuleDispatcher(new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features)));
+            var compilationProvider = new BicepCompilationProvider(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), fileResolver, new ModuleDispatcher(new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features)));
 
             var compilationManager = new BicepCompilationManager(server.Object, compilationProvider, new Workspace(), fileResolver, BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
@@ -752,7 +752,7 @@ param location string = 'testLocation'";
 
             var bicepFile = SourceFileFactory.CreateBicepFile(mainUri, bicepFileContents);
 
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(bicepFileContents, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText(bicepFileContents, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics().ToDiagnostics(bicepFile.LineStarts);
 
             var compilationManager = CreateBicepCompilationManager();

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
@@ -35,7 +35,7 @@ namespace Bicep.LangServer.UnitTests
             var fileResolver = CreateFileResolver(fileUri.ToUri(), DataSets.Parameters_LF.Bicep);
             var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features));
 
-            var provider = new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), fileResolver, dispatcher);
+            var provider = new BicepCompilationProvider(BicepTestConstants.Features, TestTypeHelper.CreateWithAzTypes(), fileResolver, dispatcher);
 
             var sourceFile = SourceFileFactory.CreateSourceFile(fileUri.ToUri(), DataSets.Parameters_LF.Bicep);
             var workspace = new Workspace();

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -29,13 +29,13 @@ namespace Bicep.LangServer.UnitTests
     {
         private static readonly MockRepository Repository = new MockRepository(MockBehavior.Strict);
         private static readonly ILanguageServerFacade Server = Repository.Create<ILanguageServerFacade>().Object;
-        private static readonly SnippetsProvider snippetsProvider = new(TestTypeHelper.CreateEmptyProvider(), BicepTestConstants.FileResolver, BicepTestConstants.ConfigurationManager);
+        private static readonly SnippetsProvider snippetsProvider = new(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), BicepTestConstants.FileResolver, BicepTestConstants.ConfigurationManager);
 
         [TestMethod]
         public void DeclarationContextShouldReturnKeywordCompletions()
         {
             var grouping = SourceFileGroupingFactory.CreateFromText(string.Empty, BicepTestConstants.FileResolver);
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             compilation.GetEntrypointSemanticModel().GetAllDiagnostics().Should().BeEmpty();
 
             var provider = new BicepCompletionProvider(BicepTestConstants.FileResolver, snippetsProvider, new TelemetryProvider(Server), BicepTestConstants.Features);
@@ -109,14 +109,14 @@ namespace Bicep.LangServer.UnitTests
         {
             var grouping = SourceFileGroupingFactory.CreateFromText(@"
 param p string
-var v = 
+var v =
 resource r 'Microsoft.Foo/foos@2020-09-01' = {
   name: 'foo'
 }
 output o int = 42
 ", BicepTestConstants.FileResolver);
             var offset = grouping.EntryPoint.ProgramSyntax.Declarations.OfType<VariableDeclarationSyntax>().Single().Value.Span.Position;
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             var provider = new BicepCompletionProvider(BicepTestConstants.FileResolver, snippetsProvider, new TelemetryProvider(Server), BicepTestConstants.Features);
             var context = BicepCompletionContext.Create(BicepTestConstants.Features, compilation, offset);
@@ -153,7 +153,7 @@ output o int = 42
         public void CompletionsForOneLinerParameterDefaultValueShouldIncludeFunctionsValidInDefaultValues()
         {
             var grouping = SourceFileGroupingFactory.CreateFromText(@"param p string = ", BicepTestConstants.FileResolver);
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             var offset = ((ParameterDefaultValueSyntax)grouping.EntryPoint.ProgramSyntax.Declarations.OfType<ParameterDeclarationSyntax>().Single().Modifier!).DefaultValue.Span.Position;
 
@@ -185,11 +185,11 @@ var resourceGroup = true
 resource base64 'Microsoft.Foo/foos@2020-09-01' = {
   name: 'foo'
 }
-output length int = 
+output length int =
 ", BicepTestConstants.FileResolver);
             var offset = grouping.EntryPoint.ProgramSyntax.Declarations.OfType<OutputDeclarationSyntax>().Single().Value.Span.Position;
 
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var provider = new BicepCompletionProvider(BicepTestConstants.FileResolver, snippetsProvider, new TelemetryProvider(Server), BicepTestConstants.Features);
             var context = BicepCompletionContext.Create(BicepTestConstants.Features, compilation, offset);
             var completions = provider.GetFilteredCompletions(compilation, context).ToList();
@@ -231,7 +231,7 @@ output length int =
         public void OutputTypeContextShouldReturnDeclarationTypeCompletions()
         {
             var grouping = SourceFileGroupingFactory.CreateFromText("output test ", BicepTestConstants.FileResolver);
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var provider = new BicepCompletionProvider(BicepTestConstants.FileResolver, snippetsProvider, new TelemetryProvider(Server), BicepTestConstants.Features);
 
             var offset = grouping.EntryPoint.ProgramSyntax.Declarations.OfType<OutputDeclarationSyntax>().Single().Type.Span.Position;
@@ -248,7 +248,7 @@ output length int =
         public void ParameterTypeContextShouldReturnDeclarationTypeCompletions()
         {
             var grouping = SourceFileGroupingFactory.CreateFromText("param foo ", BicepTestConstants.FileResolver);
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var provider = new BicepCompletionProvider(BicepTestConstants.FileResolver, snippetsProvider, new TelemetryProvider(Server), BicepTestConstants.Features);
 
             var offset = grouping.EntryPoint.ProgramSyntax.Declarations.OfType<ParameterDeclarationSyntax>().Single().Type.Span.Position;
@@ -295,7 +295,7 @@ output length int =
         public void VerifyParameterTypeCompletionWithPrecedingComment()
         {
             var grouping = SourceFileGroupingFactory.CreateFromText("/*test*/param foo ", BicepTestConstants.FileResolver);
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var provider = new BicepCompletionProvider(BicepTestConstants.FileResolver, snippetsProvider, new TelemetryProvider(Server), BicepTestConstants.Features);
 
             var offset = grouping.EntryPoint.ProgramSyntax.Declarations.OfType<ParameterDeclarationSyntax>().Single().Type.Span.Position;
@@ -353,7 +353,7 @@ output length int =
         public void CommentShouldNotGiveAnyCompletions(string codeFragment)
         {
             var grouping = SourceFileGroupingFactory.CreateFromText(codeFragment, BicepTestConstants.FileResolver);
-            var compilation = new Compilation(TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), grouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
             var provider = new BicepCompletionProvider(BicepTestConstants.FileResolver, snippetsProvider, new TelemetryProvider(Server), BicepTestConstants.Features);
 
             var offset = codeFragment.IndexOf('|');

--- a/src/Bicep.LangServer.UnitTests/Completions/BicepCompletionContextTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Completions/BicepCompletionContextTests.cs
@@ -17,7 +17,7 @@ namespace Bicep.LangServer.UnitTests.Completions
         public void ZeroMatchingNodes_Create_ShouldThrow()
         {
             const string text = "var foo = 42";
-            var compilation = new Compilation(BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateFromText(text, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
+            var compilation = new Compilation(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, SourceFileGroupingFactory.CreateFromText(text, BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
 
             Action fail = () => BicepCompletionContext.Create(BicepTestConstants.Features, compilation, text.Length + 2);
             fail.Should().Throw<ArgumentException>().WithMessage("The specified offset 14 is outside the span of the specified ProgramSyntax node.");

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepBuildCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepBuildCommandHandlerTests.cs
@@ -44,7 +44,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         public void Handle_WithInvalidPath_ShouldThrowArgumentException(string path)
         {
             ICompilationManager bicepCompilationManager = Repository.Create<ICompilationManager>().Object;
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.Features,  BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
 
             Action sut = () => bicepBuildCommandHandler.Handle(path, CancellationToken.None);
 
@@ -62,7 +62,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             DocumentUri documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
             // Do not upsert compilation. This will cause CompilationContext to be null
             BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, upsertCompilation: false);
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.Features, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
             string expected = await bicepBuildCommandHandler.Handle(bicepFilePath, CancellationToken.None);
 
             expected.Should().Be(@"Build succeeded. Created file input.json");
@@ -85,7 +85,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
 
             DocumentUri documentUri = DocumentUri.From(bicepFileUri);
             BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.Features, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
             string expected = await bicepBuildCommandHandler.Handle(bicepFilePath, CancellationToken.None);
 
             expected.Should().Be(@"Build succeeded. Created file input.json");
@@ -111,7 +111,7 @@ targetScope = { }
 targetScope = true
 param accountName string = 'testAccount'
 ", true);
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.Features, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
             string expected = await bicepBuildCommandHandler.Handle(documentUri.Path, CancellationToken.None);
 
             expected.Should().BeEquivalentToIgnoringNewlines(@"Build failed. Please fix below errors:
@@ -145,7 +145,7 @@ param accountName string = 'testAccount'
             FileHelper.SaveResultFile(TestContext, "input.json", string.Empty, outputPath);
             DocumentUri documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
             BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, string.Empty, true);
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.Features, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
             string expected = await bicepBuildCommandHandler.Handle(bicepFilePath, CancellationToken.None);
 
             expected.Should().Be(@"Build failed. The file ""input.json"" already exists and was not generated by Bicep. If overwriting the file is intended, delete it manually and retry the Build command.");
@@ -159,7 +159,7 @@ param accountName string = 'testAccount'
             FileHelper.SaveResultFile(TestContext, "input.json", "invalid json", outputPath);
             DocumentUri documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
             BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, string.Empty, true);
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.Features, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
             string expected = await bicepBuildCommandHandler.Handle(bicepFilePath, CancellationToken.None);
 
             expected.Should().Be(@"Build failed. The file ""input.json"" already exists and was not generated by Bicep. If overwriting the file is intended, delete it manually and retry the Build command.");
@@ -176,7 +176,7 @@ param accountName string = 'testAccount'
 ");
             DocumentUri documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
             BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, string.Empty, true);
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Repository.Create<ISerializer>().Object, BicepTestConstants.Features, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
             string expected = await bicepBuildCommandHandler.Handle(bicepFilePath, CancellationToken.None);
 
             expected.Should().Be(@"Build succeeded. Created file input.json");
@@ -189,7 +189,7 @@ param accountName string = 'testAccount'
         public void TemplateContainsBicepGeneratorMetadata_WithInvalidInput_ReturnsFalse(string template)
         {
             ICompilationManager bicepCompilationManager = Repository.Create<ICompilationManager>().Object;
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.Features, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
 
             bool actual = bicepBuildCommandHandler.TemplateContainsBicepGeneratorMetadata(template);
 
@@ -200,7 +200,7 @@ param accountName string = 'testAccount'
         public void TemplateContainsBicepGeneratorMetadata_WithBicepGeneratorMetadataInInput_ReturnsTrue()
         {
             ICompilationManager bicepCompilationManager = Repository.Create<ICompilationManager>().Object;
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.Features, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
             string template = @"{
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
   ""contentVersion"": ""1.0.0.0"",
@@ -224,7 +224,7 @@ param accountName string = 'testAccount'
         public void TemplateContainsBicepGeneratorMetadata_WithoutBicepGeneratorMetadataInInput_ReturnsFalse()
         {
             ICompilationManager bicepCompilationManager = Repository.Create<ICompilationManager>().Object;
-            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
+            BicepBuildCommandHandler bicepBuildCommandHandler = new BicepBuildCommandHandler(bicepCompilationManager, Serializer, BicepTestConstants.Features, BicepTestConstants.EmitterSettings, BicepTestConstants.NamespaceProvider, FileResolver, ModuleDispatcher, configurationManager);
             string template = @"{
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
   ""contentVersion"": ""1.0.0.0"",

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -21,7 +21,7 @@ namespace Bicep.LangServer.UnitTests.Snippets
     [TestClass]
     public class SnippetsProviderTests
     {
-        private readonly SnippetsProvider snippetsProvider = new(BicepTestConstants.NamespaceProvider, BicepTestConstants.FileResolver, BicepTestConstants.ConfigurationManager);
+        private readonly SnippetsProvider snippetsProvider = new(BicepTestConstants.Features, BicepTestConstants.NamespaceProvider, BicepTestConstants.FileResolver, BicepTestConstants.ConfigurationManager);
         private readonly NamespaceType azNamespaceType = BicepTestConstants.NamespaceProvider.TryGetNamespace("az", "az", ResourceScope.ResourceGroup)!;
 
         [TestMethod]

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -342,7 +342,7 @@ namespace Bicep.LanguageServer
             var declarationsInMainFile = bicepFile.ProgramSyntax.Declarations;
             properties.Add("Modules", declarationsInMainFile.Count(x => x is ModuleDeclarationSyntax).ToString());
             properties.Add("Parameters", declarationsInMainFile.Count(x => x is ParameterDeclarationSyntax).ToString());
-            properties.Add("Resources", sematicModel.AllResources.Length.ToString());
+            properties.Add("Resources", sematicModel.DeclaredResources.Length.ToString());
             properties.Add("Variables", declarationsInMainFile.Count(x => x is VariableDeclarationSyntax).ToString());
 
             var localPath = bicepFile.FileUri.LocalPath;

--- a/src/Bicep.LangServer/CodeFixes/ParameterCodeFixProvider.cs
+++ b/src/Bicep.LangServer/CodeFixes/ParameterCodeFixProvider.cs
@@ -35,7 +35,7 @@ namespace Bicep.LanguageServer.CodeFixes
             {
                 yield break;
             }
-            if(!supportedTypes.Any(t => parameterSyntax.ParameterType?.TypeName == t))
+            if(parameterSyntax.ParameterType is SimpleTypeSyntax simpleType && !supportedTypes.Any(t => simpleType.TypeName == t))
             {
                 yield break;
             }

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -242,26 +242,65 @@ namespace Bicep.LanguageServer.Completions
             // local function
             bool CheckTypeIsExpected(SyntaxBase name, SyntaxBase type) => name.Span.Length > 0 && offset > name.GetEndPosition() && offset <= type.Span.Position;
 
+            bool CheckParameterResourceTypeIsExpected(ResourceTypeSyntax type) =>
+                // This handles the case where we have the resource keyword but no type-string for a parameter.
+                // Must be inside the type
+                type.Span.Length > 0 &&
+                offset >= type.Keyword.GetEndPosition() &&
+                (type.Type is null || type.Type is SkippedTriviaSyntax);
+
+            bool CheckOutputResourceTypeIsExpected(OutputDeclarationSyntax output) =>
+                // This handles the case where we have the resource keyword but no type-string for an output.
+                // Must be after the type (`resource` is valid for type) and
+                // Before the `=` if `=` is present
+                output.Type is ResourceTypeSyntax type &&
+                offset >= type.Keyword.GetEndPosition() &&
+                (type.Type is null || type.Type is SkippedTriviaSyntax) &&
+                (output.Assignment is SkippedTriviaSyntax || (output.Assignment is Token assignment && offset <= assignment.GetPosition()));
+
             if (SyntaxMatcher.IsTailMatch<ParameterDeclarationSyntax>(matchingNodes, parameter => CheckTypeIsExpected(parameter.Name, parameter.Type)) ||
-                SyntaxMatcher.IsTailMatch<ParameterDeclarationSyntax, TypeSyntax, Token>(matchingNodes, (_, _, token) => token.Type == TokenType.Identifier))
+                SyntaxMatcher.IsTailMatch<ParameterDeclarationSyntax, SimpleTypeSyntax, Token>(matchingNodes, (_, _, token) => token.Type == TokenType.Identifier))
             {
                 // the most specific matching node is a parameter declaration
                 // the declaration syntax is "param <identifier> <type> ..."
                 // the cursor position is on the type if we have an identifier (non-zero length span) and the offset matches the type position
                 // OR
-                // we are in a token that is inside a TypeSyntax node, which is inside a parameter node
+                // we are in a token that is inside a SimpleTypeSyntax node, which is inside a parameter node
                 return BicepCompletionContextKind.ParameterType;
             }
 
+            if (SyntaxMatcher.IsTailMatch<ParameterDeclarationSyntax, ResourceTypeSyntax>(matchingNodes, (parameter, type) => CheckParameterResourceTypeIsExpected(type)) ||
+                SyntaxMatcher.IsTailMatch<ParameterDeclarationSyntax, ResourceTypeSyntax, StringSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.StringComplete))
+            {
+                // the most specific matching node is a parameter declaration with the resource keyword
+                // the declaration syntax is "param <identifier> resource ..."
+                // the cursor position is on the resource type if we have the resource keyword but nothing else
+                // OR
+                // we are in a token that is inside a ResourceTypeSyntax node, which is inside a parameter node
+                return BicepCompletionContextKind.ResourceType;
+            }
+
             if (SyntaxMatcher.IsTailMatch<OutputDeclarationSyntax>(matchingNodes, output => CheckTypeIsExpected(output.Name, output.Type)) ||
-                SyntaxMatcher.IsTailMatch<OutputDeclarationSyntax, TypeSyntax, Token>(matchingNodes, (_, _, token) => token.Type == TokenType.Identifier))
+                SyntaxMatcher.IsTailMatch<OutputDeclarationSyntax, SimpleTypeSyntax, Token>(matchingNodes, (_, _, token) => token.Type == TokenType.Identifier))
             {
                 // the most specific matching node is an output declaration
                 // the declaration syntax is "output <identifier> <type> ..."
                 // the cursor position is on the type if we have an identifier (non-zero length span) and the offset matches the type position
                 // OR
-                // we are in a token that is inside a TypeSyntax node, which is inside an output node
+                // we are in a token that is inside a SimpleTypeSyntax node, which is inside an output node
                 return BicepCompletionContextKind.OutputType;
+            }
+
+             // NOTE: this logic is different between parameters and outputs because the resource type is optional for outputs.
+            if (SyntaxMatcher.IsTailMatch<OutputDeclarationSyntax>(matchingNodes, output => CheckOutputResourceTypeIsExpected(output)) ||
+                SyntaxMatcher.IsTailMatch<OutputDeclarationSyntax, ResourceTypeSyntax, StringSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.StringComplete))
+            {
+                // the most specific matching node is an output declaration with the resource keyword
+                // the declaration syntax is "output <identifier> resource ..."
+                // the cursor position is on the resource type if we have the resource keyword but nothing else
+                // OR
+                // we are in a token that is inside a ResourceTypeSyntax node, which is inside an output node
+                return BicepCompletionContextKind.ResourceType;
             }
 
             if (SyntaxMatcher.IsTailMatch<ResourceDeclarationSyntax>(matchingNodes, resource => CheckTypeIsExpected(resource.Name, resource.Type)) ||

--- a/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
@@ -16,6 +16,7 @@ using Bicep.Core.Analyzers.Linter;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
+using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
@@ -36,16 +37,18 @@ namespace Bicep.LanguageServer.Handlers
     {
         private readonly ICompilationManager compilationManager;
         private readonly EmitterSettings emitterSettings;
+        private readonly IFeatureProvider features;
         private readonly IFileResolver fileResolver;
         private readonly IModuleDispatcher moduleDispatcher;
         private readonly INamespaceProvider namespaceProvider;
         private readonly IConfigurationManager configurationManager;
 
-        public BicepBuildCommandHandler(ICompilationManager compilationManager, ISerializer serializer, EmitterSettings emitterSettings, INamespaceProvider namespaceProvider, IFileResolver fileResolver, IModuleDispatcher moduleDispatcher, IConfigurationManager configurationManager)
+        public BicepBuildCommandHandler(ICompilationManager compilationManager, ISerializer serializer, IFeatureProvider features, EmitterSettings emitterSettings, INamespaceProvider namespaceProvider, IFileResolver fileResolver, IModuleDispatcher moduleDispatcher, IConfigurationManager configurationManager)
             : base(LanguageConstants.Build, serializer)
         {
             this.compilationManager = compilationManager;
             this.emitterSettings = emitterSettings;
+            this.features = features;
             this.namespaceProvider = namespaceProvider;
             this.fileResolver = fileResolver;
             this.moduleDispatcher = moduleDispatcher;
@@ -96,7 +99,7 @@ namespace Bicep.LanguageServer.Handlers
             if (context is null)
             {
                 SourceFileGrouping sourceFileGrouping = SourceFileGroupingBuilder.Build(this.fileResolver, this.moduleDispatcher, new Workspace(), fileUri, configuration);
-                compilation = new Compilation(namespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
+                compilation = new Compilation(features, namespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
             }
             else
             {

--- a/src/Bicep.LangServer/Providers/BicepCompilationProvider.cs
+++ b/src/Bicep.LangServer/Providers/BicepCompilationProvider.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using Bicep.Core.Analyzers.Linter;
 using Bicep.Core.Configuration;
+using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
@@ -19,12 +20,14 @@ namespace Bicep.LanguageServer.Providers
     /// <remarks>This class exists only so we can mock fatal exceptions in tests.</remarks>
     public class BicepCompilationProvider : ICompilationProvider
     {
+        private readonly IFeatureProvider features;
         private readonly INamespaceProvider namespaceProvider;
         private readonly IFileResolver fileResolver;
         private readonly IModuleDispatcher moduleDispatcher;
 
-        public BicepCompilationProvider(INamespaceProvider namespaceProvider, IFileResolver fileResolver, IModuleDispatcher moduleDispatcher)
+        public BicepCompilationProvider(IFeatureProvider features, INamespaceProvider namespaceProvider, IFileResolver fileResolver, IModuleDispatcher moduleDispatcher)
         {
+            this.features = features;
             this.namespaceProvider = namespaceProvider;
             this.fileResolver = fileResolver;
             this.moduleDispatcher = moduleDispatcher;
@@ -44,7 +47,7 @@ namespace Bicep.LanguageServer.Providers
 
         private CompilationContext CreateContext(SourceFileGrouping syntaxTreeGrouping, ImmutableDictionary<ISourceFile, ISemanticModel> modelLookup, RootConfiguration configuration, LinterAnalyzer linterAnalyzer)
         {
-            var compilation = new Compilation(namespaceProvider, syntaxTreeGrouping, configuration, linterAnalyzer, modelLookup);
+            var compilation = new Compilation(this.features, namespaceProvider, syntaxTreeGrouping, configuration, linterAnalyzer, modelLookup);
             return new CompilationContext(compilation);
         }
     }

--- a/src/Bicep.LangServer/SemanticTokenVisitor.cs
+++ b/src/Bicep.LangServer/SemanticTokenVisitor.cs
@@ -264,10 +264,17 @@ namespace Bicep.LanguageServer
             }
         }
 
-        public override void VisitTypeSyntax(TypeSyntax syntax)
+        public override void VisitResourceTypeSyntax(ResourceTypeSyntax syntax)
+        {
+            // This is intentional, we want 'resource' to look like 'object' or 'array'.
+            AddTokenType(syntax.Keyword, SemanticTokenType.Type);
+            base.VisitResourceTypeSyntax(syntax);
+        }
+
+        public override void VisitSimpleTypeSyntax(SimpleTypeSyntax syntax)
         {
             AddTokenType(syntax.Identifier, SemanticTokenType.Type);
-            base.VisitTypeSyntax(syntax);
+            base.VisitSimpleTypeSyntax(syntax);
         }
 
         public override void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax)

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -15,6 +15,7 @@ using Bicep.Core.Analyzers.Linter;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
+using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Parsing;
 using Bicep.Core.Resources;
@@ -67,13 +68,15 @@ namespace Bicep.LanguageServer.Snippets
             "tags",
             "properties"
         };
+        private readonly IFeatureProvider features;
         private readonly INamespaceProvider namespaceProvider;
         private readonly IFileResolver fileResolver;
         private readonly RootConfiguration configuration;
         private readonly LinterAnalyzer linterAnalyzer;
 
-        public SnippetsProvider(INamespaceProvider namespaceProvider, IFileResolver fileResolver, IConfigurationManager configurationManager)
+        public SnippetsProvider(IFeatureProvider features, INamespaceProvider namespaceProvider, IFileResolver fileResolver, IConfigurationManager configurationManager)
         {
+            this.features = features;
             this.namespaceProvider = namespaceProvider;
             this.fileResolver = fileResolver;
 
@@ -228,7 +231,7 @@ namespace Bicep.LanguageServer.Snippets
                 ImmutableDictionary.Create<ModuleDeclarationSyntax, DiagnosticBuilder.ErrorBuilderDelegate>(),
                 ImmutableHashSet<ModuleDeclarationSyntax>.Empty);
 
-            Compilation compilation = new Compilation(namespaceProvider, sourceFileGrouping, configuration, linterAnalyzer);
+            Compilation compilation = new Compilation(this.features, namespaceProvider, sourceFileGrouping, configuration, linterAnalyzer);
 
             SemanticModel semanticModel = compilation.GetEntrypointSemanticModel();
 

--- a/src/Bicep.Wasm/Interop.cs
+++ b/src/Bicep.Wasm/Interop.cs
@@ -64,7 +64,7 @@ namespace Bicep.Wasm
             try
             {
                 var bicepUri = PathHelper.ChangeToBicepExtension(jsonUri);
-                var decompiler = new TemplateDecompiler(namespaceProvider, fileResolver, new EmptyModuleRegistryProvider(), new ConfigurationManager(new IOFileSystem()));
+                var decompiler = new TemplateDecompiler(features, namespaceProvider, fileResolver, new EmptyModuleRegistryProvider(), new ConfigurationManager(new IOFileSystem()));
                 var (entrypointUri, filesToSave) = decompiler.DecompileFileWithModules(jsonUri, bicepUri);
 
                 return new DecompileResult(filesToSave[entrypointUri], null);
@@ -171,7 +171,7 @@ namespace Bicep.Wasm
             var configuration = configurationManager.GetBuiltInConfiguration(disableAnalyzers: true);
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, dispatcher, workspace, fileUri, configuration);
 
-            return new Compilation(namespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
+            return new Compilation(features, namespaceProvider, sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
         }
 
         private static string ReadStreamToEnd(Stream stream)

--- a/src/Bicep.Wasm/LanguageHelpers/SemanticTokenVisitor.cs
+++ b/src/Bicep.Wasm/LanguageHelpers/SemanticTokenVisitor.cs
@@ -246,10 +246,17 @@ namespace Bicep.Wasm.LanguageHelpers
             }
         }
 
-        public override void VisitTypeSyntax(TypeSyntax syntax)
+        public override void VisitResourceTypeSyntax(ResourceTypeSyntax syntax)
+        {
+             // This is intentional, we want 'resource' to look like 'object' or 'array'.
+            AddTokenType(syntax.Keyword, SemanticTokenType.Type);
+            base.VisitResourceTypeSyntax(syntax);
+        }
+
+        public override void VisitSimpleTypeSyntax(SimpleTypeSyntax syntax)
         {
             AddTokenType(syntax.Identifier, SemanticTokenType.Type);
-            base.VisitTypeSyntax(syntax);
+            base.VisitSimpleTypeSyntax(syntax);
         }
 
         public override void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax)


### PR DESCRIPTION
Fixes: #2246

This change implements functionality for declaring strongly type
parameters and outputs using resource types.

Example:

```
param storage resource 'Microsoft.Storage/storageAccounts@2020-01-01'
```

This declares a parameter that can be interacted with as-if it were an
'existing' resource type declaration of the provided type.

In addition you can do the same with outputs:

```
output out resource 'Microsoft.Storage/storageAccounts@2020-01-01' = foo
```

or using type inference (outputs):

```
output out resource = foo
```

These features together allow you to pass resources across module
boundaries, and as command line parameters (using the resource ID).

---

This PR implements #2246 with a few caveats that I discussed offline
with one of the maintainers.

1. It does not include the 'any resource type' that's outlined in the
   proposal. It's not clear how that part of the proposal will work
   in the future with extensibility.
2. It does not support extensibility resources currently. To do this we
   need to define the semantics of how an extensibility resource can
   be serialized (what's the equivalent of `.id`). This is explicitly
   blocked in the first cut and can be added as extensibility is
   designed.
3. Parameter resources cannot be used with the `.parent` or `.scope`
   properties because it would allow you to bypass scope validation
   easily. The set of cases that we could actually provide validation
   for these use cases are really limited.


## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature
