### PR TITLE
Removed empty functions property from being emitted.

### DIFF
--- a/docs/examples/000/01-hello-world/main.json
+++ b/docs/examples/000/01-hello-world/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14991011523779832704"
+      "templateHash": "14581149650543949797"
     }
   },
   "parameters": {
@@ -13,7 +13,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "hello": "Hello World! - Hi"
   },

--- a/docs/examples/000/10-string-functions/main.json
+++ b/docs/examples/000/10-string-functions/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13393916281535455793"
+      "templateHash": "6743810072432383776"
     }
   },
-  "functions": [],
   "variables": {
     "list": "a,b,c,d",
     "arrayFromString": "[split(variables('list'), ',')]",

--- a/docs/examples/000/11-multiline-strings/main.json
+++ b/docs/examples/000/11-multiline-strings/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10860486142934276811"
+      "templateHash": "4281628529517920243"
     }
   },
-  "functions": [],
   "variables": {
     "pipe": "|",
     "myVar": "test\n",

--- a/docs/examples/000/20-array-loop/main.json
+++ b/docs/examples/000/20-array-loop/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5388467861077554068"
+      "templateHash": "15819040288581240344"
     }
   },
-  "functions": [],
   "variables": {
     "bicepVarArray": [
       "Michael",

--- a/docs/examples/000/21-array-lookup/main.json
+++ b/docs/examples/000/21-array-lookup/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4364058019818662856"
+      "templateHash": "2947018854200886449"
     }
   },
   "parameters": {
@@ -23,7 +23,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "regionToTimezone": {
       "eastus": "Eastern Standard Time",

--- a/docs/examples/000/22-array-lookup-complex/main.json
+++ b/docs/examples/000/22-array-lookup-complex/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7623356381841001829"
+      "templateHash": "474658414899474755"
     }
   },
-  "functions": [],
   "variables": {
     "subnetArray": [
       "GatewaySubnet",

--- a/docs/examples/000/30-json-object-simple/main.json
+++ b/docs/examples/000/30-json-object-simple/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "517951156189212798"
+      "templateHash": "3992377844835363830"
     }
   },
-  "functions": [],
   "variables": {
     "jsonString": "[\n  \"one\",\n  \"two\",\n  \"three\"\n]\n",
     "jsonArray": "[json(variables('jsonString'))]",

--- a/docs/examples/000/31-json-object-complex/main.json
+++ b/docs/examples/000/31-json-object-complex/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3580499861620967124"
+      "templateHash": "6387300780410304062"
     }
   },
-  "functions": [],
   "variables": {
     "routeArray": [
       "OnPrem1",

--- a/docs/examples/101/1vm-2nics-2subnets-1vnet/main.json
+++ b/docs/examples/101/1vm-2nics-2subnets-1vnet/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15882862518723645512"
+      "templateHash": "2749966307222727374"
     }
   },
   "parameters": {
@@ -47,7 +47,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "virtualMachineName": "VM-MultiNic",
     "nic1Name": "nic-1",

--- a/docs/examples/101/aad-domainservices/main.json
+++ b/docs/examples/101/aad-domainservices/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7692443432302620124"
+      "templateHash": "4044771961515085745"
     }
   },
   "parameters": {
@@ -72,7 +72,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "domainServicesNSGName": "[format('{0}-nsg', parameters('domainServicesSubnetName'))]",
     "PSRemotingSlicePIPAddresses": [

--- a/docs/examples/101/aadds-dual-region-replica-sets/main.json
+++ b/docs/examples/101/aadds-dual-region-replica-sets/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11092524824015723457"
+      "templateHash": "12477514229007498846"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "defaultValue": "aaddscontoso.com"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.AAD/domainServices",

--- a/docs/examples/101/aci-linuxcontainer-public-ip/main.json
+++ b/docs/examples/101/aci-linuxcontainer-public-ip/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14952033248081756653"
+      "templateHash": "12814019956177237664"
     }
   },
   "parameters": {
@@ -64,7 +64,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ContainerInstance/containerGroups",

--- a/docs/examples/101/aks-vmss-systemassigned-identity/main.json
+++ b/docs/examples/101/aks-vmss-systemassigned-identity/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8178613380287402826"
+      "templateHash": "11692241275699026060"
     }
   },
   "parameters": {
@@ -47,7 +47,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "subnetRef": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnetName'))]",
     "addressPrefix": "20.0.0.0/16",

--- a/docs/examples/101/aks/main.json
+++ b/docs/examples/101/aks/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10495848497300076865"
+      "templateHash": "10513803264942190847"
     }
   },
   "parameters": {
@@ -49,7 +49,6 @@
       "defaultValue": "Standard_DS2_v2"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ContainerService/managedClusters",

--- a/docs/examples/101/api-management-create-with-msi/main.json
+++ b/docs/examples/101/api-management-create-with-msi/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4952456891125984913"
+      "templateHash": "11715651127742515742"
     }
   },
   "parameters": {
@@ -52,7 +52,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ApiManagement/service",

--- a/docs/examples/101/api-management-modular/NameValues.json
+++ b/docs/examples/101/api-management-modular/NameValues.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2914496037611283856"
+      "templateHash": "5498141100152018886"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "minLength": 1
     }
   },
-  "functions": [],
   "variables": {
     "apimNameValueSet": [
       {

--- a/docs/examples/101/api-management-modular/groups.json
+++ b/docs/examples/101/api-management-modular/groups.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14706570379215138555"
+      "templateHash": "16874817407208375046"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "minLength": 1
     }
   },
-  "functions": [],
   "variables": {
     "groupsSet": [
       {

--- a/docs/examples/101/api-management-modular/main.json
+++ b/docs/examples/101/api-management-modular/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2628096472336873538"
+      "templateHash": "8241693336761189748"
     }
   },
   "parameters": {
@@ -71,7 +71,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "deployGroups": true,
     "deployUsers": true,
@@ -160,7 +159,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14706570379215138555"
+              "templateHash": "16874817407208375046"
             }
           },
           "parameters": {
@@ -169,7 +168,6 @@
               "minLength": 1
             }
           },
-          "functions": [],
           "variables": {
             "groupsSet": [
               {
@@ -239,7 +237,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17785568548409074386"
+              "templateHash": "5207859696763036868"
             }
           },
           "parameters": {
@@ -248,7 +246,6 @@
               "minLength": 1
             }
           },
-          "functions": [],
           "variables": {
             "usersSet": [
               {
@@ -315,7 +312,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2914496037611283856"
+              "templateHash": "5498141100152018886"
             }
           },
           "parameters": {
@@ -324,7 +321,6 @@
               "minLength": 1
             }
           },
-          "functions": [],
           "variables": {
             "apimNameValueSet": [
               {

--- a/docs/examples/101/api-management-modular/users.json
+++ b/docs/examples/101/api-management-modular/users.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17785568548409074386"
+      "templateHash": "5207859696763036868"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "minLength": 1
     }
   },
-  "functions": [],
   "variables": {
     "usersSet": [
       {

--- a/docs/examples/101/app-config/main.json
+++ b/docs/examples/101/app-config/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1090700724652915602"
+      "templateHash": "6691820365612966943"
     }
   },
   "parameters": {
@@ -36,7 +36,6 @@
       "defaultValue": "the-content-type"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.AppConfiguration/configurationStores",

--- a/docs/examples/101/app-service-regional-vnet-integration/main.json
+++ b/docs/examples/101/app-service-regional-vnet-integration/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "861346519223189514"
+      "templateHash": "3242320020932357364"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[format('{0}{1}', parameters('appName'), uniqueString(subscription().subscriptionId))]",
     "vnetName": "[format('{0}vnet', parameters('appName'))]",

--- a/docs/examples/101/application-gateway-v2-autoscale-create/main.json
+++ b/docs/examples/101/application-gateway-v2-autoscale-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "657361687573006237"
+      "templateHash": "1287524601595468349"
     }
   },
   "parameters": {
@@ -105,7 +105,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "appGwPublicIpName": "[format('{0}-pip', parameters('applicationGatewayName'))]",
     "appGwSize": "Standard_v2"

--- a/docs/examples/101/avd-backplane/main.json
+++ b/docs/examples/101/avd-backplane/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11435914357705837168"
+      "templateHash": "18045462463900965650"
     }
   },
   "parameters": {
@@ -54,7 +54,6 @@
       "defaultValue": "BreadthFirst"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.DesktopVirtualization/hostPools",

--- a/docs/examples/101/azure-automation-account/main.json
+++ b/docs/examples/101/azure-automation-account/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11943737649630419837"
+      "templateHash": "4229699038022914740"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": "[uniqueString(resourceGroup().id)]"
     }
   },
-  "functions": [],
   "variables": {
     "workspaceName": "[toLower(format('la-{0}', parameters('appName')))]",
     "automationaccountName": "[toLower(format('aa{0}', parameters('appName')))]",

--- a/docs/examples/101/azure-bastion/main.json
+++ b/docs/examples/101/azure-bastion/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4692163733907268534"
+      "templateHash": "7911246077083205182"
     }
   },
   "parameters": {
@@ -55,7 +55,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "publicIpAddressName": "[format('{0}-pip', parameters('bastionHostName'))]",
     "bastionSubnetName": "AzureBastionSubnet"

--- a/docs/examples/101/azure-search-create/main.json
+++ b/docs/examples/101/azure-search-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17696463296650700918"
+      "templateHash": "17491111130964775226"
     }
   },
   "parameters": {
@@ -76,7 +76,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Search/searchServices",

--- a/docs/examples/101/azure-sentinel/main.json
+++ b/docs/examples/101/azure-sentinel/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16080991071473909590"
+      "templateHash": "12592264116281642941"
     }
   },
   "parameters": {
@@ -17,7 +17,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.OperationalInsights/workspaces",

--- a/docs/examples/101/azure-spring-cloud/activedeployment.json
+++ b/docs/examples/101/azure-spring-cloud/activedeployment.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14716049199041538326"
+      "templateHash": "5754326839291847658"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.AppPlatform/Spring/apps",

--- a/docs/examples/101/azure-spring-cloud/main.json
+++ b/docs/examples/101/azure-spring-cloud/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1871411128533601104"
+      "templateHash": "1079263028876230776"
     }
   },
   "parameters": {
@@ -29,7 +29,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.AppPlatform/Spring",
@@ -152,7 +151,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14716049199041538326"
+              "templateHash": "5754326839291847658"
             }
           },
           "parameters": {
@@ -166,7 +165,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.AppPlatform/Spring/apps",

--- a/docs/examples/101/azurefirewall-create-with-zones/main.json
+++ b/docs/examples/101/azurefirewall-create-with-zones/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1241648137071561964"
+      "templateHash": "9707219038654328345"
     }
   },
   "parameters": {
@@ -38,7 +38,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "azureFirewallSubnetName": "AzureFirewallSubnet"
   },

--- a/docs/examples/101/basic-batch-account/main.json
+++ b/docs/examples/101/basic-batch-account/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18246013453415253777"
+      "templateHash": "14399301132784284519"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Batch/batchAccounts",

--- a/docs/examples/101/basic-publicip/main.json
+++ b/docs/examples/101/basic-publicip/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3949719055369974346"
+      "templateHash": "16554428201548314630"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "defaultValue": "mypublicip"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
@@ -40,7 +39,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17282422556248381741"
+              "templateHash": "7368437974421050543"
             }
           },
           "parameters": {
@@ -59,7 +58,6 @@
               "type": "bool"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/publicIPAddresses",

--- a/docs/examples/101/basic-publicip/publicIpAddress.json
+++ b/docs/examples/101/basic-publicip/publicIpAddress.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17282422556248381741"
+      "templateHash": "7368437974421050543"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       "type": "bool"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/docs/examples/101/cognitive-services/main.json
+++ b/docs/examples/101/cognitive-services/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6346475403779900689"
+      "templateHash": "5873570432888469584"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "defaultValue": "S0"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.CognitiveServices/accounts",

--- a/docs/examples/101/container-registry/main.json
+++ b/docs/examples/101/container-registry/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8783196267296526557"
+      "templateHash": "371500996590452575"
     }
   },
   "parameters": {
@@ -44,7 +44,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ContainerRegistry/registries",

--- a/docs/examples/101/cosmosdb-free/main.json
+++ b/docs/examples/101/cosmosdb-free/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7905015631986025863"
+      "templateHash": "13099933352562359027"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.DocumentDB/databaseAccounts",

--- a/docs/examples/101/cosmosdb-private-endpoint/main.json
+++ b/docs/examples/101/cosmosdb-private-endpoint/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4055350238960821924"
+      "templateHash": "1622348765867924935"
     }
   },
   "parameters": {
@@ -32,7 +32,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",

--- a/docs/examples/101/cosmosdb-webapp/main.json
+++ b/docs/examples/101/cosmosdb-webapp/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "108437092261803770"
+      "templateHash": "10795510445676372349"
     }
   },
   "parameters": {
@@ -83,7 +83,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "cosmosAccountName": "[toLower(parameters('applicationName'))]",
     "websiteName": "[parameters('applicationName')]",

--- a/docs/examples/101/create-managedidentity-rbac/main.json
+++ b/docs/examples/101/create-managedidentity-rbac/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15518569730369960091"
+      "templateHash": "7609057008814330827"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "defaultValue": "b24988ac-6180-42a0-ab88-20f7382dd24c"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",

--- a/docs/examples/101/create-rg-lock-role-assignment/applylock.json
+++ b/docs/examples/101/create-rg-lock-role-assignment/applylock.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15567308115178212258"
+      "templateHash": "6218015697076008944"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Authorization/locks",

--- a/docs/examples/101/create-rg-lock-role-assignment/main.json
+++ b/docs/examples/101/create-rg-lock-role-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13175341687267981437"
+      "templateHash": "5222639659355267707"
     }
   },
   "parameters": {
@@ -42,7 +42,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",
@@ -82,7 +81,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15567308115178212258"
+              "templateHash": "6218015697076008944"
             }
           },
           "parameters": {
@@ -105,7 +104,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Authorization/locks",

--- a/docs/examples/101/custom-role-definition-assignment/main.json
+++ b/docs/examples/101/custom-role-definition-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1502977987485717788"
+      "templateHash": "5048724502667668975"
     }
   },
   "parameters": {
@@ -13,7 +13,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "roleName": "Bicep Custom Role demo"
   },

--- a/docs/examples/101/cyclecloud/main.json
+++ b/docs/examples/101/cyclecloud/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11661510030689656202"
+      "templateHash": "1585737288452125417"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "defaultValue": "20.49.199.4"
     }
   },
-  "functions": [],
   "variables": {
     "roleDefinitions": {
       "owner": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",

--- a/docs/examples/101/cyclecloud/sub.json
+++ b/docs/examples/101/cyclecloud/sub.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3531722014132222615"
+      "templateHash": "6486513756060996114"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",

--- a/docs/examples/101/data-factory-v2-blob-to-blob-copy/main.json
+++ b/docs/examples/101/data-factory-v2-blob-to-blob-copy/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16215686198522466676"
+      "templateHash": "8431332347365725334"
     }
   },
   "parameters": {
@@ -38,7 +38,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "dataFactoryLinkedServiceName": "ArmtemplateStorageLinkedService",
     "dataFactoryDataSetInName": "ArmtemplateTestDatasetIn",

--- a/docs/examples/101/data-factory-v2/main.json
+++ b/docs/examples/101/data-factory-v2/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7958237444528491028"
+      "templateHash": "4280826704478190185"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.DataFactory/factories",

--- a/docs/examples/101/data-lake-store-encryption-adls/main.json
+++ b/docs/examples/101/data-lake-store-encryption-adls/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6881182543139474466"
+      "templateHash": "123868417449409364"
     }
   },
   "parameters": {
@@ -23,7 +23,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.DataLakeStore/accounts",

--- a/docs/examples/101/databricks-all-in-one-template-for-vnet-injection/main.json
+++ b/docs/examples/101/databricks-all-in-one-template-for-vnet-injection/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10219143978370365451"
+      "templateHash": "8307523008160609786"
     }
   },
   "parameters": {
@@ -91,7 +91,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "managedResourceGroupName": "[format('databricks-rg-{0}-{1}', parameters('workspaceName'), uniqueString(parameters('workspaceName'), resourceGroup().id))]"
   },

--- a/docs/examples/101/databricks-workspace/main.json
+++ b/docs/examples/101/databricks-workspace/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8144897288233525089"
+      "templateHash": "12215355446540140927"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "managedResourceGroupName": "[format('databricks-rg-{0}-{1}', parameters('workspaceName'), uniqueString(parameters('workspaceName'), resourceGroup().id))]"
   },

--- a/docs/examples/101/deployment-script-no-auth/main.json
+++ b/docs/examples/101/deployment-script-no-auth/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9298564361327375536"
+      "templateHash": "5825830842373980012"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "defaultValue": "[format('ds{0}', uniqueString(resourceGroup().name))]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/deploymentScripts",

--- a/docs/examples/101/deployment-script-with-storage/main.json
+++ b/docs/examples/101/deployment-script-with-storage/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2397731199273610691"
+      "templateHash": "12599727556925904881"
     }
   },
   "parameters": {
@@ -34,7 +34,6 @@
       "defaultValue": "[utcNow()]"
     }
   },
-  "functions": [],
   "variables": {
     "uamiId": "[resourceId(parameters('subId'), parameters('rgName'), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
   },

--- a/docs/examples/101/event-grid-servicebus-queue/main.json
+++ b/docs/examples/101/event-grid-servicebus-queue/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4137132686096668824"
+      "templateHash": "14460997394831118971"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",

--- a/docs/examples/101/eventhub-namespace/main.json
+++ b/docs/examples/101/eventhub-namespace/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1891190626721479632"
+      "templateHash": "6986273389867179581"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "defaultValue": "Standard"
     }
   },
-  "functions": [],
   "variables": {
     "eventHubNamespaceName": "[format('{0}ns', parameters('projectName'))]",
     "eventHubName": "[parameters('projectName')]"

--- a/docs/examples/101/expressroute-circuit-create/main.json
+++ b/docs/examples/101/expressroute-circuit-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12018690323025637593"
+      "templateHash": "10331308754093078001"
     }
   },
   "parameters": {
@@ -63,7 +63,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/expressRouteCircuits",

--- a/docs/examples/101/front-door-basic/main.json
+++ b/docs/examples/101/front-door-basic/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13593432903189678257"
+      "templateHash": "15769619050669280205"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "frontEndEndpointName": "frontEndEndpoint",
     "loadBalancingSettingsName": "loadBalancingSettings",

--- a/docs/examples/101/front-door-custom-domain/main.json
+++ b/docs/examples/101/front-door-custom-domain/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "921760795293439997"
+      "templateHash": "6192717057772764829"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "frontEndEndpointDefaultName": "frontEndEndpointDefault",
     "frontEndEndpointCustomName": "frontEndEndpointCustom",

--- a/docs/examples/101/front-door-redirect/main.json
+++ b/docs/examples/101/front-door-redirect/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14633856064052260422"
+      "templateHash": "14639328854817024200"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "frontEndEndpointName": "frontEndEndpoint",
     "loadBalancingSettingsName": "loadBalancingSettings",

--- a/docs/examples/101/function-app-create/main.json
+++ b/docs/examples/101/function-app-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "969745789068173569"
+      "templateHash": "428471722115151696"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "functionAppName": "[format('{0}-functionapp', parameters('appNamePrefix'))]",
     "appServiceName": "[format('{0}-appservice', parameters('appNamePrefix'))]",

--- a/docs/examples/101/function-http-trigger/main.json
+++ b/docs/examples/101/function-http-trigger/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8302437122195538337"
+      "templateHash": "3802252279271303889"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "defaultValue": "Standard"
     }
   },
-  "functions": [],
   "variables": {
     "functionAppName": "[format('fn-{0}', parameters('appNameSuffix'))]",
     "appServicePlanName": "FunctionPlan",

--- a/docs/examples/101/function-premium-vnet-integration/main.json
+++ b/docs/examples/101/function-premium-vnet-integration/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12577151766898505388"
+      "templateHash": "10341295360967822644"
     }
   },
   "parameters": {
@@ -66,7 +66,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "vnetAddressPrefix": "10.0.0.0/16",
     "subnetAddressPrefix": "10.0.0.0/24",

--- a/docs/examples/101/hdinsight-spark-linux/main.json
+++ b/docs/examples/101/hdinsight-spark-linux/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8124490358582889361"
+      "templateHash": "17616152062973047505"
     }
   },
   "parameters": {
@@ -89,7 +89,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",

--- a/docs/examples/101/hub-and-spoke/main.json
+++ b/docs/examples/101/hub-and-spoke/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14244910561863265451"
+      "templateHash": "2760206701276618716"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "defaultValue": "westeurope"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",
@@ -65,7 +64,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3715870865053330009"
+              "templateHash": "15495507930110483956"
             }
           },
           "parameters": {
@@ -79,7 +78,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/virtualNetworks",
@@ -151,7 +149,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3715870865053330009"
+              "templateHash": "15495507930110483956"
             }
           },
           "parameters": {
@@ -165,7 +163,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/virtualNetworks",
@@ -222,7 +219,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11918431151627110969"
+              "templateHash": "13311839235455797530"
             }
           },
           "parameters": {
@@ -233,7 +230,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/publicIPAddresses",
@@ -314,7 +310,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5614441752281108595"
+              "templateHash": "15531165796545459208"
             }
           },
           "parameters": {
@@ -328,7 +324,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
@@ -381,7 +376,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5614441752281108595"
+              "templateHash": "15531165796545459208"
             }
           },
           "parameters": {
@@ -395,7 +390,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
@@ -445,7 +439,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12110720187620775770"
+              "templateHash": "16189283045692667809"
             }
           },
           "parameters": {
@@ -456,7 +450,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/routeTables",

--- a/docs/examples/101/hub-and-spoke/modules/fwl.json
+++ b/docs/examples/101/hub-and-spoke/modules/fwl.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11918431151627110969"
+      "templateHash": "13311839235455797530"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/docs/examples/101/hub-and-spoke/modules/peering.json
+++ b/docs/examples/101/hub-and-spoke/modules/peering.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5614441752281108595"
+      "templateHash": "15531165796545459208"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",

--- a/docs/examples/101/hub-and-spoke/modules/rot.json
+++ b/docs/examples/101/hub-and-spoke/modules/rot.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12110720187620775770"
+      "templateHash": "16189283045692667809"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/routeTables",

--- a/docs/examples/101/hub-and-spoke/modules/vnet.json
+++ b/docs/examples/101/hub-and-spoke/modules/vnet.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3715870865053330009"
+      "templateHash": "15495507930110483956"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",

--- a/docs/examples/101/key-vault-create/main.json
+++ b/docs/examples/101/key-vault-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9592777238542559736"
+      "templateHash": "8924064920603961080"
     }
   },
   "parameters": {
@@ -113,7 +113,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.KeyVault/vaults",

--- a/docs/examples/101/key-vault-secret-only/main.json
+++ b/docs/examples/101/key-vault-secret-only/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8105070701854868101"
+      "templateHash": "15576315323975893183"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "type": "secureString"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.KeyVault/vaults/secrets",

--- a/docs/examples/101/logic-app-create/main.json
+++ b/docs/examples/101/logic-app-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3594538944700350892"
+      "templateHash": "4440531950594760658"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "frequency": "Hour",
     "interval": "1",

--- a/docs/examples/101/media-services-create/main.json
+++ b/docs/examples/101/media-services-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4068937165195911526"
+      "templateHash": "6116784116946033021"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountName": "[format('storage{0}', uniqueString(resourceGroup().id))]"
   },

--- a/docs/examples/101/mg-policy/main.json
+++ b/docs/examples/101/mg-policy/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4645215035624560254"
+      "templateHash": "12630195116226956816"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "mgScope": "[tenantResourceId('Microsoft.Management/managementGroups', parameters('targetMG'))]",
     "policyDefinitionName": "LocationRestriction"

--- a/docs/examples/101/monitor-action-groups/main.json
+++ b/docs/examples/101/monitor-action-groups/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18418944260197435155"
+      "templateHash": "7034305354985346660"
     }
   },
   "parameters": {
@@ -56,7 +56,6 @@
       "defaultValue": []
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "microsoft.insights/actionGroups",

--- a/docs/examples/101/nat-gateway-vnet/main.json
+++ b/docs/examples/101/nat-gateway-vnet/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6286385429065988966"
+      "templateHash": "16460937844012558125"
     }
   },
   "parameters": {
@@ -59,7 +59,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "publicIpName": "[format('{0}-ip', parameters('natGatewayName'))]",
     "publicIpAddresses": [

--- a/docs/examples/101/private-dns-zone/main.json
+++ b/docs/examples/101/private-dns-zone/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17310351777819035411"
+      "templateHash": "12389141475039237910"
     }
   },
   "parameters": {
@@ -38,7 +38,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",

--- a/docs/examples/101/private-endpoint-webapp/main.json
+++ b/docs/examples/101/private-endpoint-webapp/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6405035342659563535"
+      "templateHash": "14722846075836206922"
     }
   },
   "parameters": {
@@ -70,7 +70,6 @@
       "defaultValue": ".azurewebsites.net"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",

--- a/docs/examples/101/redis-cache/main.json
+++ b/docs/examples/101/redis-cache/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "438163938561705107"
+      "templateHash": "6965233980809723068"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "redisCacheName": "[format('{0}{1}', parameters('environmentName'), uniqueString(resourceGroup().id))]"
   },

--- a/docs/examples/101/resource-with-lock-existing/main.json
+++ b/docs/examples/101/resource-with-lock-existing/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6251836513852075781"
+      "templateHash": "819688779765671306"
     }
   },
   "parameters": {
@@ -13,7 +13,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Authorization/locks",

--- a/docs/examples/101/resource-with-lock/main.json
+++ b/docs/examples/101/resource-with-lock/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4312598347921939130"
+      "templateHash": "12432572088371158198"
     }
   },
   "parameters": {
@@ -13,7 +13,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",

--- a/docs/examples/101/sql-database/main.json
+++ b/docs/examples/101/sql-database/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5868187186886427302"
+      "templateHash": "14952617381517963413"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "type": "secureString"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Sql/servers",

--- a/docs/examples/101/sqlmi-new-vnet/main.json
+++ b/docs/examples/101/sqlmi-new-vnet/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4598814261157091151"
+      "templateHash": "15742516654704605838"
     }
   },
   "parameters": {
@@ -66,7 +66,6 @@
       "minValue": 32
     }
   },
-  "functions": [],
   "variables": {
     "networkSecurityGroupName": "[format('{0}-nsg', parameters('managedInstanceName'))]",
     "routeTableName": "[format('{0}-routetable', parameters('managedInstanceName'))]"

--- a/docs/examples/101/storage-blob-container/main.json
+++ b/docs/examples/101/storage-blob-container/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6030705166262700097"
+      "templateHash": "3876154308177328967"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",

--- a/docs/examples/101/storage-static-website/main.json
+++ b/docs/examples/101/storage-static-website/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1442580549654606089"
+      "templateHash": "3641556810042792892"
     }
   },
   "parameters": {
@@ -37,7 +37,6 @@
       "defaultValue": "error.html"
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountContributorRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')]"
   },

--- a/docs/examples/101/template-spec-deploy/main.json
+++ b/docs/examples/101/template-spec-deploy/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7674149474155193249"
+      "templateHash": "10418043907618452415"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",

--- a/docs/examples/101/templatespec-create/main.json
+++ b/docs/examples/101/templatespec-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17638708546035585412"
+      "templateHash": "8019227817451205647"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/templateSpecs",

--- a/docs/examples/101/vm-simple-linux/main.json
+++ b/docs/examples/101/vm-simple-linux/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10043314188766115640"
+      "templateHash": "2323322890109997891"
     }
   },
   "parameters": {
@@ -95,7 +95,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "publicIPAddressName": "[format('{0}PublicIP', parameters('vmName'))]",
     "networkInterfaceName": "[format('{0}NetInt', parameters('vmName'))]",

--- a/docs/examples/101/vm-simple-windows/main.json
+++ b/docs/examples/101/vm-simple-windows/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "147447926519047422"
+      "templateHash": "1239276404599769166"
     }
   },
   "parameters": {
@@ -103,7 +103,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountName": "[format('bootdiags{0}', uniqueString(resourceGroup().id))]",
     "nicName": "myVMNic",

--- a/docs/examples/101/vnet-two-subnets/main.json
+++ b/docs/examples/101/vnet-two-subnets/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16512295221089606821"
+      "templateHash": "13274476665266675087"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": "10.0.0.0/15"
     }
   },
-  "functions": [],
   "variables": {
     "vnetName": "[format('vnet-{0}', parameters('suffix'))]"
   },

--- a/docs/examples/101/web-app-linux/main.json
+++ b/docs/examples/101/web-app-linux/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2526357515241197461"
+      "templateHash": "9520805362169562150"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('AppServicePlan-{0}', parameters('webAppName')))]",
     "webSiteName": "[toLower(format('wapp-{0}', parameters('webAppName')))]"

--- a/docs/examples/101/web-app-windows/main.json
+++ b/docs/examples/101/web-app-windows/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1535164562759769815"
+      "templateHash": "5787099956571712004"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": "[uniqueString(resourceGroup().id)]"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]",
     "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"

--- a/docs/examples/101/webapp-managed-mysql/main.json
+++ b/docs/examples/101/webapp-managed-mysql/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3516581484793368788"
+      "templateHash": "8300956721063303527"
     }
   },
   "parameters": {
@@ -111,7 +111,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "databaseName": "[format('{0}-database', parameters('siteName'))]",
     "serverName": "[format('{0}-server', parameters('siteName'))]",

--- a/docs/examples/101/webapp-privateendpoint-vnet-injection/main.json
+++ b/docs/examples/101/webapp-privateendpoint-vnet-injection/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2670077569169270536"
+      "templateHash": "4183069466382039979"
     }
   },
   "parameters": {
@@ -130,7 +130,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "webapp_dns_name": ".azurewebsites.net",
     "privateDNSZoneName": "privatelink.azurewebsites.net",

--- a/docs/examples/101/website-with-container/main.json
+++ b/docs/examples/101/website-with-container/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14151585724625675119"
+      "templateHash": "16652782834123299017"
     }
   },
   "parameters": {
@@ -38,7 +38,6 @@
       "defaultValue": "[subscription().subscriptionId]"
     }
   },
-  "functions": [],
   "variables": {
     "websiteName": "[format('{0}-site', parameters('name'))]",
     "farmName": "[format('{0}-farm', parameters('name'))]"

--- a/docs/examples/201/1vm-2nics-2subnets-1vnet/main.json
+++ b/docs/examples/201/1vm-2nics-2subnets-1vnet/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14653990625764897327"
+      "templateHash": "2493220218069259213"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "nic1Name": "nic-1",
     "nic2Name": "nic-2",
@@ -212,7 +211,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13125082143369532135"
+              "templateHash": "14259845034974441060"
             }
           },
           "parameters": {
@@ -242,7 +241,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Compute/virtualMachines",

--- a/docs/examples/201/1vm-2nics-2subnets-1vnet/vm.json
+++ b/docs/examples/201/1vm-2nics-2subnets-1vnet/vm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13125082143369532135"
+      "templateHash": "14259845034974441060"
     }
   },
   "parameters": {
@@ -35,7 +35,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Compute/virtualMachines",

--- a/docs/examples/201/aci-sftp-files/main.json
+++ b/docs/examples/201/aci-sftp-files/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11043621352403633164"
+      "templateHash": "511767396565550885"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "scriptName": "createFileShare",
     "identityName": "scratch",

--- a/docs/examples/201/aci-wordpress/main.json
+++ b/docs/examples/201/aci-wordpress/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10003846258238755689"
+      "templateHash": "5618173839261506858"
     }
   },
   "parameters": {
@@ -34,7 +34,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "cpuCores": "0.5",
     "memoryInGb": "0.7",

--- a/docs/examples/201/anchored-proximity-placement-group/linux-vm-as.json
+++ b/docs/examples/201/anchored-proximity-placement-group/linux-vm-as.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7325281056093512278"
+      "templateHash": "902766231246252587"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/networkInterfaces",

--- a/docs/examples/201/anchored-proximity-placement-group/linux-vm-az.json
+++ b/docs/examples/201/anchored-proximity-placement-group/linux-vm-az.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12368116353023022869"
+      "templateHash": "3088228858602383667"
     }
   },
   "parameters": {
@@ -34,7 +34,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/docs/examples/201/anchored-proximity-placement-group/main.json
+++ b/docs/examples/201/anchored-proximity-placement-group/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11777732354347161703"
+      "templateHash": "2127362373278027992"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "defaultValue": "20.49.199.4"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Compute/proximityPlacementGroups",
@@ -73,7 +72,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6221020817843547137"
+              "templateHash": "10154278416046209142"
             }
           },
           "parameters": {
@@ -86,7 +85,6 @@
               "defaultValue": "1.1.1.1"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/networkSecurityGroups",
@@ -207,7 +205,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12368116353023022869"
+              "templateHash": "3088228858602383667"
             }
           },
           "parameters": {
@@ -236,7 +234,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/publicIPAddresses",
@@ -373,7 +370,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7325281056093512278"
+              "templateHash": "902766231246252587"
             }
           },
           "parameters": {
@@ -394,7 +391,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/networkInterfaces",
@@ -507,7 +503,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7325281056093512278"
+              "templateHash": "902766231246252587"
             }
           },
           "parameters": {
@@ -528,7 +524,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/networkInterfaces",

--- a/docs/examples/201/anchored-proximity-placement-group/network.json
+++ b/docs/examples/201/anchored-proximity-placement-group/network.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6221020817843547137"
+      "templateHash": "10154278416046209142"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "defaultValue": "1.1.1.1"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/networkSecurityGroups",

--- a/docs/examples/201/anchored-proximity-placement-group/sub.json
+++ b/docs/examples/201/anchored-proximity-placement-group/sub.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10348740316805403775"
+      "templateHash": "13339573607207668286"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",

--- a/docs/examples/201/api-management-create-all-resources/main.json
+++ b/docs/examples/201/api-management-create-all-resources/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16319124812109372780"
+      "templateHash": "17616543420192955257"
     }
   },
   "parameters": {
@@ -60,7 +60,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "apiManagementServiceName": "[format('apiservice{0}', uniqueString(resourceGroup().id))]"
   },

--- a/docs/examples/201/asev2-ilb-with-web-app/main.json
+++ b/docs/examples/201/asev2-ilb-with-web-app/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3429125868248426249"
+      "templateHash": "15988558302197664211"
     }
   },
   "parameters": {
@@ -49,7 +49,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",

--- a/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.json
+++ b/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4464042552642153847"
+      "templateHash": "3145735088227289128"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.OperationalInsights/workspaces",
@@ -71,7 +70,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1455955442339016099"
+              "templateHash": "4134091672904132879"
             }
           },
           "parameters": {
@@ -85,7 +84,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Insights/diagnosticSettings",

--- a/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.json
+++ b/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10433270836189804974"
+      "templateHash": "16394804768752424975"
     }
   },
   "parameters": {
@@ -64,7 +64,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.DesktopVirtualization/hostPools",
@@ -144,7 +143,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4464042552642153847"
+              "templateHash": "3145735088227289128"
             }
           },
           "parameters": {
@@ -169,7 +168,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.OperationalInsights/workspaces",
@@ -210,7 +208,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "1455955442339016099"
+                      "templateHash": "4134091672904132879"
                     }
                   },
                   "parameters": {
@@ -224,7 +222,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Insights/diagnosticSettings",

--- a/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-module.json
+++ b/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-module.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4546637334796479546"
+      "templateHash": "13719396606305828840"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "defaultValue": "profilecontainers"
     }
   },
-  "functions": [],
   "variables": {
     "filesharelocation": "[format('{0}/default/{1}', parameters('storageaccountName'), parameters('fileshareFolderName'))]"
   },

--- a/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-privateendpoint-module.json
+++ b/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-privateendpoint-module.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10923208776356047399"
+      "templateHash": "2260198603101712361"
     }
   },
   "parameters": {
@@ -34,7 +34,6 @@
       "defaultValue": "privatelink.file.core.windows.net"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",

--- a/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-image-builder-module.json
+++ b/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-image-builder-module.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11901003945765009081"
+      "templateHash": "5788686735444811125"
     }
   },
   "parameters": {
@@ -51,7 +51,6 @@
       "defaultValue": "[resourceGroup().name]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.VirtualMachineImages/imageTemplates",

--- a/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-monitor-diag.json
+++ b/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-monitor-diag.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1455955442339016099"
+      "templateHash": "4134091672904132879"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Insights/diagnosticSettings",

--- a/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-network-module.json
+++ b/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-network-module.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14703761931839700056"
+      "templateHash": "5817043132999951390"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "defaultValue": "AVD"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",

--- a/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-sig-module.json
+++ b/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/avd-sig-module.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2423311947255325908"
+      "templateHash": "1528651399167082047"
     }
   },
   "parameters": {
@@ -34,7 +34,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Compute/galleries",

--- a/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/main.json
+++ b/docs/examples/201/avd-backplane-with-network-and-storage-and-monitoring/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7390117122005755401"
+      "templateHash": "15254467993445042476"
     }
   },
   "parameters": {
@@ -130,7 +130,6 @@
       "defaultValue": false
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",
@@ -226,7 +225,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10433270836189804974"
+              "templateHash": "16394804768752424975"
             }
           },
           "parameters": {
@@ -285,7 +284,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.DesktopVirtualization/hostPools",
@@ -365,7 +363,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "4464042552642153847"
+                      "templateHash": "3145735088227289128"
                     }
                   },
                   "parameters": {
@@ -390,7 +388,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.OperationalInsights/workspaces",
@@ -431,7 +428,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "1455955442339016099"
+                              "templateHash": "4134091672904132879"
                             }
                           },
                           "parameters": {
@@ -445,7 +442,6 @@
                               "type": "string"
                             }
                           },
-                          "functions": [],
                           "resources": [
                             {
                               "type": "Microsoft.Insights/diagnosticSettings",
@@ -562,7 +558,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14703761931839700056"
+              "templateHash": "5817043132999951390"
             }
           },
           "parameters": {
@@ -584,7 +580,6 @@
               "defaultValue": "AVD"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/virtualNetworks",
@@ -659,7 +654,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4546637334796479546"
+              "templateHash": "13719396606305828840"
             }
           },
           "parameters": {
@@ -681,7 +676,6 @@
               "defaultValue": "profilecontainers"
             }
           },
-          "functions": [],
           "variables": {
             "filesharelocation": "[format('{0}/default/{1}', parameters('storageaccountName'), parameters('fileshareFolderName'))]"
           },
@@ -751,7 +745,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10923208776356047399"
+              "templateHash": "2260198603101712361"
             }
           },
           "parameters": {
@@ -780,7 +774,6 @@
               "defaultValue": "privatelink.file.core.windows.net"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
@@ -896,7 +889,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2423311947255325908"
+              "templateHash": "1528651399167082047"
             }
           },
           "parameters": {
@@ -925,7 +918,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Compute/galleries",
@@ -1068,7 +1060,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11901003945765009081"
+              "templateHash": "5788686735444811125"
             }
           },
           "parameters": {
@@ -1114,7 +1106,6 @@
               "defaultValue": "[resourceGroup().name]"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.VirtualMachineImages/imageTemplates",

--- a/docs/examples/201/budget-subscription-with-notifications/main.json
+++ b/docs/examples/201/budget-subscription-with-notifications/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15340131888003421698"
+      "templateHash": "355457022239797229"
     }
   },
   "parameters": {
@@ -66,7 +66,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Consumption/budgets",

--- a/docs/examples/201/cdn-with-storage-account/main.json
+++ b/docs/examples/201/cdn-with-storage-account/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6691240461596735890"
+      "templateHash": "12531169173066130470"
     }
   },
   "parameters": {
@@ -17,7 +17,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountName": "[format('storage{0}', uniqueString(resourceGroup().id))]",
     "endpointName": "[format('endpoint-{0}', uniqueString(resourceGroup().id))]",

--- a/docs/examples/201/cloud-shell-vnet/main.json
+++ b/docs/examples/201/cloud-shell-vnet/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7678246143339351059"
+      "templateHash": "9584729251604657934"
     }
   },
   "parameters": {
@@ -81,7 +81,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "networkProfileName": "[format('aci-networkProfile-{0}', parameters('location'))]",
     "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",

--- a/docs/examples/201/create-and-enable-ddos-protection-plans/main.json
+++ b/docs/examples/201/create-and-enable-ddos-protection-plans/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5864153784304662289"
+      "templateHash": "10891479611326316367"
     }
   },
   "parameters": {
@@ -50,7 +50,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/ddosProtectionPlans",

--- a/docs/examples/201/cyclecloud/cycleserver-vm.json
+++ b/docs/examples/201/cyclecloud/cycleserver-vm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14316110104637742647"
+      "templateHash": "4861645218776431507"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/docs/examples/201/cyclecloud/main.json
+++ b/docs/examples/201/cyclecloud/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12514855640909406627"
+      "templateHash": "7977167358735621829"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "defaultValue": "20.49.199.4"
     }
   },
-  "functions": [],
   "variables": {
     "roleDefinitions": {
       "owner": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
@@ -86,7 +85,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1939485911648662340"
+              "templateHash": "897418147390595997"
             }
           },
           "parameters": {
@@ -99,7 +98,6 @@
               "defaultValue": "1.1.1.1"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/networkSecurityGroups",
@@ -217,7 +215,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14316110104637742647"
+              "templateHash": "4861645218776431507"
             }
           },
           "parameters": {
@@ -239,7 +237,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/publicIPAddresses",

--- a/docs/examples/201/cyclecloud/network.json
+++ b/docs/examples/201/cyclecloud/network.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1939485911648662340"
+      "templateHash": "897418147390595997"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "defaultValue": "1.1.1.1"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/networkSecurityGroups",

--- a/docs/examples/201/cyclecloud/sub.json
+++ b/docs/examples/201/cyclecloud/sub.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10348740316805403775"
+      "templateHash": "13339573607207668286"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",

--- a/docs/examples/201/decrypt-running-windows-vm-without-aad/main.json
+++ b/docs/examples/201/decrypt-running-windows-vm-without-aad/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "573345119519894858"
+      "templateHash": "4287454098057335087"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",

--- a/docs/examples/201/event-hub-and-consumer-group/main.json
+++ b/docs/examples/201/event-hub-and-consumer-group/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3463049745789072361"
+      "templateHash": "14328881484475865442"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.EventHub/namespaces",

--- a/docs/examples/201/existing-vnet-to-vnet-peering/main.json
+++ b/docs/examples/201/existing-vnet-to-vnet-peering/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1214696560148845297"
+      "templateHash": "13268380835426105532"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",

--- a/docs/examples/201/firewall-with-ip-from-prefix/main.json
+++ b/docs/examples/201/firewall-with-ip-from-prefix/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12072048631897717900"
+      "templateHash": "2831520916330363176"
     }
   },
   "parameters": {
@@ -51,7 +51,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "firewallname": "[format('{0}-fw', parameters('vnetname'))]",
     "publicipname": "[format('{0}-pip', parameters('vnetname'))]",

--- a/docs/examples/201/front-door-with-webapplication-firewall/main.json
+++ b/docs/examples/201/front-door-with-webapplication-firewall/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1822521508074159212"
+      "templateHash": "16808045335522622772"
     }
   },
   "parameters": {
@@ -42,7 +42,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "frontDoorNameLower": "[toLower(parameters('frontDoorName'))]",
     "backendPool1Name": "[format('{0}-backendPool1', variables('frontDoorNameLower'))]",

--- a/docs/examples/201/iot-with-storage/main.json
+++ b/docs/examples/201/iot-with-storage/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4482504764276967972"
+      "templateHash": "12046213833593348371"
     }
   },
   "parameters": {
@@ -32,7 +32,6 @@
       "defaultValue": 4
     }
   },
-  "functions": [],
   "variables": {
     "unique": "[uniqueString(resourceGroup().id)]",
     "iotHubName": "[format('{0}Hub{1}', parameters('projectName'), variables('unique'))]",

--- a/docs/examples/201/key-vault-secret-create/main.json
+++ b/docs/examples/201/key-vault-secret-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13593744847859493909"
+      "templateHash": "12912365708546008340"
     }
   },
   "parameters": {
@@ -92,7 +92,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.KeyVault/vaults",

--- a/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.json
+++ b/docs/examples/201/log-analytics-with-solutions-and-diagnostics/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "606685342937214454"
+      "templateHash": "3252090373674473917"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "defaultValue": "[format('la-{0}', uniqueString(resourceGroup().id))]"
     }
   },
-  "functions": [],
   "variables": {
     "vmInsights": {
       "name": "[format('VMInsights({0})', parameters('logAnalyticsWorkspaceName'))]",

--- a/docs/examples/201/policy-azmonitor-agent-and-dcr-association/main.json
+++ b/docs/examples/201/policy-azmonitor-agent-and-dcr-association/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13546460887536036386"
+      "templateHash": "2643481720850062821"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
@@ -44,7 +43,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5064640466393476653"
+              "templateHash": "6817604326916833649"
             }
           },
           "parameters": {
@@ -52,7 +51,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "policyDefCategory": "Custom",
             "policySource": "Bicep",
@@ -414,7 +412,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4114066697075790073"
+              "templateHash": "16452404009444874291"
             }
           },
           "parameters": {
@@ -428,7 +426,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Authorization/policyAssignments",

--- a/docs/examples/201/policy-azmonitor-agent-and-dcr-association/policyAssignment.json
+++ b/docs/examples/201/policy-azmonitor-agent-and-dcr-association/policyAssignment.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4114066697075790073"
+      "templateHash": "16452404009444874291"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Authorization/policyAssignments",

--- a/docs/examples/201/policy-azmonitor-agent-and-dcr-association/policyDefinition.json
+++ b/docs/examples/201/policy-azmonitor-agent-and-dcr-association/policyDefinition.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5064640466393476653"
+      "templateHash": "6817604326916833649"
     }
   },
   "parameters": {
@@ -13,7 +13,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "policyDefCategory": "Custom",
     "policySource": "Bicep",

--- a/docs/examples/201/policy-definition-with-assignment/main.json
+++ b/docs/examples/201/policy-definition-with-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2605189513208279262"
+      "templateHash": "8842163985142754986"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Authorization/policyDefinitions",

--- a/docs/examples/201/policy-with-initiative-definition-and-assignment/main.json
+++ b/docs/examples/201/policy-with-initiative-definition-and-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11769852566665193630"
+      "templateHash": "16725308854916544444"
     }
   },
   "parameters": {
@@ -33,7 +33,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "initiativeDefinitionName": "BICEP Example Initiative"
   },

--- a/docs/examples/201/portal-dashboard-with-appinsights/main.json
+++ b/docs/examples/201/portal-dashboard-with-appinsights/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4833412814982595185"
+      "templateHash": "4526302250036862177"
     }
   },
   "parameters": {
@@ -17,7 +17,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Insights/components",

--- a/docs/examples/201/private-aks-cluster/aks.json
+++ b/docs/examples/201/private-aks-cluster/aks.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5882575949678654988"
+      "templateHash": "8669984809251085106"
     }
   },
   "parameters": {
@@ -314,7 +314,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "aadProfileConfiguration": {
       "managed": "[parameters('aadProfileManaged')]",

--- a/docs/examples/201/private-aks-cluster/bastion.json
+++ b/docs/examples/201/private-aks-cluster/bastion.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9608724785177199123"
+      "templateHash": "17746964786378268703"
     }
   },
   "parameters": {
@@ -29,7 +29,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "bastionPublicIpAddressName": "[format('{0}PublicIp', parameters('bastionHostName'))]"
   },

--- a/docs/examples/201/private-aks-cluster/jumpbox.json
+++ b/docs/examples/201/private-aks-cluster/jumpbox.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7111355816980958501"
+      "templateHash": "12829523487718671926"
     }
   },
   "parameters": {
@@ -150,7 +150,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "vmNicName": "[format('{0}Nic', parameters('vmName'))]",
     "vmNicId": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]",

--- a/docs/examples/201/private-aks-cluster/log-analytics.json
+++ b/docs/examples/201/private-aks-cluster/log-analytics.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "957041648486849486"
+      "templateHash": "14176816021127228926"
     }
   },
   "parameters": {
@@ -43,7 +43,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.OperationalInsights/workspaces",

--- a/docs/examples/201/private-aks-cluster/main.json
+++ b/docs/examples/201/private-aks-cluster/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9087559349354084645"
+      "templateHash": "9780166229571418326"
     }
   },
   "parameters": {
@@ -492,7 +492,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
@@ -536,7 +535,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4573629760399744599"
+              "templateHash": "16544072065088913224"
             }
           },
           "parameters": {
@@ -596,7 +595,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "bastionSubnetName": "AzureBastionSubnet",
             "bastionSubnetNsgName": "[format('{0}Nsg', variables('bastionSubnetName'))]",
@@ -837,7 +835,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9608724785177199123"
+              "templateHash": "17746964786378268703"
             }
           },
           "parameters": {
@@ -861,7 +859,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "bastionPublicIpAddressName": "[format('{0}PublicIp', parameters('bastionHostName'))]"
           },
@@ -939,7 +936,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "957041648486849486"
+              "templateHash": "14176816021127228926"
             }
           },
           "parameters": {
@@ -977,7 +974,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.OperationalInsights/workspaces",
@@ -1076,7 +1072,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7111355816980958501"
+              "templateHash": "12829523487718671926"
             }
           },
           "parameters": {
@@ -1221,7 +1217,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "vmNicName": "[format('{0}Nic', parameters('vmName'))]",
             "vmNicId": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]",
@@ -1591,7 +1586,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5882575949678654988"
+              "templateHash": "8669984809251085106"
             }
           },
           "parameters": {
@@ -1900,7 +1895,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "aadProfileConfiguration": {
               "managed": "[parameters('aadProfileManaged')]",

--- a/docs/examples/201/private-aks-cluster/vnet.json
+++ b/docs/examples/201/private-aks-cluster/vnet.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4573629760399744599"
+      "templateHash": "16544072065088913224"
     }
   },
   "parameters": {
@@ -65,7 +65,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "bastionSubnetName": "AzureBastionSubnet",
     "bastionSubnetNsgName": "[format('{0}Nsg', variables('bastionSubnetName'))]",

--- a/docs/examples/201/proximity-placement-with-multi-resource-groups/anchored-ppg.json
+++ b/docs/examples/201/proximity-placement-with-multi-resource-groups/anchored-ppg.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16228755905477314031"
+      "templateHash": "17798777799174646976"
     }
   },
   "parameters": {
@@ -31,7 +31,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Compute/proximityPlacementGroups",

--- a/docs/examples/201/proximity-placement-with-multi-resource-groups/linux-vm-as.json
+++ b/docs/examples/201/proximity-placement-with-multi-resource-groups/linux-vm-as.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4387499852680388806"
+      "templateHash": "838009304435023175"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Compute/availabilitySets",

--- a/docs/examples/201/proximity-placement-with-multi-resource-groups/main.json
+++ b/docs/examples/201/proximity-placement-with-multi-resource-groups/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7531632338313062776"
+      "templateHash": "1963734572438868460"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": 1
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",
@@ -68,7 +67,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6221020817843547137"
+              "templateHash": "10154278416046209142"
             }
           },
           "parameters": {
@@ -81,7 +80,6 @@
               "defaultValue": "1.1.1.1"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/networkSecurityGroups",
@@ -203,7 +201,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16228755905477314031"
+              "templateHash": "17798777799174646976"
             }
           },
           "parameters": {
@@ -229,7 +227,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Compute/proximityPlacementGroups",
@@ -383,7 +380,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4387499852680388806"
+              "templateHash": "838009304435023175"
             }
           },
           "parameters": {
@@ -404,7 +401,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Compute/availabilitySets",
@@ -536,7 +532,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4387499852680388806"
+              "templateHash": "838009304435023175"
             }
           },
           "parameters": {
@@ -557,7 +553,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Compute/availabilitySets",

--- a/docs/examples/201/proximity-placement-with-multi-resource-groups/network.json
+++ b/docs/examples/201/proximity-placement-with-multi-resource-groups/network.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6221020817843547137"
+      "templateHash": "10154278416046209142"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "defaultValue": "1.1.1.1"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/networkSecurityGroups",

--- a/docs/examples/201/redis-premium-cluster-diagnostics/main.json
+++ b/docs/examples/201/redis-premium-cluster-diagnostics/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2123622275800868186"
+      "templateHash": "16493242120892807638"
     }
   },
   "parameters": {
@@ -82,7 +82,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Cache/redis",

--- a/docs/examples/201/redis-premium-persistence/main.json
+++ b/docs/examples/201/redis-premium-persistence/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7898404051007989226"
+      "templateHash": "18376013986871716906"
     }
   },
   "parameters": {
@@ -88,7 +88,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Cache/redis",

--- a/docs/examples/201/redis-premium-persistence/prereqs.json
+++ b/docs/examples/201/redis-premium-persistence/prereqs.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10932448770179421717"
+      "templateHash": "14977276075463618826"
     }
   },
   "parameters": {
@@ -17,7 +17,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",

--- a/docs/examples/201/servicebus-create-queue/main.json
+++ b/docs/examples/201/servicebus-create-queue/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4001173461839411878"
+      "templateHash": "7132447711531719593"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",

--- a/docs/examples/201/shared-image-gallery-with-image-defintition-and-role-assignment/main.json
+++ b/docs/examples/201/shared-image-gallery-with-image-defintition-and-role-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6061572376334368051"
+      "templateHash": "7412961710344620480"
     }
   },
   "parameters": {
@@ -43,7 +43,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "templateImageResourceGroupId": "[format('/subscriptions/{0}/resourcegroups/{1}', parameters('azureSubscriptionID'), parameters('templateImageResourceGroup'))]"
   },

--- a/docs/examples/201/sql/main.json
+++ b/docs/examples/201/sql/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16046128587010768920"
+      "templateHash": "11609579889945901205"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "databaseName": "sample-db-with-tde",
     "databaseEdition": "Basic",

--- a/docs/examples/201/traffic-manager-webapp/main.json
+++ b/docs/examples/201/traffic-manager-webapp/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7725203689471739007"
+      "templateHash": "12122858581609267396"
     }
   },
   "parameters": {
@@ -38,7 +38,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Web/serverfarms",

--- a/docs/examples/201/vm-copy-managed-disks/main.json
+++ b/docs/examples/201/vm-copy-managed-disks/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4203155055355210930"
+      "templateHash": "351492020115716885"
     }
   },
   "parameters": {
@@ -50,7 +50,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "myVNETName": "myVNET",
     "myVNETPrefix": "10.0.0.0/16",

--- a/docs/examples/201/vm-domain-join/main.json
+++ b/docs/examples/201/vm-domain-join/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5652906742106607423"
+      "templateHash": "4920029699139795418"
     }
   },
   "parameters": {
@@ -54,7 +54,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountName": "[uniqueString(resourceGroup().id, deployment().name)]",
     "imagePublisher": "MicrosoftWindowsServer",

--- a/docs/examples/201/vm-new-or-existing-conditions/main.json
+++ b/docs/examples/201/vm-new-or-existing-conditions/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "658565437290705996"
+      "templateHash": "3311313440455778920"
     }
   },
   "parameters": {
@@ -154,7 +154,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountId": "[if(parameters('createNewStorageAccount'), resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), resourceId(parameters('storageAccountResourceGroupName'), 'Microsoft.Storage/storageAccounts/', parameters('storageAccountName')))]",
     "subnetId": "[if(parameters('createNewVnet'), resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('vnetName'), parameters('subnetName')), '/')[0], split(format('{0}/{1}', parameters('vnetName'), parameters('subnetName')), '/')[1]), resourceId(parameters('vnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName')))]",

--- a/docs/examples/201/vm-push-certificate-windows/main.json
+++ b/docs/examples/201/vm-push-certificate-windows/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7812687626069318265"
+      "templateHash": "4085144587624051739"
     }
   },
   "parameters": {
@@ -42,7 +42,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "kvId": "[resourceId(parameters('subId'), parameters('rgName'), 'Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
     "subnet1Name": "subnet-1",

--- a/docs/examples/201/vm-windows-with-custom-script-extension/main.json
+++ b/docs/examples/201/vm-windows-with-custom-script-extension/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14618145107924036487"
+      "templateHash": "967788323158124194"
     }
   },
   "parameters": {
@@ -76,7 +76,6 @@
       "defaultValue": "https://raw.githubusercontent.com/Azure/bicep/main/docs/examples/201/vm-windows-with-custom-script-extension/install.ps1"
     }
   },
-  "functions": [],
   "variables": {
     "metadata": {
       "longName": "[format('{{0}}-{0}-{1}', parameters('name'), if(equals(coalesce(parameters('suffix'), ''), ''), '', concat('-', parameters('suffix'))))]",

--- a/docs/examples/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.json
+++ b/docs/examples/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14734149438817986739"
+      "templateHash": "5581484437105421652"
     }
   },
   "parameters": {
@@ -37,7 +37,6 @@
       "defaultValue": "bicep-demo-vm"
     }
   },
-  "functions": [],
   "variables": {
     "defaultLocation": "[resourceGroup().location]",
     "defaultVmNicName": "[format('{0}-nic', parameters('vmName'))]",

--- a/docs/examples/201/vmss-windows-autoscale/main.json
+++ b/docs/examples/201/vmss-windows-autoscale/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15303513457722336163"
+      "templateHash": "15789291631431946618"
     }
   },
   "parameters": {
@@ -43,7 +43,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "namingInfix": "[toLower(substring(format('{0}{1}', parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
     "longNamingInfix": "[toLower(parameters('vmssName'))]",

--- a/docs/examples/201/vnet-to-vnet-bgp/main.json
+++ b/docs/examples/201/vnet-to-vnet-bgp/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4649085311515098157"
+      "templateHash": "15425055517223875586"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "vnet1cfg": {
       "name": "[format('vnet1-{0}', parameters('location'))]",

--- a/docs/examples/201/vnet-to-vnet-peering/main.json
+++ b/docs/examples/201/vnet-to-vnet-peering/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3485675834858320580"
+      "templateHash": "13083441436053994862"
     }
   },
   "parameters": {
@@ -31,7 +31,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "vnet1Config": {
       "addressSpacePrefix": "10.0.0.0/24",

--- a/docs/examples/201/vnet-with-subnet-and-user-defined-route/main.json
+++ b/docs/examples/201/vnet-with-subnet-and-user-defined-route/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18428279402374731557"
+      "templateHash": "17315306733794399610"
     }
   },
   "parameters": {
@@ -54,7 +54,6 @@
       "defaultValue": "10.10.3.4"
     }
   },
-  "functions": [],
   "variables": {
     "vnetName": "[format('vnet-{0}', parameters('vnetSuffix'))]"
   },

--- a/docs/examples/201/vwan-shared-services/main.json
+++ b/docs/examples/201/vwan-shared-services/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12371818426879841991"
+      "templateHash": "13928214381687450227"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "vwan_cfg": {
       "name": "vwan",

--- a/docs/examples/201/web-app-asev2-create/main.json
+++ b/docs/examples/201/web-app-asev2-create/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13031907000558588020"
+      "templateHash": "1558433929532206392"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": "[uniqueString(resourceGroup().name)]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",

--- a/docs/examples/201/web-app-conditional-log/logging.json
+++ b/docs/examples/201/web-app-conditional-log/logging.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13009186405517622186"
+      "templateHash": "16717574754976290273"
     }
   },
   "parameters": {
@@ -17,7 +17,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "appInsightName": "[toLower(format('appi-{0}', parameters('appName')))]",
     "logAnalyticsName": "[toLower(format('la-{0}', parameters('appName')))]"

--- a/docs/examples/201/web-app-conditional-log/main.json
+++ b/docs/examples/201/web-app-conditional-log/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15876327905859377550"
+      "templateHash": "10937767574163985036"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "defaultValue": false
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
@@ -41,7 +40,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1240988414714428155"
+              "templateHash": "7041487136027912103"
             }
           },
           "parameters": {
@@ -61,7 +60,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]",
             "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"
@@ -163,7 +161,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13009186405517622186"
+              "templateHash": "16717574754976290273"
             }
           },
           "parameters": {
@@ -175,7 +173,6 @@
               "defaultValue": "[resourceGroup().location]"
             }
           },
-          "functions": [],
           "variables": {
             "appInsightName": "[toLower(format('appi-{0}', parameters('appName')))]",
             "logAnalyticsName": "[toLower(format('la-{0}', parameters('appName')))]"

--- a/docs/examples/201/web-app-conditional-log/webapp.json
+++ b/docs/examples/201/web-app-conditional-log/webapp.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1240988414714428155"
+      "templateHash": "7041487136027912103"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]",
     "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"

--- a/docs/examples/201/web-app-loganalytics-mod/app-insights.json
+++ b/docs/examples/201/web-app-loganalytics-mod/app-insights.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15097235235814757526"
+      "templateHash": "13415136452678460192"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "appInsightName": "[toLower(format('appi-{0}', parameters('appName')))]"
   },

--- a/docs/examples/201/web-app-loganalytics-mod/app-service-plan.json
+++ b/docs/examples/201/web-app-loganalytics-mod/app-service-plan.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10741606016888264590"
+      "templateHash": "6377278430554620476"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]"
   },

--- a/docs/examples/201/web-app-loganalytics-mod/app-service.json
+++ b/docs/examples/201/web-app-loganalytics-mod/app-service.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11917327337287752626"
+      "templateHash": "18103039888546629598"
     }
   },
   "parameters": {
@@ -23,7 +23,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"
   },

--- a/docs/examples/201/web-app-loganalytics-mod/log-analytics.json
+++ b/docs/examples/201/web-app-loganalytics-mod/log-analytics.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10127040548662503532"
+      "templateHash": "5504464194433425799"
     }
   },
   "parameters": {
@@ -17,7 +17,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "logAnalyticsName": "[toLower(format('la-{0}', parameters('appName')))]"
   },

--- a/docs/examples/201/web-app-loganalytics-mod/main.json
+++ b/docs/examples/201/web-app-loganalytics-mod/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3831278900086936670"
+      "templateHash": "3017085690141632969"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "defaultValue": "[uniqueString(resourceGroup().id)]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
@@ -37,7 +36,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10741606016888264590"
+              "templateHash": "6377278430554620476"
             }
           },
           "parameters": {
@@ -57,7 +56,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]"
           },
@@ -113,7 +111,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11917327337287752626"
+              "templateHash": "18103039888546629598"
             }
           },
           "parameters": {
@@ -131,7 +129,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"
           },
@@ -234,7 +231,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15097235235814757526"
+              "templateHash": "13415136452678460192"
             }
           },
           "parameters": {
@@ -249,7 +246,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "appInsightName": "[toLower(format('appi-{0}', parameters('appName')))]"
           },
@@ -303,7 +299,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10127040548662503532"
+              "templateHash": "5504464194433425799"
             }
           },
           "parameters": {
@@ -315,7 +311,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "logAnalyticsName": "[toLower(format('la-{0}', parameters('appName')))]"
           },

--- a/docs/examples/201/web-app-loganalytics/main.json
+++ b/docs/examples/201/web-app-loganalytics/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8253833847310498693"
+      "templateHash": "3916294298560318870"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": "[uniqueString(resourceGroup().id)]"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]",
     "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]",

--- a/docs/examples/201/web-app-sql-database/main.json
+++ b/docs/examples/201/web-app-sql-database/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10311308664354777755"
+      "templateHash": "2168193440551224912"
     }
   },
   "parameters": {
@@ -43,7 +43,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "hostingPlanName": "[format('hostingplan{0}', uniqueString(resourceGroup().id))]",
     "webSiteName": "[format('webSite{0}', uniqueString(resourceGroup().id))]",

--- a/docs/examples/201/wvd-create-hostpool/main.json
+++ b/docs/examples/201/wvd-create-hostpool/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1734095579549029138"
+      "templateHash": "9339942367308052706"
     }
   },
   "parameters": {
@@ -500,7 +500,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "copy": [
       {
@@ -599,7 +598,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11596780352137584181"
+              "templateHash": "10744375107263133706"
             }
           },
           "parameters": {
@@ -613,7 +612,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.DesktopVirtualization/workspaces",
@@ -666,7 +664,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "871329429336967058"
+              "templateHash": "2813905246495879379"
             }
           },
           "parameters": {
@@ -689,7 +687,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Compute/availabilitySets",
@@ -840,7 +837,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14809252553564219752"
+              "templateHash": "2254377562618197384"
             }
           },
           "parameters": {
@@ -1106,7 +1103,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "emptyArray": [],
             "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -1356,7 +1352,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "9768223943364163858"
+                      "templateHash": "8777864661194051401"
                     }
                   },
                   "parameters": {
@@ -1376,7 +1372,6 @@
                       "type": "array"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "condition": "[parameters('createNetworkSecurityGroup')]",
@@ -1528,7 +1523,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5237605788409454466"
+              "templateHash": "5621803929184499400"
             }
           },
           "parameters": {
@@ -1794,7 +1789,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "emptyArray": [],
             "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -2029,7 +2023,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "9768223943364163858"
+                      "templateHash": "8777864661194051401"
                     }
                   },
                   "parameters": {
@@ -2049,7 +2043,6 @@
                       "type": "array"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "condition": "[parameters('createNetworkSecurityGroup')]",
@@ -2201,7 +2194,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16527790120289967558"
+              "templateHash": "2543136060854123246"
             }
           },
           "parameters": {
@@ -2467,7 +2460,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "emptyArray": [],
             "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -2698,7 +2690,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "9768223943364163858"
+                      "templateHash": "8777864661194051401"
                     }
                   },
                   "parameters": {
@@ -2718,7 +2710,6 @@
                       "type": "array"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "condition": "[parameters('createNetworkSecurityGroup')]",
@@ -2870,7 +2861,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16139408109861987276"
+              "templateHash": "15587261685692328756"
             }
           },
           "parameters": {
@@ -3136,7 +3127,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "emptyArray": [],
             "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -3370,7 +3360,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "9768223943364163858"
+                      "templateHash": "8777864661194051401"
                     }
                   },
                   "parameters": {
@@ -3390,7 +3380,6 @@
                       "type": "array"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/docs/examples/201/wvd-create-hostpool/modules/AVSet.json
+++ b/docs/examples/201/wvd-create-hostpool/modules/AVSet.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "871329429336967058"
+      "templateHash": "2813905246495879379"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Compute/availabilitySets",

--- a/docs/examples/201/wvd-create-hostpool/modules/NSG.json
+++ b/docs/examples/201/wvd-create-hostpool/modules/NSG.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9768223943364163858"
+      "templateHash": "8777864661194051401"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": [
     {
       "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/docs/examples/201/wvd-create-hostpool/modules/managedDisks-customimagevm.json
+++ b/docs/examples/201/wvd-create-hostpool/modules/managedDisks-customimagevm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16527790120289967558"
+      "templateHash": "2543136060854123246"
     }
   },
   "parameters": {
@@ -271,7 +271,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "emptyArray": [],
     "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -502,7 +501,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9768223943364163858"
+              "templateHash": "8777864661194051401"
             }
           },
           "parameters": {
@@ -522,7 +521,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/docs/examples/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.json
+++ b/docs/examples/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14809252553564219752"
+      "templateHash": "2254377562618197384"
     }
   },
   "parameters": {
@@ -271,7 +271,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "emptyArray": [],
     "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -521,7 +520,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9768223943364163858"
+              "templateHash": "8777864661194051401"
             }
           },
           "parameters": {
@@ -541,7 +540,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/docs/examples/201/wvd-create-hostpool/modules/managedDisks-galleryvm.json
+++ b/docs/examples/201/wvd-create-hostpool/modules/managedDisks-galleryvm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16139408109861987276"
+      "templateHash": "15587261685692328756"
     }
   },
   "parameters": {
@@ -271,7 +271,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "emptyArray": [],
     "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -505,7 +504,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9768223943364163858"
+              "templateHash": "8777864661194051401"
             }
           },
           "parameters": {
@@ -525,7 +524,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/docs/examples/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.json
+++ b/docs/examples/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5237605788409454466"
+      "templateHash": "5621803929184499400"
     }
   },
   "parameters": {
@@ -271,7 +271,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "emptyArray": [],
     "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -506,7 +505,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9768223943364163858"
+              "templateHash": "8777864661194051401"
             }
           },
           "parameters": {
@@ -526,7 +525,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/docs/examples/201/wvd-create-hostpool/modules/workspace.json
+++ b/docs/examples/201/wvd-create-hostpool/modules/workspace.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11596780352137584181"
+      "templateHash": "10744375107263133706"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.DesktopVirtualization/workspaces",

--- a/docs/examples/301/automation-account-import-runbooks-and-modules/main.json
+++ b/docs/examples/301/automation-account-import-runbooks-and-modules/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17984519031339270084"
+      "templateHash": "7700084129878109462"
     }
   },
   "parameters": {
@@ -105,7 +105,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "lockName": "[format('{0}-lck', parameters('name'))]",
     "diagnosticsName": "[format('{0}-dgs', parameters('name'))]"

--- a/docs/examples/301/deployifnotexists-policy-with-initiative-and-assignment/actionGroup.json
+++ b/docs/examples/301/deployifnotexists-policy-with-initiative-and-assignment/actionGroup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3405712656690483630"
+      "templateHash": "12934238208461793439"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "type": "bool"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "microsoft.insights/actionGroups",

--- a/docs/examples/301/deployifnotexists-policy-with-initiative-and-assignment/main.json
+++ b/docs/examples/301/deployifnotexists-policy-with-initiative-and-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14151164023474411165"
+      "templateHash": "5725644287220517104"
     }
   },
   "parameters": {
@@ -106,7 +106,6 @@
       "defaultValue": "Default"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/resourceGroups",
@@ -151,7 +150,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3405712656690483630"
+              "templateHash": "12934238208461793439"
             }
           },
           "parameters": {
@@ -174,7 +173,6 @@
               "type": "bool"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "microsoft.insights/actionGroups",
@@ -283,7 +281,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8518948478731971920"
+              "templateHash": "7507947354320390204"
             }
           },
           "parameters": {
@@ -342,7 +340,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "policyDefCategory": "Custom",
             "policySource": "Bicep"
@@ -612,7 +609,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14649207840315700227"
+              "templateHash": "2499499889172227804"
             }
           },
           "parameters": {
@@ -626,7 +623,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Authorization/policyAssignments",

--- a/docs/examples/301/deployifnotexists-policy-with-initiative-and-assignment/policyAssignment.json
+++ b/docs/examples/301/deployifnotexists-policy-with-initiative-and-assignment/policyAssignment.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14649207840315700227"
+      "templateHash": "2499499889172227804"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Authorization/policyAssignments",

--- a/docs/examples/301/deployifnotexists-policy-with-initiative-and-assignment/policyDefinition.json
+++ b/docs/examples/301/deployifnotexists-policy-with-initiative-and-assignment/policyDefinition.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8518948478731971920"
+      "templateHash": "7507947354320390204"
     }
   },
   "parameters": {
@@ -64,7 +64,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "policyDefCategory": "Custom",
     "policySource": "Bicep"

--- a/docs/examples/301/deployment-script-dev-environment/containergroups.json
+++ b/docs/examples/301/deployment-script-dev-environment/containergroups.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6673808017610235563"
+      "templateHash": "12360193174347893668"
     }
   },
   "parameters": {
@@ -58,7 +58,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "version": "[if(and(equals(parameters('type'), 'AzureCLI'), equals(parameters('toolVersion'), '')), 'latest', if(and(equals(parameters('type'), 'AzurePowerShell'), equals(parameters('toolVersion'), '')), '5.6', parameters('toolVersion')))]",
     "azcliImage": "[format('mcr.microsoft.com/azure-cli:{0}', variables('version'))]",

--- a/docs/examples/301/deployment-script-dev-environment/main.json
+++ b/docs/examples/301/deployment-script-dev-environment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11634997279449412299"
+      "templateHash": "9011626793936551294"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
@@ -66,7 +65,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10072553779848923110"
+              "templateHash": "9461343632591088191"
             }
           },
           "parameters": {
@@ -115,7 +114,6 @@
               "defaultValue": "[resourceGroup().id]"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Storage/storageAccounts",
@@ -195,7 +193,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6673808017610235563"
+              "templateHash": "12360193174347893668"
             }
           },
           "parameters": {
@@ -248,7 +246,6 @@
               "defaultValue": "[resourceGroup().location]"
             }
           },
-          "functions": [],
           "variables": {
             "version": "[if(and(equals(parameters('type'), 'AzureCLI'), equals(parameters('toolVersion'), '')), 'latest', if(and(equals(parameters('type'), 'AzurePowerShell'), equals(parameters('toolVersion'), '')), '5.6', parameters('toolVersion')))]",
             "azcliImage": "[format('mcr.microsoft.com/azure-cli:{0}', variables('version'))]",

--- a/docs/examples/301/deployment-script-dev-environment/storage.json
+++ b/docs/examples/301/deployment-script-dev-environment/storage.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10072553779848923110"
+      "templateHash": "9461343632591088191"
     }
   },
   "parameters": {
@@ -54,7 +54,6 @@
       "defaultValue": "[resourceGroup().id]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",

--- a/docs/examples/301/expressroute-circuit-vnet-connection/main.json
+++ b/docs/examples/301/expressroute-circuit-vnet-connection/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3493822942554386929"
+      "templateHash": "12511392809354820622"
     }
   },
   "parameters": {
@@ -42,7 +42,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",

--- a/docs/examples/301/function-app-with-custom-domain-managed-certificate/main.json
+++ b/docs/examples/301/function-app-with-custom-domain-managed-certificate/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5515000954184944254"
+      "templateHash": "14611854507760837110"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "location": "[resourceGroup().location]",
     "componentBase": "[format('{0}-{1}', substring(uniqueString(resourceGroup().id), 4), parameters('applicationName'))]"
@@ -207,7 +206,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11275464343508829008"
+              "templateHash": "5111727942093536492"
             }
           },
           "parameters": {
@@ -221,7 +220,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Web/sites/hostNameBindings",

--- a/docs/examples/301/function-app-with-custom-domain-managed-certificate/sni-enable.json
+++ b/docs/examples/301/function-app-with-custom-domain-managed-certificate/sni-enable.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11275464343508829008"
+      "templateHash": "5111727942093536492"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Web/sites/hostNameBindings",

--- a/docs/examples/301/insights-alertrules-application-insights/main.json
+++ b/docs/examples/301/insights-alertrules-application-insights/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6932515354107245659"
+      "templateHash": "18221291617889272327"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "responseAlertName": "[format('ResponseTime-{0}', toLower(parameters('applicationInsightsName')))]"
   },

--- a/docs/examples/301/log-analytics-with-datasources-solutions/main.json
+++ b/docs/examples/301/log-analytics-with-datasources-solutions/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7762388379069236663"
+      "templateHash": "7661581430833195871"
     }
   },
   "parameters": {
@@ -94,7 +94,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "lockName": "[format('{0}-lck', parameters('name'))]",
     "diagnosticsName": "[format('{0}-dgs', parameters('name'))]"

--- a/docs/examples/301/management-groups-nested-with-subscriptions/main.json
+++ b/docs/examples/301/management-groups-nested-with-subscriptions/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14507995084482624053"
+      "templateHash": "16963693881196701218"
     }
   },
   "parameters": {
@@ -35,7 +35,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Management/managementGroups",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/azfw.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/azfw.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8852671976007191851"
+      "templateHash": "13061494399356137884"
     }
   },
   "parameters": {
@@ -61,7 +61,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "hubfwproperties": {
       "properties": {

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/azfwpip.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/azfwpip.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8402162185499815973"
+      "templateHash": "15270029119568726075"
     }
   },
   "parameters": {
@@ -35,7 +35,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/publicIPPrefixes",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/azfwpolicy.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/azfwpolicy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3995320789217660109"
+      "templateHash": "11491474669810947162"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/firewallPolicies",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/main.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "42812146254330995"
+      "templateHash": "2565114148790334711"
     }
   },
   "parameters": {
@@ -38,7 +38,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "vnetname": "[format('{0}-vnet', parameters('nameprefix'))]",
     "vpngwname": "[format('{0}-vpn-gw', variables('vnetname'))]",
@@ -108,7 +107,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17593228818037020755"
+              "templateHash": "6169687425211550359"
             }
           },
           "parameters": {
@@ -155,7 +154,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "servernsgname": "[format('{0}-snet-servers-nsg', parameters('vnetname'))]",
             "bastionnsgname": "[format('{0}-AzureBastionSubnet-nsg', parameters('vnetname'))]",
@@ -365,7 +363,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "668994565981920361"
+              "templateHash": "7888079620585144668"
             }
           },
           "parameters": {
@@ -392,7 +390,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/publicIPAddresses",
@@ -494,7 +491,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3995320789217660109"
+              "templateHash": "11491474669810947162"
             }
           },
           "parameters": {
@@ -515,7 +512,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/firewallPolicies",
@@ -669,7 +665,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8402162185499815973"
+              "templateHash": "15270029119568726075"
             }
           },
           "parameters": {
@@ -699,7 +695,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/publicIPPrefixes",
@@ -783,7 +778,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8852671976007191851"
+              "templateHash": "13061494399356137884"
             }
           },
           "parameters": {
@@ -839,7 +834,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "hubfwproperties": {
               "properties": {
@@ -931,7 +925,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2750460495032513094"
+              "templateHash": "280056674023652647"
             }
           },
           "parameters": {
@@ -954,7 +948,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/virtualWans",
@@ -1012,7 +1005,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6471938911786706761"
+              "templateHash": "6267441064966571983"
             }
           },
           "parameters": {
@@ -1037,7 +1030,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/virtualHubs",
@@ -1098,7 +1090,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3995320789217660109"
+              "templateHash": "11491474669810947162"
             }
           },
           "parameters": {
@@ -1119,7 +1111,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/firewallPolicies",
@@ -1279,7 +1270,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8852671976007191851"
+              "templateHash": "13061494399356137884"
             }
           },
           "parameters": {
@@ -1335,7 +1326,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "hubfwproperties": {
               "properties": {
@@ -1429,7 +1419,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10433069750951100331"
+              "templateHash": "10469250134169586077"
             }
           },
           "parameters": {
@@ -1453,7 +1443,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/vpnGateways",
@@ -1539,7 +1528,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4413852781831650034"
+              "templateHash": "8505973820543281231"
             }
           },
           "parameters": {
@@ -1581,7 +1570,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/vpnSites",
@@ -1652,7 +1640,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7703400377581823349"
+              "templateHash": "5178333219212442667"
             }
           },
           "parameters": {
@@ -1672,7 +1660,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/vpnGateways/vpnConnections",
@@ -1744,7 +1731,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12528836535334827814"
+              "templateHash": "14339240566669068445"
             }
           },
           "parameters": {
@@ -1796,7 +1783,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/localNetworkGateways",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vhub.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vhub.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6471938911786706761"
+      "templateHash": "6267441064966571983"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualHubs",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngw.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngw.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10433069750951100331"
+      "templateHash": "10469250134169586077"
     }
   },
   "parameters": {
@@ -29,7 +29,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/vpnGateways",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngwcon.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngwcon.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7703400377581823349"
+      "templateHash": "5178333219212442667"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/vpnGateways/vpnConnections",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vnet.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vnet.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17593228818037020755"
+      "templateHash": "6169687425211550359"
     }
   },
   "parameters": {
@@ -52,7 +52,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "servernsgname": "[format('{0}-snet-servers-nsg', parameters('vnetname'))]",
     "bastionnsgname": "[format('{0}-AzureBastionSubnet-nsg', parameters('vnetname'))]",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12528836535334827814"
+      "templateHash": "14339240566669068445"
     }
   },
   "parameters": {
@@ -57,7 +57,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/localNetworkGateways",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vnetvpngw.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vnetvpngw.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "668994565981920361"
+      "templateHash": "7888079620585144668"
     }
   },
   "parameters": {
@@ -32,7 +32,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vwan.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vwan.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2750460495032513094"
+      "templateHash": "280056674023652647"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualWans",

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vwanvpnsite.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/vwanvpnsite.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4413852781831650034"
+      "templateHash": "8505973820543281231"
     }
   },
   "parameters": {
@@ -47,7 +47,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/vpnSites",

--- a/docs/examples/301/nested-vms-in-virtual-network/main.json
+++ b/docs/examples/301/nested-vms-in-virtual-network/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6697841974774740985"
+      "templateHash": "10531657942066035492"
     }
   },
   "parameters": {
@@ -115,7 +115,6 @@
       "type": "secureString"
     }
   },
-  "functions": [],
   "variables": {
     "NATSubnetNSGName": "[format('{0}NSG', parameters('NATSubnetName'))]",
     "hyperVSubnetNSGName": "[format('{0}NSG', parameters('hyperVSubnetName'))]",
@@ -367,7 +366,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17428818831523905567"
+              "templateHash": "5886354623703578688"
             }
           },
           "parameters": {
@@ -402,7 +401,6 @@
               "defaultValue": false
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/networkInterfaces",
@@ -472,7 +470,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17428818831523905567"
+              "templateHash": "5886354623703578688"
             }
           },
           "parameters": {
@@ -507,7 +505,6 @@
               "defaultValue": false
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/networkInterfaces",
@@ -582,7 +579,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17428818831523905567"
+              "templateHash": "5886354623703578688"
             }
           },
           "parameters": {
@@ -617,7 +614,6 @@
               "defaultValue": false
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/networkInterfaces",
@@ -694,7 +690,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17428818831523905567"
+              "templateHash": "5886354623703578688"
             }
           },
           "parameters": {
@@ -729,7 +725,6 @@
               "defaultValue": false
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/networkInterfaces",
@@ -793,7 +788,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13461864852699596542"
+              "templateHash": "13192308342682473598"
             }
           },
           "parameters": {
@@ -813,7 +808,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/routeTables",
@@ -861,7 +855,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13461864852699596542"
+              "templateHash": "13192308342682473598"
             }
           },
           "parameters": {
@@ -881,7 +875,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Network/routeTables",

--- a/docs/examples/301/nested-vms-in-virtual-network/nic.json
+++ b/docs/examples/301/nested-vms-in-virtual-network/nic.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17428818831523905567"
+      "templateHash": "5886354623703578688"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       "defaultValue": false
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/networkInterfaces",

--- a/docs/examples/301/nested-vms-in-virtual-network/udr.json
+++ b/docs/examples/301/nested-vms-in-virtual-network/udr.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13461864852699596542"
+      "templateHash": "13192308342682473598"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "defaultValue": ""
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/routeTables",

--- a/docs/examples/301/publish-api-to-apim-opendocs/main.json
+++ b/docs/examples/301/publish-api-to-apim-opendocs/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9254032152856996155"
+      "templateHash": "1298853548212285545"
     }
   },
   "parameters": {
@@ -45,7 +45,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "productsSet": [
       {

--- a/docs/examples/301/servicebus-namespace-vnet/main.json
+++ b/docs/examples/301/servicebus-namespace-vnet/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14889434749996442139"
+      "templateHash": "14904215116833058261"
     }
   },
   "parameters": {
@@ -23,7 +23,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",

--- a/docs/examples/301/sql-database-with-management/main.json
+++ b/docs/examples/301/sql-database-with-management/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3272166138089580697"
+      "templateHash": "1680231113171308524"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "defaultResourceGroupProperties": {
       "tags": {},
@@ -58,7 +57,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13336441185399082470"
+              "templateHash": "12921433042511684704"
             }
           },
           "parameters": {
@@ -72,7 +71,6 @@
               "type": "object"
             }
           },
-          "functions": [],
           "variables": {
             "defaultSqlLogicalServerProperties": {
               "name": "",
@@ -159,7 +157,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7713578241009111792"
+                      "templateHash": "15141668408029376015"
                     }
                   },
                   "parameters": {
@@ -179,7 +177,6 @@
                       "type": "object"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "defaultAuditActionsAndGroups": [
                       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
@@ -429,7 +426,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "14005243826429444249"
+                              "templateHash": "9146811373829415744"
                             }
                           },
                           "parameters": {
@@ -446,7 +443,6 @@
                               }
                             }
                           },
-                          "functions": [],
                           "resources": [
                             {
                               "type": "Microsoft.Sql/servers/firewallRules",
@@ -495,7 +491,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17820208337665717935"
+                              "templateHash": "6379589353022514288"
                             }
                           },
                           "parameters": {
@@ -515,7 +511,6 @@
                               "type": "object"
                             }
                           },
-                          "functions": [],
                           "resources": [
                             {
                               "type": "Microsoft.Sql/servers/databases",
@@ -664,7 +659,7 @@
                                     "_generator": {
                                       "name": "bicep",
                                       "version": "dev",
-                                      "templateHash": "13857232367360321477"
+                                      "templateHash": "2953203708405635961"
                                     }
                                   },
                                   "parameters": {
@@ -675,7 +670,6 @@
                                       "type": "string"
                                     }
                                   },
-                                  "functions": [],
                                   "resources": [
                                     {
                                       "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
@@ -717,7 +711,7 @@
                                     "_generator": {
                                       "name": "bicep",
                                       "version": "dev",
-                                      "templateHash": "2829092679645401993"
+                                      "templateHash": "12798430629813662906"
                                     }
                                   },
                                   "parameters": {
@@ -728,7 +722,6 @@
                                       "type": "string"
                                     }
                                   },
-                                  "functions": [],
                                   "resources": [
                                     {
                                       "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
@@ -773,7 +766,7 @@
                                     "_generator": {
                                       "name": "bicep",
                                       "version": "dev",
-                                      "templateHash": "5447449594683998530"
+                                      "templateHash": "336987510423517988"
                                     }
                                   },
                                   "parameters": {
@@ -784,7 +777,6 @@
                                       "type": "string"
                                     }
                                   },
-                                  "functions": [],
                                   "variables": {
                                     "defaultAuditActionsAndGroups": [
                                       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/docs/examples/301/sql-database-with-management/modules/audit-settings.json
+++ b/docs/examples/301/sql-database-with-management/modules/audit-settings.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5447449594683998530"
+      "templateHash": "336987510423517988"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "defaultAuditActionsAndGroups": [
       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/docs/examples/301/sql-database-with-management/modules/azure-defender.json
+++ b/docs/examples/301/sql-database-with-management/modules/azure-defender.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2829092679645401993"
+      "templateHash": "12798430629813662906"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",

--- a/docs/examples/301/sql-database-with-management/modules/short-term-backup.json
+++ b/docs/examples/301/sql-database-with-management/modules/short-term-backup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13857232367360321477"
+      "templateHash": "2953203708405635961"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",

--- a/docs/examples/301/sql-database-with-management/modules/sql-database.json
+++ b/docs/examples/301/sql-database-with-management/modules/sql-database.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17820208337665717935"
+      "templateHash": "6379589353022514288"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "type": "object"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Sql/servers/databases",
@@ -174,7 +173,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13857232367360321477"
+              "templateHash": "2953203708405635961"
             }
           },
           "parameters": {
@@ -185,7 +184,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
@@ -227,7 +225,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2829092679645401993"
+              "templateHash": "12798430629813662906"
             }
           },
           "parameters": {
@@ -238,7 +236,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
@@ -283,7 +280,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5447449594683998530"
+              "templateHash": "336987510423517988"
             }
           },
           "parameters": {
@@ -294,7 +291,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "defaultAuditActionsAndGroups": [
               "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/docs/examples/301/sql-database-with-management/modules/sql-firewall-rule.json
+++ b/docs/examples/301/sql-database-with-management/modules/sql-firewall-rule.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14005243826429444249"
+      "templateHash": "9146811373829415744"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       }
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Sql/servers/firewallRules",

--- a/docs/examples/301/sql-database-with-management/modules/sql-logical-server.json
+++ b/docs/examples/301/sql-database-with-management/modules/sql-logical-server.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7713578241009111792"
+      "templateHash": "15141668408029376015"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "type": "object"
     }
   },
-  "functions": [],
   "variables": {
     "defaultAuditActionsAndGroups": [
       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
@@ -275,7 +274,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14005243826429444249"
+              "templateHash": "9146811373829415744"
             }
           },
           "parameters": {
@@ -292,7 +291,6 @@
               }
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Sql/servers/firewallRules",
@@ -341,7 +339,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17820208337665717935"
+              "templateHash": "6379589353022514288"
             }
           },
           "parameters": {
@@ -361,7 +359,6 @@
               "type": "object"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Sql/servers/databases",
@@ -510,7 +507,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "13857232367360321477"
+                      "templateHash": "2953203708405635961"
                     }
                   },
                   "parameters": {
@@ -521,7 +518,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
@@ -563,7 +559,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "2829092679645401993"
+                      "templateHash": "12798430629813662906"
                     }
                   },
                   "parameters": {
@@ -574,7 +570,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
@@ -619,7 +614,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "5447449594683998530"
+                      "templateHash": "336987510423517988"
                     }
                   },
                   "parameters": {
@@ -630,7 +625,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "defaultAuditActionsAndGroups": [
                       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/docs/examples/301/sql-database-with-management/modules/sql-logical-servers.json
+++ b/docs/examples/301/sql-database-with-management/modules/sql-logical-servers.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13336441185399082470"
+      "templateHash": "12921433042511684704"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "object"
     }
   },
-  "functions": [],
   "variables": {
     "defaultSqlLogicalServerProperties": {
       "name": "",
@@ -106,7 +105,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7713578241009111792"
+              "templateHash": "15141668408029376015"
             }
           },
           "parameters": {
@@ -126,7 +125,6 @@
               "type": "object"
             }
           },
-          "functions": [],
           "variables": {
             "defaultAuditActionsAndGroups": [
               "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
@@ -376,7 +374,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "14005243826429444249"
+                      "templateHash": "9146811373829415744"
                     }
                   },
                   "parameters": {
@@ -393,7 +391,6 @@
                       }
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Sql/servers/firewallRules",
@@ -442,7 +439,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "17820208337665717935"
+                      "templateHash": "6379589353022514288"
                     }
                   },
                   "parameters": {
@@ -462,7 +459,6 @@
                       "type": "object"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Sql/servers/databases",
@@ -611,7 +607,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "13857232367360321477"
+                              "templateHash": "2953203708405635961"
                             }
                           },
                           "parameters": {
@@ -622,7 +618,6 @@
                               "type": "string"
                             }
                           },
-                          "functions": [],
                           "resources": [
                             {
                               "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
@@ -664,7 +659,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "2829092679645401993"
+                              "templateHash": "12798430629813662906"
                             }
                           },
                           "parameters": {
@@ -675,7 +670,6 @@
                               "type": "string"
                             }
                           },
-                          "functions": [],
                           "resources": [
                             {
                               "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
@@ -720,7 +714,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "5447449594683998530"
+                              "templateHash": "336987510423517988"
                             }
                           },
                           "parameters": {
@@ -731,7 +725,6 @@
                               "type": "string"
                             }
                           },
-                          "functions": [],
                           "variables": {
                             "defaultAuditActionsAndGroups": [
                               "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/docs/examples/301/web-app-managed-identity-sql-db/main.json
+++ b/docs/examples/301/web-app-managed-identity-sql-db/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11111261162854596376"
+      "templateHash": "6304729299566766267"
     }
   },
   "parameters": {
@@ -50,7 +50,6 @@
       "defaultValue": "b24988ac-6180-42a0-ab88-20f7382dd24c"
     }
   },
-  "functions": [],
   "variables": {
     "hostingPlanName": "[format('hostingplan{0}', uniqueString(resourceGroup().id))]",
     "webSiteName": "[format('webSite{0}', uniqueString(resourceGroup().id))]",

--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -205,7 +205,7 @@ Hello from Bicep!"));
     ""_generator"": {
       ""name"": ""bicep"",
       ""version"": ""dev"",
-      ""templateHash"": ""9158779975087827920""
+      ""templateHash"": ""16730399226644616469""
     }
   },
   ""parameters"": {
@@ -213,7 +213,6 @@ Hello from Bicep!"));
       ""type"": ""string""
     }
   },
-  ""functions"": [],
   ""resources"": {
     ""stgAccount"": {
       ""type"": ""Microsoft.Storage/storageAccounts"",
@@ -248,7 +247,7 @@ Hello from Bicep!"));
             ""_generator"": {
               ""name"": ""bicep"",
               ""version"": ""dev"",
-              ""templateHash"": ""16326706520666172134""
+              ""templateHash"": ""10447496472055117853""
             }
           },
           ""parameters"": {
@@ -256,7 +255,6 @@ Hello from Bicep!"));
               ""type"": ""secureString""
             }
           },
-          ""functions"": [],
           ""imports"": {
             ""stg"": {
               ""provider"": ""AzureStorage"",

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -2778,5 +2778,21 @@ output out4 string = 'hello' + 'world'
                 ("BCP045", DiagnosticLevel.Error, "Cannot apply operator \"+\" to operands of type \"'hello'\" and \"'world'\". Use string interpolation instead.")
             });
         }
+
+        // https://github.com/Azure/bicep/issues/3749
+        [TestMethod]
+        public void Test_Issue3749()
+        {
+            // missing new line at the start and end of the object
+            var result = CompilationHelper.Compile(@"
+param foo string
+param bar string
+
+output out1 string = foo
+");
+
+            result.Template.Should().NotHaveValueAtPath("$.functions");
+            result.Should().OnlyContainDiagnostic("no-unused-params", DiagnosticLevel.Warning, "Parameter \"bar\" is declared but never used.");
+        }
     }
 }

--- a/src/Bicep.Core.Samples/Files/AKS_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/AKS_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6180820816529192267"
+      "templateHash": "9016440230757337651"
     }
   },
   "parameters": {
@@ -49,7 +49,6 @@
       "defaultValue": "Standard_DS2_v2"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ContainerService/managedClusters",

--- a/src/Bicep.Core.Samples/Files/AKS_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/AKS_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9971488615286434153"
+      "templateHash": "1972295839313712854"
     }
   },
   "parameters": {
@@ -51,7 +51,6 @@
       "defaultValue": "Standard_DS2_v2"
     }
   },
-  "functions": [],
   "resources": {
     "aks": {
       "type": "Microsoft.ContainerService/managedClusters",

--- a/src/Bicep.Core.Samples/Files/Dependencies_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Dependencies_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14200432294566499835"
+      "templateHash": "7668963420318347864"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "defaultValue": "steve"
     }
   },
-  "functions": [],
   "variables": {
     "deployTimeVar": "nigel",
     "dependentVar": {

--- a/src/Bicep.Core.Samples/Files/Dependencies_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Dependencies_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16530369506774489957"
+      "templateHash": "14685136966221240722"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "defaultValue": "steve"
     }
   },
-  "functions": [],
   "variables": {
     "deployTimeVar": "nigel",
     "dependentVar": {

--- a/src/Bicep.Core.Samples/Files/DisableNextLineDiagnosticsDirective_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/DisableNextLineDiagnosticsDirective_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7325700590945300032"
+      "templateHash": "10265253010862566764"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "defaultValue": "testStorageAccount"
     }
   },
-  "functions": [],
   "variables": {
     "vmProperties": {
       "diagnosticsProfile": {

--- a/src/Bicep.Core.Samples/Files/DisableNextLineDiagnosticsDirective_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/DisableNextLineDiagnosticsDirective_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3833569478389834963"
+      "templateHash": "15068560912148769948"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "testStorageAccount"
     }
   },
-  "functions": [],
   "variables": {
     "vmProperties": {
       "diagnosticsProfile": {

--- a/src/Bicep.Core.Samples/Files/Empty/main.json
+++ b/src/Bicep.Core.Samples/Files/Empty/main.json
@@ -5,9 +5,8 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17010621301386190"
+      "templateHash": "12740863314443779634"
     }
   },
-  "functions": [],
   "resources": []
 }

--- a/src/Bicep.Core.Samples/Files/Empty/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Empty/main.symbolicnames.json
@@ -7,9 +7,8 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16782108113460109987"
+      "templateHash": "1249206478152780556"
     }
   },
-  "functions": [],
   "resources": {}
 }

--- a/src/Bicep.Core.Samples/Files/IntermediaryVariables_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/IntermediaryVariables_LF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17933762267756232561"
+      "templateHash": "11118299664848190018"
     }
   },
-  "functions": [],
   "variables": {
     "copy": [
       {

--- a/src/Bicep.Core.Samples/Files/IntermediaryVariables_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/IntermediaryVariables_LF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3804865924597182597"
+      "templateHash": "2182740218108153565"
     }
   },
-  "functions": [],
   "variables": {
     "copy": [
       {

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/moduled.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/moduled.json
@@ -17,7 +17,6 @@
     }
   },
   "variables": {},
-  "functions": [],
   "resources": [
   ],
   "outputs": {}

--- a/src/Bicep.Core.Samples/Files/LargeTemplate_Stress_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/LargeTemplate_Stress_LF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18229817273387110064"
+      "templateHash": "10080301090781247662"
     }
   },
-  "functions": [],
   "variables": {
     "test": [
       {},

--- a/src/Bicep.Core.Samples/Files/LargeTemplate_Stress_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/LargeTemplate_Stress_LF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13546617579620654762"
+      "templateHash": "8474193105824245405"
     }
   },
-  "functions": [],
   "variables": {
     "test": [
       {},

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17833570492578988092"
+      "templateHash": "14848888791268729508"
     }
   },
-  "functions": [],
   "variables": {
     "loadedText1": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\r\n\tProin varius in nunc et laoreet.\r\n  Nam pulvinar ipsum sed lectus porttitor, at porttitor ipsum faucibus.\r\n  \tAliquam euismod, odio tincidunt convallis pulvinar, felis sem porttitor turpis, a condimentum dui erat nec tellus.\r\n  Duis elementum cursus est, congue efficitur risus.\r\n\tMauris sit amet.\r\nExcepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n",
     "loadedText2": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
@@ -85,7 +84,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2604694273145136377"
+              "templateHash": "8283448113925260975"
             }
           },
           "parameters": {
@@ -93,7 +92,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": []
         }
       }
@@ -119,7 +117,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2604694273145136377"
+              "templateHash": "8283448113925260975"
             }
           },
           "parameters": {
@@ -127,7 +125,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": []
         }
       }

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "225048583879521361"
+      "templateHash": "2718842242410903783"
     }
   },
-  "functions": [],
   "variables": {
     "loadedText1": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\r\n\tProin varius in nunc et laoreet.\r\n  Nam pulvinar ipsum sed lectus porttitor, at porttitor ipsum faucibus.\r\n  \tAliquam euismod, odio tincidunt convallis pulvinar, felis sem porttitor turpis, a condimentum dui erat nec tellus.\r\n  Duis elementum cursus est, congue efficitur risus.\r\n\tMauris sit amet.\r\nExcepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\r\n",
     "loadedText2": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
@@ -89,7 +88,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9609610930880808495"
+              "templateHash": "13015323608273881861"
             }
           },
           "parameters": {
@@ -97,7 +96,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {}
         }
       }
@@ -125,7 +123,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9609610930880808495"
+              "templateHash": "13015323608273881861"
             }
           },
           "parameters": {
@@ -133,7 +131,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {}
         }
       }

--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6252727050195852008"
+      "templateHash": "2314675668532301895"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "int"
     }
   },
-  "functions": [],
   "variables": {
     "vnetConfigurations": [
       {
@@ -421,7 +420,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -429,7 +428,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -467,7 +465,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -475,7 +473,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -515,7 +512,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -523,7 +520,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -559,7 +555,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -567,7 +563,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -608,7 +603,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -616,7 +611,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -657,7 +651,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -665,7 +659,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {

--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11875800929175748875"
+      "templateHash": "5991333156697487016"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "int"
     }
   },
-  "functions": [],
   "variables": {
     "vnetConfigurations": [
       {
@@ -435,7 +434,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -443,7 +442,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -483,7 +481,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -491,7 +489,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -533,7 +530,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -541,7 +538,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -579,7 +575,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -587,7 +583,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -630,7 +625,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -638,7 +633,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -681,7 +675,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -689,7 +683,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13842042192424725038"
+      "templateHash": "1859129425407400548"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "int"
     }
   },
-  "functions": [],
   "variables": {
     "vnetConfigurations": [
       {
@@ -443,7 +442,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -451,7 +450,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -489,7 +487,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -497,7 +495,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -537,7 +534,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -545,7 +542,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -581,7 +577,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -589,7 +585,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -630,7 +625,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -638,7 +633,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -679,7 +673,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -687,7 +681,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -724,7 +717,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -732,7 +725,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {
@@ -769,7 +761,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9254499349295781979"
+              "templateHash": "14375999048727010492"
             }
           },
           "parameters": {
@@ -777,7 +769,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "myOutput": {

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9421149111910721032"
+      "templateHash": "4677966447708206616"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "int"
     }
   },
-  "functions": [],
   "variables": {
     "vnetConfigurations": [
       {
@@ -457,7 +456,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -465,7 +464,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -505,7 +503,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -513,7 +511,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -555,7 +552,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -563,7 +560,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -601,7 +597,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -609,7 +605,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -652,7 +647,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -660,7 +655,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -703,7 +697,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -711,7 +705,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -750,7 +743,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -758,7 +751,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {
@@ -797,7 +789,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16677402125539667887"
+              "templateHash": "6221643429023379733"
             }
           },
           "parameters": {
@@ -805,7 +797,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "myOutput": {

--- a/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11255138175414255618"
+      "templateHash": "12683322013974962530"
     }
   },
   "parameters": {
@@ -14,7 +14,6 @@
       "defaultValue": "majastrz"
     }
   },
-  "functions": [],
   "variables": {
     "groups": [
       "bicep1",
@@ -61,7 +60,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6131559399212667737"
+              "templateHash": "9518912405470532169"
             }
           },
           "parameters": {
@@ -69,7 +68,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Resources/deploymentScripts",
@@ -122,7 +120,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6131559399212667737"
+              "templateHash": "9518912405470532169"
             }
           },
           "parameters": {
@@ -130,7 +128,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Resources/deploymentScripts",

--- a/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8193330612892248610"
+      "templateHash": "9940822325495192514"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "defaultValue": "majastrz"
     }
   },
-  "functions": [],
   "variables": {
     "groups": [
       "bicep1",
@@ -65,7 +64,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7808808203419259898"
+              "templateHash": "9485730268039858376"
             }
           },
           "parameters": {
@@ -73,7 +72,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "script": {
               "type": "Microsoft.Resources/deploymentScripts",
@@ -128,7 +126,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7808808203419259898"
+              "templateHash": "9485730268039858376"
             }
           },
           "parameters": {
@@ -136,7 +134,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "script": {
               "type": "Microsoft.Resources/deploymentScripts",

--- a/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2781207168497950503"
+      "templateHash": "9953290088275834912"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
@@ -28,10 +27,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9877962590465051990"
+              "templateHash": "14837156659711607947"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
@@ -51,10 +49,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7186981207559950852"
+                      "templateHash": "15729984543815100695"
                     }
                   },
-                  "functions": [],
                   "resources": [],
                   "outputs": {
                     "myOutput": {
@@ -83,10 +80,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "14461866382005670926"
+                      "templateHash": "2139830058681583241"
                     }
                   },
-                  "functions": [],
                   "resources": []
                 }
               }
@@ -109,10 +105,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "17449021711969342669"
+                      "templateHash": "1395382333336833730"
                     }
                   },
-                  "functions": [],
                   "resources": []
                 }
               }
@@ -145,10 +140,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14461866382005670926"
+              "templateHash": "2139830058681583241"
             }
           },
-          "functions": [],
           "resources": []
         }
       }
@@ -171,10 +165,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18061624106415456848"
+              "templateHash": "7511971768810580074"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
@@ -193,10 +186,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "10147675461470298011"
+                      "templateHash": "12489028739876509792"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
@@ -216,10 +208,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7186981207559950852"
+                              "templateHash": "15729984543815100695"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -248,10 +239,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17592458934032508201"
+                              "templateHash": "7469434526073292388"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -280,10 +270,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -306,10 +295,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -345,10 +333,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "10147675461470298011"
+                      "templateHash": "12489028739876509792"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
@@ -368,10 +355,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7186981207559950852"
+                              "templateHash": "15729984543815100695"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -400,10 +386,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17592458934032508201"
+                              "templateHash": "7469434526073292388"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -432,10 +417,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -458,10 +442,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -498,10 +481,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "10147675461470298011"
+                      "templateHash": "12489028739876509792"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
@@ -521,10 +503,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7186981207559950852"
+                              "templateHash": "15729984543815100695"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -553,10 +534,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17592458934032508201"
+                              "templateHash": "7469434526073292388"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -585,10 +565,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -611,10 +590,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -651,10 +629,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7186981207559950852"
+                      "templateHash": "15729984543815100695"
                     }
                   },
-                  "functions": [],
                   "resources": [],
                   "outputs": {
                     "myOutput": {
@@ -702,10 +679,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18061624106415456848"
+              "templateHash": "7511971768810580074"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
@@ -724,10 +700,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "10147675461470298011"
+                      "templateHash": "12489028739876509792"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
@@ -747,10 +722,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7186981207559950852"
+                              "templateHash": "15729984543815100695"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -779,10 +753,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17592458934032508201"
+                              "templateHash": "7469434526073292388"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -811,10 +784,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -837,10 +809,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -876,10 +847,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "10147675461470298011"
+                      "templateHash": "12489028739876509792"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
@@ -899,10 +869,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7186981207559950852"
+                              "templateHash": "15729984543815100695"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -931,10 +900,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17592458934032508201"
+                              "templateHash": "7469434526073292388"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -963,10 +931,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -989,10 +956,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -1029,10 +995,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "10147675461470298011"
+                      "templateHash": "12489028739876509792"
                     }
                   },
-                  "functions": [],
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
@@ -1052,10 +1017,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7186981207559950852"
+                              "templateHash": "15729984543815100695"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -1084,10 +1048,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17592458934032508201"
+                              "templateHash": "7469434526073292388"
                             }
                           },
-                          "functions": [],
                           "resources": [],
                           "outputs": {
                             "myOutput": {
@@ -1116,10 +1079,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -1142,10 +1104,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17449021711969342669"
+                              "templateHash": "1395382333336833730"
                             }
                           },
-                          "functions": [],
                           "resources": []
                         }
                       }
@@ -1182,10 +1143,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7186981207559950852"
+                      "templateHash": "15729984543815100695"
                     }
                   },
-                  "functions": [],
                   "resources": [],
                   "outputs": {
                     "myOutput": {
@@ -1232,10 +1192,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17449021711969342669"
+              "templateHash": "1395382333336833730"
             }
           },
-          "functions": [],
           "resources": []
         }
       }

--- a/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9451425537701688468"
+      "templateHash": "9285317521394475539"
     }
   },
-  "functions": [],
   "resources": {
     "myManagementGroupMod": {
       "type": "Microsoft.Resources/deployments",
@@ -32,10 +31,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16280859909667524604"
+              "templateHash": "8693938215366824450"
             }
           },
-          "functions": [],
           "resources": {
             "myTenantMod": {
               "type": "Microsoft.Resources/deployments",
@@ -57,10 +55,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "13795227476051739062"
+                      "templateHash": "5192803437910961230"
                     }
                   },
-                  "functions": [],
                   "resources": {},
                   "outputs": {
                     "myOutput": {
@@ -91,10 +88,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "797197645865752552"
+                      "templateHash": "8579565390553187175"
                     }
                   },
-                  "functions": [],
                   "resources": {}
                 }
               }
@@ -119,10 +115,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7728902878217370074"
+                      "templateHash": "5913949326104398861"
                     }
                   },
-                  "functions": [],
                   "resources": {}
                 }
               }
@@ -157,10 +152,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "797197645865752552"
+              "templateHash": "8579565390553187175"
             }
           },
-          "functions": [],
           "resources": {}
         }
       }
@@ -185,10 +179,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5050669221819578396"
+              "templateHash": "2134859116493901568"
             }
           },
-          "functions": [],
           "resources": {
             "myResourceGroupMod": {
               "type": "Microsoft.Resources/deployments",
@@ -209,10 +202,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "8706733343442957113"
+                      "templateHash": "5013142189424141217"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
@@ -234,10 +226,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "13795227476051739062"
+                              "templateHash": "5192803437910961230"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -268,10 +259,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17932567062051050182"
+                              "templateHash": "2040383910825521107"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -302,10 +292,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -330,10 +319,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -371,10 +359,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "8706733343442957113"
+                      "templateHash": "5013142189424141217"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
@@ -396,10 +383,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "13795227476051739062"
+                              "templateHash": "5192803437910961230"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -430,10 +416,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17932567062051050182"
+                              "templateHash": "2040383910825521107"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -464,10 +449,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -492,10 +476,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -534,10 +517,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "8706733343442957113"
+                      "templateHash": "5013142189424141217"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
@@ -559,10 +541,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "13795227476051739062"
+                              "templateHash": "5192803437910961230"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -593,10 +574,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17932567062051050182"
+                              "templateHash": "2040383910825521107"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -627,10 +607,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -655,10 +634,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -697,10 +675,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "13795227476051739062"
+                      "templateHash": "5192803437910961230"
                     }
                   },
-                  "functions": [],
                   "resources": {},
                   "outputs": {
                     "myOutput": {
@@ -750,10 +727,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5050669221819578396"
+              "templateHash": "2134859116493901568"
             }
           },
-          "functions": [],
           "resources": {
             "myResourceGroupMod": {
               "type": "Microsoft.Resources/deployments",
@@ -774,10 +750,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "8706733343442957113"
+                      "templateHash": "5013142189424141217"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
@@ -799,10 +774,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "13795227476051739062"
+                              "templateHash": "5192803437910961230"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -833,10 +807,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17932567062051050182"
+                              "templateHash": "2040383910825521107"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -867,10 +840,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -895,10 +867,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -936,10 +907,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "8706733343442957113"
+                      "templateHash": "5013142189424141217"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
@@ -961,10 +931,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "13795227476051739062"
+                              "templateHash": "5192803437910961230"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -995,10 +964,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17932567062051050182"
+                              "templateHash": "2040383910825521107"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -1029,10 +997,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -1057,10 +1024,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -1099,10 +1065,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "8706733343442957113"
+                      "templateHash": "5013142189424141217"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
@@ -1124,10 +1089,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "13795227476051739062"
+                              "templateHash": "5192803437910961230"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -1158,10 +1122,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "17932567062051050182"
+                              "templateHash": "2040383910825521107"
                             }
                           },
-                          "functions": [],
                           "resources": {},
                           "outputs": {
                             "myOutput": {
@@ -1192,10 +1155,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -1220,10 +1182,9 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7728902878217370074"
+                              "templateHash": "5913949326104398861"
                             }
                           },
-                          "functions": [],
                           "resources": {}
                         }
                       }
@@ -1262,10 +1223,9 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "13795227476051739062"
+                      "templateHash": "5192803437910961230"
                     }
                   },
-                  "functions": [],
                   "resources": {},
                   "outputs": {
                     "myOutput": {
@@ -1314,10 +1274,9 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7728902878217370074"
+              "templateHash": "5913949326104398861"
             }
           },
-          "functions": [],
           "resources": {}
         }
       }

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/child/modulec.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/child/modulec.json
@@ -7,7 +7,6 @@
     }
   },
   "variables": {},
-  "functions": [],
   "resources": [
     {
       "name": "myResource",

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18326271388556339005"
+      "templateHash": "12079244958605727878"
     }
   },
   "parameters": {
@@ -17,7 +17,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "myModules": [
       {
@@ -121,7 +120,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -139,7 +138,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -202,7 +200,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2690166781482293239"
+              "templateHash": "13693869390953445824"
             }
           },
           "parameters": {
@@ -210,7 +208,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -253,7 +250,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2690166781482293239"
+              "templateHash": "13693869390953445824"
             }
           },
           "parameters": {
@@ -261,7 +258,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -302,7 +298,6 @@
             }
           },
           "variables": {},
-          "functions": [],
           "resources": [
             {
               "name": "myResource",
@@ -344,7 +339,6 @@
             }
           },
           "variables": {},
-          "functions": [],
           "resources": [
             {
               "name": "myResource",
@@ -378,7 +372,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10738077103160673326"
+              "templateHash": "4191259681487754679"
             }
           },
           "parameters": {
@@ -405,7 +399,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "outputObj": {
@@ -438,7 +431,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10738077103160673326"
+              "templateHash": "4191259681487754679"
             }
           },
           "parameters": {
@@ -465,7 +458,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "outputObj": {
@@ -511,7 +503,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10738077103160673326"
+              "templateHash": "4191259681487754679"
             }
           },
           "parameters": {
@@ -538,7 +530,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "outputObj": {
@@ -584,7 +575,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10738077103160673326"
+              "templateHash": "4191259681487754679"
             }
           },
           "parameters": {
@@ -611,7 +602,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "outputObj": {
@@ -661,7 +651,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10738077103160673326"
+              "templateHash": "4191259681487754679"
             }
           },
           "parameters": {
@@ -688,7 +678,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "outputObj": {
@@ -738,7 +727,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10738077103160673326"
+              "templateHash": "4191259681487754679"
             }
           },
           "parameters": {
@@ -765,7 +754,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "outputObj": {
@@ -816,7 +804,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -834,7 +822,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -909,7 +896,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -927,7 +914,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -1003,7 +989,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -1021,7 +1007,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -1100,7 +1085,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -1118,7 +1103,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -1197,7 +1181,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -1215,7 +1199,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -1291,7 +1274,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -1309,7 +1292,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -1414,7 +1396,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -1432,7 +1414,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -1538,7 +1519,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -1556,7 +1537,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -1665,7 +1645,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13267921988990488399"
+              "templateHash": "454017335624971246"
             }
           },
           "parameters": {
@@ -1683,7 +1663,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Mock.Rp/mockResource",
@@ -1757,7 +1736,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8835955120763275123"
+              "templateHash": "15522334618541518671"
             }
           },
           "parameters": {
@@ -1769,7 +1748,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "exposedSecureString": {
@@ -1815,7 +1793,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8835955120763275123"
+              "templateHash": "15522334618541518671"
             }
           },
           "parameters": {
@@ -1827,7 +1805,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "exposedSecureString": {
@@ -1877,7 +1854,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8835955120763275123"
+              "templateHash": "15522334618541518671"
             }
           },
           "parameters": {
@@ -1889,7 +1866,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "exposedSecureString": {
@@ -1916,7 +1892,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7552407620176760980"
+              "templateHash": "1347091426241151379"
             }
           },
           "parameters": {
@@ -1925,7 +1901,6 @@
               "defaultValue": "westus"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "loc": {
@@ -1952,7 +1927,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7552407620176760980"
+              "templateHash": "1347091426241151379"
             }
           },
           "parameters": {
@@ -1961,7 +1936,6 @@
               "defaultValue": "westus"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "loc": {

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2219703399229896567"
+      "templateHash": "892041710681338064"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "myModules": [
       {
@@ -147,7 +146,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -165,7 +164,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -230,7 +228,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6572075570921491216"
+              "templateHash": "6637013673043956613"
             }
           },
           "parameters": {
@@ -238,7 +236,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "myResource": {
               "type": "Mock.Rp/mockResource",
@@ -283,7 +280,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6572075570921491216"
+              "templateHash": "6637013673043956613"
             }
           },
           "parameters": {
@@ -291,7 +288,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "myResource": {
               "type": "Mock.Rp/mockResource",
@@ -332,7 +328,6 @@
             }
           },
           "variables": {},
-          "functions": [],
           "resources": [
             {
               "name": "myResource",
@@ -374,7 +369,6 @@
             }
           },
           "variables": {},
-          "functions": [],
           "resources": [
             {
               "name": "myResource",
@@ -410,7 +404,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1070180491716064275"
+              "templateHash": "4287484651820756942"
             }
           },
           "parameters": {
@@ -437,7 +431,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "outputObj": {
@@ -472,7 +465,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1070180491716064275"
+              "templateHash": "4287484651820756942"
             }
           },
           "parameters": {
@@ -499,7 +492,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "outputObj": {
@@ -547,7 +539,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1070180491716064275"
+              "templateHash": "4287484651820756942"
             }
           },
           "parameters": {
@@ -574,7 +566,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "outputObj": {
@@ -622,7 +613,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1070180491716064275"
+              "templateHash": "4287484651820756942"
             }
           },
           "parameters": {
@@ -649,7 +640,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "outputObj": {
@@ -701,7 +691,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1070180491716064275"
+              "templateHash": "4287484651820756942"
             }
           },
           "parameters": {
@@ -728,7 +718,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "outputObj": {
@@ -780,7 +769,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1070180491716064275"
+              "templateHash": "4287484651820756942"
             }
           },
           "parameters": {
@@ -807,7 +796,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "outputObj": {
@@ -860,7 +848,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -878,7 +866,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -955,7 +942,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -973,7 +960,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -1051,7 +1037,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -1069,7 +1055,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -1150,7 +1135,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -1168,7 +1153,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -1249,7 +1233,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -1267,7 +1251,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -1345,7 +1328,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -1363,7 +1346,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -1470,7 +1452,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -1488,7 +1470,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -1596,7 +1577,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -1614,7 +1595,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -1725,7 +1705,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18057694821683840069"
+              "templateHash": "18418380103340601060"
             }
           },
           "parameters": {
@@ -1743,7 +1723,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "basicStorage": {
               "type": "Mock.Rp/mockResource",
@@ -1819,7 +1798,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10432101837374249677"
+              "templateHash": "4810941191388001716"
             }
           },
           "parameters": {
@@ -1831,7 +1810,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "exposedSecureString": {
@@ -1879,7 +1857,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10432101837374249677"
+              "templateHash": "4810941191388001716"
             }
           },
           "parameters": {
@@ -1891,7 +1869,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "exposedSecureString": {
@@ -1943,7 +1920,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10432101837374249677"
+              "templateHash": "4810941191388001716"
             }
           },
           "parameters": {
@@ -1955,7 +1932,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "exposedSecureString": {
@@ -1984,7 +1960,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11505952790079205229"
+              "templateHash": "3151588781798756865"
             }
           },
           "parameters": {
@@ -1993,7 +1969,6 @@
               "defaultValue": "westus"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "loc": {
@@ -2022,7 +1997,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11505952790079205229"
+              "templateHash": "3151588781798756865"
             }
           },
           "parameters": {
@@ -2031,7 +2006,6 @@
               "defaultValue": "westus"
             }
           },
-          "functions": [],
           "resources": {},
           "outputs": {
             "loc": {

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3957939271160532086"
+      "templateHash": "17608560117045014269"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "bool"
     }
   },
-  "functions": [],
   "variables": {
     "items": [
       "a",

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6448654680612256108"
+      "templateHash": "15395751030098486023"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "bool"
     }
   },
-  "functions": [],
   "variables": {
     "items": [
       "a",

--- a/src/Bicep.Core.Samples/Files/Outputs_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Outputs_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5451171354963125801"
+      "templateHash": "16196292690847002686"
     }
   },
   "parameters": {
@@ -13,7 +13,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "varWithOverlappingOutput": "hello"
   },

--- a/src/Bicep.Core.Samples/Files/Outputs_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Outputs_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14167964906188646820"
+      "templateHash": "10045053806153862855"
     }
   },
   "parameters": {
@@ -15,7 +15,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "varWithOverlappingOutput": "hello"
   },

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2537872389677377067"
+      "templateHash": "517357840239191871"
     }
   },
   "parameters": {
@@ -222,6 +222,5 @@
       "maxLength": 20
     }
   },
-  "functions": [],
   "resources": []
 }

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1604298324060108067"
+      "templateHash": "16914771096237055388"
     }
   },
   "parameters": {
@@ -224,6 +224,5 @@
       "maxLength": 20
     }
   },
-  "functions": [],
   "resources": {}
 }

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1706136566230351855"
+      "templateHash": "14638900775751402738"
     }
   },
   "parameters": {
@@ -232,6 +232,5 @@
       "maxLength": 20
     }
   },
-  "functions": [],
   "resources": []
 }

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14823644294419510839"
+      "templateHash": "10722652887416726913"
     }
   },
   "parameters": {
@@ -234,6 +234,5 @@
       "maxLength": 20
     }
   },
-  "functions": [],
   "resources": {}
 }

--- a/src/Bicep.Core.Samples/Files/Registry_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Registry_LF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12155511442967661456"
+      "templateHash": "12951815579850745399"
     }
   },
-  "functions": [],
   "variables": {
     "websites": [
       {
@@ -60,7 +59,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4938872769570543882"
+              "templateHash": "15019246960605065046"
             }
           },
           "parameters": {
@@ -72,7 +71,6 @@
               "defaultValue": "B1"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Web/serverfarms",
@@ -122,7 +120,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4938872769570543882"
+              "templateHash": "15019246960605065046"
             }
           },
           "parameters": {
@@ -134,7 +132,6 @@
               "defaultValue": "B1"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Web/serverfarms",
@@ -197,7 +194,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "228337352270462398"
+              "templateHash": "16733674086069502117"
             }
           },
           "parameters": {
@@ -218,7 +215,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Web/sites",
@@ -299,7 +295,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "228337352270462398"
+              "templateHash": "16733674086069502117"
             }
           },
           "parameters": {
@@ -320,7 +316,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Web/sites",
@@ -464,7 +459,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11372722735750462419"
+              "templateHash": "2505217721104922110"
             }
           },
           "parameters": {
@@ -472,7 +467,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "port": {
@@ -508,7 +502,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13832203834710666930"
+              "templateHash": "12121705673191614943"
             }
           },
           "parameters": {
@@ -516,7 +510,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "ipv4": {
@@ -552,7 +545,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6585722063237736357"
+              "templateHash": "7823936554124086035"
             }
           },
           "parameters": {
@@ -560,7 +553,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "ipv4port": {
@@ -596,7 +588,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15909077893907372746"
+              "templateHash": "5093140793351809054"
             }
           },
           "parameters": {
@@ -604,7 +596,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "ipv6": {
@@ -640,7 +631,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1421603444460114359"
+              "templateHash": "969477156678070948"
             }
           },
           "parameters": {
@@ -648,7 +639,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "ipv6port": {

--- a/src/Bicep.Core.Samples/Files/Registry_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Registry_LF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7694139291897762231"
+      "templateHash": "3495279111630936794"
     }
   },
-  "functions": [],
   "variables": {
     "websites": [
       {
@@ -62,7 +61,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4938872769570543882"
+              "templateHash": "15019246960605065046"
             }
           },
           "parameters": {
@@ -74,7 +73,6 @@
               "defaultValue": "B1"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Web/serverfarms",
@@ -124,7 +122,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4938872769570543882"
+              "templateHash": "15019246960605065046"
             }
           },
           "parameters": {
@@ -136,7 +134,6 @@
               "defaultValue": "B1"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Web/serverfarms",
@@ -199,7 +196,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "228337352270462398"
+              "templateHash": "16733674086069502117"
             }
           },
           "parameters": {
@@ -220,7 +217,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Web/sites",
@@ -301,7 +297,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "228337352270462398"
+              "templateHash": "16733674086069502117"
             }
           },
           "parameters": {
@@ -322,7 +318,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [
             {
               "type": "Microsoft.Web/sites",
@@ -466,7 +461,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11372722735750462419"
+              "templateHash": "2505217721104922110"
             }
           },
           "parameters": {
@@ -474,7 +469,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "port": {
@@ -510,7 +504,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13832203834710666930"
+              "templateHash": "12121705673191614943"
             }
           },
           "parameters": {
@@ -518,7 +512,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "ipv4": {
@@ -554,7 +547,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6585722063237736357"
+              "templateHash": "7823936554124086035"
             }
           },
           "parameters": {
@@ -562,7 +555,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "ipv4port": {
@@ -598,7 +590,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15909077893907372746"
+              "templateHash": "5093140793351809054"
             }
           },
           "parameters": {
@@ -606,7 +598,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "ipv6": {
@@ -642,7 +633,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1421603444460114359"
+              "templateHash": "969477156678070948"
             }
           },
           "parameters": {
@@ -650,7 +641,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": [],
           "outputs": {
             "ipv6port": {

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2821996608423621848"
+      "templateHash": "7073737674999620234"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Authorization/roleAssignments",

--- a/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/ResourcesManagementGroup_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12788406199508216443"
+      "templateHash": "6720899685906928501"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": {
     "owner": {
       "type": "Microsoft.Authorization/roleAssignments",

--- a/src/Bicep.Core.Samples/Files/ResourcesSubscription_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/ResourcesSubscription_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15798991469480854087"
+      "templateHash": "5636276313478268592"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Authorization/roleAssignments",

--- a/src/Bicep.Core.Samples/Files/ResourcesSubscription_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/ResourcesSubscription_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1743320483462000080"
+      "templateHash": "4931761800682122609"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": {
     "owner": {
       "type": "Microsoft.Authorization/roleAssignments",

--- a/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16074299724825260767"
+      "templateHash": "3469345291207429346"
     }
   },
-  "functions": [],
   "variables": {
     "managementGroups": [
       {

--- a/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9543823438320420064"
+      "templateHash": "12727959800773466862"
     }
   },
-  "functions": [],
   "variables": {
     "managementGroups": [
       {

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8321999725224914862"
+      "templateHash": "4897965198946026578"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       "defaultValue": true
     }
   },
-  "functions": [],
   "variables": {
     "hostingPlanName": "[parameters('applicationName')]",
     "location": "[resourceGroup().location]",

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "655941307434348616"
+      "templateHash": "9169360111549169913"
     }
   },
   "parameters": {
@@ -32,7 +32,6 @@
       "defaultValue": true
     }
   },
-  "functions": [],
   "variables": {
     "hostingPlanName": "[parameters('applicationName')]",
     "location": "[resourceGroup().location]",

--- a/src/Bicep.Core.Samples/Files/Unicode_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Unicode_LF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11590423349714353104"
+      "templateHash": "14957212358466844811"
     }
   },
-  "functions": [],
   "variables": {
     "emojis": "💪😊😈🍕☕",
     "ninjaCat": "🐱‍👤",

--- a/src/Bicep.Core.Samples/Files/Unicode_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Unicode_LF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16711869089173829770"
+      "templateHash": "13226086285105174826"
     }
   },
-  "functions": [],
   "variables": {
     "emojis": "💪😊😈🍕☕",
     "ninjaCat": "🐱‍👤",

--- a/src/Bicep.Core.Samples/Files/VariablesManagementGroup_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/VariablesManagementGroup_LF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17741954177192089607"
+      "templateHash": "14474387274517937293"
     }
   },
-  "functions": [],
   "variables": {
     "deploymentLocation": "[deployment().location]",
     "scopesWithArmRepresentation": {

--- a/src/Bicep.Core.Samples/Files/VariablesManagementGroup_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/VariablesManagementGroup_LF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2822310283818058049"
+      "templateHash": "14164987733159054799"
     }
   },
-  "functions": [],
   "variables": {
     "deploymentLocation": "[deployment().location]",
     "scopesWithArmRepresentation": {

--- a/src/Bicep.Core.Samples/Files/VariablesSubscription_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/VariablesSubscription_LF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9725769582191952212"
+      "templateHash": "18132682572862864781"
     }
   },
-  "functions": [],
   "variables": {
     "deploymentLocation": "[deployment().location]",
     "scopesWithArmRepresentation": {

--- a/src/Bicep.Core.Samples/Files/VariablesSubscription_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/VariablesSubscription_LF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2183892910287605192"
+      "templateHash": "17791810501975051656"
     }
   },
-  "functions": [],
   "variables": {
     "deploymentLocation": "[deployment().location]",
     "scopesWithArmRepresentation": {

--- a/src/Bicep.Core.Samples/Files/VariablesTenant_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/VariablesTenant_LF/main.json
@@ -5,10 +5,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3392336402006968988"
+      "templateHash": "9287755082425452314"
     }
   },
-  "functions": [],
   "variables": {
     "deploymentLocation": "[deployment().location]",
     "scopesWithArmRepresentation": {

--- a/src/Bicep.Core.Samples/Files/VariablesTenant_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/VariablesTenant_LF/main.symbolicnames.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9515858492227493845"
+      "templateHash": "18339823402766370363"
     }
   },
-  "functions": [],
   "variables": {
     "deploymentLocation": "[deployment().location]",
     "scopesWithArmRepresentation": {

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16129668488211519461"
+      "templateHash": "15538951648763968076"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "defaultValue": true
     }
   },
-  "functions": [],
   "variables": {
     "copy": [
       {

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "167637713640915716"
+      "templateHash": "6079751447973968942"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       "defaultValue": true
     }
   },
-  "functions": [],
   "variables": {
     "copy": [
       {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/01-hello-world/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/01-hello-world/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16487811083865212984"
+      "templateHash": "12423713358974211013"
     }
   },
   "parameters": {
@@ -15,7 +15,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "hello": "Hello World! - Hi"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/10-string-functions/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/10-string-functions/main.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15805764205732976860"
+      "templateHash": "17332191513775852648"
     }
   },
-  "functions": [],
   "variables": {
     "list": "a,b,c,d",
     "arrayFromString": "[split(variables('list'), ',')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/11-multiline-strings/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/11-multiline-strings/main.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6802741095883222521"
+      "templateHash": "16374437907030929150"
     }
   },
-  "functions": [],
   "variables": {
     "pipe": "|",
     "myVar": "test\n",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/20-array-loop/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/20-array-loop/main.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3376488954149491149"
+      "templateHash": "11278121320758451501"
     }
   },
-  "functions": [],
   "variables": {
     "bicepVarArray": [
       "Michael",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/21-array-lookup/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/21-array-lookup/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5706061224615216925"
+      "templateHash": "17895804241305860710"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "regionToTimezone": {
       "eastus": "Eastern Standard Time",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/22-array-lookup-complex/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/22-array-lookup-complex/main.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6641120866000338650"
+      "templateHash": "1422062392290462110"
     }
   },
-  "functions": [],
   "variables": {
     "subnetArray": [
       "GatewaySubnet",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/30-json-object-simple/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/30-json-object-simple/main.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11048355249342662017"
+      "templateHash": "5654013624082658449"
     }
   },
-  "functions": [],
   "variables": {
     "jsonString": "[\n  \"one\",\n  \"two\",\n  \"three\"\n]\n",
     "jsonArray": "[json(variables('jsonString'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/31-json-object-complex/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/000/31-json-object-complex/main.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5846512791414110174"
+      "templateHash": "12132162637504313338"
     }
   },
-  "functions": [],
   "variables": {
     "routeArray": [
       "OnPrem1",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/1vm-2nics-2subnets-1vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/1vm-2nics-2subnets-1vnet/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13828106448534538485"
+      "templateHash": "8152388388227616061"
     }
   },
   "parameters": {
@@ -49,7 +49,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "virtualMachineName": "VM-MultiNic",
     "nic1Name": "nic-1",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aad-domainservices/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aad-domainservices/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17652745218955888516"
+      "templateHash": "16347670609787336159"
     }
   },
   "parameters": {
@@ -74,7 +74,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "domainServicesNSGName": "[format('{0}-nsg', parameters('domainServicesSubnetName'))]",
     "PSRemotingSlicePIPAddresses": [

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aadds-dual-region-replica-sets/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aadds-dual-region-replica-sets/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9723583700361957461"
+      "templateHash": "11268484500963126492"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "defaultValue": "aaddscontoso.com"
     }
   },
-  "functions": [],
   "resources": {
     "aadds": {
       "type": "Microsoft.AAD/domainServices",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aci-linuxcontainer-public-ip/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aci-linuxcontainer-public-ip/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2678384896391539051"
+      "templateHash": "5831215240908727726"
     }
   },
   "parameters": {
@@ -66,7 +66,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "containerGroup": {
       "type": "Microsoft.ContainerInstance/containerGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aks-vmss-systemassigned-identity/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aks-vmss-systemassigned-identity/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2825377514138805988"
+      "templateHash": "12814844210718538151"
     }
   },
   "parameters": {
@@ -49,7 +49,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "subnetRef": "[format('{0}/subnets/{1}', resourceInfo('vn').id, variables('subnetName'))]",
     "addressPrefix": "20.0.0.0/16",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aks/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/aks/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5662310637241185269"
+      "templateHash": "6502817401635233985"
     }
   },
   "parameters": {
@@ -51,7 +51,6 @@
       "defaultValue": "Standard_DS2_v2"
     }
   },
-  "functions": [],
   "resources": {
     "aks": {
       "type": "Microsoft.ContainerService/managedClusters",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-create-with-msi/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-create-with-msi/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3335219328384845541"
+      "templateHash": "14406754463904417018"
     }
   },
   "parameters": {
@@ -54,7 +54,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "apiManagement": {
       "type": "Microsoft.ApiManagement/service",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-modular/NameValues.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-modular/NameValues.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8513514407798096027"
+      "templateHash": "8206791972216185227"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "minLength": 1
     }
   },
-  "functions": [],
   "variables": {
     "apimNameValueSet": [
       {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-modular/groups.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-modular/groups.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10004024546362286984"
+      "templateHash": "2119805176608925930"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "minLength": 1
     }
   },
-  "functions": [],
   "variables": {
     "groupsSet": [
       {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-modular/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-modular/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "956540201588906296"
+      "templateHash": "12974686970687920477"
     }
   },
   "parameters": {
@@ -73,7 +73,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "deployGroups": true,
     "deployUsers": true,
@@ -164,7 +163,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10004024546362286984"
+              "templateHash": "2119805176608925930"
             }
           },
           "parameters": {
@@ -173,7 +172,6 @@
               "minLength": 1
             }
           },
-          "functions": [],
           "variables": {
             "groupsSet": [
               {
@@ -251,7 +249,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12399821129382504434"
+              "templateHash": "17601713073798705334"
             }
           },
           "parameters": {
@@ -260,7 +258,6 @@
               "minLength": 1
             }
           },
-          "functions": [],
           "variables": {
             "usersSet": [
               {
@@ -335,7 +332,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8513514407798096027"
+              "templateHash": "8206791972216185227"
             }
           },
           "parameters": {
@@ -344,7 +341,6 @@
               "minLength": 1
             }
           },
-          "functions": [],
           "variables": {
             "apimNameValueSet": [
               {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-modular/users.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/api-management-modular/users.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12399821129382504434"
+      "templateHash": "17601713073798705334"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "minLength": 1
     }
   },
-  "functions": [],
   "variables": {
     "usersSet": [
       {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/app-config/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/app-config/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8961250868775091784"
+      "templateHash": "7212141133516879039"
     }
   },
   "parameters": {
@@ -38,7 +38,6 @@
       "defaultValue": "the-content-type"
     }
   },
-  "functions": [],
   "resources": {
     "config": {
       "type": "Microsoft.AppConfiguration/configurationStores",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/app-service-regional-vnet-integration/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/app-service-regional-vnet-integration/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18011505267539576780"
+      "templateHash": "8575852814515557461"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[format('{0}{1}', parameters('appName'), uniqueString(subscription().subscriptionId))]",
     "vnetName": "[format('{0}vnet', parameters('appName'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/application-gateway-v2-autoscale-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/application-gateway-v2-autoscale-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17352922436081701374"
+      "templateHash": "7002792351289027529"
     }
   },
   "parameters": {
@@ -107,7 +107,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "appGwPublicIpName": "[format('{0}-pip', parameters('applicationGatewayName'))]",
     "appGwSize": "Standard_v2"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/avd-backplane/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/avd-backplane/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6711216031592329791"
+      "templateHash": "11838934206254110311"
     }
   },
   "parameters": {
@@ -56,7 +56,6 @@
       "defaultValue": "BreadthFirst"
     }
   },
-  "functions": [],
   "resources": {
     "hp": {
       "type": "Microsoft.DesktopVirtualization/hostPools",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-automation-account/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-automation-account/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1492837669317878193"
+      "templateHash": "8652073553810096838"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[uniqueString(resourceGroup().id)]"
     }
   },
-  "functions": [],
   "variables": {
     "workspaceName": "[toLower(format('la-{0}', parameters('appName')))]",
     "automationaccountName": "[toLower(format('aa{0}', parameters('appName')))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-bastion/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-bastion/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9954857221080626112"
+      "templateHash": "8389530258169044388"
     }
   },
   "parameters": {
@@ -57,7 +57,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "publicIpAddressName": "[format('{0}-pip', parameters('bastionHostName'))]",
     "bastionSubnetName": "AzureBastionSubnet"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-search-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-search-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13125140964846786608"
+      "templateHash": "5660626394238246387"
     }
   },
   "parameters": {
@@ -78,7 +78,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "search": {
       "type": "Microsoft.Search/searchServices",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-sentinel/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-sentinel/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11357095747275498494"
+      "templateHash": "7162212153615016392"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "workspace": {
       "type": "Microsoft.OperationalInsights/workspaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-spring-cloud/activedeployment.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-spring-cloud/activedeployment.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18205414248542328208"
+      "templateHash": "13068796727206317896"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "app1": {
       "type": "Microsoft.AppPlatform/Spring/apps",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-spring-cloud/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azure-spring-cloud/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15563536504146422461"
+      "templateHash": "4143664787852491676"
     }
   },
   "parameters": {
@@ -31,7 +31,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "service": {
       "type": "Microsoft.AppPlatform/Spring",
@@ -156,7 +155,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18205414248542328208"
+              "templateHash": "13068796727206317896"
             }
           },
           "parameters": {
@@ -170,7 +169,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "app1": {
               "type": "Microsoft.AppPlatform/Spring/apps",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azurefirewall-create-with-zones/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/azurefirewall-create-with-zones/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13318120810868564"
+      "templateHash": "13172056939225995862"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "azureFirewallSubnetName": "AzureFirewallSubnet"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/basic-batch-account/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/basic-batch-account/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7752773588692600778"
+      "templateHash": "628947867624060512"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "batchAccount": {
       "type": "Microsoft.Batch/batchAccounts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/basic-publicip/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/basic-publicip/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2080738593509979141"
+      "templateHash": "2279181919040668751"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "defaultValue": "mypublicip"
     }
   },
-  "functions": [],
   "resources": {
     "publicIp": {
       "type": "Microsoft.Resources/deployments",
@@ -44,7 +43,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12377203809343917723"
+              "templateHash": "17379421061317987789"
             }
           },
           "parameters": {
@@ -63,7 +62,6 @@
               "type": "bool"
             }
           },
-          "functions": [],
           "resources": {
             "publicIp": {
               "type": "Microsoft.Network/publicIPAddresses",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/basic-publicip/publicIpAddress.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/basic-publicip/publicIpAddress.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12377203809343917723"
+      "templateHash": "17379421061317987789"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "type": "bool"
     }
   },
-  "functions": [],
   "resources": {
     "publicIp": {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cognitive-services/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cognitive-services/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10527606218652870666"
+      "templateHash": "17031091653875063729"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       "defaultValue": "S0"
     }
   },
-  "functions": [],
   "resources": {
     "cognitiveService": {
       "type": "Microsoft.CognitiveServices/accounts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/container-registry/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/container-registry/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4615087513664892522"
+      "templateHash": "12642938373302011166"
     }
   },
   "parameters": {
@@ -46,7 +46,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": {
     "acr": {
       "type": "Microsoft.ContainerRegistry/registries",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cosmosdb-free/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cosmosdb-free/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1232113087017290403"
+      "templateHash": "14015889880722387132"
     }
   },
   "parameters": {
@@ -32,7 +32,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "cosmosAccount": {
       "type": "Microsoft.DocumentDB/databaseAccounts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cosmosdb-private-endpoint/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cosmosdb-private-endpoint/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1770039253502711402"
+      "templateHash": "9614498971262374103"
     }
   },
   "parameters": {
@@ -34,7 +34,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "virtualNetwork": {
       "type": "Microsoft.Network/virtualNetworks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cosmosdb-webapp/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cosmosdb-webapp/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10412279700134669295"
+      "templateHash": "16446097041576627113"
     }
   },
   "parameters": {
@@ -85,7 +85,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "cosmosAccountName": "[toLower(parameters('applicationName'))]",
     "websiteName": "[parameters('applicationName')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/create-managedidentity-rbac/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/create-managedidentity-rbac/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16198543403995158819"
+      "templateHash": "17950968957848901349"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "defaultValue": "b24988ac-6180-42a0-ab88-20f7382dd24c"
     }
   },
-  "functions": [],
   "resources": {
     "msi": {
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/create-rg-lock-role-assignment/applylock.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/create-rg-lock-role-assignment/applylock.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10462737407853481980"
+      "templateHash": "12145708462599333811"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "dontDeleteLock": {
       "type": "Microsoft.Authorization/locks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/create-rg-lock-role-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/create-rg-lock-role-assignment/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15467470731904966241"
+      "templateHash": "2748876017922510703"
     }
   },
   "parameters": {
@@ -44,7 +44,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "newRg": {
       "type": "Microsoft.Resources/resourceGroups",
@@ -86,7 +85,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10462737407853481980"
+              "templateHash": "12145708462599333811"
             }
           },
           "parameters": {
@@ -109,7 +108,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "dontDeleteLock": {
               "type": "Microsoft.Authorization/locks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/custom-role-definition-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/custom-role-definition-assignment/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14389371298408625041"
+      "templateHash": "13195608625247533346"
     }
   },
   "parameters": {
@@ -15,7 +15,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "roleName": "Bicep Custom Role demo"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cyclecloud/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cyclecloud/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2172520311037190703"
+      "templateHash": "13652133161447918929"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "defaultValue": "20.49.199.4"
     }
   },
-  "functions": [],
   "variables": {
     "roleDefinitions": {
       "owner": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cyclecloud/sub.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/cyclecloud/sub.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4634281030914945145"
+      "templateHash": "14709297534671903997"
     }
   },
-  "functions": [],
   "resources": {
     "rg": {
       "type": "Microsoft.Resources/resourceGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/data-factory-v2-blob-to-blob-copy/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/data-factory-v2-blob-to-blob-copy/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15457170947325010376"
+      "templateHash": "3409616685856980337"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "dataFactoryLinkedServiceName": "ArmtemplateStorageLinkedService",
     "dataFactoryDataSetInName": "ArmtemplateTestDatasetIn",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/data-factory-v2/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/data-factory-v2/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1508538944648462658"
+      "templateHash": "6134292084136829936"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "dataFactory": {
       "type": "Microsoft.DataFactory/factories",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/data-lake-store-encryption-adls/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/data-lake-store-encryption-adls/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4527047503057791302"
+      "templateHash": "16609898542336495908"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "dataLake": {
       "type": "Microsoft.DataLakeStore/accounts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/databricks-all-in-one-template-for-vnet-injection/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/databricks-all-in-one-template-for-vnet-injection/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5700586290913965024"
+      "templateHash": "18417593559327655298"
     }
   },
   "parameters": {
@@ -93,7 +93,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "managedResourceGroupName": "[format('databricks-rg-{0}-{1}', parameters('workspaceName'), uniqueString(parameters('workspaceName'), resourceGroup().id))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/databricks-workspace/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/databricks-workspace/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12582199038883211544"
+      "templateHash": "16404602097477377949"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "managedResourceGroupName": "[format('databricks-rg-{0}-{1}', parameters('workspaceName'), uniqueString(parameters('workspaceName'), resourceGroup().id))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/deployment-script-no-auth/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/deployment-script-no-auth/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3130066377201847090"
+      "templateHash": "16065037464086584474"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       "defaultValue": "[format('ds{0}', uniqueString(resourceGroup().name))]"
     }
   },
-  "functions": [],
   "resources": {
     "script": {
       "type": "Microsoft.Resources/deploymentScripts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/deployment-script-with-storage/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/deployment-script-with-storage/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "561553518241831218"
+      "templateHash": "15516798207265659166"
     }
   },
   "parameters": {
@@ -36,7 +36,6 @@
       "defaultValue": "[utcNow()]"
     }
   },
-  "functions": [],
   "variables": {
     "uamiId": "[resourceId(parameters('subId'), parameters('rgName'), 'Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName'))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/event-grid-servicebus-queue/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/event-grid-servicebus-queue/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12787600159709138251"
+      "templateHash": "9881242511737122857"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "serviceBusNamespace": {
       "type": "Microsoft.ServiceBus/namespaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/eventhub-namespace/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/eventhub-namespace/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5417997377814644790"
+      "templateHash": "5243812580579835537"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       "defaultValue": "Standard"
     }
   },
-  "functions": [],
   "variables": {
     "eventHubNamespaceName": "[format('{0}ns', parameters('projectName'))]",
     "eventHubName": "[parameters('projectName')]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/expressroute-circuit-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/expressroute-circuit-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6208542158778129603"
+      "templateHash": "17252196052378360540"
     }
   },
   "parameters": {
@@ -65,7 +65,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "circuit": {
       "type": "Microsoft.Network/expressRouteCircuits",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/front-door-basic/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/front-door-basic/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16451412309236607713"
+      "templateHash": "11472328688619006550"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "frontEndEndpointName": "frontEndEndpoint",
     "loadBalancingSettingsName": "loadBalancingSettings",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/front-door-custom-domain/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/front-door-custom-domain/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8851741923215963609"
+      "templateHash": "1594522113635119409"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "frontEndEndpointDefaultName": "frontEndEndpointDefault",
     "frontEndEndpointCustomName": "frontEndEndpointCustom",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/front-door-redirect/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/front-door-redirect/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11096605491391377587"
+      "templateHash": "8287095659103081792"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "frontEndEndpointName": "frontEndEndpoint",
     "loadBalancingSettingsName": "loadBalancingSettings",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/function-app-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/function-app-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3468090399701756867"
+      "templateHash": "6865430929447030832"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "functionAppName": "[format('{0}-functionapp', parameters('appNamePrefix'))]",
     "appServiceName": "[format('{0}-appservice', parameters('appNamePrefix'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/function-http-trigger/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/function-http-trigger/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12157994041649169535"
+      "templateHash": "9335090027480898711"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       "defaultValue": "Standard"
     }
   },
-  "functions": [],
   "variables": {
     "functionAppName": "[format('fn-{0}', parameters('appNameSuffix'))]",
     "appServicePlanName": "FunctionPlan",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/function-premium-vnet-integration/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/function-premium-vnet-integration/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2389110507228612461"
+      "templateHash": "5235194615415693509"
     }
   },
   "parameters": {
@@ -68,7 +68,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "vnetAddressPrefix": "10.0.0.0/16",
     "subnetAddressPrefix": "10.0.0.0/24",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hdinsight-spark-linux/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hdinsight-spark-linux/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4214573630377470020"
+      "templateHash": "6998554863925629628"
     }
   },
   "parameters": {
@@ -91,7 +91,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "defaultStorageAccount": {
       "type": "Microsoft.Storage/storageAccounts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13969707225649599028"
+      "templateHash": "7117207067536742139"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "defaultValue": "westeurope"
     }
   },
-  "functions": [],
   "resources": {
     "hubrg": {
       "type": "Microsoft.Resources/resourceGroups",
@@ -69,7 +68,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3116639986482016372"
+              "templateHash": "12270136273460033904"
             }
           },
           "parameters": {
@@ -83,7 +82,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "vnet": {
               "type": "Microsoft.Network/virtualNetworks",
@@ -157,7 +155,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3116639986482016372"
+              "templateHash": "12270136273460033904"
             }
           },
           "parameters": {
@@ -171,7 +169,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "vnet": {
               "type": "Microsoft.Network/virtualNetworks",
@@ -230,7 +227,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15735783156697902395"
+              "templateHash": "8445558628565527022"
             }
           },
           "parameters": {
@@ -241,7 +238,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "publicIp": {
               "type": "Microsoft.Network/publicIPAddresses",
@@ -324,7 +320,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1640248940128810957"
+              "templateHash": "5486147621836069600"
             }
           },
           "parameters": {
@@ -338,7 +334,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "peer": {
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
@@ -393,7 +388,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1640248940128810957"
+              "templateHash": "5486147621836069600"
             }
           },
           "parameters": {
@@ -407,7 +402,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "peer": {
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
@@ -459,7 +453,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6952691429387144402"
+              "templateHash": "16912744758535388376"
             }
           },
           "parameters": {
@@ -470,7 +464,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "route": {
               "type": "Microsoft.Network/routeTables",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/modules/fwl.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/modules/fwl.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15735783156697902395"
+      "templateHash": "8445558628565527022"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "publicIp": {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/modules/peering.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/modules/peering.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1640248940128810957"
+      "templateHash": "5486147621836069600"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "peer": {
       "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/modules/rot.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/modules/rot.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6952691429387144402"
+      "templateHash": "16912744758535388376"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "route": {
       "type": "Microsoft.Network/routeTables",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/modules/vnet.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/hub-and-spoke/modules/vnet.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3116639986482016372"
+      "templateHash": "12270136273460033904"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": {
     "vnet": {
       "type": "Microsoft.Network/virtualNetworks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/key-vault-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/key-vault-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16813686960358328800"
+      "templateHash": "17629072442831034415"
     }
   },
   "parameters": {
@@ -115,7 +115,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "keyvault": {
       "type": "Microsoft.KeyVault/vaults",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/key-vault-secret-only/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/key-vault-secret-only/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1706609072695335836"
+      "templateHash": "18226845404466399456"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "type": "secureString"
     }
   },
-  "functions": [],
   "resources": {
     "secret": {
       "type": "Microsoft.KeyVault/vaults/secrets",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/logic-app-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/logic-app-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13674766085305483811"
+      "templateHash": "10257750025690024869"
     }
   },
   "parameters": {
@@ -32,7 +32,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "frequency": "Hour",
     "interval": "1",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/media-services-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/media-services-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9144553242681631300"
+      "templateHash": "12122690282091444112"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountName": "[format('storage{0}', uniqueString(resourceGroup().id))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/mg-policy/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/mg-policy/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7006719489223519842"
+      "templateHash": "3629437482120268534"
     }
   },
   "parameters": {
@@ -29,7 +29,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "mgScope": "[tenantResourceId('Microsoft.Management/managementGroups', parameters('targetMG'))]",
     "policyDefinitionName": "LocationRestriction"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/monitor-action-groups/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/monitor-action-groups/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18388597164313022066"
+      "templateHash": "3941996007012514275"
     }
   },
   "parameters": {
@@ -58,7 +58,6 @@
       "defaultValue": []
     }
   },
-  "functions": [],
   "resources": {
     "actionGroup": {
       "type": "microsoft.insights/actionGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/nat-gateway-vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/nat-gateway-vnet/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4928263490538882609"
+      "templateHash": "1239573909043118015"
     }
   },
   "parameters": {
@@ -61,7 +61,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "publicIpName": "[format('{0}-ip', parameters('natGatewayName'))]",
     "publicIpAddresses": [

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/private-dns-zone/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/private-dns-zone/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "825104727402888112"
+      "templateHash": "8034478159621396993"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "virtualNetwork": {
       "type": "Microsoft.Network/virtualNetworks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/private-endpoint-webapp/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/private-endpoint-webapp/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13005546734320715485"
+      "templateHash": "9319299136230453878"
     }
   },
   "parameters": {
@@ -72,7 +72,6 @@
       "defaultValue": ".azurewebsites.net"
     }
   },
-  "functions": [],
   "resources": {
     "virtualNetwork": {
       "type": "Microsoft.Network/virtualNetworks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/redis-cache/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/redis-cache/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4815438706054484684"
+      "templateHash": "3178426058418424488"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "redisCacheName": "[format('{0}{1}', parameters('environmentName'), uniqueString(resourceGroup().id))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/resource-with-lock-existing/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/resource-with-lock-existing/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2003869932911986521"
+      "templateHash": "7778014452728540746"
     }
   },
   "parameters": {
@@ -15,7 +15,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "storageAcc": {
       "existing": true,

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/resource-with-lock/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/resource-with-lock/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4433596017581258264"
+      "templateHash": "16823296441565760379"
     }
   },
   "parameters": {
@@ -15,7 +15,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "storageAcc": {
       "type": "Microsoft.Storage/storageAccounts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/sql-database/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/sql-database/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15833754718106880235"
+      "templateHash": "12818580016231391461"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       "type": "secureString"
     }
   },
-  "functions": [],
   "resources": {
     "server": {
       "type": "Microsoft.Sql/servers",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/sqlmi-new-vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/sqlmi-new-vnet/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4176017426826292338"
+      "templateHash": "12874224626936891094"
     }
   },
   "parameters": {
@@ -68,7 +68,6 @@
       "minValue": 32
     }
   },
-  "functions": [],
   "variables": {
     "networkSecurityGroupName": "[format('{0}-nsg', parameters('managedInstanceName'))]",
     "routeTableName": "[format('{0}-routetable', parameters('managedInstanceName'))]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/storage-blob-container/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/storage-blob-container/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3810820475161539061"
+      "templateHash": "8024929790370605115"
     }
   },
   "parameters": {
@@ -23,7 +23,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "sa": {
       "type": "Microsoft.Storage/storageAccounts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/storage-static-website/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/storage-static-website/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6746989842547989983"
+      "templateHash": "1104244600112865551"
     }
   },
   "parameters": {
@@ -39,7 +39,6 @@
       "defaultValue": "error.html"
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountContributorRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/template-spec-deploy/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/template-spec-deploy/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4356323807367846654"
+      "templateHash": "3214106287326946885"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "tsVersion": {
       "existing": true,

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/templatespec-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/templatespec-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3243281388365321542"
+      "templateHash": "9601535715397097182"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "templateSpec": {
       "type": "Microsoft.Resources/templateSpecs",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/vm-simple-linux/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/vm-simple-linux/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2603784831314808284"
+      "templateHash": "12240871411670070986"
     }
   },
   "parameters": {
@@ -97,7 +97,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "publicIPAddressName": "[format('{0}PublicIP', parameters('vmName'))]",
     "networkInterfaceName": "[format('{0}NetInt', parameters('vmName'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/vm-simple-windows/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/vm-simple-windows/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3818240346884159269"
+      "templateHash": "7382529889681118350"
     }
   },
   "parameters": {
@@ -105,7 +105,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountName": "[format('bootdiags{0}', uniqueString(resourceGroup().id))]",
     "nicName": "myVMNic",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/vnet-two-subnets/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/vnet-two-subnets/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14088281385183570870"
+      "templateHash": "7978079330546512561"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "10.0.0.0/15"
     }
   },
-  "functions": [],
   "variables": {
     "vnetName": "[format('vnet-{0}', parameters('suffix'))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/web-app-linux/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/web-app-linux/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12704738746034970308"
+      "templateHash": "751016444728062805"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('AppServicePlan-{0}', parameters('webAppName')))]",
     "webSiteName": "[toLower(format('wapp-{0}', parameters('webAppName')))]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/web-app-windows/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/web-app-windows/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1297725538648707290"
+      "templateHash": "963766496882964125"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[uniqueString(resourceGroup().id)]"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]",
     "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/webapp-managed-mysql/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/webapp-managed-mysql/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16217450318182037029"
+      "templateHash": "4175233103735518485"
     }
   },
   "parameters": {
@@ -113,7 +113,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "databaseName": "[format('{0}-database', parameters('siteName'))]",
     "serverName": "[format('{0}-server', parameters('siteName'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/webapp-privateendpoint-vnet-injection/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/webapp-privateendpoint-vnet-injection/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11025469466743780383"
+      "templateHash": "11572722614392511295"
     }
   },
   "parameters": {
@@ -132,7 +132,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "webapp_dns_name": ".azurewebsites.net",
     "privateDNSZoneName": "privatelink.azurewebsites.net",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/website-with-container/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/website-with-container/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3750381001111368245"
+      "templateHash": "97755062618535923"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       "defaultValue": "[subscription().subscriptionId]"
     }
   },
-  "functions": [],
   "variables": {
     "websiteName": "[format('{0}-site', parameters('name'))]",
     "farmName": "[format('{0}-farm', parameters('name'))]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/1vm-2nics-2subnets-1vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/1vm-2nics-2subnets-1vnet/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12260353099991892329"
+      "templateHash": "11995169114773616821"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "nic1Name": "nic-1",
     "nic2Name": "nic-2",
@@ -216,7 +215,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14730528799415713647"
+              "templateHash": "9505657871150856913"
             }
           },
           "parameters": {
@@ -246,7 +245,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "vm": {
               "type": "Microsoft.Compute/virtualMachines",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/1vm-2nics-2subnets-1vnet/vm.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/1vm-2nics-2subnets-1vnet/vm.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14730528799415713647"
+      "templateHash": "9505657871150856913"
     }
   },
   "parameters": {
@@ -37,7 +37,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "vm": {
       "type": "Microsoft.Compute/virtualMachines",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/aci-sftp-files/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/aci-sftp-files/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17921285011367370930"
+      "templateHash": "12114583236596559523"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "scriptName": "createFileShare",
     "identityName": "scratch",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/aci-wordpress/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/aci-wordpress/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2539878779386005088"
+      "templateHash": "11268939364565345832"
     }
   },
   "parameters": {
@@ -36,7 +36,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "cpuCores": "0.5",
     "memoryInGb": "0.7",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/linux-vm-as.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/linux-vm-as.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10716442026835589146"
+      "templateHash": "4276294977590982766"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "nic": {
       "type": "Microsoft.Network/networkInterfaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/linux-vm-az.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/linux-vm-az.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1520780044416055958"
+      "templateHash": "8118302315487989204"
     }
   },
   "parameters": {
@@ -36,7 +36,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": {
     "pip": {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12012350860846244396"
+      "templateHash": "8337145022368235691"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       "defaultValue": "20.49.199.4"
     }
   },
-  "functions": [],
   "resources": {
     "ppg1": {
       "type": "Microsoft.Compute/proximityPlacementGroups",
@@ -77,7 +76,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6480195888241511838"
+              "templateHash": "3850583703916111889"
             }
           },
           "parameters": {
@@ -90,7 +89,6 @@
               "defaultValue": "1.1.1.1"
             }
           },
-          "functions": [],
           "resources": {
             "nsg": {
               "type": "Microsoft.Network/networkSecurityGroups",
@@ -213,7 +211,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1520780044416055958"
+              "templateHash": "8118302315487989204"
             }
           },
           "parameters": {
@@ -242,7 +240,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {
             "pip": {
               "type": "Microsoft.Network/publicIPAddresses",
@@ -381,7 +378,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10716442026835589146"
+              "templateHash": "4276294977590982766"
             }
           },
           "parameters": {
@@ -402,7 +399,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "nic": {
               "type": "Microsoft.Network/networkInterfaces",
@@ -517,7 +513,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10716442026835589146"
+              "templateHash": "4276294977590982766"
             }
           },
           "parameters": {
@@ -538,7 +534,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "nic": {
               "type": "Microsoft.Network/networkInterfaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/network.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/network.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6480195888241511838"
+      "templateHash": "3850583703916111889"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "defaultValue": "1.1.1.1"
     }
   },
-  "functions": [],
   "resources": {
     "nsg": {
       "type": "Microsoft.Network/networkSecurityGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/sub.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/anchored-proximity-placement-group/sub.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14683157560804164378"
+      "templateHash": "3390790335480531883"
     }
   },
-  "functions": [],
   "resources": {
     "rg": {
       "type": "Microsoft.Resources/resourceGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3161486998798141348"
+      "templateHash": "554096486254860362"
     }
   },
   "parameters": {
@@ -62,7 +62,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "apiManagementServiceName": "[format('apiservice{0}', uniqueString(resourceGroup().id))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/asev2-ilb-with-web-app/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/asev2-ilb-with-web-app/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6662919394556696474"
+      "templateHash": "17604191896133774954"
     }
   },
   "parameters": {
@@ -51,7 +51,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": {
     "virtualNetwork": {
       "type": "Microsoft.Network/virtualNetworks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15952827541288753365"
+      "templateHash": "15289507394833495128"
     }
   },
   "parameters": {
@@ -32,7 +32,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "avdla": {
       "type": "Microsoft.OperationalInsights/workspaces",
@@ -75,7 +74,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10996175173856467619"
+              "templateHash": "1620512394627203274"
             }
           },
           "parameters": {
@@ -89,7 +88,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "hostPool": {
               "existing": true,

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15297506896368941142"
+      "templateHash": "5292768385938170215"
     }
   },
   "parameters": {
@@ -66,7 +66,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "hp": {
       "type": "Microsoft.DesktopVirtualization/hostPools",
@@ -148,7 +147,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15952827541288753365"
+              "templateHash": "15289507394833495128"
             }
           },
           "parameters": {
@@ -173,7 +172,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "avdla": {
               "type": "Microsoft.OperationalInsights/workspaces",
@@ -216,7 +214,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "10996175173856467619"
+                      "templateHash": "1620512394627203274"
                     }
                   },
                   "parameters": {
@@ -230,7 +228,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "hostPool": {
                       "existing": true,

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-module.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-module.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18155317466407965240"
+      "templateHash": "3646938118059409476"
     }
   },
   "parameters": {
@@ -29,7 +29,6 @@
       "defaultValue": "profilecontainers"
     }
   },
-  "functions": [],
   "variables": {
     "filesharelocation": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('fileshareFolderName'))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-privateendpoint-module.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-privateendpoint-module.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5787402335250242721"
+      "templateHash": "13675653132844872894"
     }
   },
   "parameters": {
@@ -36,7 +36,6 @@
       "defaultValue": "privatelink.file.core.windows.net"
     }
   },
-  "functions": [],
   "resources": {
     "privateDNSZoneGroup": {
       "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-image-builder-module.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-image-builder-module.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17023233329059124249"
+      "templateHash": "7366460419688481408"
     }
   },
   "parameters": {
@@ -53,7 +53,6 @@
       "defaultValue": "[resourceGroup().name]"
     }
   },
-  "functions": [],
   "resources": {
     "managedidentity": {
       "existing": true,

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-monitor-diag.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-monitor-diag.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10996175173856467619"
+      "templateHash": "1620512394627203274"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "hostPool": {
       "existing": true,

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-network-module.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-network-module.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14998095338942063206"
+      "templateHash": "14440187448325350653"
     }
   },
   "parameters": {
@@ -29,7 +29,6 @@
       "defaultValue": "AVD"
     }
   },
-  "functions": [],
   "resources": {
     "vnet": {
       "type": "Microsoft.Network/virtualNetworks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-sig-module.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/avd-sig-module.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1899033175673285632"
+      "templateHash": "10796674423451692405"
     }
   },
   "parameters": {
@@ -36,7 +36,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "avdsig": {
       "type": "Microsoft.Compute/galleries",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/avd-backplane-with-network-and-storage-and-monitoring/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10910894560050238019"
+      "templateHash": "16734801473738910113"
     }
   },
   "parameters": {
@@ -132,7 +132,6 @@
       "defaultValue": false
     }
   },
-  "functions": [],
   "resources": {
     "rgavd": {
       "type": "Microsoft.Resources/resourceGroups",
@@ -230,7 +229,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15297506896368941142"
+              "templateHash": "5292768385938170215"
             }
           },
           "parameters": {
@@ -289,7 +288,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "hp": {
               "type": "Microsoft.DesktopVirtualization/hostPools",
@@ -371,7 +369,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "15952827541288753365"
+                      "templateHash": "15289507394833495128"
                     }
                   },
                   "parameters": {
@@ -396,7 +394,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "avdla": {
                       "type": "Microsoft.OperationalInsights/workspaces",
@@ -439,7 +436,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "10996175173856467619"
+                              "templateHash": "1620512394627203274"
                             }
                           },
                           "parameters": {
@@ -453,7 +450,6 @@
                               "type": "string"
                             }
                           },
-                          "functions": [],
                           "resources": {
                             "hostPool": {
                               "existing": true,
@@ -584,7 +580,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14998095338942063206"
+              "templateHash": "14440187448325350653"
             }
           },
           "parameters": {
@@ -606,7 +602,6 @@
               "defaultValue": "AVD"
             }
           },
-          "functions": [],
           "resources": {
             "vnet": {
               "type": "Microsoft.Network/virtualNetworks",
@@ -683,7 +678,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18155317466407965240"
+              "templateHash": "3646938118059409476"
             }
           },
           "parameters": {
@@ -705,7 +700,6 @@
               "defaultValue": "profilecontainers"
             }
           },
-          "functions": [],
           "variables": {
             "filesharelocation": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('fileshareFolderName'))]"
           },
@@ -777,7 +771,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5787402335250242721"
+              "templateHash": "13675653132844872894"
             }
           },
           "parameters": {
@@ -806,7 +800,6 @@
               "defaultValue": "privatelink.file.core.windows.net"
             }
           },
-          "functions": [],
           "resources": {
             "privateDNSZoneGroup": {
               "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
@@ -924,7 +917,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1899033175673285632"
+              "templateHash": "10796674423451692405"
             }
           },
           "parameters": {
@@ -953,7 +946,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "avdsig": {
               "type": "Microsoft.Compute/galleries",
@@ -1098,7 +1090,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17023233329059124249"
+              "templateHash": "7366460419688481408"
             }
           },
           "parameters": {
@@ -1144,7 +1136,6 @@
               "defaultValue": "[resourceGroup().name]"
             }
           },
-          "functions": [],
           "resources": {
             "managedidentity": {
               "existing": true,

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/budget-subscription-with-notifications/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/budget-subscription-with-notifications/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11788224146297537649"
+      "templateHash": "14522253761761664829"
     }
   },
   "parameters": {
@@ -68,7 +68,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "budget": {
       "type": "Microsoft.Consumption/budgets",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cdn-with-storage-account/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cdn-with-storage-account/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16108886032851165637"
+      "templateHash": "164658607170661262"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountName": "[format('storage{0}', uniqueString(resourceGroup().id))]",
     "endpointName": "[format('endpoint-{0}', uniqueString(resourceGroup().id))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cloud-shell-vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cloud-shell-vnet/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8181642828149196821"
+      "templateHash": "8681590305980920430"
     }
   },
   "parameters": {
@@ -83,7 +83,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "networkProfileName": "[format('aci-networkProfile-{0}', parameters('location'))]",
     "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/create-and-enable-ddos-protection-plans/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/create-and-enable-ddos-protection-plans/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17051768435805799169"
+      "templateHash": "10447185699273457920"
     }
   },
   "parameters": {
@@ -52,7 +52,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "ddosProtectionPlan": {
       "type": "Microsoft.Network/ddosProtectionPlans",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cyclecloud/cycleserver-vm.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cyclecloud/cycleserver-vm.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6849390527810909284"
+      "templateHash": "11894316390754474367"
     }
   },
   "parameters": {
@@ -29,7 +29,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "pip": {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cyclecloud/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cyclecloud/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11540454296860165981"
+      "templateHash": "9378525231230447099"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "defaultValue": "20.49.199.4"
     }
   },
-  "functions": [],
   "variables": {
     "roleDefinitions": {
       "owner": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
@@ -90,7 +89,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18242259942357983107"
+              "templateHash": "8834221979714337166"
             }
           },
           "parameters": {
@@ -103,7 +102,6 @@
               "defaultValue": "1.1.1.1"
             }
           },
-          "functions": [],
           "resources": {
             "nsg": {
               "type": "Microsoft.Network/networkSecurityGroups",
@@ -223,7 +221,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6849390527810909284"
+              "templateHash": "11894316390754474367"
             }
           },
           "parameters": {
@@ -245,7 +243,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "pip": {
               "type": "Microsoft.Network/publicIPAddresses",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cyclecloud/network.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cyclecloud/network.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18242259942357983107"
+      "templateHash": "8834221979714337166"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "defaultValue": "1.1.1.1"
     }
   },
-  "functions": [],
   "resources": {
     "nsg": {
       "type": "Microsoft.Network/networkSecurityGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cyclecloud/sub.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/cyclecloud/sub.json
@@ -7,10 +7,9 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14683157560804164378"
+      "templateHash": "3390790335480531883"
     }
   },
-  "functions": [],
   "resources": {
     "rg": {
       "type": "Microsoft.Resources/resourceGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/decrypt-running-windows-vm-without-aad/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/decrypt-running-windows-vm-without-aad/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12117825778412917129"
+      "templateHash": "4348512865043834733"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "vmExt": {
       "type": "Microsoft.Compute/virtualMachines/extensions",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/event-hub-and-consumer-group/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/event-hub-and-consumer-group/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3793515412349032942"
+      "templateHash": "6916775773978176410"
     }
   },
   "parameters": {
@@ -42,7 +42,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "namespace": {
       "type": "Microsoft.EventHub/namespaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/existing-vnet-to-vnet-peering/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/existing-vnet-to-vnet-peering/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11720436215123159117"
+      "templateHash": "17935694761826815712"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "peer": {
       "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/firewall-with-ip-from-prefix/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/firewall-with-ip-from-prefix/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5973792154747211288"
+      "templateHash": "13196174561056870538"
     }
   },
   "parameters": {
@@ -53,7 +53,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "firewallname": "[format('{0}-fw', parameters('vnetname'))]",
     "publicipname": "[format('{0}-pip', parameters('vnetname'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/front-door-with-webapplication-firewall/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/front-door-with-webapplication-firewall/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4030133491330352149"
+      "templateHash": "8201654231428073964"
     }
   },
   "parameters": {
@@ -44,7 +44,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "frontDoorNameLower": "[toLower(parameters('frontDoorName'))]",
     "backendPool1Name": "[format('{0}-backendPool1', variables('frontDoorNameLower'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/iot-with-storage/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/iot-with-storage/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3817662086076719427"
+      "templateHash": "10012970682760693099"
     }
   },
   "parameters": {
@@ -34,7 +34,6 @@
       "defaultValue": 4
     }
   },
-  "functions": [],
   "variables": {
     "unique": "[uniqueString(resourceGroup().id)]",
     "iotHubName": "[format('{0}Hub{1}', parameters('projectName'), variables('unique'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/key-vault-secret-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/key-vault-secret-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3365371850629872577"
+      "templateHash": "799455549358052227"
     }
   },
   "parameters": {
@@ -94,7 +94,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "vault": {
       "type": "Microsoft.KeyVault/vaults",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/log-analytics-with-solutions-and-diagnostics/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/log-analytics-with-solutions-and-diagnostics/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7857401576039545193"
+      "templateHash": "7479514119272576374"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "defaultValue": "[format('la-{0}', uniqueString(resourceGroup().id))]"
     }
   },
-  "functions": [],
   "variables": {
     "vmInsights": {
       "name": "[format('VMInsights({0})', parameters('logAnalyticsWorkspaceName'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-azmonitor-agent-and-dcr-association/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-azmonitor-agent-and-dcr-association/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16493228908903635516"
+      "templateHash": "10102360753725595070"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "policy": {
       "type": "Microsoft.Resources/deployments",
@@ -48,7 +47,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2900571262339678012"
+              "templateHash": "2457970379301751180"
             }
           },
           "parameters": {
@@ -56,7 +55,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "policyDefCategory": "Custom",
             "policySource": "Bicep",
@@ -420,7 +418,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3057911705389341300"
+              "templateHash": "3313635155036670047"
             }
           },
           "parameters": {
@@ -434,7 +432,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "monitoringGovernanceAssignment": {
               "type": "Microsoft.Authorization/policyAssignments",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-azmonitor-agent-and-dcr-association/policyAssignment.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-azmonitor-agent-and-dcr-association/policyAssignment.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3057911705389341300"
+      "templateHash": "3313635155036670047"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "monitoringGovernanceAssignment": {
       "type": "Microsoft.Authorization/policyAssignments",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-azmonitor-agent-and-dcr-association/policyDefinition.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-azmonitor-agent-and-dcr-association/policyDefinition.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2900571262339678012"
+      "templateHash": "2457970379301751180"
     }
   },
   "parameters": {
@@ -15,7 +15,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "policyDefCategory": "Custom",
     "policySource": "Bicep",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-definition-with-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-definition-with-assignment/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2028804678894765898"
+      "templateHash": "3215855334487358317"
     }
   },
   "parameters": {
@@ -26,7 +26,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": {
     "locationPolicyDefinition": {
       "type": "Microsoft.Authorization/policyDefinitions",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-with-initiative-definition-and-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-with-initiative-definition-and-assignment/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17086860997343722388"
+      "templateHash": "9860965441495139106"
     }
   },
   "parameters": {
@@ -35,7 +35,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "initiativeDefinitionName": "BICEP Example Initiative"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/portal-dashboard-with-appinsights/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/portal-dashboard-with-appinsights/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "293210833048465123"
+      "templateHash": "15165108275644164521"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "appinsights": {
       "type": "Microsoft.Insights/components",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/aks.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/aks.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3548758362621322445"
+      "templateHash": "9697433238765311144"
     }
   },
   "parameters": {
@@ -316,7 +316,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "aadProfileConfiguration": {
       "managed": "[parameters('aadProfileManaged')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/bastion.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/bastion.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3181622900167712412"
+      "templateHash": "7108512484788460945"
     }
   },
   "parameters": {
@@ -31,7 +31,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "bastionPublicIpAddressName": "[format('{0}PublicIp', parameters('bastionHostName'))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/jumpbox.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/jumpbox.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "220947672133229591"
+      "templateHash": "2606259165118348826"
     }
   },
   "parameters": {
@@ -152,7 +152,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "vmNicName": "[format('{0}Nic', parameters('vmName'))]",
     "vmNicId": "[resourceInfo('vmNic').id]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/log-analytics.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/log-analytics.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14026314123047208315"
+      "templateHash": "16306238993413596590"
     }
   },
   "parameters": {
@@ -45,7 +45,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "logAnalyticsWorkspace": {
       "type": "Microsoft.OperationalInsights/workspaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1738761125357915028"
+      "templateHash": "9446563508745952394"
     }
   },
   "parameters": {
@@ -494,7 +494,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "vnet": {
       "type": "Microsoft.Resources/deployments",
@@ -540,7 +539,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17038988552482683858"
+              "templateHash": "2127873313917417280"
             }
           },
           "parameters": {
@@ -600,7 +599,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "bastionSubnetName": "AzureBastionSubnet",
             "bastionSubnetNsgName": "[format('{0}Nsg', variables('bastionSubnetName'))]",
@@ -870,7 +868,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3181622900167712412"
+              "templateHash": "7108512484788460945"
             }
           },
           "parameters": {
@@ -894,7 +892,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "bastionPublicIpAddressName": "[format('{0}PublicIp', parameters('bastionHostName'))]"
           },
@@ -974,7 +971,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14026314123047208315"
+              "templateHash": "16306238993413596590"
             }
           },
           "parameters": {
@@ -1012,7 +1009,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "logAnalyticsWorkspace": {
               "type": "Microsoft.OperationalInsights/workspaces",
@@ -1113,7 +1109,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "220947672133229591"
+              "templateHash": "2606259165118348826"
             }
           },
           "parameters": {
@@ -1258,7 +1254,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "vmNicName": "[format('{0}Nic', parameters('vmName'))]",
             "vmNicId": "[resourceInfo('vmNic').id]",
@@ -1636,7 +1631,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3548758362621322445"
+              "templateHash": "9697433238765311144"
             }
           },
           "parameters": {
@@ -1945,7 +1940,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "aadProfileConfiguration": {
               "managed": "[parameters('aadProfileManaged')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/vnet.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/private-aks-cluster/vnet.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17038988552482683858"
+      "templateHash": "2127873313917417280"
     }
   },
   "parameters": {
@@ -67,7 +67,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "bastionSubnetName": "AzureBastionSubnet",
     "bastionSubnetNsgName": "[format('{0}Nsg', variables('bastionSubnetName'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/proximity-placement-with-multi-resource-groups/anchored-ppg.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/proximity-placement-with-multi-resource-groups/anchored-ppg.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4645049081461158424"
+      "templateHash": "15358292048584713508"
     }
   },
   "parameters": {
@@ -33,7 +33,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": {
     "ppg": {
       "type": "Microsoft.Compute/proximityPlacementGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/proximity-placement-with-multi-resource-groups/linux-vm-as.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/proximity-placement-with-multi-resource-groups/linux-vm-as.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16280521018377216764"
+      "templateHash": "16490443389180409510"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "as": {
       "type": "Microsoft.Compute/availabilitySets",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/proximity-placement-with-multi-resource-groups/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/proximity-placement-with-multi-resource-groups/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2127989398470611115"
+      "templateHash": "8082458138149972255"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": 1
     }
   },
-  "functions": [],
   "resources": {
     "rgnet": {
       "type": "Microsoft.Resources/resourceGroups",
@@ -72,7 +71,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6480195888241511838"
+              "templateHash": "3850583703916111889"
             }
           },
           "parameters": {
@@ -85,7 +84,6 @@
               "defaultValue": "1.1.1.1"
             }
           },
-          "functions": [],
           "resources": {
             "nsg": {
               "type": "Microsoft.Network/networkSecurityGroups",
@@ -209,7 +207,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4645049081461158424"
+              "templateHash": "15358292048584713508"
             }
           },
           "parameters": {
@@ -235,7 +233,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {
             "ppg": {
               "type": "Microsoft.Compute/proximityPlacementGroups",
@@ -391,7 +388,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16280521018377216764"
+              "templateHash": "16490443389180409510"
             }
           },
           "parameters": {
@@ -412,7 +409,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "as": {
               "type": "Microsoft.Compute/availabilitySets",
@@ -546,7 +542,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16280521018377216764"
+              "templateHash": "16490443389180409510"
             }
           },
           "parameters": {
@@ -567,7 +563,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "as": {
               "type": "Microsoft.Compute/availabilitySets",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/proximity-placement-with-multi-resource-groups/network.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/proximity-placement-with-multi-resource-groups/network.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6480195888241511838"
+      "templateHash": "3850583703916111889"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "defaultValue": "1.1.1.1"
     }
   },
-  "functions": [],
   "resources": {
     "nsg": {
       "type": "Microsoft.Network/networkSecurityGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/redis-premium-cluster-diagnostics/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/redis-premium-cluster-diagnostics/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7257916549061959934"
+      "templateHash": "7584081585570631801"
     }
   },
   "parameters": {
@@ -84,7 +84,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "cache": {
       "type": "Microsoft.Cache/redis",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/redis-premium-persistence/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/redis-premium-persistence/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4245897447309454428"
+      "templateHash": "10723573498671174948"
     }
   },
   "parameters": {
@@ -90,7 +90,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "storageAccount": {
       "existing": true,

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/redis-premium-persistence/prereqs.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/redis-premium-persistence/prereqs.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "939827246187459718"
+      "templateHash": "12688862376099572684"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "cacheAccount": {
       "type": "Microsoft.Storage/storageAccounts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/servicebus-create-queue/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/servicebus-create-queue/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6351579017796515420"
+      "templateHash": "8748774500298793821"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "serviceBusNamespace": {
       "type": "Microsoft.ServiceBus/namespaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/shared-image-gallery-with-image-defintition-and-role-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/shared-image-gallery-with-image-defintition-and-role-assignment/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11326726915184059277"
+      "templateHash": "14970545098027917449"
     }
   },
   "parameters": {
@@ -45,7 +45,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "templateImageResourceGroupId": "[format('/subscriptions/{0}/resourcegroups/{1}', parameters('azureSubscriptionID'), parameters('templateImageResourceGroup'))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/sql/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/sql/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16183110875361653440"
+      "templateHash": "11202647491466524907"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "databaseName": "sample-db-with-tde",
     "databaseEdition": "Basic",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/traffic-manager-webapp/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/traffic-manager-webapp/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1839055630757131041"
+      "templateHash": "2233406945940440377"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "appServicePlan": {
       "type": "Microsoft.Web/serverfarms",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-copy-managed-disks/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-copy-managed-disks/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16395023054000421561"
+      "templateHash": "10314259165616058714"
     }
   },
   "parameters": {
@@ -52,7 +52,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "myVNETName": "myVNET",
     "myVNETPrefix": "10.0.0.0/16",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-domain-join/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-domain-join/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11761610079538613606"
+      "templateHash": "12346330178046526255"
     }
   },
   "parameters": {
@@ -56,7 +56,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountName": "[uniqueString(resourceGroup().id, deployment().name)]",
     "imagePublisher": "MicrosoftWindowsServer",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-new-or-existing-conditions/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-new-or-existing-conditions/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11623202059400725024"
+      "templateHash": "6759233609306016340"
     }
   },
   "parameters": {
@@ -156,7 +156,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "storageAccountId": "[if(parameters('createNewStorageAccount'), resourceInfo('storageAccount').id, resourceId(parameters('storageAccountResourceGroupName'), 'Microsoft.Storage/storageAccounts/', parameters('storageAccountName')))]",
     "subnetId": "[if(parameters('createNewVnet'), resourceInfo('subnet').id, resourceId(parameters('vnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName')))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-push-certificate-windows/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-push-certificate-windows/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9371882081892643852"
+      "templateHash": "9763081476321444683"
     }
   },
   "parameters": {
@@ -44,7 +44,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "kvId": "[resourceId(parameters('subId'), parameters('rgName'), 'Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
     "subnet1Name": "subnet-1",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-windows-with-custom-script-extension/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-windows-with-custom-script-extension/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1052641397051283830"
+      "templateHash": "5698201711636336924"
     }
   },
   "parameters": {
@@ -78,7 +78,6 @@
       "defaultValue": "https://raw.githubusercontent.com/Azure/bicep/main/docs/examples/201/vm-windows-with-custom-script-extension/install.ps1"
     }
   },
-  "functions": [],
   "variables": {
     "metadata": {
       "longName": "[format('{{0}}-{0}-{1}', parameters('name'), if(equals(coalesce(parameters('suffix'), ''), ''), '', concat('-', parameters('suffix'))))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3183603680113590113"
+      "templateHash": "16488040895619523397"
     }
   },
   "parameters": {
@@ -39,7 +39,6 @@
       "defaultValue": "bicep-demo-vm"
     }
   },
-  "functions": [],
   "variables": {
     "defaultLocation": "[resourceGroup().location]",
     "defaultVmNicName": "[format('{0}-nic', parameters('vmName'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vmss-windows-autoscale/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vmss-windows-autoscale/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8827004317952449181"
+      "templateHash": "15264817147163729952"
     }
   },
   "parameters": {
@@ -45,7 +45,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "namingInfix": "[toLower(substring(format('{0}{1}', parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
     "longNamingInfix": "[toLower(parameters('vmssName'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vnet-to-vnet-bgp/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vnet-to-vnet-bgp/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14302662418538179888"
+      "templateHash": "365740299004534431"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "vnet1cfg": {
       "name": "[format('vnet1-{0}', parameters('location'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vnet-to-vnet-peering/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vnet-to-vnet-peering/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14389696199294115786"
+      "templateHash": "9639800809061920471"
     }
   },
   "parameters": {
@@ -33,7 +33,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "vnet1Config": {
       "addressSpacePrefix": "10.0.0.0/24",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vnet-with-subnet-and-user-defined-route/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vnet-with-subnet-and-user-defined-route/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16237216576330181006"
+      "templateHash": "16639371633903290676"
     }
   },
   "parameters": {
@@ -56,7 +56,6 @@
       "defaultValue": "10.10.3.4"
     }
   },
-  "functions": [],
   "variables": {
     "vnetName": "[format('vnet-{0}', parameters('vnetSuffix'))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vwan-shared-services/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/vwan-shared-services/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1502251450386844737"
+      "templateHash": "15739186155633208382"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "vwan_cfg": {
       "name": "vwan",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-asev2-create/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-asev2-create/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8438970366294898221"
+      "templateHash": "3142187188898322244"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[uniqueString(resourceGroup().name)]"
     }
   },
-  "functions": [],
   "resources": {
     "virtualNetwork": {
       "type": "Microsoft.Network/virtualNetworks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-conditional-log/logging.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-conditional-log/logging.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15829090324176702955"
+      "templateHash": "16360286843581299856"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "appInsightName": "[toLower(format('appi-{0}', parameters('appName')))]",
     "logAnalyticsName": "[toLower(format('la-{0}', parameters('appName')))]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-conditional-log/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-conditional-log/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2566864244715309887"
+      "templateHash": "3086015972253679264"
     }
   },
   "parameters": {
@@ -20,7 +20,6 @@
       "defaultValue": false
     }
   },
-  "functions": [],
   "resources": {
     "webappModule": {
       "type": "Microsoft.Resources/deployments",
@@ -45,7 +44,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16930629051351428013"
+              "templateHash": "11741697022736338181"
             }
           },
           "parameters": {
@@ -65,7 +64,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]",
             "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"
@@ -169,7 +167,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15829090324176702955"
+              "templateHash": "16360286843581299856"
             }
           },
           "parameters": {
@@ -181,7 +179,6 @@
               "defaultValue": "[resourceGroup().location]"
             }
           },
-          "functions": [],
           "variables": {
             "appInsightName": "[toLower(format('appi-{0}', parameters('appName')))]",
             "logAnalyticsName": "[toLower(format('la-{0}', parameters('appName')))]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-conditional-log/webapp.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-conditional-log/webapp.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16930629051351428013"
+      "templateHash": "11741697022736338181"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]",
     "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/app-insights.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/app-insights.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16931680506919734641"
+      "templateHash": "17786095178266411096"
     }
   },
   "parameters": {
@@ -22,7 +22,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "appInsightName": "[toLower(format('appi-{0}', parameters('appName')))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/app-service-plan.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/app-service-plan.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6475566060310462114"
+      "templateHash": "17011904784298391986"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/app-service.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/app-service.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13947646110502359032"
+      "templateHash": "16621618591576177853"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/log-analytics.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/log-analytics.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6920818832844712742"
+      "templateHash": "1509661387361677849"
     }
   },
   "parameters": {
@@ -19,7 +19,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "logAnalyticsName": "[toLower(format('la-{0}', parameters('appName')))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics-mod/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13328486114904833657"
+      "templateHash": "4377935105155693964"
     }
   },
   "parameters": {
@@ -16,7 +16,6 @@
       "defaultValue": "[uniqueString(resourceGroup().id)]"
     }
   },
-  "functions": [],
   "resources": {
     "appServicePlanModule": {
       "type": "Microsoft.Resources/deployments",
@@ -41,7 +40,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6475566060310462114"
+              "templateHash": "17011904784298391986"
             }
           },
           "parameters": {
@@ -61,7 +60,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]"
           },
@@ -119,7 +117,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13947646110502359032"
+              "templateHash": "16621618591576177853"
             }
           },
           "parameters": {
@@ -137,7 +135,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]"
           },
@@ -242,7 +239,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16931680506919734641"
+              "templateHash": "17786095178266411096"
             }
           },
           "parameters": {
@@ -257,7 +254,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "appInsightName": "[toLower(format('appi-{0}', parameters('appName')))]"
           },
@@ -313,7 +309,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6920818832844712742"
+              "templateHash": "1509661387361677849"
             }
           },
           "parameters": {
@@ -325,7 +321,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "logAnalyticsName": "[toLower(format('la-{0}', parameters('appName')))]"
           },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-loganalytics/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2124035967996084264"
+      "templateHash": "18266300592124015987"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       "defaultValue": "[uniqueString(resourceGroup().id)]"
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]",
     "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-sql-database/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/web-app-sql-database/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2897632719423204943"
+      "templateHash": "2307688559503002542"
     }
   },
   "parameters": {
@@ -45,7 +45,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "hostingPlanName": "[format('hostingplan{0}', uniqueString(resourceGroup().id))]",
     "webSiteName": "[format('webSite{0}', uniqueString(resourceGroup().id))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5915215774680937096"
+      "templateHash": "12714539326532824331"
     }
   },
   "parameters": {
@@ -502,7 +502,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "copy": [
       {
@@ -603,7 +602,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7312403041374597157"
+              "templateHash": "5180923156111509853"
             }
           },
           "parameters": {
@@ -617,7 +616,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "workSpace": {
               "type": "Microsoft.DesktopVirtualization/workspaces",
@@ -672,7 +670,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1310292062566099270"
+              "templateHash": "13597904005241275944"
             }
           },
           "parameters": {
@@ -695,7 +693,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "availabilitySet": {
               "type": "Microsoft.Compute/availabilitySets",
@@ -848,7 +845,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12803195105479768873"
+              "templateHash": "8896621598340419959"
             }
           },
           "parameters": {
@@ -1114,7 +1111,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "emptyArray": [],
             "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -1366,7 +1362,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "11062318330053370487"
+                      "templateHash": "18233818777227830375"
                     }
                   },
                   "parameters": {
@@ -1386,7 +1382,6 @@
                       "type": "array"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "newNsg": {
                       "condition": "[parameters('createNetworkSecurityGroup')]",
@@ -1540,7 +1535,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10221138661537585248"
+              "templateHash": "16517357188773793233"
             }
           },
           "parameters": {
@@ -1806,7 +1801,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "emptyArray": [],
             "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -2043,7 +2037,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "11062318330053370487"
+                      "templateHash": "18233818777227830375"
                     }
                   },
                   "parameters": {
@@ -2063,7 +2057,6 @@
                       "type": "array"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "newNsg": {
                       "condition": "[parameters('createNetworkSecurityGroup')]",
@@ -2217,7 +2210,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17353466569456978138"
+              "templateHash": "218031779920447603"
             }
           },
           "parameters": {
@@ -2483,7 +2476,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "emptyArray": [],
             "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -2716,7 +2708,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "11062318330053370487"
+                      "templateHash": "18233818777227830375"
                     }
                   },
                   "parameters": {
@@ -2736,7 +2728,6 @@
                       "type": "array"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "newNsg": {
                       "condition": "[parameters('createNetworkSecurityGroup')]",
@@ -2890,7 +2881,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4418196960236946836"
+              "templateHash": "11216553347585315765"
             }
           },
           "parameters": {
@@ -3156,7 +3147,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "emptyArray": [],
             "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -3392,7 +3382,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "11062318330053370487"
+                      "templateHash": "18233818777227830375"
                     }
                   },
                   "parameters": {
@@ -3412,7 +3402,6 @@
                       "type": "array"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "newNsg": {
                       "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/AVSet.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/AVSet.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1310292062566099270"
+      "templateHash": "13597904005241275944"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "availabilitySet": {
       "type": "Microsoft.Compute/availabilitySets",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/NSG.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/NSG.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11062318330053370487"
+      "templateHash": "18233818777227830375"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": {
     "newNsg": {
       "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/managedDisks-customimagevm.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/managedDisks-customimagevm.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17353466569456978138"
+      "templateHash": "218031779920447603"
     }
   },
   "parameters": {
@@ -273,7 +273,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "emptyArray": [],
     "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -506,7 +505,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11062318330053370487"
+              "templateHash": "18233818777227830375"
             }
           },
           "parameters": {
@@ -526,7 +525,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "newNsg": {
               "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12803195105479768873"
+      "templateHash": "8896621598340419959"
     }
   },
   "parameters": {
@@ -273,7 +273,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "emptyArray": [],
     "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -525,7 +524,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11062318330053370487"
+              "templateHash": "18233818777227830375"
             }
           },
           "parameters": {
@@ -545,7 +544,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "newNsg": {
               "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/managedDisks-galleryvm.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/managedDisks-galleryvm.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4418196960236946836"
+      "templateHash": "11216553347585315765"
     }
   },
   "parameters": {
@@ -273,7 +273,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "emptyArray": [],
     "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -509,7 +508,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11062318330053370487"
+              "templateHash": "18233818777227830375"
             }
           },
           "parameters": {
@@ -529,7 +528,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "newNsg": {
               "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10221138661537585248"
+      "templateHash": "16517357188773793233"
     }
   },
   "parameters": {
@@ -273,7 +273,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "emptyArray": [],
     "domain_var": "[if(equals(parameters('domain'), ''), last(split(parameters('administratorAccountUsername'), '@')), parameters('domain'))]",
@@ -510,7 +509,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11062318330053370487"
+              "templateHash": "18233818777227830375"
             }
           },
           "parameters": {
@@ -530,7 +529,6 @@
               "type": "array"
             }
           },
-          "functions": [],
           "resources": {
             "newNsg": {
               "condition": "[parameters('createNetworkSecurityGroup')]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/workspace.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/modules/workspace.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7312403041374597157"
+      "templateHash": "5180923156111509853"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "array"
     }
   },
-  "functions": [],
   "resources": {
     "workSpace": {
       "type": "Microsoft.DesktopVirtualization/workspaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/automation-account-import-runbooks-and-modules/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/automation-account-import-runbooks-and-modules/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3499537664147370062"
+      "templateHash": "3876533941227178498"
     }
   },
   "parameters": {
@@ -107,7 +107,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "lockName": "[format('{0}-lck', resourceInfo('automationAccount').name)]",
     "diagnosticsName": "[format('{0}-dgs', resourceInfo('automationAccount').name)]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployifnotexists-policy-with-initiative-and-assignment/actionGroup.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployifnotexists-policy-with-initiative-and-assignment/actionGroup.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15375990374214365506"
+      "templateHash": "7523823652853157466"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       "type": "bool"
     }
   },
-  "functions": [],
   "resources": {
     "actionGroup": {
       "type": "microsoft.insights/actionGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployifnotexists-policy-with-initiative-and-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployifnotexists-policy-with-initiative-and-assignment/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8501058184574018125"
+      "templateHash": "7914120834673898986"
     }
   },
   "parameters": {
@@ -108,7 +108,6 @@
       "defaultValue": "Default"
     }
   },
-  "functions": [],
   "resources": {
     "rg": {
       "type": "Microsoft.Resources/resourceGroups",
@@ -155,7 +154,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15375990374214365506"
+              "templateHash": "7523823652853157466"
             }
           },
           "parameters": {
@@ -178,7 +177,6 @@
               "type": "bool"
             }
           },
-          "functions": [],
           "resources": {
             "actionGroup": {
               "type": "microsoft.insights/actionGroups",
@@ -289,7 +287,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3257616718067046466"
+              "templateHash": "3124856912890673547"
             }
           },
           "parameters": {
@@ -348,7 +346,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "policyDefCategory": "Custom",
             "policySource": "Bicep"
@@ -620,7 +617,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1688877772395552209"
+              "templateHash": "4504663721558284015"
             }
           },
           "parameters": {
@@ -634,7 +631,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "bicepExampleAssignment": {
               "type": "Microsoft.Authorization/policyAssignments",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployifnotexists-policy-with-initiative-and-assignment/policyAssignment.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployifnotexists-policy-with-initiative-and-assignment/policyAssignment.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1688877772395552209"
+      "templateHash": "4504663721558284015"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "bicepExampleAssignment": {
       "type": "Microsoft.Authorization/policyAssignments",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployifnotexists-policy-with-initiative-and-assignment/policyDefinition.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployifnotexists-policy-with-initiative-and-assignment/policyDefinition.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3257616718067046466"
+      "templateHash": "3124856912890673547"
     }
   },
   "parameters": {
@@ -66,7 +66,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "policyDefCategory": "Custom",
     "policySource": "Bicep"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployment-script-dev-environment/containergroups.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployment-script-dev-environment/containergroups.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4346160734782299103"
+      "templateHash": "10766962329556810795"
     }
   },
   "parameters": {
@@ -60,7 +60,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "variables": {
     "version": "[if(and(equals(parameters('type'), 'AzureCLI'), equals(parameters('toolVersion'), '')), 'latest', if(and(equals(parameters('type'), 'AzurePowerShell'), equals(parameters('toolVersion'), '')), '5.6', parameters('toolVersion')))]",
     "azcliImage": "[format('mcr.microsoft.com/azure-cli:{0}', variables('version'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployment-script-dev-environment/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployment-script-dev-environment/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "176429456247611231"
+      "templateHash": "1848161169272839328"
     }
   },
   "parameters": {
@@ -42,7 +42,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "storage": {
       "type": "Microsoft.Resources/deployments",
@@ -70,7 +69,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5022879701253378012"
+              "templateHash": "3979230528101032463"
             }
           },
           "parameters": {
@@ -119,7 +118,6 @@
               "defaultValue": "[resourceGroup().id]"
             }
           },
-          "functions": [],
           "resources": {
             "storage": {
               "type": "Microsoft.Storage/storageAccounts",
@@ -201,7 +199,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4346160734782299103"
+              "templateHash": "10766962329556810795"
             }
           },
           "parameters": {
@@ -254,7 +252,6 @@
               "defaultValue": "[resourceGroup().location]"
             }
           },
-          "functions": [],
           "variables": {
             "version": "[if(and(equals(parameters('type'), 'AzureCLI'), equals(parameters('toolVersion'), '')), 'latest', if(and(equals(parameters('type'), 'AzurePowerShell'), equals(parameters('toolVersion'), '')), '5.6', parameters('toolVersion')))]",
             "azcliImage": "[format('mcr.microsoft.com/azure-cli:{0}', variables('version'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployment-script-dev-environment/storage.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/deployment-script-dev-environment/storage.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5022879701253378012"
+      "templateHash": "3979230528101032463"
     }
   },
   "parameters": {
@@ -56,7 +56,6 @@
       "defaultValue": "[resourceGroup().id]"
     }
   },
-  "functions": [],
   "resources": {
     "storage": {
       "type": "Microsoft.Storage/storageAccounts",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/expressroute-circuit-vnet-connection/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/expressroute-circuit-vnet-connection/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9161100781122074184"
+      "templateHash": "16893944642504668302"
     }
   },
   "parameters": {
@@ -44,7 +44,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "virtualNetwork": {
       "type": "Microsoft.Network/virtualNetworks",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/function-app-with-custom-domain-managed-certificate/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/function-app-with-custom-domain-managed-certificate/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12701705877588966173"
+      "templateHash": "15072852059888565243"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "location": "[resourceGroup().location]",
     "componentBase": "[format('{0}-{1}', substring(uniqueString(resourceGroup().id), 4), parameters('applicationName'))]"
@@ -211,7 +210,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10952594413755937991"
+              "templateHash": "16897329147706656136"
             }
           },
           "parameters": {
@@ -225,7 +224,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "functionAppCustomHostEnable": {
               "type": "Microsoft.Web/sites/hostNameBindings",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/function-app-with-custom-domain-managed-certificate/sni-enable.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/function-app-with-custom-domain-managed-certificate/sni-enable.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10952594413755937991"
+      "templateHash": "16897329147706656136"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "functionAppCustomHostEnable": {
       "type": "Microsoft.Web/sites/hostNameBindings",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/insights-alertrules-application-insights/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/insights-alertrules-application-insights/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2475215425175033444"
+      "templateHash": "4251910498878880350"
     }
   },
   "parameters": {
@@ -42,7 +42,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "responseAlertName": "[format('ResponseTime-{0}', toLower(parameters('applicationInsightsName')))]"
   },

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/log-analytics-with-datasources-solutions/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/log-analytics-with-datasources-solutions/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9228875185578849999"
+      "templateHash": "4403720800122513563"
     }
   },
   "parameters": {
@@ -96,7 +96,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "lockName": "[format('{0}-lck', resourceInfo('logAnalyticsWorkspace').name)]",
     "diagnosticsName": "[format('{0}-dgs', resourceInfo('logAnalyticsWorkspace').name)]"

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/management-groups-nested-with-subscriptions/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/management-groups-nested-with-subscriptions/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18095556503139160092"
+      "templateHash": "1270972582386827750"
     }
   },
   "parameters": {
@@ -37,7 +37,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "managementGroup": {
       "type": "Microsoft.Management/managementGroups",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/azfw.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/azfw.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "843109748297468026"
+      "templateHash": "14385259627011021943"
     }
   },
   "parameters": {
@@ -63,7 +63,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "hubfwproperties": {
       "properties": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/azfwpip.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/azfwpip.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4751412643609413507"
+      "templateHash": "17181936323639575057"
     }
   },
   "parameters": {
@@ -37,7 +37,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": {
     "fwipprefix": {
       "type": "Microsoft.Network/publicIPPrefixes",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/azfwpolicy.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/azfwpolicy.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11406935289322070369"
+      "templateHash": "15325289422607085455"
     }
   },
   "parameters": {
@@ -28,7 +28,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "policy": {
       "type": "Microsoft.Network/firewallPolicies",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17685429378324542781"
+      "templateHash": "439817625238446761"
     }
   },
   "parameters": {
@@ -40,7 +40,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "vnetname": "[format('{0}-vnet', parameters('nameprefix'))]",
     "vpngwname": "[format('{0}-vpn-gw', variables('vnetname'))]",
@@ -112,7 +111,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7986398767681664162"
+              "templateHash": "3943071108607446816"
             }
           },
           "parameters": {
@@ -159,7 +158,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "servernsgname": "[format('{0}-snet-servers-nsg', parameters('vnetname'))]",
             "bastionnsgname": "[format('{0}-AzureBastionSubnet-nsg', parameters('vnetname'))]",
@@ -371,7 +369,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14337470301579219667"
+              "templateHash": "18212306837198330264"
             }
           },
           "parameters": {
@@ -398,7 +396,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "vpngwpip": {
               "type": "Microsoft.Network/publicIPAddresses",
@@ -502,7 +499,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11406935289322070369"
+              "templateHash": "15325289422607085455"
             }
           },
           "parameters": {
@@ -523,7 +520,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "policy": {
               "type": "Microsoft.Network/firewallPolicies",
@@ -679,7 +675,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4751412643609413507"
+              "templateHash": "17181936323639575057"
             }
           },
           "parameters": {
@@ -709,7 +705,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {
             "fwipprefix": {
               "type": "Microsoft.Network/publicIPPrefixes",
@@ -795,7 +790,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "843109748297468026"
+              "templateHash": "14385259627011021943"
             }
           },
           "parameters": {
@@ -851,7 +846,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "hubfwproperties": {
               "properties": {
@@ -945,7 +939,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1715639595272432146"
+              "templateHash": "967997001662366028"
             }
           },
           "parameters": {
@@ -968,7 +962,6 @@
               ]
             }
           },
-          "functions": [],
           "resources": {
             "wan": {
               "type": "Microsoft.Network/virtualWans",
@@ -1028,7 +1021,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4355308540613314409"
+              "templateHash": "15114646317857032390"
             }
           },
           "parameters": {
@@ -1053,7 +1046,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "hub": {
               "type": "Microsoft.Network/virtualHubs",
@@ -1116,7 +1108,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11406935289322070369"
+              "templateHash": "15325289422607085455"
             }
           },
           "parameters": {
@@ -1137,7 +1129,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "policy": {
               "type": "Microsoft.Network/firewallPolicies",
@@ -1299,7 +1290,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "843109748297468026"
+              "templateHash": "14385259627011021943"
             }
           },
           "parameters": {
@@ -1355,7 +1346,6 @@
               }
             }
           },
-          "functions": [],
           "variables": {
             "hubfwproperties": {
               "properties": {
@@ -1451,7 +1441,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7293420404572378859"
+              "templateHash": "15441215468607522142"
             }
           },
           "parameters": {
@@ -1475,7 +1465,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "hubvpngw": {
               "type": "Microsoft.Network/vpnGateways",
@@ -1563,7 +1552,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14030593813919556595"
+              "templateHash": "5186554569594679500"
             }
           },
           "parameters": {
@@ -1605,7 +1594,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "vpnsite": {
               "type": "Microsoft.Network/vpnSites",
@@ -1678,7 +1666,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9378638007715743777"
+              "templateHash": "1349873311495765855"
             }
           },
           "parameters": {
@@ -1698,7 +1686,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "hubvpnconnection": {
               "type": "Microsoft.Network/vpnGateways/vpnConnections",
@@ -1772,7 +1759,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4060504329053354121"
+              "templateHash": "7271247560517453672"
             }
           },
           "parameters": {
@@ -1824,7 +1811,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "localnetworkgw": {
               "type": "Microsoft.Network/localNetworkGateways",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vhub.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vhub.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4355308540613314409"
+      "templateHash": "15114646317857032390"
     }
   },
   "parameters": {
@@ -32,7 +32,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "hub": {
       "type": "Microsoft.Network/virtualHubs",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngw.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngw.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7293420404572378859"
+      "templateHash": "15441215468607522142"
     }
   },
   "parameters": {
@@ -31,7 +31,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "hubvpngw": {
       "type": "Microsoft.Network/vpnGateways",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngwcon.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngwcon.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9378638007715743777"
+      "templateHash": "1349873311495765855"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "hubvpnconnection": {
       "type": "Microsoft.Network/vpnGateways/vpnConnections",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vnet.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vnet.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7986398767681664162"
+      "templateHash": "3943071108607446816"
     }
   },
   "parameters": {
@@ -54,7 +54,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "servernsgname": "[format('{0}-snet-servers-nsg', parameters('vnetname'))]",
     "bastionnsgname": "[format('{0}-AzureBastionSubnet-nsg', parameters('vnetname'))]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4060504329053354121"
+      "templateHash": "7271247560517453672"
     }
   },
   "parameters": {
@@ -59,7 +59,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "localnetworkgw": {
       "type": "Microsoft.Network/localNetworkGateways",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vnetvpngw.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vnetvpngw.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14337470301579219667"
+      "templateHash": "18212306837198330264"
     }
   },
   "parameters": {
@@ -34,7 +34,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "vpngwpip": {
       "type": "Microsoft.Network/publicIPAddresses",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vwan.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vwan.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1715639595272432146"
+      "templateHash": "967997001662366028"
     }
   },
   "parameters": {
@@ -30,7 +30,6 @@
       ]
     }
   },
-  "functions": [],
   "resources": {
     "wan": {
       "type": "Microsoft.Network/virtualWans",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vwanvpnsite.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/vwanvpnsite.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14030593813919556595"
+      "templateHash": "5186554569594679500"
     }
   },
   "parameters": {
@@ -49,7 +49,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "vpnsite": {
       "type": "Microsoft.Network/vpnSites",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/nested-vms-in-virtual-network/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/nested-vms-in-virtual-network/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "543643878246113824"
+      "templateHash": "9841562694489357844"
     }
   },
   "parameters": {
@@ -117,7 +117,6 @@
       "type": "secureString"
     }
   },
-  "functions": [],
   "variables": {
     "NATSubnetNSGName": "[format('{0}NSG', parameters('NATSubnetName'))]",
     "hyperVSubnetNSGName": "[format('{0}NSG', parameters('hyperVSubnetName'))]",
@@ -371,7 +370,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12266946764841305208"
+              "templateHash": "6002572554315619854"
             }
           },
           "parameters": {
@@ -406,7 +405,6 @@
               "defaultValue": false
             }
           },
-          "functions": [],
           "resources": {
             "nic": {
               "type": "Microsoft.Network/networkInterfaces",
@@ -478,7 +476,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12266946764841305208"
+              "templateHash": "6002572554315619854"
             }
           },
           "parameters": {
@@ -513,7 +511,6 @@
               "defaultValue": false
             }
           },
-          "functions": [],
           "resources": {
             "nic": {
               "type": "Microsoft.Network/networkInterfaces",
@@ -590,7 +587,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12266946764841305208"
+              "templateHash": "6002572554315619854"
             }
           },
           "parameters": {
@@ -625,7 +622,6 @@
               "defaultValue": false
             }
           },
-          "functions": [],
           "resources": {
             "nic": {
               "type": "Microsoft.Network/networkInterfaces",
@@ -704,7 +700,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12266946764841305208"
+              "templateHash": "6002572554315619854"
             }
           },
           "parameters": {
@@ -739,7 +735,6 @@
               "defaultValue": false
             }
           },
-          "functions": [],
           "resources": {
             "nic": {
               "type": "Microsoft.Network/networkInterfaces",
@@ -805,7 +800,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10301753709145241530"
+              "templateHash": "1859635465192769327"
             }
           },
           "parameters": {
@@ -825,7 +820,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": {
             "udr": {
               "type": "Microsoft.Network/routeTables",
@@ -875,7 +869,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10301753709145241530"
+              "templateHash": "1859635465192769327"
             }
           },
           "parameters": {
@@ -895,7 +889,6 @@
               "defaultValue": ""
             }
           },
-          "functions": [],
           "resources": {
             "udr": {
               "type": "Microsoft.Network/routeTables",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/nested-vms-in-virtual-network/nic.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/nested-vms-in-virtual-network/nic.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12266946764841305208"
+      "templateHash": "6002572554315619854"
     }
   },
   "parameters": {
@@ -42,7 +42,6 @@
       "defaultValue": false
     }
   },
-  "functions": [],
   "resources": {
     "nic": {
       "type": "Microsoft.Network/networkInterfaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/nested-vms-in-virtual-network/udr.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/nested-vms-in-virtual-network/udr.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10301753709145241530"
+      "templateHash": "1859635465192769327"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "defaultValue": ""
     }
   },
-  "functions": [],
   "resources": {
     "udr": {
       "type": "Microsoft.Network/routeTables",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/publish-api-to-apim-opendocs/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/publish-api-to-apim-opendocs/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15843611222100607184"
+      "templateHash": "14331475603565032837"
     }
   },
   "parameters": {
@@ -47,7 +47,6 @@
       ]
     }
   },
-  "functions": [],
   "variables": {
     "productsSet": [
       {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/servicebus-namespace-vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/servicebus-namespace-vnet/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8074010830152231418"
+      "templateHash": "1770042464720505362"
     }
   },
   "parameters": {
@@ -25,7 +25,6 @@
       "defaultValue": "[resourceGroup().location]"
     }
   },
-  "functions": [],
   "resources": {
     "serviceBusNamespace": {
       "type": "Microsoft.ServiceBus/namespaces",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10158489108051984801"
+      "templateHash": "7491262926286587512"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "defaultResourceGroupProperties": {
       "tags": {},
@@ -62,7 +61,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7180613424274878486"
+              "templateHash": "10151444125157645848"
             }
           },
           "parameters": {
@@ -76,7 +75,6 @@
               "type": "object"
             }
           },
-          "functions": [],
           "variables": {
             "defaultSqlLogicalServerProperties": {
               "name": "",
@@ -175,7 +173,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "4197243106892100471"
+                      "templateHash": "18041704691098361149"
                     }
                   },
                   "parameters": {
@@ -195,7 +193,6 @@
                       "type": "object"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "defaultAuditActionsAndGroups": [
                       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
@@ -471,7 +468,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "7781780579480662923"
+                              "templateHash": "5996395024764564816"
                             }
                           },
                           "parameters": {
@@ -488,7 +485,6 @@
                               }
                             }
                           },
-                          "functions": [],
                           "resources": {
                             "firewallRule": {
                               "type": "Microsoft.Sql/servers/firewallRules",
@@ -539,7 +535,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "9049887160000022040"
+                              "templateHash": "17743984119146916557"
                             }
                           },
                           "parameters": {
@@ -559,7 +555,6 @@
                               "type": "object"
                             }
                           },
-                          "functions": [],
                           "resources": {
                             "sqlDb": {
                               "type": "Microsoft.Sql/servers/databases",
@@ -724,7 +719,7 @@
                                     "_generator": {
                                       "name": "bicep",
                                       "version": "dev",
-                                      "templateHash": "14166469428508227928"
+                                      "templateHash": "7769801267302127981"
                                     }
                                   },
                                   "parameters": {
@@ -735,7 +730,6 @@
                                       "type": "string"
                                     }
                                   },
-                                  "functions": [],
                                   "resources": {
                                     "shortTermBackup": {
                                       "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
@@ -779,7 +773,7 @@
                                     "_generator": {
                                       "name": "bicep",
                                       "version": "dev",
-                                      "templateHash": "16469354957335675288"
+                                      "templateHash": "12445030355610766196"
                                     }
                                   },
                                   "parameters": {
@@ -790,7 +784,6 @@
                                       "type": "string"
                                     }
                                   },
-                                  "functions": [],
                                   "resources": {
                                     "azureDefender": {
                                       "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
@@ -837,7 +830,7 @@
                                     "_generator": {
                                       "name": "bicep",
                                       "version": "dev",
-                                      "templateHash": "14799405862876158303"
+                                      "templateHash": "12633891391246310751"
                                     }
                                   },
                                   "parameters": {
@@ -848,7 +841,6 @@
                                       "type": "string"
                                     }
                                   },
-                                  "functions": [],
                                   "variables": {
                                     "defaultAuditActionsAndGroups": [
                                       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/audit-settings.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/audit-settings.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14799405862876158303"
+      "templateHash": "12633891391246310751"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "variables": {
     "defaultAuditActionsAndGroups": [
       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/azure-defender.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/azure-defender.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16469354957335675288"
+      "templateHash": "12445030355610766196"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "azureDefender": {
       "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/short-term-backup.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/short-term-backup.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14166469428508227928"
+      "templateHash": "7769801267302127981"
     }
   },
   "parameters": {
@@ -18,7 +18,6 @@
       "type": "string"
     }
   },
-  "functions": [],
   "resources": {
     "shortTermBackup": {
       "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-database.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-database.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9049887160000022040"
+      "templateHash": "17743984119146916557"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "type": "object"
     }
   },
-  "functions": [],
   "resources": {
     "sqlDb": {
       "type": "Microsoft.Sql/servers/databases",
@@ -192,7 +191,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14166469428508227928"
+              "templateHash": "7769801267302127981"
             }
           },
           "parameters": {
@@ -203,7 +202,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "shortTermBackup": {
               "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
@@ -247,7 +245,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16469354957335675288"
+              "templateHash": "12445030355610766196"
             }
           },
           "parameters": {
@@ -258,7 +256,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "resources": {
             "azureDefender": {
               "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
@@ -305,7 +302,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14799405862876158303"
+              "templateHash": "12633891391246310751"
             }
           },
           "parameters": {
@@ -316,7 +313,6 @@
               "type": "string"
             }
           },
-          "functions": [],
           "variables": {
             "defaultAuditActionsAndGroups": [
               "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-firewall-rule.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-firewall-rule.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7781780579480662923"
+      "templateHash": "5996395024764564816"
     }
   },
   "parameters": {
@@ -24,7 +24,6 @@
       }
     }
   },
-  "functions": [],
   "resources": {
     "firewallRule": {
       "type": "Microsoft.Sql/servers/firewallRules",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-logical-server.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-logical-server.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4197243106892100471"
+      "templateHash": "18041704691098361149"
     }
   },
   "parameters": {
@@ -27,7 +27,6 @@
       "type": "object"
     }
   },
-  "functions": [],
   "variables": {
     "defaultAuditActionsAndGroups": [
       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
@@ -303,7 +302,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7781780579480662923"
+              "templateHash": "5996395024764564816"
             }
           },
           "parameters": {
@@ -320,7 +319,6 @@
               }
             }
           },
-          "functions": [],
           "resources": {
             "firewallRule": {
               "type": "Microsoft.Sql/servers/firewallRules",
@@ -371,7 +369,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9049887160000022040"
+              "templateHash": "17743984119146916557"
             }
           },
           "parameters": {
@@ -391,7 +389,6 @@
               "type": "object"
             }
           },
-          "functions": [],
           "resources": {
             "sqlDb": {
               "type": "Microsoft.Sql/servers/databases",
@@ -556,7 +553,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "14166469428508227928"
+                      "templateHash": "7769801267302127981"
                     }
                   },
                   "parameters": {
@@ -567,7 +564,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "shortTermBackup": {
                       "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
@@ -611,7 +607,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "16469354957335675288"
+                      "templateHash": "12445030355610766196"
                     }
                   },
                   "parameters": {
@@ -622,7 +618,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "azureDefender": {
                       "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
@@ -669,7 +664,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "14799405862876158303"
+                      "templateHash": "12633891391246310751"
                     }
                   },
                   "parameters": {
@@ -680,7 +675,6 @@
                       "type": "string"
                     }
                   },
-                  "functions": [],
                   "variables": {
                     "defaultAuditActionsAndGroups": [
                       "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-logical-servers.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-logical-servers.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7180613424274878486"
+      "templateHash": "10151444125157645848"
     }
   },
   "parameters": {
@@ -21,7 +21,6 @@
       "type": "object"
     }
   },
-  "functions": [],
   "variables": {
     "defaultSqlLogicalServerProperties": {
       "name": "",
@@ -120,7 +119,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4197243106892100471"
+              "templateHash": "18041704691098361149"
             }
           },
           "parameters": {
@@ -140,7 +139,6 @@
               "type": "object"
             }
           },
-          "functions": [],
           "variables": {
             "defaultAuditActionsAndGroups": [
               "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
@@ -416,7 +414,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7781780579480662923"
+                      "templateHash": "5996395024764564816"
                     }
                   },
                   "parameters": {
@@ -433,7 +431,6 @@
                       }
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "firewallRule": {
                       "type": "Microsoft.Sql/servers/firewallRules",
@@ -484,7 +481,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "9049887160000022040"
+                      "templateHash": "17743984119146916557"
                     }
                   },
                   "parameters": {
@@ -504,7 +501,6 @@
                       "type": "object"
                     }
                   },
-                  "functions": [],
                   "resources": {
                     "sqlDb": {
                       "type": "Microsoft.Sql/servers/databases",
@@ -669,7 +665,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "14166469428508227928"
+                              "templateHash": "7769801267302127981"
                             }
                           },
                           "parameters": {
@@ -680,7 +676,6 @@
                               "type": "string"
                             }
                           },
-                          "functions": [],
                           "resources": {
                             "shortTermBackup": {
                               "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
@@ -724,7 +719,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "16469354957335675288"
+                              "templateHash": "12445030355610766196"
                             }
                           },
                           "parameters": {
@@ -735,7 +730,6 @@
                               "type": "string"
                             }
                           },
-                          "functions": [],
                           "resources": {
                             "azureDefender": {
                               "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
@@ -782,7 +776,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "14799405862876158303"
+                              "templateHash": "12633891391246310751"
                             }
                           },
                           "parameters": {
@@ -793,7 +787,6 @@
                               "type": "string"
                             }
                           },
-                          "functions": [],
                           "variables": {
                             "defaultAuditActionsAndGroups": [
                               "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/web-app-managed-identity-sql-db/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/web-app-managed-identity-sql-db/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1890148443949690437"
+      "templateHash": "4718910372236072460"
     }
   },
   "parameters": {
@@ -52,7 +52,6 @@
       "defaultValue": "b24988ac-6180-42a0-ab88-20f7382dd24c"
     }
   },
-  "functions": [],
   "variables": {
     "hostingPlanName": "[format('hostingplan{0}', uniqueString(resourceGroup().id))]",
     "webSiteName": "[format('webSite{0}', uniqueString(resourceGroup().id))]",

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -141,9 +141,9 @@ namespace Bicep.Core.Emit
 
             this.EmitParametersIfPresent(jsonWriter, emitter);
 
-            jsonWriter.WritePropertyName("functions");
-            jsonWriter.WriteStartArray();
-            jsonWriter.WriteEndArray();
+            // jsonWriter.WritePropertyName("functions");
+            // jsonWriter.WriteStartArray();
+            // jsonWriter.WriteEndArray();
 
             this.EmitVariablesIfPresent(jsonWriter, emitter);
 

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -141,10 +141,6 @@ namespace Bicep.Core.Emit
 
             this.EmitParametersIfPresent(jsonWriter, emitter);
 
-            // jsonWriter.WritePropertyName("functions");
-            // jsonWriter.WriteStartArray();
-            // jsonWriter.WriteEndArray();
-
             this.EmitVariablesIfPresent(jsonWriter, emitter);
 
             this.EmitImports(jsonWriter, emitter);


### PR DESCRIPTION
Fixes #3749

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [x] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [x] This is a bug fix for an existing example
* [x] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [x] I have checked that all tests are passing by running `dotnet test`
* [x] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
