### PR TITLE
Bicep nuget packages fixes

### DIFF
--- a/src/Bicep.MSBuild.E2eTests/examples/empty/empty.proj
+++ b/src/Bicep.MSBuild.E2eTests/examples/empty/empty.proj
@@ -3,9 +3,7 @@
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <!-- Ensure the package supports multi-targeting -->
-    <TargetFrameworks>net5;net472</TargetFrameworks>
-    <BicepOutputPath>bin\$(Configuration)\templates</BicepOutputPath>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <!-- 
@@ -17,10 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Bicep Include="passthrough.bicep"/>
-    <Bicep Include="empty.bicep"/>
-    <Bicep Include="subdir\theAnswer.bicep">
-      <OutputFile>$(BicepOutputPath)\special\special.arm</OutputFile>
-    </Bicep>
+    <!-- Do not set any Bicep item: this ensures the package correctly does not error on projects without Bicep items -->
   </ItemGroup>
 </Project>

--- a/src/Bicep.MSBuild.E2eTests/examples/missingCli/missingCli.proj
+++ b/src/Bicep.MSBuild.E2eTests/examples/missingCli/missingCli.proj
@@ -16,7 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- the following file name is intentionally wrong -->
     <Bicep Include="empty.bicep"/>
   </ItemGroup>
 </Project>

--- a/src/Bicep.MSBuild.E2eTests/examples/multiple/multiple.proj
+++ b/src/Bicep.MSBuild.E2eTests/examples/multiple/multiple.proj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <!-- Ensure the package supports multi-targeting -->
     <TargetFrameworks>net5;net472</TargetFrameworks>
+    <LanguageTargets>$(MSBuildThisFileDirectory)\multitarget-mitigation.targets</LanguageTargets> <!-- https://github.com/microsoft/MSBuildSdks/issues/155 -->
     <BicepOutputPath>bin\$(Configuration)\templates</BicepOutputPath>
   </PropertyGroup>
 

--- a/src/Bicep.MSBuild.E2eTests/examples/multiple/multitarget-mitigation.targets
+++ b/src/Bicep.MSBuild.E2eTests/examples/multiple/multitarget-mitigation.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <!-- Mitigation for https://github.com/microsoft/MSBuildSdks/issues/155 -->
+    <Import Project="$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets" Condition="$(IsCrossTargetingBuild) == 'true'" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="$(IsCrossTargetingBuild) != 'true'" />
+</Project>

--- a/src/Bicep.MSBuild/Bicep.MSBuild.csproj
+++ b/src/Bicep.MSBuild/Bicep.MSBuild.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- do not upgrade these packages - we need to support mesbuild 16 -->
+    <!-- do not upgrade these packages - we need to support msbuild 16 -->
     <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.targets
+++ b/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.targets
@@ -7,7 +7,7 @@
     <BicepOutputPath Condition=" $(BicepOutputPath) == '' ">$(OutputPath)</BicepOutputPath>
   </PropertyGroup>
 
-  <Target Name="BicepCompile" Condition=" @(Bicep) != '' " DependsOnTargets="$(BicepCompileDependsOn)" AfterTargets="$(BicepCompileAfterTargets)" BeforeTargets="$(BicepCompileBeforeTargets)">
+  <Target Name="BeforeBicepCompile" Condition=" @(Bicep) != '' " BeforeTargets="BicepCompile">
     <ItemGroup>
       <_BicepResolved Include="@(Bicep)">
         <!-- populate missing output file metadata using the default path -->
@@ -16,13 +16,13 @@
 
       <_BicepOutputFile Include="%(_BicepResolved.OutputFile)" />
     </ItemGroup>
-
     <!-- pre-create directories for all the outputs in case they don't exist -->
     <MakeDir Directories=" %(_BicepOutputFile.RootDir)%(Directory)" />
-
     <Error Text="The path to the Bicep compiler is not set. Reference the appropriate Azure.Bicep.CommandLine.* package for your runtime or set the BicepPath property." Condition=" $(BicepPath) == '' " />
-    <Bicep SourceFile="%(_BicepResolved.FullPath)" OutputFile="%(OutputFile)" ToolExe="$(BicepPath)" />
-    
+  </Target>
+
+  <Target Name="BicepCompile" Inputs="@(_BicepResolved)" Outputs="%(_BicepResolved.OutputFile)" DependsOnTargets="$(BicepCompileDependsOn)" AfterTargets="$(BicepCompileAfterTargets)" BeforeTargets="$(BicepCompileBeforeTargets)">
+    <Bicep SourceFile="%(_BicepResolved.FullPath)" OutputFile="%(OutputFile)" ToolExe="$(BicepPath)" YieldDuringToolExecution="true" />
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; %(_BicepResolved.OutputFile)" />
 
     <ItemGroup>

--- a/src/Bicep.MSBuild/buildMultiTargeting/Azure.Bicep.MSBuild.props
+++ b/src/Bicep.MSBuild/buildMultiTargeting/Azure.Bicep.MSBuild.props
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\build\BicepTasks.props" />
+  <Import Project="..\build\Azure.Bicep.MSBuild.props" />
 </Project>

--- a/src/Bicep.MSBuild/buildMultiTargeting/Azure.Bicep.MSBuild.targets
+++ b/src/Bicep.MSBuild/buildMultiTargeting/Azure.Bicep.MSBuild.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\build\BicepTasks.targets" />
+  <Import Project="..\build\Azure.Bicep.MSBuild.targets" />
 </Project>


### PR DESCRIPTION
Fixes #5253
Fixes #5238
Fixes #5236

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
