### PR TITLE
support digests in `br` module references

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -1,15 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Configuration;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Samples;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Mock;
+using Bicep.Core.UnitTests.Registry;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -160,6 +164,60 @@ namespace Bicep.Cli.IntegrationTests
                 JToken.Parse(dataSet.Compiled!),
                 expectedLocation: Path.Combine("src", "Bicep.Core.Samples", "Files", dataSet.Name, DataSet.TestFileMainCompiled),
                 actualLocation: compiledFilePath);
+        }
+
+        [TestMethod]
+        public async Task Build_Valid_SingleFile_WithDigestReference_ShouldSucceed()
+        {
+            var registry = "example.com";
+            var registryUri = new Uri("https://" + registry);
+            var repository = "hello/there";
+
+            var client = new MockRegistryBlobClient();
+
+            var clientFactory = StrictMock.Of<IContainerRegistryClientFactory>();
+            clientFactory.Setup(m => m.CreateBlobClient(It.IsAny<RootConfiguration>(), registryUri, repository)).Returns(client);
+
+            var templateSpecRepositoryFactory = BicepTestConstants.TemplateSpecRepositoryFactory;
+
+            var settings = new InvocationSettings(BicepTestConstants.CreateFeaturesProvider(TestContext, registryEnabled: true), clientFactory.Object, BicepTestConstants.TemplateSpecRepositoryFactory);
+
+            var tempDirectory = FileHelper.GetUniqueTestOutputPath(TestContext);
+            Directory.CreateDirectory(tempDirectory);
+
+            var publishedBicepFilePath = Path.Combine(tempDirectory, "published.bicep");
+            File.WriteAllText(publishedBicepFilePath, string.Empty);
+
+            var (publishOutput, publishError, publishResult) = await Bicep(settings, "publish", publishedBicepFilePath, "--target", $"br:{registry}/{repository}:v1");
+            using (new AssertionScope())
+            {
+                publishResult.Should().Be(0);
+                publishOutput.Should().BeEmpty();
+                publishError.Should().BeEmpty();
+            }
+
+            client.Blobs.Should().HaveCount(2);
+            client.Manifests.Should().HaveCount(1);
+            client.ManifestTags.Should().HaveCount(1);
+
+            string digest = client.Manifests.Single().Key;
+
+            var bicep = $@"
+module empty 'br:{registry}/{repository}@{digest}' = {{
+  name: 'empty'
+}}
+";
+
+            var bicepFilePath = Path.Combine(tempDirectory, "built.bicep");
+            File.WriteAllText(bicepFilePath, bicep);
+
+            var (output, error, result) = await Bicep(settings, "build", bicepFilePath);
+            using (new AssertionScope())
+            {
+                result.Should().Be(0);
+                output.Should().BeEmpty();
+                error.Should().BeEmpty();
+            }
         }
 
         [DataTestMethod]

--- a/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Core;
-using Bicep.Core.Registry;
 using Bicep.Core.Samples;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
@@ -10,7 +8,6 @@ using Bicep.Core.UnitTests.Registry;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -82,6 +79,17 @@ namespace Bicep.Cli.IntegrationTests
             result.Should().Be(1);
             output.Should().BeEmpty();
             error.Should().Contain("The specified module target \"./test.bicep\" is not supported.");
+        }
+
+        [TestMethod]
+        public async Task Publish_OciDigestTarget_ShouldProduceExpectedError()
+        {
+            var settings = new InvocationSettings(BicepTestConstants.CreateFeaturesProvider(TestContext, registryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var (output, error, result) = await Bicep(settings, "publish", "WrongFile.bicep", "--target", "br:example.com/test@sha256:80f63ced0b80b63874c808a321f472755a3c9e93987d1fa0a51e13c65e4a52b9");
+
+            result.Should().Be(1);
+            output.Should().BeEmpty();
+            error.Should().Contain("The specified module target \"br:example.com/test@sha256:80f63ced0b80b63874c808a321f472755a3c9e93987d1fa0a51e13c65e4a52b9\" is not supported.");
         }
 
         [DataTestMethod]

--- a/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
@@ -1,12 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Configuration;
+using Bicep.Core.Registry;
 using Bicep.Core.Samples;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Mock;
+using Bicep.Core.UnitTests.Registry;
+using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -62,6 +70,60 @@ namespace Bicep.Cli.IntegrationTests
             {
                 // ensure something got restored
                 settings.Features.Should().HaveValidModules();
+            }
+        }
+
+        [TestMethod]
+        public async Task Restore_ByDigest_ShouldSucceed()
+        {
+            var registry = "example.com";
+            var registryUri = new Uri("https://" + registry);
+            var repository = "hello/there";
+
+            var client = new MockRegistryBlobClient();
+
+            var clientFactory = StrictMock.Of<IContainerRegistryClientFactory>();
+            clientFactory.Setup(m => m.CreateBlobClient(It.IsAny<RootConfiguration>(), registryUri, repository)).Returns(client);
+
+            var templateSpecRepositoryFactory = BicepTestConstants.TemplateSpecRepositoryFactory;
+
+            var settings = new InvocationSettings(BicepTestConstants.CreateFeaturesProvider(TestContext, registryEnabled: true), clientFactory.Object, BicepTestConstants.TemplateSpecRepositoryFactory);
+
+            var tempDirectory = FileHelper.GetUniqueTestOutputPath(TestContext);
+            Directory.CreateDirectory(tempDirectory);
+
+            var publishedBicepFilePath = Path.Combine(tempDirectory, "published.bicep");
+File.WriteAllText(publishedBicepFilePath, string.Empty);
+
+            var (publishOutput, publishError, publishResult) = await Bicep(settings, "publish", publishedBicepFilePath, "--target", $"br:{registry}/{repository}:v1");
+            using (new AssertionScope())
+            {
+                publishResult.Should().Be(0);
+                publishOutput.Should().BeEmpty();
+                publishError.Should().BeEmpty();
+            }
+
+            client.Blobs.Should().HaveCount(2);
+            client.Manifests.Should().HaveCount(1);
+            client.ManifestTags.Should().HaveCount(1);
+
+            string digest = client.Manifests.Single().Key;
+
+            var bicep = $@"
+module empty 'br:{registry}/{repository}@{digest}' = {{
+  name: 'empty'
+}}
+";
+
+            var restoreBicepFilePath = Path.Combine(tempDirectory, "restored.bicep");
+            File.WriteAllText(restoreBicepFilePath, bicep);
+
+            var (output, error, result) = await Bicep(settings, "restore", restoreBicepFilePath);
+            using (new AssertionScope())
+            {
+                result.Should().Be(0);
+                output.Should().BeEmpty();
+                error.Should().BeEmpty();
             }
         }
 

--- a/src/Bicep.Core.UnitTests/Modules/OciArtifactModuleReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/OciArtifactModuleReferenceTests.cs
@@ -27,7 +27,7 @@ namespace Bicep.Core.UnitTests.Modules
 
         public const string ExamplePathSegment2 = "a.b-0_1";
 
-        public record ValidCase(string Value, string ExpectedRegistry, string ExpectedRepository, string ExpectedTag);
+        public record ValidCase(string Value, string ExpectedRegistry, string ExpectedRepository, string? ExpectedTag, string? ExpectedDigest);
 
         [TestMethod]
         public void ExamplesShouldMatchExpectedConstraints()
@@ -48,7 +48,8 @@ namespace Bicep.Core.UnitTests.Modules
                 parsed.Registry.Should().Be(@case.ExpectedRegistry);
                 parsed.Repository.Should().Be(@case.ExpectedRepository);
                 parsed.Tag.Should().Be(@case.ExpectedTag);
-                parsed.ArtifactId.Should().Be(@case.Value);
+                parsed.Digest.Should().Be(@case.ExpectedDigest);
+                parsed.ArtifactId.Should().Be(@case.Value);                
             }
         }
 
@@ -81,8 +82,8 @@ namespace Bicep.Core.UnitTests.Modules
         [DataRow("", "BCP193", "The specified OCI artifact reference \"br:\" is not valid. Specify a reference in the format of \"br:<artifact-uri>:<tag>\", or \"br/<module-alias>:<module-name-or-path>:<tag>\".")]
         [DataRow("a", "BCP193", "The specified OCI artifact reference \"br:a\" is not valid. Specify a reference in the format of \"br:<artifact-uri>:<tag>\", or \"br/<module-alias>:<module-name-or-path>:<tag>\".")]
         [DataRow("a/", "BCP193", "The specified OCI artifact reference \"br:a/\" is not valid. Specify a reference in the format of \"br:<artifact-uri>:<tag>\", or \"br/<module-alias>:<module-name-or-path>:<tag>\".")]
-        [DataRow("a/b", "BCP196", "The specified OCI artifact reference \"br:a/b\" is not valid. The module tag is missing.")]
-        [DataRow("a/b:", "BCP196", "The specified OCI artifact reference \"br:a/b:\" is not valid. The module tag is missing.")]
+        [DataRow("a/b", "BCP196", "The specified OCI artifact reference \"br:a/b\" is not valid. The module tag or digest is missing.")]
+        [DataRow("a/b:", "BCP196", "The specified OCI artifact reference \"br:a/b:\" is not valid. The module tag or digest is missing.")]
         [DataRow("a/b:$", "BCP198", "The specified OCI artifact reference \"br:a/b:$\" is not valid. The tag \"$\" is not valid. Valid characters are alphanumeric, \".\", \"_\", or \"-\" but the tag cannot begin with \".\", \"_\", or \"-\".")]
         [DataRow("example.com/hello.", "BCP195", "The specified OCI artifact reference \"br:example.com/hello.\" is not valid. The module path segment \"hello.\" is not valid. Each module name path segment must be a lowercase alphanumeric string optionally separated by a \".\", \"_\" , or \"-\".")]
         [DataRow("example.com/hello./there", "BCP195", "The specified OCI artifact reference \"br:example.com/hello./there\" is not valid. The module path segment \"hello.\" is not valid. Each module name path segment must be a lowercase alphanumeric string optionally separated by a \".\", \"_\" , or \"-\".")]
@@ -92,6 +93,10 @@ namespace Bicep.Core.UnitTests.Modules
         [DataRow("test.azurecr.io/foo/bar:" + ExampleTagOfMaxLength + "a", "BCP197", "The specified OCI artifact reference \"br:test.azurecr.io/foo/bar:abcdefghijklmnopqrstuvxyz0123456789._-._-._-._-ABCDEFGHIJKLMNOPQRSTUVXYZ0123456789._-._-._-._-abcdefghijklmnopqrstuvxyz012345678a\" is not valid. The tag \"abcdefghijklmnopqrstuvxyz0123456789._-._-._-._-ABCDEFGHIJKLMNOPQRSTUVXYZ0123456789._-._-._-._-abcdefghijklmnopqrstuvxyz012345678a\" exceeds the maximum length of 128 characters.")]
         [DataRow("example.com/" + ExampleRepositoryOfMaxLength + "a:v3", "BCP199", "The specified OCI artifact reference \"br:example.com/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abca:v3\" is not valid. Module path \"abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abcdefghijklmnopqrstuvxyz0123456789/abca\" exceeds the maximum length of 255 characters.")]
         [DataRow(ExampleRegistryOfMaxLength + "a/hello/there:1.0", "BCP200", "The specified OCI artifact reference \"br:abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abca/hello/there:1.0\" is not valid. The registry \"abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abcdefghijklmnopqrstuvxyz0123456789.abca\" exceeds the maximum length of 255 characters.")]
+        [DataRow("example.com/hello/there@wrong", "BCP224", "The specified OCI artifact reference \"br:example.com/hello/there@wrong\" is not valid. The digest \"wrong\" is not valid. The valid format is a string \"sha256:\" followed by exactly 64 lowercase hexadecimal digits.")]
+        // valid digest plus 1 char
+        [DataRow("example.com/hello/there@sha256:9aeb50c4b1a84de2315e2272c03bf940fa76c7c15e95dd6c5faabdb0945e6f8f1", "BCP224", "The specified OCI artifact reference \"br:example.com/hello/there@sha256:9aeb50c4b1a84de2315e2272c03bf940fa76c7c15e95dd6c5faabdb0945e6f8f1\" is not valid. The digest \"sha256:9aeb50c4b1a84de2315e2272c03bf940fa76c7c15e95dd6c5faabdb0945e6f8f1\" is not valid. The valid format is a string \"sha256:\" followed by exactly 64 lowercase hexadecimal digits.")]
+        [DataRow("example.com/hello/there@sha256:9AEB50C4B1A84DE2315E2272C03BF940FA76C7C15E95DD6C5FAABDB0945E6F8F", "BCP224", "The specified OCI artifact reference \"br:example.com/hello/there@sha256:9AEB50C4B1A84DE2315E2272C03BF940FA76C7C15E95DD6C5FAABDB0945E6F8F\" is not valid. The digest \"sha256:9AEB50C4B1A84DE2315E2272C03BF940FA76C7C15E95DD6C5FAABDB0945E6F8F\" is not valid. The valid format is a string \"sha256:\" followed by exactly 64 lowercase hexadecimal digits.")]
         [DataTestMethod]
         public void InvalidReferencesShouldProduceExpectedError(string value, string expectedCode, string expectedError)
         {
@@ -193,17 +198,18 @@ namespace Bicep.Core.UnitTests.Modules
 
         private static IEnumerable<object[]> GetValidCases()
         {
-            static object[] CreateRow(string value, string expectedRegistry, string expectedRepository, string expectedTag) =>
-                new object[] { new ValidCase(value, expectedRegistry, expectedRepository, expectedTag) };
+            static object[] CreateRow(string value, string expectedRegistry, string expectedRepository, string? expectedTag, string? expectedDigest) =>
+                new object[] { new ValidCase(value, expectedRegistry, expectedRepository, expectedTag, expectedDigest) };
 
-            yield return CreateRow("a/b:C", "a", "b", "C");
-            yield return CreateRow("localhost/hello:V1", "localhost", "hello", "V1");
-            yield return CreateRow("localhost:123/hello:V1", "localhost:123", "hello", "V1");
-            yield return CreateRow("test.azurecr.io/foo/bar:latest", "test.azurecr.io", "foo/bar", "latest");
-            yield return CreateRow("test.azurecr.io/foo/bar:" + ExampleTagOfMaxLength, "test.azurecr.io", "foo/bar", ExampleTagOfMaxLength);
-            yield return CreateRow("example.com/" + ExamplePathSegment1 + "/" + ExamplePathSegment2 + ":1", "example.com", ExamplePathSegment1 + "/" + ExamplePathSegment2, "1");
-            yield return CreateRow("example.com/" + ExampleRepositoryOfMaxLength + ":v3", "example.com", ExampleRepositoryOfMaxLength, "v3");
-            yield return CreateRow(ExampleRegistryOfMaxLength + "/hello/there:1.0", ExampleRegistryOfMaxLength, "hello/there", "1.0");
+            yield return CreateRow("a/b:C", "a", "b", "C", null);
+            yield return CreateRow("localhost/hello:V1", "localhost", "hello", "V1", null);
+            yield return CreateRow("localhost:123/hello:V1", "localhost:123", "hello", "V1", null);
+            yield return CreateRow("test.azurecr.io/foo/bar:latest", "test.azurecr.io", "foo/bar", "latest", null);
+            yield return CreateRow("test.azurecr.io/foo/bar:" + ExampleTagOfMaxLength, "test.azurecr.io", "foo/bar", ExampleTagOfMaxLength, null);
+            yield return CreateRow("example.com/" + ExamplePathSegment1 + "/" + ExamplePathSegment2 + ":1", "example.com", ExamplePathSegment1 + "/" + ExamplePathSegment2, "1", null);
+            yield return CreateRow("example.com/" + ExampleRepositoryOfMaxLength + ":v3", "example.com", ExampleRepositoryOfMaxLength, "v3", null);
+            yield return CreateRow(ExampleRegistryOfMaxLength + "/hello/there:1.0", ExampleRegistryOfMaxLength, "hello/there", "1.0", null);
+            yield return CreateRow("hello-there.azurecr.io/general/kenobi@sha256:b131a80d6764593360293a4a0a55e6850356c16754c4b5eb9a2286293fddcdfb", "hello-there.azurecr.io", "general/kenobi", null, "sha256:b131a80d6764593360293a4a0a55e6850356c16754c4b5eb9a2286293fddcdfb");
         }
 
         private static IEnumerable<object[]> GetInvalidAliasData()

--- a/src/Bicep.Core.UnitTests/Registry/MockRegistryBlobClient.cs
+++ b/src/Bicep.Core.UnitTests/Registry/MockRegistryBlobClient.cs
@@ -8,7 +8,6 @@ using Bicep.Core.Registry.Oci;
 using Bicep.Core.UnitTests.Mock;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Threading;

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1184,10 +1184,10 @@ namespace Bicep.Core.Diagnostics
                 "BCP195",
                 $"{BuildInvalidOciArtifactReferenceClause(aliasName, badRef)} The module path segment \"{badSegment}\" is not valid. Each module name path segment must be a lowercase alphanumeric string optionally separated by a \".\", \"_\" , or \"-\".");
 
-            public ErrorDiagnostic InvalidOciArtifactReferenceMissingTag(string? aliasName, string badRef) => new(
+            public ErrorDiagnostic InvalidOciArtifactReferenceMissingTagOrDigest(string? aliasName, string badRef) => new(
                 TextSpan,
                 "BCP196",
-                $"{BuildInvalidOciArtifactReferenceClause(aliasName, badRef)} The module tag is missing.");
+                $"{BuildInvalidOciArtifactReferenceClause(aliasName, badRef)} The module tag or digest is missing.");
 
             public ErrorDiagnostic InvalidOciArtifactReferenceTagTooLong(string? aliasName, string badRef, string badTag, int maxLength) => new(
                 TextSpan,
@@ -1307,7 +1307,12 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic InvalidTemplateSpecReferenceInvalidTemplateSpecVersion(string? aliasName, string templateSpecVersion, string referenceValue) => new(
                 TextSpan,
                 "BCP223",
-                $"{BuildInvalidTemplateSpecReferenceClause(aliasName, referenceValue)} The Template Spec version \"{templateSpecVersion}\" is invalid. Valid characters are alphanumeric, \".\", \"_\", \"-\", \"(\", or \")\", but the Template Spec name cannot end with \".\"."); 
+                $"{BuildInvalidTemplateSpecReferenceClause(aliasName, referenceValue)} The Template Spec version \"{templateSpecVersion}\" is invalid. Valid characters are alphanumeric, \".\", \"_\", \"-\", \"(\", or \")\", but the Template Spec name cannot end with \".\".");
+
+            public ErrorDiagnostic InvalidOciArtifactReferenceInvalidDigest(string? aliasName, string badRef, string badDigest) => new(
+                TextSpan,
+                "BCP224",
+                $"{BuildInvalidOciArtifactReferenceClause(aliasName, badRef)} The digest \"{badDigest}\" is not valid. The valid format is a string \"sha256:\" followed by exactly 64 lowercase hexadecimal digits.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
+++ b/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
@@ -82,7 +82,8 @@ namespace Bicep.Core.Registry
             Response<DownloadManifestResult> manifestResponse;
             try
             {
-                manifestResponse = await client.DownloadManifestAsync(new DownloadManifestOptions(tag: moduleReference.Tag));
+                // either Tag or Digest is null (enforced by reference parser) and DownloadManifestOptions throws if both or neither are null
+                manifestResponse = await client.DownloadManifestAsync(new DownloadManifestOptions(tag: moduleReference.Tag, digest: moduleReference.Digest));
             }
             catch(RequestFailedException exception) when (exception.Status == 404)
             {

--- a/src/Bicep.Core/Registry/IModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/IModuleRegistry.cs
@@ -22,9 +22,10 @@ namespace Bicep.Core.Registry
         string Scheme { get; }
 
         /// <summary>
-        /// Gets the capabilities of this registry.
+        /// Gets the capabilities of this registry for the specified module reference.
         /// </summary>
-        RegistryCapabilities Capabilities { get; }
+        /// <param name="reference">The module reference</param>
+        RegistryCapabilities GetCapabilities(ModuleReference reference);
 
         /// <summary>
         /// Attempts to parse the specified unqualified reference or returns a failure builder.

--- a/src/Bicep.Core/Registry/LocalModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/LocalModuleRegistry.cs
@@ -24,7 +24,7 @@ namespace Bicep.Core.Registry
 
         public override string Scheme => ModuleReferenceSchemes.Local;
 
-        public override RegistryCapabilities Capabilities => RegistryCapabilities.Default;
+        public override RegistryCapabilities GetCapabilities(LocalModuleReference reference) => RegistryCapabilities.Default;
 
         public override ModuleReference? TryParseModuleReference(string? alias, string reference, RootConfiguration configuration, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder) =>
             LocalModuleReference.TryParse(reference, out failureBuilder);

--- a/src/Bicep.Core/Registry/ModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/ModuleDispatcher.cs
@@ -92,7 +92,7 @@ namespace Bicep.Core.Registry
         public RegistryCapabilities GetRegistryCapabilities(ModuleReference moduleReference)
         {
             var registry = this.GetRegistry(moduleReference);
-            return registry.Capabilities;
+            return registry.GetCapabilities(moduleReference);
         }
 
         public ModuleRestoreStatus GetModuleRestoreStatus(ModuleReference moduleReference, RootConfiguration configuration, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)

--- a/src/Bicep.Core/Registry/ModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/ModuleRegistry.cs
@@ -16,7 +16,7 @@ namespace Bicep.Core.Registry
     {
         public abstract string Scheme { get; }
 
-        public abstract RegistryCapabilities Capabilities { get; }
+        public RegistryCapabilities GetCapabilities(ModuleReference reference) => this.GetCapabilities(ConvertReference(reference));
 
         public abstract bool IsModuleRestoreRequired(T reference);
 
@@ -37,6 +37,8 @@ namespace Bicep.Core.Registry
 
         public Uri? TryGetLocalModuleEntryPointUri(Uri? parentModuleUri, ModuleReference reference, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder) =>
             this.TryGetLocalModuleEntryPointUri(parentModuleUri, ConvertReference(reference), out failureBuilder);
+
+        public abstract RegistryCapabilities GetCapabilities(T reference);
 
         private static T ConvertReference(ModuleReference reference) => reference switch
         {

--- a/src/Bicep.Core/Registry/OciModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/OciModuleRegistry.cs
@@ -38,7 +38,11 @@ namespace Bicep.Core.Registry
 
         public override string Scheme => ModuleReferenceSchemes.Oci;
 
-        public override RegistryCapabilities Capabilities => RegistryCapabilities.Publish;
+        public override RegistryCapabilities GetCapabilities(OciArtifactModuleReference reference)
+        {
+            // cannot publish without tag
+            return reference.Tag is null ? RegistryCapabilities.Default : RegistryCapabilities.Publish;
+        }
 
         public override ModuleReference? TryParseModuleReference(string? aliasName, string reference, RootConfiguration configuration, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder) =>
             OciArtifactModuleReference.TryParse(aliasName, reference, configuration, out failureBuilder);
@@ -249,11 +253,27 @@ namespace Bicep.Core.Registry
             // the replacement char must one that is not valid in a repository string but is valid in common type systems
             var repository = reference.Repository.Replace('/', '$');
 
-            // tags are case-sensitive with length up to 128
-            var tag = TagEncoder.Encode(reference.Tag);
+            string? tagOrDigest;
+            if (reference.Tag is not null)
+            {
+                // tags are case-sensitive with length up to 128
+                tagOrDigest = TagEncoder.Encode(reference.Tag);
+            }
+            else if(reference.Digest is not null)
+            {
+                // digests are strings like "sha256:e207a69d02b3de40d48ede9fd208d80441a9e590a83a0bc915d46244c03310d4"
+                // and are already guaranteed to be lowercase
+                // the only problematic character is the : which we will replace with a #
+                // however the encoding we choose must not be ambiguous with the tag encoding
+                tagOrDigest = reference.Digest.Replace(':', '#');
+            }
+            else
+            {
+                throw new InvalidOperationException("Module reference is missing both tag and digest.");
+            }
 
             //var packageDir = WebUtility.UrlEncode(reference.UnqualifiedReference);
-            return Path.Combine(this.cachePath, registry, repository, tag);
+            return Path.Combine(this.cachePath, registry, repository, tagOrDigest);
         }
 
         private enum ModuleFileType

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -29,7 +29,7 @@ namespace Bicep.Core.Registry
 
         public override string Scheme => ModuleReferenceSchemes.TemplateSpecs;
 
-        public override RegistryCapabilities Capabilities => RegistryCapabilities.Default;
+        public override RegistryCapabilities GetCapabilities(TemplateSpecModuleReference reference) => RegistryCapabilities.Default;
 
         public override ModuleReference? TryParseModuleReference(string? aliasName, string reference, RootConfiguration configuration, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder) =>
             TemplateSpecModuleReference.TryParse(aliasName, reference, configuration, out failureBuilder);

--- a/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
@@ -176,7 +176,7 @@ namespace Bicep.LangServer.UnitTests.Registry
 
             public string Scheme => "mock";
 
-            public RegistryCapabilities Capabilities => throw new NotImplementedException();
+            public RegistryCapabilities GetCapabilities(ModuleReference reference) => throw new NotImplementedException();
 
             public bool IsModuleRestoreRequired(ModuleReference reference) => true;
 


### PR DESCRIPTION
This fixes #4741.

The reference syntax is the following:
```bicep
module test 'br:example.com/one/two@sha256:4aea1793a7ae4883972fb25443524817c51a457a7303b4f9966aca540199aece' = {
 ...
}
```

`bicep publish` will reject digests in values of the `--target` parameter.