### PR TITLE
Updated ARM and ACR SDKs

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -142,20 +142,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2281,12 +2281,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -142,20 +142,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -1331,12 +1331,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -50,8 +50,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -115,20 +115,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -349,12 +349,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -142,20 +142,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2271,12 +2271,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -142,20 +142,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2271,12 +2271,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -168,8 +168,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -233,20 +233,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2268,12 +2268,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -12,9 +12,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Containers.ContainerRegistry" Version="1.1.0-beta.2" />
+		<PackageReference Include="Azure.Containers.ContainerRegistry" Version="1.1.0-beta.3" />
 		<PackageReference Include="Azure.Identity" Version="1.5.0" />
-		<PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-beta.2" />
+		<PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-beta.3" />
 		<PackageReference Include="JetBrains.Annotations" Version="2021.2.0">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Direct",
-        "requested": "[1.1.0-beta.2, )",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "requested": "[1.1.0-beta.3, )",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -78,12 +78,12 @@
       },
       "Azure.ResourceManager.Resources": {
         "type": "Direct",
-        "requested": "[1.0.0-beta.2, )",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "requested": "[1.0.0-beta.3, )",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -173,10 +173,10 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -142,20 +142,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2261,12 +2261,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -142,20 +142,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2261,12 +2261,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -44,8 +44,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -109,20 +109,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -311,12 +311,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -99,8 +99,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -164,20 +164,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2284,12 +2284,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -99,8 +99,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -164,20 +164,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -2284,12 +2284,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -44,8 +44,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -109,20 +109,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -591,12 +591,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -51,8 +51,8 @@
       },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
-        "resolved": "1.1.0-beta.2",
-        "contentHash": "6YvevNtaQdiwPJ50gBpf2RQUcrcjixg4flU6T0NeHih79VCCtf1rDOu1CL5la7mDbIfwVMbEL/rSb7ABabEKOA==",
+        "resolved": "1.1.0-beta.3",
+        "contentHash": "VQGYiGCBMQOFb8kC5qetb0sslVKMKpH0zfndszI0fk7umyV3k0sKVvNJDa8++tvrNpTtaKXoFrSq057J0WVZYA==",
         "dependencies": {
           "Azure.Core": "1.19.0",
           "System.Text.Json": "4.6.0"
@@ -116,20 +116,20 @@
       },
       "Azure.ResourceManager": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.3",
-        "contentHash": "X5m16xERightEwIfn5gqkl2F4VsLsbkko7ZhpuGXJTiadJoyYA2OywwDBpNv4iYgSgmZoMr4TZwdxdSwpLoJwg==",
+        "resolved": "1.0.0-beta.5",
+        "contentHash": "mdf6Y4RnjTr/cZyhUdFBVW0R/iwVH9RGjgA/EBQchcjqobP/cGzJBzkc3kdpldX7jSvprW4MnkHskQBQr9LQXA==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.20.0",
           "System.Text.Json": "4.6.0"
         }
       },
       "Azure.ResourceManager.Resources": {
         "type": "Transitive",
-        "resolved": "1.0.0-beta.2",
-        "contentHash": "LqcMKCg12Ukzr9oCpAAIlBlUcEXIxnK/c8TGG5Bh9YW8MKdm5+1yQjaE7liJ9P6M+uyZfzNb4ghaSXsU/JASvA==",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "GPnpZvqfSyBR2JbcBT98ZwrTd3Jlxjwb8F4h5No9wYTE0pLjHeVAIxR9b9QUDnp1t4034xMbm8p60nVrDdMqWw==",
         "dependencies": {
-          "Azure.Core": "1.19.0",
-          "Azure.ResourceManager": "1.0.0-beta.3",
+          "Azure.Core": "1.20.0",
+          "Azure.ResourceManager": "1.0.0-beta.5",
           "System.Text.Json": "4.6.0"
         }
       },
@@ -433,12 +433,12 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.304",
           "Azure.Bicep.Types.Az": "0.1.304",
-          "Azure.Containers.ContainerRegistry": "1.1.0-beta.2",
+          "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
           "Azure.Deployments.Core": "1.0.253",
           "Azure.Deployments.Expression": "1.0.253",
           "Azure.Deployments.Templates": "1.0.253",
           "Azure.Identity": "1.5.0",
-          "Azure.ResourceManager.Resources": "1.0.0-beta.2",
+          "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Binder": "5.0.0",
           "Microsoft.Extensions.Configuration.Json": "5.0.0",


### PR DESCRIPTION
The new ACR SDK enables implementation of #5031. This can't be done by dependabot due to NuGet lock files until #4772 is done.