### PR TITLE
Speed up playground

### DIFF
--- a/src/Bicep.Core/Semantics/Namespaces/DefaultNamespaceProvider.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/DefaultNamespaceProvider.cs
@@ -9,12 +9,12 @@ namespace Bicep.Core.Semantics.Namespaces
 {
     public class DefaultNamespaceProvider : INamespaceProvider
     {
-        private readonly IAzResourceTypeLoader azResourceTypeLoader;
+        private readonly AzResourceTypeProvider azResourceTypeProvider;
         private readonly IFeatureProvider featureProvider;
 
         public DefaultNamespaceProvider(IAzResourceTypeLoader azResourceTypeLoader, IFeatureProvider featureProvider)
         {
-            this.azResourceTypeLoader = azResourceTypeLoader;
+            this.azResourceTypeProvider = new AzResourceTypeProvider(azResourceTypeLoader);
             this.featureProvider = featureProvider;
         }
 
@@ -25,7 +25,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 case SystemNamespaceType.BuiltInName:
                     return SystemNamespaceType.Create(aliasName);
                 case AzNamespaceType.BuiltInName:
-                    return AzNamespaceType.Create(aliasName, resourceScope, new AzResourceTypeProvider(azResourceTypeLoader));
+                    return AzNamespaceType.Create(aliasName, resourceScope, azResourceTypeProvider);
             }
 
             return null;

--- a/src/Bicep.Wasm/Interop.cs
+++ b/src/Bicep.Wasm/Interop.cs
@@ -124,8 +124,8 @@ namespace Bicep.Wasm
         {
             try
             {
-                var lineStarts = TextCoordinateConverter.GetLineStarts(content);
                 var compilation = GetCompilation(content);
+                var lineStarts = compilation.SourceFileGrouping.EntryPoint.LineStarts;
                 var emitterSettings = new EmitterSettings(features);
                 var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), emitterSettings);
 
@@ -159,7 +159,7 @@ namespace Bicep.Wasm
             var fileResolver = new FileResolver();
             var dispatcher = new ModuleDispatcher(new EmptyModuleRegistryProvider());
             var configurationManager = new ConfigurationManager(new IOFileSystem());
-            var configuration = configurationManager.GetBuiltInConfiguration();
+            var configuration = configurationManager.GetBuiltInConfiguration(disableAnalyzers: true);
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, dispatcher, workspace, fileUri, configuration);
 
             return new Compilation(namespaceProvider, sourceFileGrouping, configuration);


### PR DESCRIPTION
1. Types weren't being cached as `AzResourceTypeProvider` was being reconstructed on every keypress - fixed this
2. Linter rules were slowing things down quite a bit - disabled them

I've already pushed the changes to https://aka.ms/bicepdemo - still not super snappy, but it was previously taking ~4s to handle each keypress.