### PR TITLE
Remove "preview" flag from VSCode extension

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -7,7 +7,7 @@
   "version": "0.0.0-placeholder",
   "publisher": "ms-azuretools",
   "icon": "icons/bicep-logo-256.png",
-  "preview": true,
+  "preview": false,
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
   "engines": {
     "vscode": "^1.52.0"


### PR DESCRIPTION
Just noticed we're still setting "Preview". This PR removes the flag to set this.

Web Marketplace:
![image](https://user-images.githubusercontent.com/38542602/141131779-151a222a-a0e0-4eb5-85d4-bec0ed757469.png)

Inside VSCode:
![image](https://user-images.githubusercontent.com/38542602/141131823-f4b4db57-a379-4048-9a32-4984a29b3853.png)
