### PR TITLE
Add completion support for disable next line diagnostics directive

### DIFF
--- a/src/Bicep.Core.Samples/Files/DisableNextLineDiagnosticsDirective_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/DisableNextLineDiagnosticsDirective_CRLF/main.formatted.bicep
@@ -18,7 +18,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
 param storageAccount1 string = 'testStorageAccount'
 #disable-next-line          no-unused-params
 param storageAccount2 string = 'testStorageAccount'
-#disable-next-line   no-unused-params                 /* Test comment 1 */
+#disable-next-line   no-unused-params /* Test comment 1 */
 param storageAccount3 string = 'testStorageAccount'
-#disable-next-line   no-unused-params                 // Test comment 2
+#disable-next-line   no-unused-params // Test comment 2
 param storageAccount5 string = 'testStorageAccount'

--- a/src/Bicep.Core.UnitTests/Parsing/LexerTests.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/LexerTests.cs
@@ -265,7 +265,7 @@ namespace Bicep.Core.UnitTests.Parsing
         }
 
         [TestMethod]
-        public void ValidDisableNextLineDiagnosticsDirective_WithTrailingWhiteSpace_ShouldLexCorrectly()
+        public void ValidDisableNextLineDiagnosticsDirective_WithTrailingWhiteSpaceFollowedByComment_ShouldLexCorrectly()
         {
             string text = "#disable-next-line BCP226   // test";
             var diagnosticWriter = ToListDiagnosticWriter.Create();
@@ -297,6 +297,39 @@ namespace Bicep.Core.UnitTests.Parsing
                     x.Type.Should().Be(SyntaxTriviaType.SingleLineComment);
                 });
         }
+
+        [TestMethod]
+        public void ValidDisableNextLineDiagnosticsDirective_WithinResourceAndWithTrailingWhiteSpace_ShouldLexCorrectly()
+        {
+            string text = @"resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
+#disable-next-line BCP226   
+  properties: vmProperties
+}";
+            var diagnosticWriter = ToListDiagnosticWriter.Create();
+            var lexer = new Lexer(new SlidingTextWindow(text), diagnosticWriter);
+            lexer.Lex();
+
+            diagnosticWriter.GetDiagnostics().Should().BeEmpty();
+
+            var tokens = lexer.GetTokens();
+            tokens.Count().Should().Be(13);
+
+            var leadingTrivia = tokens.ElementAt(6).LeadingTrivia;
+            leadingTrivia.Count().Should().Be(2);
+
+            leadingTrivia.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Text.Should().Be("#disable-next-line BCP226");
+                    x.Type.Should().Be(SyntaxTriviaType.DisableNextLineDiagnosticsDirective);
+                },
+                x =>
+                {
+                    x.Text.Should().Be("   ");
+                    x.Type.Should().Be(SyntaxTriviaType.Whitespace);
+                });
+        }
+
 
         [TestMethod]
         public void UnterminatedString_ShouldBeRecognizedWithError()

--- a/src/Bicep.Core/Parsing/Lexer.cs
+++ b/src/Bicep.Core/Parsing/Lexer.cs
@@ -423,11 +423,11 @@ namespace Bicep.Core.Parsing
                     var delta = end - lastCodeSpanEnd;
                     textWindow.Rewind(delta);
 
-                    return new DisableNextLineDiagnosticsSyntaxTrivia(SyntaxTriviaType.DisableNextLineDiagnosticsDirective, new TextSpan(start, lastCodeSpanEnd), text[0..^delta], codes);
+                    return new DisableNextLineDiagnosticsSyntaxTrivia(SyntaxTriviaType.DisableNextLineDiagnosticsDirective, new TextSpan(start, lastCodeSpanEnd - start), text[0..^delta], codes);
                 }
             }
 
-            return new DisableNextLineDiagnosticsSyntaxTrivia(SyntaxTriviaType.DisableNextLineDiagnosticsDirective, new TextSpan(start, end), text, codes);
+            return new DisableNextLineDiagnosticsSyntaxTrivia(SyntaxTriviaType.DisableNextLineDiagnosticsDirective, new TextSpan(start, end - start), text, codes);
         }
 
         private Token? GetToken()

--- a/src/Bicep.Core/Parsing/Lexer.cs
+++ b/src/Bicep.Core/Parsing/Lexer.cs
@@ -333,7 +333,7 @@ namespace Bicep.Core.Parsing
 
             var span = textWindow.GetSpan();
             int start = span.Position;
-            int length = span.Length;
+            int end = span.GetEndPosition();
 
             StringBuilder sb = new StringBuilder();
             sb.Append(textWindow.GetText());
@@ -360,7 +360,7 @@ namespace Bicep.Core.Parsing
                             if (GetToken() is { } token)
                             {
                                 codes.Add(token);
-                                length += token.Span.Length;
+                                end += token.Span.Length;
                                 sb.Append(token.Text);
 
                                 continue;
@@ -375,7 +375,7 @@ namespace Bicep.Core.Parsing
                 {
                     textWindow.Advance();
                     sb.Append(nextChar);
-                    length++;
+                    end++;
                     textWindow.Reset();
                 }
                 else
@@ -389,7 +389,7 @@ namespace Bicep.Core.Parsing
                 AddDiagnostic(b => b.MissingDiagnosticCodes());
             }
 
-            return GetDisableNextLineDiagnosticsSyntaxTrivia(codes, start, length, sb.ToString());
+            return GetDisableNextLineDiagnosticsSyntaxTrivia(codes, start, end, sb.ToString());
         }
 
         private bool CheckAdjacentText(string text)
@@ -409,7 +409,7 @@ namespace Bicep.Core.Parsing
             return true;
         }
 
-        private DisableNextLineDiagnosticsSyntaxTrivia GetDisableNextLineDiagnosticsSyntaxTrivia(List<Token> codes, int start, int length, string text)
+        private DisableNextLineDiagnosticsSyntaxTrivia GetDisableNextLineDiagnosticsSyntaxTrivia(List<Token> codes, int start, int end, string text)
         {
             if (codes.Any())
             {
@@ -418,15 +418,16 @@ namespace Bicep.Core.Parsing
 
                 // There could be whitespace following #disable-next-line directive, in which case we need to adjust the span and text.
                 // E.g. #disable-next-line BCP226   // test
-                if (length > lastCodeSpanEnd)
+                if (end > lastCodeSpanEnd)
                 {
-                    textWindow.Rewind(length - lastCodeSpanEnd);
+                    var delta = end - lastCodeSpanEnd;
+                    textWindow.Rewind(delta);
 
-                    return new DisableNextLineDiagnosticsSyntaxTrivia(SyntaxTriviaType.DisableNextLineDiagnosticsDirective, new TextSpan(start, lastCodeSpanEnd), text.Substring(0, lastCodeSpanEnd), codes);
+                    return new DisableNextLineDiagnosticsSyntaxTrivia(SyntaxTriviaType.DisableNextLineDiagnosticsDirective, new TextSpan(start, lastCodeSpanEnd), text[0..^delta], codes);
                 }
             }
 
-            return new DisableNextLineDiagnosticsSyntaxTrivia(SyntaxTriviaType.DisableNextLineDiagnosticsDirective, new TextSpan(start, length), text, codes);
+            return new DisableNextLineDiagnosticsSyntaxTrivia(SyntaxTriviaType.DisableNextLineDiagnosticsDirective, new TextSpan(start, end), text, codes);
         }
 
         private Token? GetToken()

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -1475,7 +1475,7 @@ var testF = stg.listAccountSas('2021-06-01', {}).|
         public async Task VerifyCompletionRequestAfterPoundSign_ShouldReturnCompletionItem()
         {
             var fileWithCursors = @"#|
-param storageAccount1 string = 'testAccount";
+param storageAccount string = 'testAccount";
             var (file, cursors) = ParserHelper.GetFileWithCursors(fileWithCursors);
 
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri("file:///main.bicep"), file);

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -143,5 +143,15 @@ namespace Bicep.LanguageServer.Completions
         /// We're inside a function parentheses: 'someFunc(|)'
         /// </summary>
         FunctionArgument = 1 << 25,
+
+        /// <summary>
+        /// The current location is after # sign.
+        /// </summary>
+        DisableNextLineDiagnosticsDirectiveStart = 1 << 25,
+
+        /// <summary>
+        /// The current location is after '#disable-next-line |'.
+        /// </summary>
+        DisableNextLineDiagnosticsCodes = 1 << 26
     }
 }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
-using System.Web;
 using Azure.Deployments.Core.Comparers;
 using Bicep.Core;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
 using Bicep.Core.Extensions;
 using Bicep.Core.Features;
@@ -17,6 +17,7 @@ using Bicep.Core.Parsing;
 using Bicep.Core.Resources;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
+using Bicep.Core.Text;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.Extensions;
@@ -72,7 +73,9 @@ namespace Bicep.LanguageServer.Completions
                 .Concat(GetOutputValueCompletions(model, context))
                 .Concat(GetTargetScopeCompletions(model, context))
                 .Concat(GetImportCompletions(model, context))
-                .Concat(GetFunctionParamCompletions(model, context));
+                .Concat(GetFunctionParamCompletions(model, context))
+                .Concat(GetDisableNextLineDiagnosticsDirectiveCompletion(context))
+                .Concat(GetDisableNextLineDiagnosticsDirectiveCodesCompletion(model, context)); ;
         }
 
         private IEnumerable<CompletionItem> GetDeclarationCompletions(SemanticModel model, BicepCompletionContext context)
@@ -907,6 +910,72 @@ namespace Bicep.LanguageServer.Completions
                     snippet.CompletionPriority,
                     preselect: true);
             }
+        }
+
+        private IEnumerable<CompletionItem> GetDisableNextLineDiagnosticsDirectiveCompletion(BicepCompletionContext context)
+        {
+            if (context.Kind.HasFlag(BicepCompletionContextKind.DisableNextLineDiagnosticsDirectiveStart))
+            {
+                yield return CreateKeywordCompletion(LanguageConstants.DisableNextLineDiagnosticsKeyword, "Disable next line diagnostics directive", context.ReplacementRange);
+            }
+        }
+
+        private IEnumerable<CompletionItem> GetDisableNextLineDiagnosticsDirectiveCodesCompletion(SemanticModel model, BicepCompletionContext context)
+        {
+            if (context.Kind.HasFlag(BicepCompletionContextKind.DisableNextLineDiagnosticsCodes))
+            {
+                foreach (var diagnostic in GetDiagnosticCodes(context.ReplacementRange, model))
+                {
+                    yield return CreateKeywordCompletion(diagnostic.Code, diagnostic.Message, context.ReplacementRange);
+                }
+            }
+        }
+
+        private IEnumerable<IDiagnostic> GetDiagnosticCodes(Range range, SemanticModel model)
+        {
+            var lineStarts = model.SourceFile.LineStarts;
+            var position = GetPosition(range, lineStarts);
+            (var line, _) = TextCoordinateConverter.GetPosition(lineStarts, position);
+            var nextLineSpan = GetNextLineSpan(lineStarts, line, model.SourceFile.ProgramSyntax);
+
+            if (nextLineSpan is null)
+            {
+                return Enumerable.Empty<IDiagnostic>();
+            }
+
+            return model.GetAllDiagnostics()
+                .Where(diagnostic => nextLineSpan.ContainsInclusive(diagnostic.Span.Position) && nextLineSpan.ContainsInclusive(diagnostic.Span.GetEndPosition()))
+                .DistinctBy(x => x.Code);
+        }
+
+        private int GetPosition(Range range, ImmutableArray<int> lineStarts)
+        {
+            var rangeStart = range.Start;
+            return lineStarts[rangeStart.Line] + rangeStart.Character;
+        }
+
+        private TextSpan? GetNextLineSpan(ImmutableArray<int> lineStarts, int line, ProgramSyntax programSyntax)
+        {
+            var nextLine = line + 1;
+            if (lineStarts.Length > nextLine)
+            {
+                var nextLineStart = lineStarts[nextLine];
+
+                int nextLineEnd;
+
+                if (lineStarts.Length > nextLine + 1)
+                {
+                    nextLineEnd = lineStarts[nextLine + 1] - 1;
+                }
+                else
+                {
+                    nextLineEnd = programSyntax.GetEndPosition();
+                }
+
+                return new TextSpan(nextLineStart, nextLineEnd - nextLineStart);
+            }
+
+            return null;
         }
 
         private static CompletionItem CreateResourceOrModuleConditionCompletion(Range replacementRange)

--- a/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCompletionHandler.cs
@@ -64,7 +64,7 @@ namespace Bicep.LanguageServer.Handlers
             DocumentSelector = DocumentSelectorFactory.Create(),
             AllCommitCharacters = new Container<string>(),
             ResolveProvider = false,
-            TriggerCharacters = new Container<string>(":", " ", ".", "/", "'", "@", "{")
+            TriggerCharacters = new Container<string>(":", " ", ".", "/", "'", "@", "{", "#")
         };
     }
 }


### PR DESCRIPTION
Fixes #5178 
Adds completion support for #disable-next-line directive. Completion is triggered in below cases:
1. #|
2. #disable-next-line |