### PR TITLE
WIP: convert expression generation logic to use IR

### DIFF
--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5991333156697487016"
+      "templateHash": "7954807953577812069"
     }
   },
   "parameters": {
@@ -717,7 +717,7 @@
     },
     "indexedCollectionIdentity": {
       "type": "object",
-      "value": "[reference('storageAccounts', '2019-06-01', 'full').identity]"
+      "value": "[reference(format('storageAccounts[{0}]', parameters('index')), '2019-06-01', 'full').identity]"
     },
     "indexedEndpointPair": {
       "type": "object",
@@ -756,7 +756,7 @@
     },
     "existingIndexedResourceLocation": {
       "type": "string",
-      "value": "[reference('existingStorageAccounts', '2019-06-01', 'full').location]"
+      "value": "[reference(format('existingStorageAccounts[{0}]', div(parameters('index'), 2)), '2019-06-01', 'full').location]"
     },
     "existingIndexedResourceAccessTier": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4677966447708206616"
+      "templateHash": "15901839838635651120"
     }
   },
   "parameters": {
@@ -831,7 +831,7 @@
     },
     "indexedCollectionIdentity": {
       "type": "object",
-      "value": "[reference('storageAccounts', '2019-06-01', 'full').identity]"
+      "value": "[reference(format('storageAccounts[{0}]', parameters('index')), '2019-06-01', 'full').identity]"
     },
     "indexedEndpointPair": {
       "type": "object",
@@ -870,7 +870,7 @@
     },
     "existingIndexedResourceLocation": {
       "type": "string",
-      "value": "[reference('existingStorageAccounts', '2019-06-01', 'full').location]"
+      "value": "[reference(format('existingStorageAccounts[{0}]', div(parameters('index'), 2)), '2019-06-01', 'full').location]"
     },
     "existingIndexedResourceAccessTier": {
       "type": "string",

--- a/src/Bicep.Core/CodeAnalysis/ArrayAccessOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ArrayAccessOperation.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ArrayAccessOperation : Operation
+    {
+        public ArrayAccessOperation(Operation @base, Operation access)
+        {
+            Base = @base;
+            Access = access;
+        }
+
+        public Operation Base { get; }
+
+        public Operation Access { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitArrayAccessOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ConstantValueOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ConstantValueOperation.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ConstantValueOperation : Operation
+    {
+        public ConstantValueOperation(string value)
+        {
+            Value = value;
+        }
+
+        public ConstantValueOperation(int value)
+        {
+            Value = value;
+        }
+
+        public object Value { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitConstantValueOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/FunctionCallOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/FunctionCallOperation.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class FunctionCallOperation : Operation
+    {
+        public FunctionCallOperation(string name, ImmutableArray<Operation> parameters)
+        {
+            Name = name;
+            Parameters = parameters;
+        }
+
+        public FunctionCallOperation(string name, params Operation[] parameters)
+            : this(name, parameters.ToImmutableArray())
+        {
+        }
+
+        public string Name { get; }
+
+        public ImmutableArray<Operation> Parameters { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitFunctionCallOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/IOperationVisitor.cs
+++ b/src/Bicep.Core/CodeAnalysis/IOperationVisitor.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public interface IOperationVisitor
+    {
+        void VisitConstantValueOperation(ConstantValueOperation operation);
+
+        void VisitPropertyAccessOperation(PropertyAccessOperation operation);
+
+        void VisitArrayAccessOperation(ArrayAccessOperation operation);
+
+        void VisitResourceIdOperation(ResourceIdOperation operation);
+
+        void VisitResourceNameOperation(ResourceNameOperation operation);
+
+        void VisitResourceTypeOperation(ResourceTypeOperation operation);
+
+        void VisitResourceApiVersionOperation(ResourceApiVersionOperation operation);
+
+        void VisitResourceReferenceOperation(ResourceReferenceOperation operation);
+
+        void VisitSymbolicResourceReferenceOperation(SymbolicResourceReferenceOperation operation);
+
+        void VisitResourceInfoOperation(ResourceInfoOperation operation);
+
+        void VisitModuleNameOperation(ModuleNameOperation operation);
+
+        void VisitModuleOutputOperation(ModuleOutputOperation operation);
+
+        void VisitVariableAccessOperation(VariableAccessOperation operation);
+
+        void VisitParameterAccessOperation(ParameterAccessOperation operation);
+
+        void VisitModuleReferenceOperation(ModuleReferenceOperation operation);
+
+        void VisitFunctionCallOperation(FunctionCallOperation operation);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/IndexReplacementContext.cs
+++ b/src/Bicep.Core/CodeAnalysis/IndexReplacementContext.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+using Azure.Deployments.Expression.Expressions;
+using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    // TODO: refactor this to remove dependency on syntax
+    public record IndexReplacementContext(
+        ImmutableDictionary<LocalVariableSymbol, Operation> LocalReplacements,
+        Operation Index);
+}

--- a/src/Bicep.Core/CodeAnalysis/ModuleNameOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ModuleNameOperation.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ModuleNameOperation : Operation
+    {
+        public ModuleNameOperation(ModuleSymbol symbol, IndexReplacementContext? indexContext)
+        {
+            Symbol = symbol;
+            IndexContext = indexContext;
+        }
+
+        public ModuleSymbol Symbol { get; }
+
+        public IndexReplacementContext? IndexContext { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitModuleNameOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ModuleOutputOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ModuleOutputOperation.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ModuleOutputOperation : Operation
+    {
+        public ModuleOutputOperation(ModuleSymbol symbol, IndexReplacementContext? indexContext, Operation propertyName)
+        {
+            Symbol = symbol;
+            IndexContext = indexContext;
+            PropertyName = propertyName;
+        }
+
+        public ModuleSymbol Symbol { get; }
+
+        public IndexReplacementContext? IndexContext { get; }
+
+        public Operation PropertyName { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitModuleOutputOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ModuleReferenceOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ModuleReferenceOperation.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ModuleReferenceOperation : Operation
+    {
+        public ModuleReferenceOperation(ModuleSymbol symbol, IndexReplacementContext? indexContext)
+        {
+            Symbol = symbol;
+        }
+
+        public ModuleSymbol Symbol { get; }
+
+        public IndexReplacementContext? IndexContext { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitModuleReferenceOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/Operation.cs
+++ b/src/Bicep.Core/CodeAnalysis/Operation.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public abstract class Operation
+    {
+        protected Operation()
+        {
+        }
+
+        public abstract void Accept(IOperationVisitor visitor);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ParameterAccessOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ParameterAccessOperation.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ParameterAccessOperation : Operation
+    {
+        public ParameterAccessOperation(ParameterSymbol symbol)
+        {
+            Symbol = symbol;
+        }
+
+        public ParameterSymbol Symbol { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitParameterAccessOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/PropertyAccessOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/PropertyAccessOperation.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class PropertyAccessOperation : Operation
+    {
+        public PropertyAccessOperation(Operation @base, string propertyName)
+        {
+            Base = @base;
+            PropertyName = propertyName;
+        }
+
+        public Operation Base { get; }
+
+        public string PropertyName { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitPropertyAccessOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ResourceApiVersionOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ResourceApiVersionOperation.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ResourceApiVersionOperation : Operation
+    {
+        public ResourceApiVersionOperation(ResourceMetadata metadata)
+        {
+            Metadata = metadata;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceApiVersionOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ResourceIdOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ResourceIdOperation.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ResourceIdOperation : Operation
+    {
+        public ResourceIdOperation(ResourceMetadata metadata, IndexReplacementContext? indexContext)
+        {
+            Metadata = metadata;
+            IndexContext = indexContext;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
+        public IndexReplacementContext? IndexContext { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceIdOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ResourceInfoOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ResourceInfoOperation.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ResourceInfoOperation : Operation
+    {
+        public ResourceInfoOperation(ResourceMetadata metadata, IndexReplacementContext? indexContext)
+        {
+            Metadata = metadata;
+            IndexContext = indexContext;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
+        public IndexReplacementContext? IndexContext { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceInfoOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ResourceNameOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ResourceNameOperation.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ResourceNameOperation : Operation
+    {
+        public ResourceNameOperation(ResourceMetadata metadata, IndexReplacementContext? indexContext, bool fullyQualified)
+        {
+            Metadata = metadata;
+            IndexContext = indexContext;
+            FullyQualified = fullyQualified;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
+        public IndexReplacementContext? IndexContext { get; }
+
+        public bool FullyQualified { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceNameOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ResourceReferenceOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ResourceReferenceOperation.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ResourceReferenceOperation : Operation
+    {
+        // reference(resourceId(...), 'apiVersion', 'full')
+        // OR
+        // reference(resourceId(...))
+        public ResourceReferenceOperation(ResourceMetadata metadata, ResourceIdOperation resourceId, bool full)
+        {
+            Metadata = metadata;
+            ResourceId = resourceId;
+            Full = full;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
+        public ResourceIdOperation ResourceId { get; }
+
+        public bool Full { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceReferenceOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/ResourceTypeOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/ResourceTypeOperation.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class ResourceTypeOperation : Operation
+    {
+        public ResourceTypeOperation(ResourceMetadata metadata)
+        {
+            Metadata = metadata;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceTypeOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/SymbolicResourceReferenceOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/SymbolicResourceReferenceOperation.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    // reference('symbol')
+    // reference('symbol[0]')
+    public class SymbolicResourceReferenceOperation : Operation
+    {
+        public SymbolicResourceReferenceOperation(ResourceMetadata metadata, IndexReplacementContext? indexContext, bool full)
+        {
+            Metadata = metadata;
+            IndexContext = indexContext;
+            Full = full;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
+        public IndexReplacementContext? IndexContext { get; }
+
+        public bool Full { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitSymbolicResourceReferenceOperation(this);
+    }
+}

--- a/src/Bicep.Core/CodeAnalysis/VariableAccessOperation.cs
+++ b/src/Bicep.Core/CodeAnalysis/VariableAccessOperation.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.CodeAnalysis
+{
+    public class VariableAccessOperation : Operation
+    {
+        public VariableAccessOperation(VariableSymbol symbol)
+        {
+            Symbol = symbol;
+        }
+
+        public VariableSymbol Symbol { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitVariableAccessOperation(this);
+    }
+}

--- a/src/Bicep.Core/Syntax/SyntaxHelper.cs
+++ b/src/Bicep.Core/Syntax/SyntaxHelper.cs
@@ -88,5 +88,12 @@ namespace Bicep.Core.Syntax
 
             return targetScope;
         }
+
+        public static (SyntaxBase baseSyntax, SyntaxBase? indexSyntax) UnwrapArrayAccessSyntax(SyntaxBase syntax)
+            => syntax switch
+            {
+                ArrayAccessSyntax arrayAccess => (arrayAccess.BaseExpression, arrayAccess.IndexExpression),
+                _ => (syntax, null),
+            };
     }
 }


### PR DESCRIPTION
# Çekme İsteği'ne Katkıda Bulunma Henüz yapmadıysanız, [katkı kılavuzunun] tamamını okuyun(https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). Kılavuz son okumadan bu yana değişmiş olabilir, bu yüzden lütfen iki kez kontrol edin. İşinizi bitirip PR'ınızı göndermeye hazır olduktan sonra, aşağıdaki ilgili kontrol listesini inceleyin. ## Belgelere katkıda bulunmak * [ ] Tüm belge katkıları doğrudan [Microsoft Dokümanlar hakkındaki Bicep belgelerinde](https://docs.microsoft.com/azure/azure-kaynak yöneticisi/bicep/) yapılmalıdır. ## Bir örneğe katkıda bulunuyoruz Bicep örneklerini [Azure QuickStart Şablonları](https://github.com/Azure/azure-hızlı başlangıç şablonları/blob/master/1-CONTRIBUTION-GUIDE/README.md) ile tümleştirmekteyiz. Dilin yeteneklerini sergileyen yeni örnek '.bicep' dosyalarına katkıda bulunmak istiyorsanız, doğrudan oraya eklemek için lütfen [bu talimatları] (https://github.com/Azure/azure-hızlı başlangıç-şablonları/blob/master/1-CONTRIBUTION-GUIDE/README.md) izleyin. Mevcut örnekler için hata raporlarını ve düzeltmeleri şimdilik almaya devam edebiliriz. * [ ] Bu mevcut bir örnek için bir hata düzeltmesi * [ ] Bicep VS Code uzantısı tarafından gösterilen tüm uyarıları ve hataları çözdüm * [ ] Tüm testlerin 'dotnet testi' çalıştırarak geçtiğini kontrol ettim * [ ] Tüm tanımlayıcılarım için tutarlı bir kasam var ve başka bir kasa stili kullanmak için bir gerekçem yoksa camelCasing kullanıyorum ## Bir özelliğe katkıda bulunmak * [ ] teklif için yeni bir sorun açtım,  veya mevcut bir özellik hakkında yorum yaptı ve Bicep bakımcılarının uygulanan özelliğin tasarımıyla iyi olduğundan emin oldu * [ ] PR açıklamasına "Fixs #{issue_number}" i dahil ettim, böylece GitHub soruna bağlanabilir ve PR birleştirildiğinde kapatabilir * [ ] Yeni özelliğimin uygun test kapsamına sahibim ## Bir snippet'e katkıda bulunmak * [ ] Tek bir snippet'im var,  [üst-alt sözdizimi] (https://docs.microsoft.com/azure/azure-kaynak-yöneticisi/bicep/alt-kaynak-ad-türü) kullanan genel kaynak veya çoklu kaynak * [ ] Zaten göndermiş eşdeğer bir snippet olmadığını denetledim * [ ] Başka bir kasa stili kullanmak için bir gerekçem olmadıkça camelCasing kullandım * [ ] Özellik adlarına karşılık gelen yer tutucu değerlerim var (örn. 'dnsPrefix: 'dnsPrefix'), sırayla değiştirilmesi veya parametrelenmesi gereken bir özellik değilse  dağıtmak için. Bu durumda, 'REQUIRED' kullanıyorum, örneğin [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26) * [ ] Snippet'te ilk sekme durağı (1 $) olarak sembolik adım var. örneğin [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep) * [ ] "ad" e eşit bir kaynak adı özelliğim var, örneğin. '''bicep resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = { name: 'name' '''