### PR TITLE
Fix formatting issue involving #disable-next-line directive

### DIFF
--- a/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterValidSyntaxTests.cs
+++ b/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterValidSyntaxTests.cs
@@ -612,5 +612,62 @@ where */
 }
 /* I can be anywhere */");
         }
+
+        [TestMethod]
+        public void PrintProgram_WithDisableNextLineDiagnosticsDirective_ShouldFormatCorrectly()
+        {
+            var input = @"/* asdfasdf */
+var test = 'adfsdf'
+
+
+#disable-next-line asdf /*
+
+
+*/
+#disable-next-line BCP036
+param string storageAccount = 'testAccount'
+          #disable-next-line BCP036  // test
+param string location1 = 'testLocation'
+         #disable-next-line BCP036       
+param string location2 = 'testLocation'";
+
+            var output = @"/* asdfasdf */
+var test = 'adfsdf'
+
+#disable-next-line asdf /*
+
+
+*/
+#disable-next-line BCP036
+param string storageAccount = 'testAccount'
+#disable-next-line BCP036 // test
+param string location1 = 'testLocation'
+#disable-next-line BCP036
+param string location2 = 'testLocation'";
+            this.TestPrintProgram(input, output);
+        }
+
+        [TestMethod]
+        public void PrintProgram_WithDisableNextLineDiagnosticsDirectivePartOfEofToken_ShouldFormatCorrectly1()
+        {
+            var input = @"/* asdfasdf */
+var test = 'adfsdf'
+
+
+
+#disable-next-line asdf /*
+
+
+*/";
+
+            var output = @"/* asdfasdf */
+var test = 'adfsdf'
+
+#disable-next-line asdf /*
+
+
+*/";
+            this.TestPrintProgram(input, output);
+        }
     }
 }

--- a/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
+++ b/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
@@ -59,7 +59,12 @@ namespace Bicep.Core.PrettyPrint
             {
                 this.PushDocument(NoLine);
                 this.VisitNodes(syntax.Children);
-                this.PushDocument(NoLine);
+
+                if (!syntax.EndOfFile.LeadingTrivia.Any(x => x.Type == SyntaxTriviaType.DisableNextLineDiagnosticsDirective))
+                {
+                    this.PushDocument(NoLine);
+                }
+
                 this.Visit(syntax.EndOfFile);
             });
 


### PR DESCRIPTION
Fix for #5222

Fixes below issue:

```bicep
/* asdfasdf */
var test = 'adfsdf'


#disable-next-line asdf /*


*/
```

Gets formatted to:
```bicep
/* asdfasdf */
var test = 'adfsdf'#disable-next-line asdf /*


*/
```