### PR TITLE
Add other useful CLI utils to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
   "name": "Bicep Development Environment",
   "dockerFile": "Dockerfile",
   "runArgs": [
-    "-v", "/var/run/docker.sock:/var/run/docker.sock"
+    "-v",
+    "/var/run/docker.sock:/var/run/docker.sock"
   ],
   "settings": {
     "terminal.integrated.profiles.linux": {
@@ -21,5 +22,13 @@
     "github.copilot",
     "github.vscode-pull-request-github",
     "davidanson.vscode-markdownlint"
-  ]
+  ],
+  "features": {
+    "github-cli": "latest",
+    "azure-cli": "latest",
+    "node": {
+      "version": "lts",
+      "nodeGypDependencies": true
+    }
+  }
 }


### PR DESCRIPTION
Adds the following:
* `gh` (GitHub CLI)
* `az` (Az CLI)
* `node` & `npm`