### PR TITLE
fix: correct "as" typo to "at"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Contributing a Pull Request
 
-If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.
+If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.
 
 ## Contributing to documentation
 

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.diagnostics.bicep
@@ -314,7 +314,7 @@ var fakeVar = concat(totallyFakeVar, 's')
 // bad functions arguments
 var concatNotEnough = concat()
 //@[4:19) [no-unused-vars (Warning)] Variable "concatNotEnough" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |concatNotEnough|
-//@[28:30) [BCP071 (Error)] Expected as least 1 argument, but got 0. (CodeDescription: none) |()|
+//@[28:30) [BCP071 (Error)] Expected at least 1 argument, but got 0. (CodeDescription: none) |()|
 var padLeftNotEnough = padLeft('s')
 //@[4:20) [no-unused-vars (Warning)] Variable "padLeftNotEnough" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |padLeftNotEnough|
 //@[30:35) [BCP071 (Error)] Expected 2 to 3 arguments, but got 1. (CodeDescription: none) |('s')|

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -468,21 +468,21 @@ namespace Bicep.Core.Diagnostics
                 "BCP070",
                 $"Argument of type \"{argumentType}\" is not assignable to parameter of type \"{parameterType}\".");
 
-            public ErrorDiagnostic ArgumentCountMismatch(int argumentCount, int mininumArgumentCount, int? maximumArgumentCount)
+            public ErrorDiagnostic ArgumentCountMismatch(int argumentCount, int minimumArgumentCount, int? maximumArgumentCount)
             {
                 string expected;
 
                 if (!maximumArgumentCount.HasValue)
                 {
-                    expected = $"at least {mininumArgumentCount} {(mininumArgumentCount == 1 ? "argument" : "arguments")}";
+                    expected = $"at least {minimumArgumentCount} {(minimumArgumentCount == 1 ? "argument" : "arguments")}";
                 }
-                else if (mininumArgumentCount == maximumArgumentCount.Value)
+                else if (minimumArgumentCount == maximumArgumentCount.Value)
                 {
-                    expected = $"{mininumArgumentCount} {(mininumArgumentCount == 1 ? "argument" : "arguments")}";
+                    expected = $"{minimumArgumentCount} {(minimumArgumentCount == 1 ? "argument" : "arguments")}";
                 }
                 else
                 {
-                    expected = $"{mininumArgumentCount} to {maximumArgumentCount} arguments";
+                    expected = $"{minimumArgumentCount} to {maximumArgumentCount} arguments";
                 }
 
                 return new ErrorDiagnostic(

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -474,7 +474,7 @@ namespace Bicep.Core.Diagnostics
 
                 if (!maximumArgumentCount.HasValue)
                 {
-                    expected = $"as least {mininumArgumentCount} {(mininumArgumentCount == 1 ? "argument" : "arguments")}";
+                    expected = $"at least {mininumArgumentCount} {(mininumArgumentCount == 1 ? "argument" : "arguments")}";
                 }
                 else if (mininumArgumentCount == maximumArgumentCount.Value)
                 {


### PR DESCRIPTION
Heya!

This is a mini PR; literally one character in terms of developer experience!  It should fix this error message that I've been seeing in Bicep:

> Expected as least 2 arguments, but got 1.bicep(BCP071)

With the fix, it should instead read

> Expected at least 2 arguments, but got 1.bicep(BCP071)

So "as" to "at".

Alongside this:

- I've fixed a typo in a variable name from `mininumArgumentCount ` to `minimumArgumentCount`
- I've switched the `CONTRIBUTING.md` link in the pull request template to be absolute as I noticed the relative link isn't working.
- updated test data