### PR TITLE
Update disable next line string in light bulb

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -192,7 +192,7 @@ namespace Bicep.LangServer.IntegrationTests
             codeActions.Should().SatisfyRespectively(
                 x =>
                 {
-                    x.CodeAction!.Title.Should().Be("Disable no-unused-params for this line.");
+                    x.CodeAction!.Title.Should().Be("Disable no-unused-params for this line");
                     x.CodeAction.Edit!.Changes!.First().Value.First().NewText.Should().Be("#disable-next-line no-unused-params\n");
                 });
         }
@@ -313,12 +313,12 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
             codeActions.Should().SatisfyRespectively(
                 x =>
                 {
-                    x.CodeAction!.Title.Should().Be("Disable BCP036 for this line.");
+                    x.CodeAction!.Title.Should().Be("Disable BCP036 for this line");
                     x.CodeAction.Edit!.Changes!.First().Value.First().NewText.Should().Be("#disable-next-line BCP036\n");
                 },
                 x =>
                 {
-                    x.CodeAction!.Title.Should().Be("Disable BCP037 for this line.");
+                    x.CodeAction!.Title.Should().Be("Disable BCP037 for this line");
                     x.CodeAction.Edit!.Changes!.First().Value.First().NewText.Should().Be("#disable-next-line BCP037\n");
                 });
         }

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -192,7 +192,7 @@ namespace Bicep.LangServer.IntegrationTests
             codeActions.Should().SatisfyRespectively(
                 x =>
                 {
-                    x.CodeAction!.Title.Should().Be("Disable no-unused-params");
+                    x.CodeAction!.Title.Should().Be("Disable no-unused-params for this line.");
                     x.CodeAction.Edit!.Changes!.First().Value.First().NewText.Should().Be("#disable-next-line no-unused-params\n");
                 });
         }
@@ -313,12 +313,12 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
             codeActions.Should().SatisfyRespectively(
                 x =>
                 {
-                    x.CodeAction!.Title.Should().Be("Disable BCP036");
+                    x.CodeAction!.Title.Should().Be("Disable BCP036 for this line.");
                     x.CodeAction.Edit!.Changes!.First().Value.First().NewText.Should().Be("#disable-next-line BCP036\n");
                 },
                 x =>
                 {
-                    x.CodeAction!.Title.Should().Be("Disable BCP037");
+                    x.CodeAction!.Title.Should().Be("Disable BCP037 for this line.");
                     x.CodeAction.Edit!.Changes!.First().Value.First().NewText.Should().Be("#disable-next-line BCP037\n");
                 });
         }

--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -183,7 +183,7 @@ namespace Bicep.LangServer.IntegrationTests
                 Range = diagnostics.First().ToRange(lineStarts)
             });
 
-            var disableNextLineCodeAction = codeActions.First(x => x.CodeAction!.Title == "Disable no-unused-params for this line.").CodeAction;
+            var disableNextLineCodeAction = codeActions.First(x => x.CodeAction!.Title == "Disable no-unused-params for this line").CodeAction;
 
             _ = await client!.ResolveCodeAction(disableNextLineCodeAction!);
 

--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -183,7 +183,7 @@ namespace Bicep.LangServer.IntegrationTests
                 Range = diagnostics.First().ToRange(lineStarts)
             });
 
-            var disableNextLineCodeAction = codeActions.First(x => x.CodeAction!.Title == "Disable no-unused-params").CodeAction;
+            var disableNextLineCodeAction = codeActions.First(x => x.CodeAction!.Title == "Disable no-unused-params for this line.").CodeAction;
 
             _ = await client!.ResolveCodeAction(disableNextLineCodeAction!);
 

--- a/src/Bicep.LangServer/Handlers/BicepCodeActionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepCodeActionHandler.cs
@@ -131,7 +131,7 @@ namespace Bicep.LanguageServer.Handlers
 
             return new CodeAction
             {
-                Title = string.Format(LangServerResources.DisableDiagnostic, diagnosticCode.String),
+                Title = string.Format(LangServerResources.DisableDiagnosticForThisLine, diagnosticCode.String),
                 Edit = new WorkspaceEdit
                 {
                     Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>

--- a/src/Bicep.LangServer/LangServerResources.Designer.cs
+++ b/src/Bicep.LangServer/LangServerResources.Designer.cs
@@ -61,7 +61,7 @@ namespace Bicep.LanguageServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Disable {0} for this line..
+        ///   Looks up a localized string similar to Disable {0} for this line.
         /// </summary>
         internal static string DisableDiagnosticForThisLine {
             get {

--- a/src/Bicep.LangServer/LangServerResources.Designer.cs
+++ b/src/Bicep.LangServer/LangServerResources.Designer.cs
@@ -61,11 +61,11 @@ namespace Bicep.LanguageServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Disable {0}.
+        ///   Looks up a localized string similar to Disable {0} for this line..
         /// </summary>
-        internal static string DisableDiagnostic {
+        internal static string DisableDiagnosticForThisLine {
             get {
-                return ResourceManager.GetString("DisableDiagnostic", resourceCulture);
+                return ResourceManager.GetString("DisableDiagnosticForThisLine", resourceCulture);
             }
         }
     }

--- a/src/Bicep.LangServer/LangServerResources.resx
+++ b/src/Bicep.LangServer/LangServerResources.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="DisableDiagnostic" xml:space="preserve">
-    <value>Disable {0}</value>
+  <data name="DisableDiagnosticForThisLine" xml:space="preserve">
+    <value>Disable {0} for this line.</value>
   </data>
 </root>

--- a/src/Bicep.LangServer/LangServerResources.resx
+++ b/src/Bicep.LangServer/LangServerResources.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DisableDiagnosticForThisLine" xml:space="preserve">
-    <value>Disable {0} for this line.</value>
+    <value>Disable {0} for this line</value>
   </data>
 </root>


### PR DESCRIPTION
Update disable next line string in light bulb to include the text "for this line" to avoid confusion.