### PR TITLE
Fix issue in bicep config change telemetry

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
@@ -100,9 +100,9 @@ namespace Bicep.LangServer.UnitTests.Registry
             var thirdSource = new TaskCompletionSource<bool>();
 
             var compilationManager = Repository.Create<ICompilationManager>();
-            compilationManager.Setup(m => m.RefreshCompilation(firstUri, It.IsAny<bool>(), It.IsAny<bool>())).Callback<DocumentUri, bool>((uri, reloadBicepConfig) => firstSource.SetResult(true));
-            compilationManager.Setup(m => m.RefreshCompilation(secondUri, It.IsAny<bool>(), It.IsAny<bool>())).Callback<DocumentUri, bool>((uri, reloadBicepConfig) => secondSource.SetResult(true));
-            compilationManager.Setup(m => m.RefreshCompilation(thirdUri, It.IsAny<bool>(), It.IsAny<bool>())).Callback<DocumentUri, bool>((uri, reloadBicepConfig) => thirdSource.SetResult(true));
+            compilationManager.Setup(m => m.RefreshCompilation(firstUri, It.IsAny<bool>(), It.IsAny<bool>())).Callback<DocumentUri, bool, bool>((uri, reloadBicepConfig, sendTelemetryOnBicepConfigChange) => firstSource.SetResult(true));
+            compilationManager.Setup(m => m.RefreshCompilation(secondUri, It.IsAny<bool>(), It.IsAny<bool>())).Callback<DocumentUri, bool, bool>((uri, reloadBicepConfig, sendTelemetryOnBicepConfigChange) => secondSource.SetResult(true));
+            compilationManager.Setup(m => m.RefreshCompilation(thirdUri, It.IsAny<bool>(), It.IsAny<bool>())).Callback<DocumentUri, bool, bool>((uri, reloadBicepConfig, sendTelemetryOnBicepConfigChange) => thirdSource.SetResult(true));
 
             var firstFileSet = CreateModules("mock:one", "mock:two");
             var secondFileSet = CreateModules("mock:three", "mock:four");

--- a/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
@@ -100,9 +100,9 @@ namespace Bicep.LangServer.UnitTests.Registry
             var thirdSource = new TaskCompletionSource<bool>();
 
             var compilationManager = Repository.Create<ICompilationManager>();
-            compilationManager.Setup(m => m.RefreshCompilation(firstUri, It.IsAny<bool>())).Callback<DocumentUri, bool>((uri, reloadBicepConfig) => firstSource.SetResult(true));
-            compilationManager.Setup(m => m.RefreshCompilation(secondUri, It.IsAny<bool>())).Callback<DocumentUri, bool>((uri, reloadBicepConfig) => secondSource.SetResult(true));
-            compilationManager.Setup(m => m.RefreshCompilation(thirdUri, It.IsAny<bool>())).Callback<DocumentUri, bool>((uri, reloadBicepConfig) => thirdSource.SetResult(true));
+            compilationManager.Setup(m => m.RefreshCompilation(firstUri, It.IsAny<bool>(), It.IsAny<bool>())).Callback<DocumentUri, bool>((uri, reloadBicepConfig) => firstSource.SetResult(true));
+            compilationManager.Setup(m => m.RefreshCompilation(secondUri, It.IsAny<bool>(), It.IsAny<bool>())).Callback<DocumentUri, bool>((uri, reloadBicepConfig) => secondSource.SetResult(true));
+            compilationManager.Setup(m => m.RefreshCompilation(thirdUri, It.IsAny<bool>(), It.IsAny<bool>())).Callback<DocumentUri, bool>((uri, reloadBicepConfig) => thirdSource.SetResult(true));
 
             var firstFileSet = CreateModules("mock:one", "mock:two");
             var secondFileSet = CreateModules("mock:three", "mock:four");

--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -418,6 +418,9 @@ var useDefaultSettings = true";
             bicepTelemetryEvent = await telemetryEventsListener.WaitNext();
             bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.BicepFileOpen);
             bicepTelemetryEvent.Properties.Should().Contain(properties);
+
+            // Ensures telemetry event is sent exactly once
+            await telemetryEventsListener.EnsureNoMessageSent();
         }
 
         private async Task<BicepTelemetryEvent> GetTelemetryEventForBicepConfigChange(string prevBicepConfigFileContents, string curBicepConfigFileContents, string bicepFileContents)

--- a/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/TelemetryTests.cs
@@ -435,7 +435,6 @@ namespace Bicep.LangServer.IntegrationTests
             bicepTelemetryEvent.Properties.Should().Equal(properties);
 
             await telemetryEventsListener.EnsureNoMessageSent();
-
         }
 
         private async Task OpenFileAndVerifyTelemetryEventsAreSent(ILanguageClient client, DocumentUri documentUri, string bicepFileContents, MultipleMessageListener<BicepTelemetryEvent> telemetryEventsListener)
@@ -570,9 +569,6 @@ var useDefaultSettings = true";
             bicepTelemetryEvent = await telemetryEventsListener.WaitNext();
             bicepTelemetryEvent.EventName.Should().Be(TelemetryConstants.EventNames.BicepFileOpen);
             bicepTelemetryEvent.Properties.Should().Contain(properties);
-
-            // Ensures telemetry event is sent exactly once
-            await telemetryEventsListener.EnsureNoMessageSent();
         }
 
         private async Task<BicepTelemetryEvent> GetTelemetryEventForBicepConfigChange(string prevBicepConfigFileContents, string curBicepConfigFileContents, string bicepFileContents)

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -14,7 +14,6 @@ using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
-using Bicep.Core.Text;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Extensions;
@@ -121,7 +120,7 @@ namespace Bicep.LanguageServer
             {
                 if (removedFiles.Any(x => context.Compilation.SourceFileGrouping.SourceFiles.Contains(x)))
                 {
-                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig, sendTelemetryOnBicepConfigChange);
+                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig);
                 }
             }
         }

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -67,7 +67,7 @@ namespace Bicep.LanguageServer
             this.linterRulesLazy = new Lazy<ImmutableDictionary<string, string>>(() => GetLinterRules().ToImmutableDictionary());
         }
 
-        public void RefreshCompilation(DocumentUri documentUri, bool reloadBicepConfig = false)
+        public void RefreshCompilation(DocumentUri documentUri, bool reloadBicepConfig = false, bool sendTelemetryOnBicepConfigChange = false)
         {
             var compilationContext = this.GetCompilation(documentUri);
 
@@ -85,7 +85,7 @@ namespace Bicep.LanguageServer
                     workspace.TryGetSourceFile(documentUri.ToUri(), out ISourceFile? sourceFile) &&
                     sourceFile is BicepFile)
                 {
-                    UpsertCompilationInternal(documentUri, null, sourceFile, reloadBicepConfig);
+                    UpsertCompilationInternal(documentUri, null, sourceFile, reloadBicepConfig, sendTelemetryOnBicepConfigChange);
                 }
                 return;
             }
@@ -94,7 +94,7 @@ namespace Bicep.LanguageServer
             // need to make a shallow copy so it counts as a different file even though all the content is identical
             // this was the easiest way to force the compilation to be regenerated
             var shallowCopy = new BicepFile(compilationContext.Compilation.SourceFileGrouping.EntryPoint);
-            UpsertCompilationInternal(documentUri, null, shallowCopy, reloadBicepConfig);
+            UpsertCompilationInternal(documentUri, null, shallowCopy, reloadBicepConfig, sendTelemetryOnBicepConfigChange);
         }
 
         public void UpsertCompilation(DocumentUri documentUri, int? version, string fileContents, string? languageId = null)
@@ -106,7 +106,7 @@ namespace Bicep.LanguageServer
             }
         }
 
-        private void UpsertCompilationInternal(DocumentUri documentUri, int? version, ISourceFile newFile, bool reloadBicepConfig = false)
+        private void UpsertCompilationInternal(DocumentUri documentUri, int? version, ISourceFile newFile, bool reloadBicepConfig = false, bool sendTelemetryOnBicepConfigChange = false)
         {
             var (_, removedFiles) = workspace.UpsertSourceFile(newFile);
 
@@ -114,14 +114,14 @@ namespace Bicep.LanguageServer
             if (newFile is BicepFile)
             {
                 // Do not update compilation if it is an ARM template file, since it cannot be an entrypoint.
-                UpdateCompilationInternal(documentUri, version, modelLookup, removedFiles, reloadBicepConfig);
+                UpdateCompilationInternal(documentUri, version, modelLookup, removedFiles, reloadBicepConfig, sendTelemetryOnBicepConfigChange);
             }
 
             foreach (var (entrypointUri, context) in activeContexts)
             {
                 if (removedFiles.Any(x => context.Compilation.SourceFileGrouping.SourceFiles.Contains(x)))
                 {
-                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig);
+                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig, sendTelemetryOnBicepConfigChange);
                 }
             }
         }
@@ -208,7 +208,7 @@ namespace Bicep.LanguageServer
             return closedFiles.ToImmutableArray();
         }
 
-        private (ImmutableArray<ISourceFile> added, ImmutableArray<ISourceFile> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version, IDictionary<ISourceFile, ISemanticModel> modelLookup, IEnumerable<ISourceFile> removedFiles, bool reloadBicepConfig = false)
+        private (ImmutableArray<ISourceFile> added, ImmutableArray<ISourceFile> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version, IDictionary<ISourceFile, ISemanticModel> modelLookup, IEnumerable<ISourceFile> removedFiles, bool reloadBicepConfig = false, bool sendTelemetryOnBicepConfigChange = false)
         {
             var configuration = this.GetConfigurationSafely(documentUri, out var configurationDiagnostic);
 
@@ -235,13 +235,13 @@ namespace Bicep.LanguageServer
                             }
                         }
 
-                        if (reloadBicepConfig)
+                        var configuration = reloadBicepConfig
+                            ? this.GetConfigurationSafely(documentUri.ToUri(), out configurationDiagnostic)
+                            : prevContext.Compilation.Configuration;
+
+                        if (sendTelemetryOnBicepConfigChange)
                         {
                             SendTelemetryOnBicepConfigChange(prevConfiguration, configuration);
-                        }
-                        else
-                        {
-                            configuration = prevContext.Compilation.Configuration;
                         }
 
                         return this.provider.Create(workspace, documentUri, modelLookup.ToImmutableDictionary(), configuration);

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -120,7 +120,7 @@ namespace Bicep.LanguageServer
             {
                 if (removedFiles.Any(x => context.Compilation.SourceFileGrouping.SourceFiles.Contains(x)))
                 {
-                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig);
+                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig, sendTelemetryOnBicepConfigChange);
                 }
             }
         }

--- a/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
+++ b/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
@@ -10,7 +10,7 @@ namespace Bicep.LanguageServer.CompilationManager
     {
         void HandleFileChanges(IEnumerable<FileEvent> fileEvents);
 
-        void RefreshCompilation(DocumentUri uri, bool reloadBicepConfig = false);
+        void RefreshCompilation(DocumentUri uri, bool reloadBicepConfig = false, bool sendTelemetryOnBicepConfigChange = false);
 
         void UpsertCompilation(DocumentUri uri, int? version, string text, string? languageId = null);
 

--- a/src/Bicep.LangServer/Configuration/BicepConfigChangeHandler.cs
+++ b/src/Bicep.LangServer/Configuration/BicepConfigChangeHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
+using System.Linq;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -12,9 +12,18 @@ namespace Bicep.LanguageServer.Configuration
     {
         public static void RefreshCompilationOfSourceFilesInWorkspace(ICompilationManager compilationManager, IWorkspace workspace)
         {
-            foreach (Uri sourceFileUri in workspace.GetActiveSourceFilesByUri().Keys)
+            var sourceFiles = workspace.GetActiveSourceFilesByUri().Keys;
+            for (int i = 0; i < sourceFiles.Count(); i++)
             {
-                compilationManager.RefreshCompilation(DocumentUri.From(sourceFileUri), reloadBicepConfig: true);
+                var sourceFileUri = sourceFiles.ElementAt(i);
+                if (i == 0)
+                {
+                    compilationManager.RefreshCompilation(DocumentUri.From(sourceFileUri), reloadBicepConfig: true, sendTelemetryOnBicepConfigChange: true);
+                }
+                else
+                {
+                    compilationManager.RefreshCompilation(DocumentUri.From(sourceFileUri), reloadBicepConfig: true);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes below issue:
Bicep config change telemetry events were being sent multiple times, depending on number of active bicep files in the workspace.

Made changes to fix above issue and send out telemetry data only once.

Commit that introduced this issue:
https://github.com/Azure/bicep/commit/873075cac432d05a37be7cd00c42e6f1f1589688