### PR TITLE
Add telemetry for linter rule changes in bicepconfig.json

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -244,7 +244,7 @@ namespace Bicep.LangServer.IntegrationTests
                     { "currentDiagnosticLevel", "off" }
                 };
 
-            bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+            bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.LinterRuleStateChangeInBicepConfig);
             bicepTelemetryEvent.Properties.Should().Equal(properties);
         }
 

--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Bicep.Core.FileSystem;
@@ -201,6 +202,137 @@ namespace Bicep.LangServer.IntegrationTests
 
             bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.DisableNextLineDiagnostics);
             bicepTelemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        [TestMethod]
+        public async Task ChangingLinterRuleDiagnosticLevel_ShouldFireTelemetryEvent()
+        {
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""off""
+        }
+      }
+    }
+  }
+}";
+            var bicepFileContents = @"param storageAccount string = 'testStorageAccount'";
+
+            var bicepTelemetryEvent = await GetTelemetryEventForBicepConfigChange(prevBicepConfigFileContents, curBicepConfigFileContents, bicepFileContents);
+
+            IDictionary<string, string> properties = new Dictionary<string, string>
+                {
+                    { "rule", "no-unused-params" },
+                    { "previousDiagnosticLevel", "info" },
+                    { "currentDiagnosticLevel", "off" }
+                };
+
+            bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+            bicepTelemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        [TestMethod]
+        public async Task ChangingOverallLinterState_ShouldFireTelemetryEvent()
+        {
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var bicepFileContents = @"param storageAccount string = 'testStorageAccount'";
+
+            var bicepTelemetryEvent = await GetTelemetryEventForBicepConfigChange(prevBicepConfigFileContents, curBicepConfigFileContents, bicepFileContents);
+
+            IDictionary<string, string> properties = new Dictionary<string, string>
+                {
+                    { "previousState", "true" },
+                    { "currentState", "false" }
+                };
+
+            bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.OverallLinterStateChangeInBicepConfig);
+            bicepTelemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        private async Task<BicepTelemetryEvent> GetTelemetryEventForBicepConfigChange(string prevBicepConfigFileContents, string curBicepConfigFileContents, string bicepFileContents)
+        {
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "main.bicep", bicepFileContents, testOutputPath);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+
+            var bicepConfigFilePath = FileHelper.SaveResultFile(TestContext, "bicepconfig.json", prevBicepConfigFileContents, testOutputPath);
+            var bicepConfigUri = DocumentUri.FromFileSystemPath(bicepConfigFilePath).ToUri();
+
+            var diagsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
+            var telemetryReceived = new TaskCompletionSource<BicepTelemetryEvent>();
+
+            using var helper = await LanguageServerHelper.StartServerWithClientConnectionAsync(
+                TestContext,
+                options =>
+                {
+                    options.OnPublishDiagnostics(diags => diagsListener.AddMessage(diags));
+                    options.OnTelemetryEvent<BicepTelemetryEvent>(telemetry => telemetryReceived.SetResult(telemetry));
+                });
+            var client = helper.Client;
+
+            client.TextDocument.DidOpenTextDocument(TextDocumentParamHelper.CreateDidOpenDocumentParams(documentUri, bicepFileContents, 1));
+
+            var diagsParams = await diagsListener.WaitNext();
+            diagsParams.Uri.Should().Be(documentUri);
+
+            FileHelper.SaveResultFile(TestContext, "bicepconfig.json", curBicepConfigFileContents, testOutputPath);
+
+            client.Workspace.DidChangeWatchedFiles(new DidChangeWatchedFilesParams
+            {
+                Changes = new Container<FileEvent>(new FileEvent
+                {
+                    Type = FileChangeType.Changed,
+                    Uri = bicepConfigUri,
+                })
+            });
+
+            diagsParams = await diagsListener.WaitNext();
+            diagsParams.Uri.Should().Be(documentUri);
+
+            return await IntegrationTestHelper.WithTimeoutAsync(telemetryReceived.Task);
         }
 
         private async Task<BicepTelemetryEvent> ResolveCompletionAsync(string text, string prefix, Position position)

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
@@ -15,6 +15,7 @@ using Bicep.LanguageServer;
 using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Registry;
+using Bicep.LanguageServer.Telemetry;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -34,7 +35,7 @@ namespace Bicep.LangServer.UnitTests
 
             var document = CreateMockDocument(p => receivedParams = p);
             var server = CreateMockServer(document);
-            BicepCompilationManager bicepCompilationManager = new(server.Object, CreateEmptyCompilationProvider(), new Workspace(), FileResolver, CreateMockScheduler().Object, new ConfigurationManager(new IOFileSystem()));
+            BicepCompilationManager bicepCompilationManager = new(server.Object, CreateEmptyCompilationProvider(), new Workspace(), FileResolver, CreateMockScheduler().Object, new ConfigurationManager(new IOFileSystem()), CreateMockTelemetryProvider().Object);
 
             if (upsertCompilation)
             {
@@ -76,6 +77,14 @@ namespace Bicep.LangServer.UnitTests
         public static ICompilationProvider CreateEmptyCompilationProvider()
         {
             return new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), FileResolver, new ModuleDispatcher(BicepTestConstants.RegistryProvider));
+        }
+
+        public static Mock<ITelemetryProvider> CreateMockTelemetryProvider()
+        {
+            var telemetryProvider = Repository.Create<ITelemetryProvider>();
+            telemetryProvider.Setup(x => x.PostEvent(It.IsAny<BicepTelemetryEvent>()));
+
+            return telemetryProvider;
         }
 
         public static Mock<IModuleRestoreScheduler> CreateMockScheduler()

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -4,24 +4,26 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using Bicep.Core;
+using Bicep.Core.Configuration;
 using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
-using Bicep.Core.Semantics;
 using Bicep.Core.Registry;
+using Bicep.Core.Semantics;
 using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer;
 using Bicep.LanguageServer.Providers;
+using Bicep.LanguageServer.Telemetry;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using Bicep.Core.UnitTests.Utils;
-using Bicep.Core.Configuration;
 using IOFileSystem = System.IO.Abstractions.FileSystem;
 
 namespace Bicep.LangServer.UnitTests
@@ -85,7 +87,7 @@ namespace Bicep.LangServer.UnitTests
             var workspace = new Workspace();
             workspace.UpsertSourceFile(originalFile);
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -123,7 +125,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -172,7 +174,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -244,7 +246,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -304,7 +306,7 @@ namespace Bicep.LangServer.UnitTests
         {
             var server = Repository.Create<ILanguageServerFacade>();
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
 
             var uri = DocumentUri.File(this.TestContext.TestName);
 
@@ -319,7 +321,7 @@ namespace Bicep.LangServer.UnitTests
             var document = BicepCompilationManagerHelper.CreateMockDocument(p => receivedParams = p);
             var server = BicepCompilationManagerHelper.CreateMockServer(document);
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
 
             var uri = DocumentUri.File(this.TestContext.TestName);
 
@@ -360,7 +362,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager);
+            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
 
             // upsert should fail because of the mock fatal exception
             manager.UpsertCompilation(uri, BaseVersion, "fake", languageId);
@@ -426,7 +428,7 @@ namespace Bicep.LangServer.UnitTests
                 workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(uri.ToUri(), ""));
             }
 
-            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager);
+            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
 
             // upsert should fail because of the mock fatal exception
             manager.UpsertCompilation(uri, version, "fake", languageId);
@@ -510,7 +512,7 @@ module moduleB './moduleB.bicep' = {
             var fileResolver = new InMemoryFileResolver(fileDict);
             var compilationProvider = new BicepCompilationProvider(TestTypeHelper.CreateEmptyProvider(), fileResolver, new ModuleDispatcher(new DefaultModuleRegistryProvider(fileResolver, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory, BicepTestConstants.Features)));
 
-            var compilationManager = new BicepCompilationManager(server.Object, compilationProvider, new Workspace(), fileResolver, BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager);
+            var compilationManager = new BicepCompilationManager(server.Object, compilationProvider, new Workspace(), fileResolver, BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
 
             diagsReceieved.Should().BeEmpty();
 
@@ -596,6 +598,552 @@ module moduleB './moduleB.bicep' = {
 
                 EnsureSemanticModelsAndSourceFilesDeduplicated();
             }
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithOverallLinterStateChange_ShouldReturnTelemetryEvent()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Count().Should().Be(1);
+
+            var telemetryEvent = telemetryEvents.First();
+            telemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.OverallLinterStateChangeInBicepConfig);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "previousState", "true" },
+                { "currentState", "false" }
+            };
+
+            telemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithNoStateChange_ShouldDoNothing()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithNoEnabledSectionInCurrentConfigurationAndPreviousSettingIsFalse_ShouldFireTelemetryEvent()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Count().Should().Be(1);
+
+            var telemetryEvent = telemetryEvents.First();
+            telemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.OverallLinterStateChangeInBicepConfig);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "previousState", "false" },
+                { "currentState", "true" }
+            };
+
+            telemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithNoEnabledSectionInPreviousConfigurationAndCurrentSettingIsFalse_ShouldFireTelemetryEvent()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Count().Should().Be(1);
+
+            var telemetryEvent = telemetryEvents.First();
+            telemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.OverallLinterStateChangeInBicepConfig);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "previousState", "true" },
+                { "currentState", "false" }
+            };
+
+            telemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithNoEnabledSectionInCurrentConfigurationAndPreviousSettingIsTrue_ShouldDoNothing()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithNoEnabledSectionInPreviousConfigurationAndCurrentSettingIsTrue_ShouldDoNothing()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithEmptyCurrentConfig_ShouldUseDefaultSettingsAndFireTelemetryEvent()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{}";
+
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Count().Should().Be(1);
+
+            var telemetryEvent = telemetryEvents.First();
+            telemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.OverallLinterStateChangeInBicepConfig);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "previousState", "false" },
+                { "currentState", "true" }
+            };
+
+            telemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithEmptyPreviousConfig_ShouldUseDefaultSettingsAndFireTelemetryEvent()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Count().Should().Be(1);
+
+            var telemetryEvent = telemetryEvents.First();
+            telemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.OverallLinterStateChangeInBicepConfig);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "previousState", "true" },
+                { "currentState", "false" }
+            };
+
+            telemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithEmptyCurrentAndPreviousConfig_ShouldDoNothing()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = "{}";
+            var curBicepConfigFileContents = "{}";
+
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithOverallLinterSettingDisabledInBothPreviousAndCurrentConfig_ShouldDoNothing()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": false,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""warning""
+        }
+      }
+    }
+  }
+}";
+
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_WithMismatchInRuleSettingsInPreviousAndCurrentConfig_ShouldFireTelemetryEvent()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""info""
+        },
+        ""no-unused-vars"": {
+          ""level"": ""info""
+        }
+      }
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""warning""
+        },
+        ""no-unused-vars"": {
+          ""level"": ""warning""
+        }
+      }
+    }
+  }
+}";
+
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Count().Should().Be(2);
+
+            var telemetryEvent = telemetryEvents.First(x => x.Properties is not null && x.Properties["rule"] == "no-unused-params");
+            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "rule", "no-unused-params" },
+                { "previousDiagnosticLevel", "info" },
+                { "currentDiagnosticLevel", "warning" }
+            };
+
+            telemetryEvent.Properties.Should().Equal(properties);
+
+            telemetryEvent = telemetryEvents.First(x => x.Properties is not null && x.Properties["rule"] == "no-unused-vars");
+            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+
+            properties = new Dictionary<string, string>
+            {
+                { "rule", "no-unused-vars" },
+                { "previousDiagnosticLevel", "info" },
+                { "currentDiagnosticLevel", "warning" }
+            };
+
+            telemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        [TestMethod]
+        public void GetTelemetryEventsForBicepConfigChange_VerifyDefaultRuleSettingsAreUsed()
+        {
+            var compilationManager = CreateBicepCompilationManager();
+
+            var prevBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true
+    }
+  }
+}";
+            var curBicepConfigFileContents = @"{
+  ""analyzers"": {
+    ""core"": {
+      ""verbose"": false,
+      ""enabled"": true,
+      ""rules"": {
+        ""no-unused-params"": {
+          ""level"": ""error""
+        },
+        ""no-unused-vars"": {
+          ""level"": ""error""
+        }
+      }
+    }
+  }
+}";
+            (RootConfiguration prevConfiguration, RootConfiguration curConfiguration) = GetPreviousAndCurrentRootConfiguration(prevBicepConfigFileContents, curBicepConfigFileContents);
+
+            var telemetryEvents = compilationManager.GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration);
+
+            telemetryEvents.Count().Should().Be(2);
+
+            var telemetryEvent = telemetryEvents.First(x => x.Properties is not null && x.Properties["rule"] == "no-unused-params");
+            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+
+            var properties = new Dictionary<string, string>
+            {
+                { "rule", "no-unused-params" },
+                { "previousDiagnosticLevel", "warning" },
+                { "currentDiagnosticLevel", "error" }
+            };
+
+            telemetryEvent.Properties.Should().Equal(properties);
+
+            telemetryEvent = telemetryEvents.First(x => x.Properties is not null && x.Properties["rule"] == "no-unused-vars");
+            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+
+            properties = new Dictionary<string, string>
+            {
+                { "rule", "no-unused-vars" },
+                { "previousDiagnosticLevel", "warning" },
+                { "currentDiagnosticLevel", "error" }
+            };
+
+            telemetryEvent.Properties.Should().Equal(properties);
+        }
+
+        private (RootConfiguration, RootConfiguration) GetPreviousAndCurrentRootConfiguration(string prevBicepConfigContents, string curBicepConfigContents)
+        {
+            var configurationManager = new ConfigurationManager(new IOFileSystem());
+
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+
+            var bicepConfigFilePath = FileHelper.SaveResultFile(TestContext, "bicepconfig.json", prevBicepConfigContents, testOutputPath);
+            var bicepConfigUri = DocumentUri.FromFileSystemPath(bicepConfigFilePath);
+
+            var prevConfiguration = configurationManager.GetConfiguration(bicepConfigUri.ToUri());
+
+            bicepConfigFilePath = FileHelper.SaveResultFile(TestContext, "bicepconfig.json", curBicepConfigContents, testOutputPath);
+            bicepConfigUri = DocumentUri.FromFileSystemPath(bicepConfigFilePath);
+
+            var curConfiguration = configurationManager.GetConfiguration(bicepConfigUri.ToUri());
+
+            return (prevConfiguration, curConfiguration);
+        }
+
+        private BicepCompilationManager CreateBicepCompilationManager()
+        {
+            PublishDiagnosticsParams? receivedParams = null;
+
+            var document = BicepCompilationManagerHelper.CreateMockDocument(p => receivedParams = p);
+            var server = BicepCompilationManagerHelper.CreateMockServer(document);
+            var uri = DocumentUri.File(this.TestContext.TestName);
+            var workspace = new Workspace();
+
+            return new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, configurationManager, BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
         }
     }
 }

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -1031,7 +1031,7 @@ module moduleB './moduleB.bicep' = {
             telemetryEvents.Count().Should().Be(2);
 
             var telemetryEvent = telemetryEvents.First(x => x.Properties is not null && x.Properties["rule"] == "no-unused-params");
-            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.LinterRuleStateChangeInBicepConfig);
 
             var properties = new Dictionary<string, string>
             {
@@ -1043,7 +1043,7 @@ module moduleB './moduleB.bicep' = {
             telemetryEvent.Properties.Should().Equal(properties);
 
             telemetryEvent = telemetryEvents.First(x => x.Properties is not null && x.Properties["rule"] == "no-unused-vars");
-            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.LinterRuleStateChangeInBicepConfig);
 
             properties = new Dictionary<string, string>
             {
@@ -1091,7 +1091,7 @@ module moduleB './moduleB.bicep' = {
             telemetryEvents.Count().Should().Be(2);
 
             var telemetryEvent = telemetryEvents.First(x => x.Properties is not null && x.Properties["rule"] == "no-unused-params");
-            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.LinterRuleStateChangeInBicepConfig);
 
             var properties = new Dictionary<string, string>
             {
@@ -1103,7 +1103,7 @@ module moduleB './moduleB.bicep' = {
             telemetryEvent.Properties.Should().Equal(properties);
 
             telemetryEvent = telemetryEvents.First(x => x.Properties is not null && x.Properties["rule"] == "no-unused-vars");
-            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.DisableRuleInBicepConfig);
+            telemetryEvent.EventName!.Should().Be(TelemetryConstants.EventNames.LinterRuleStateChangeInBicepConfig);
 
             properties = new Dictionary<string, string>
             {

--- a/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
@@ -218,7 +218,7 @@ namespace Bicep.LangServer.UnitTests.Configuration
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents, testOutputPath);
             var workspace = new Workspace();
 
-            var bicepCompilationManager = new BicepCompilationManager(server, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, new ConfigurationManager(new IOFileSystem()));
+            var bicepCompilationManager = new BicepCompilationManager(server, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, new FileResolver(), BicepCompilationManagerHelper.CreateMockScheduler().Object, new ConfigurationManager(new IOFileSystem()), BicepCompilationManagerHelper.CreateMockTelemetryProvider().Object);
             bicepCompilationManager.UpsertCompilation(DocumentUri.From(bicepFilePath), null, bicepFileContents, LanguageConstants.LanguageId);
 
             var bicepConfigDocumentUri = DocumentUri.FromFileSystemPath(bicepFilePath);

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -327,7 +327,7 @@ namespace Bicep.LanguageServer
 
                     if (prevLinterRuleDiagnosticLevelValue != curLinterRuleDiagnosticLevelValue)
                     {
-                        var telemetryEvent = BicepTelemetryEvent.CreateDisableRuleInBicepConfig(kvp.Key, prevLinterRuleDiagnosticLevelValue, curLinterRuleDiagnosticLevelValue);
+                        var telemetryEvent = BicepTelemetryEvent.CreateLinterRuleStateChangeInBicepConfig(kvp.Key, prevLinterRuleDiagnosticLevelValue, curLinterRuleDiagnosticLevelValue);
                         telemetryEvents.Add(telemetryEvent);
                     }
                 }

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -4,9 +4,10 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
+using System.Reflection;
 using Bicep.Core;
+using Bicep.Core.Analyzers.Interfaces;
 using Bicep.Core.Configuration;
 using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
@@ -16,6 +17,7 @@ using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Extensions;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Registry;
+using Bicep.LanguageServer.Telemetry;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -32,6 +34,10 @@ namespace Bicep.LanguageServer
         private readonly IFileResolver fileResolver;
         private readonly IModuleRestoreScheduler scheduler;
         private readonly IConfigurationManager configurationManager;
+        private readonly ITelemetryProvider TelemetryProvider;
+
+        private readonly Lazy<ImmutableDictionary<string, string>> linterRulesLazy;
+        private ImmutableDictionary<string, string> LinterRules => linterRulesLazy.Value;
 
         // represents compilations of open bicep files
         private readonly ConcurrentDictionary<DocumentUri, CompilationContext> activeContexts = new ConcurrentDictionary<DocumentUri, CompilationContext>();
@@ -42,7 +48,8 @@ namespace Bicep.LanguageServer
             IWorkspace workspace,
             IFileResolver fileResolver,
             IModuleRestoreScheduler scheduler,
-            IConfigurationManager configurationManager)
+            IConfigurationManager configurationManager,
+            ITelemetryProvider telemetryProvider)
         {
             this.server = server;
             this.provider = provider;
@@ -50,6 +57,9 @@ namespace Bicep.LanguageServer
             this.fileResolver = fileResolver;
             this.scheduler = scheduler;
             this.configurationManager = configurationManager;
+            this.TelemetryProvider = telemetryProvider;
+
+            this.linterRulesLazy = new Lazy<ImmutableDictionary<string, string>>(() => GetLinterRules().ToImmutableDictionary());
         }
 
         public void RefreshCompilation(DocumentUri documentUri, bool reloadBicepConfig = false)
@@ -204,6 +214,8 @@ namespace Bicep.LanguageServer
                     (documentUri) => this.provider.Create(workspace, documentUri, modelLookup.ToImmutableDictionary(), configuration),
                     (documentUri, prevContext) =>
                     {
+                        var prevConfiguration = prevContext.Compilation.Configuration;
+
                         var sourceDependencies = removedFiles
                             .SelectMany(x => prevContext.Compilation.SourceFileGrouping.GetFilesDependingOn(x))
                             .ToImmutableHashSet();
@@ -218,9 +230,16 @@ namespace Bicep.LanguageServer
                             }
                         }
 
-                        var configuration = reloadBicepConfig
-                            ? this.GetConfigurationSafely(documentUri.ToUri(), out configurationDiagnostic)
-                            : prevContext.Compilation.Configuration;
+                        var configuration = this.GetConfigurationSafely(documentUri, out var configurationDiagnostic);
+
+                        if (reloadBicepConfig)
+                        {
+                            SendTelemetryIfLinterRuleWasDisabledInBicepConfig(prevConfiguration, configuration);
+                        }
+                        else
+                        {
+                            configuration = prevContext.Compilation.Configuration;
+                        }
 
                         return this.provider.Create(workspace, documentUri, modelLookup.ToImmutableDictionary(), configuration);
                     });
@@ -271,6 +290,78 @@ namespace Bicep.LanguageServer
 
                 return (ImmutableArray<ISourceFile>.Empty, ImmutableArray<ISourceFile>.Empty);
             }
+        }
+
+        private void SendTelemetryIfLinterRuleWasDisabledInBicepConfig(RootConfiguration prevConfiguration, RootConfiguration curConfiguration)
+        {
+            foreach (var telemetryEvent in GetTelemetryEventsForBicepConfigChange(prevConfiguration, curConfiguration))
+            {
+                TelemetryProvider.PostEvent(telemetryEvent);
+            }
+        }
+
+        public IEnumerable<BicepTelemetryEvent> GetTelemetryEventsForBicepConfigChange(RootConfiguration prevConfiguration, RootConfiguration curConfiguration)
+        {
+            var linterEnabledSetting = "core.enabled";
+            bool prevLinterEnabledSettingValue = prevConfiguration.Analyzers.GetValue(linterEnabledSetting, true);
+            bool curLinterEnabledSettingValue = curConfiguration.Analyzers.GetValue(linterEnabledSetting, true);
+
+            if (!prevLinterEnabledSettingValue && !curLinterEnabledSettingValue)
+            {
+                return Enumerable.Empty<BicepTelemetryEvent>();
+            }
+
+            List<BicepTelemetryEvent> telemetryEvents = new();
+
+            if (prevLinterEnabledSettingValue != curLinterEnabledSettingValue)
+            {
+                var telemetryEvent = BicepTelemetryEvent.CreateOverallLinterStateChangeInBicepConfig(prevLinterEnabledSettingValue.ToString().ToLowerInvariant(), curLinterEnabledSettingValue.ToString().ToLowerInvariant());
+                telemetryEvents.Add(telemetryEvent);
+            }
+            else
+            {
+                foreach (var kvp in LinterRules)
+                {
+                    string prevLinterRuleDiagnosticLevelValue = prevConfiguration.Analyzers.GetValue(kvp.Value, "warning");
+                    string curLinterRuleDiagnosticLevelValue = curConfiguration.Analyzers.GetValue(kvp.Value, "warning");
+
+                    if (prevLinterRuleDiagnosticLevelValue != curLinterRuleDiagnosticLevelValue)
+                    {
+                        var telemetryEvent = BicepTelemetryEvent.CreateDisableRuleInBicepConfig(kvp.Key, prevLinterRuleDiagnosticLevelValue, curLinterRuleDiagnosticLevelValue);
+                        telemetryEvents.Add(telemetryEvent);
+                    }
+                }
+            }
+
+            return telemetryEvents;
+        }
+
+        private Dictionary<string, string> GetLinterRules()
+        {
+            var rules = new Dictionary<string, string>();
+            var ruleTypes = Assembly.GetAssembly(typeof(IBicepAnalyzerRule))?
+                .GetTypes()
+                .Where(t => typeof(IBicepAnalyzerRule).IsAssignableFrom(t)
+                            && t.IsClass
+                            && t.IsPublic
+                            && t.GetConstructor(Type.EmptyTypes) != null);
+
+            if (ruleTypes is null)
+            {
+                return rules;
+            }
+
+            foreach (var ruleType in ruleTypes)
+            {
+                IBicepAnalyzerRule? rule = Activator.CreateInstance(ruleType) as IBicepAnalyzerRule;
+                if (rule is not null)
+                {
+                    var code = rule.Code;
+                    rules.Add(code, $"core.rules.{code}.level");
+                }
+            }
+
+            return rules;
         }
 
         private RootConfiguration GetConfigurationSafely(DocumentUri documentUri, out Diagnostic? diagnostic)

--- a/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
+++ b/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
@@ -94,10 +94,10 @@ namespace Bicep.LanguageServer.Telemetry
                 },
             };
 
-        public static BicepTelemetryEvent CreateDisableRuleInBicepConfig(string rule, string prevDiagnosticLevel, string curDiagnosticLevel)
+        public static BicepTelemetryEvent CreateLinterRuleStateChangeInBicepConfig(string rule, string prevDiagnosticLevel, string curDiagnosticLevel)
             => new BicepTelemetryEvent
             {
-                EventName = TelemetryConstants.EventNames.DisableRuleInBicepConfig,
+                EventName = TelemetryConstants.EventNames.LinterRuleStateChangeInBicepConfig,
                 Properties = new()
                 {
                     ["rule"] = rule,

--- a/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
+++ b/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
@@ -93,5 +93,28 @@ namespace Bicep.LanguageServer.Telemetry
                     ["code"] = code,
                 },
             };
+
+        public static BicepTelemetryEvent CreateDisableRuleInBicepConfig(string rule, string prevDiagnosticLevel, string curDiagnosticLevel)
+            => new BicepTelemetryEvent
+            {
+                EventName = TelemetryConstants.EventNames.DisableRuleInBicepConfig,
+                Properties = new()
+                {
+                    ["rule"] = rule,
+                    ["previousDiagnosticLevel"] = prevDiagnosticLevel,
+                    ["currentDiagnosticLevel"] = curDiagnosticLevel
+                }
+            };
+
+        public static BicepTelemetryEvent CreateOverallLinterStateChangeInBicepConfig(string prevState, string curState)
+            => new BicepTelemetryEvent
+            {
+                EventName = TelemetryConstants.EventNames.OverallLinterStateChangeInBicepConfig,
+                Properties = new()
+                {
+                    ["previousState"] = prevState,
+                    ["currentState"] = curState
+                }
+            };
     }
 }

--- a/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
+++ b/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
@@ -16,7 +16,7 @@ namespace Bicep.LanguageServer.Telemetry
             public const string ObjectBodySnippetInsertion = nameof(ObjectBodySnippetInsertion);
 
             public const string DisableNextLineDiagnostics = nameof(DisableNextLineDiagnostics);
-            public const string DisableRuleInBicepConfig = nameof(DisableRuleInBicepConfig);
+            public const string LinterRuleStateChangeInBicepConfig = nameof(LinterRuleStateChangeInBicepConfig);
             public const string OverallLinterStateChangeInBicepConfig = nameof(OverallLinterStateChangeInBicepConfig);
         }
     }

--- a/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
+++ b/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
@@ -16,6 +16,8 @@ namespace Bicep.LanguageServer.Telemetry
             public const string ObjectBodySnippetInsertion = nameof(ObjectBodySnippetInsertion);
 
             public const string DisableNextLineDiagnostics = nameof(DisableNextLineDiagnostics);
+            public const string DisableRuleInBicepConfig = nameof(DisableRuleInBicepConfig);
+            public const string OverallLinterStateChangeInBicepConfig = nameof(OverallLinterStateChangeInBicepConfig);
         }
     }
 }


### PR DESCRIPTION
Fixes #5299 and #5050

Post telemetry event when:
- Linter rule diagnostic level is changed in bicepconfig.json
- Overall linter state change in bicepconfig.json

Follow up task:
https://github.com/Azure/bicep/issues/5301