### PR TITLE
Official build workarounds

### DIFF
--- a/.pipelines/Bicep.yml
+++ b/.pipelines/Bicep.yml
@@ -42,13 +42,13 @@ steps:
       arguments: '--configuration $(BuildConfiguration) --logger trx --blame --collect:"XPlat Code Coverage" --settings ./.github/workflows/codecov.runsettings --results-directory $(Build.SourcesDirectory)/TestResults/'
       publishTestResults: false
 
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: always()
-    inputs:
-      testResultsFormat: VSTest
-      testResultsFiles: '$(Build.SourcesDirectory)/TestResults/**/*.trx'
-      failTaskOnFailedTests: true
+  # - task: PublishTestResults@2
+  #   displayName: Publish Test Results
+  #   condition: always()
+  #   inputs:
+  #     testResultsFormat: VSTest
+  #     testResultsFiles: '$(Build.SourcesDirectory)/TestResults/**/*.trx'
+  #     failTaskOnFailedTests: true
 
 - ${{ if eq(parameters.publishLanguageServer, true) }}:
   - task: DotNetCoreCLI@2

--- a/.pipelines/Common.yml
+++ b/.pipelines/Common.yml
@@ -209,26 +209,26 @@ stages:
         rid: linux-x64
         artifactSuffix: linux
 
-  - job: packages_linux_arm64
-    dependsOn: bicep_linux_arm64
-    pool:
-      # signing must happen on Windows
-      type: windows  # read more about custom job pool types at https://aka.ms/obpipelines/yaml/jobs
+  # - job: packages_linux_arm64
+  #   dependsOn: bicep_linux_arm64
+  #   pool:
+  #     # signing must happen on Windows
+  #     type: windows  # read more about custom job pool types at https://aka.ms/obpipelines/yaml/jobs
     
-    variables:
-      ob_outputDirectory: '$(Build.SourcesDirectory)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
-      # https://aka.ms/obpipelines/sdl
-      ob_sdl_binskim_enabled: true # you can disable sdl tools in non-official build 
-      ob_sdl_binskim_break: false # always break the build on binskim issues. You can disable it by setting to 'false'
-      ob_sdl_binskim_scanOutputDirectoryOnly: true
-      ob_sdl_roslyn_break: true
-      # ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\.gdn\job.gdnsuppress
-    steps:
-    - template: Packages.yml
-      parameters:
-        official: ${{ parameters.official }}
-        rid: linux-arm64
-        artifactSuffix: linux_arm64
+  #   variables:
+  #     ob_outputDirectory: '$(Build.SourcesDirectory)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+  #     # https://aka.ms/obpipelines/sdl
+  #     ob_sdl_binskim_enabled: true # you can disable sdl tools in non-official build 
+  #     ob_sdl_binskim_break: false # always break the build on binskim issues. You can disable it by setting to 'false'
+  #     ob_sdl_binskim_scanOutputDirectoryOnly: true
+  #     ob_sdl_roslyn_break: true
+  #     # ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\.gdn\job.gdnsuppress
+  #   steps:
+  #   - template: Packages.yml
+  #     parameters:
+  #       official: ${{ parameters.official }}
+  #       rid: linux-arm64
+  #       artifactSuffix: linux_arm64
 
   - job: packages_osx
     dependsOn: bicep_osx
@@ -251,26 +251,26 @@ stages:
         rid: osx-x64
         artifactSuffix: osx
 
-  - job: packages_osx_arm64
-    dependsOn: bicep_osx_arm64
-    pool:
-      # signing must happen on Windows
-      type: windows  # read more about custom job pool types at https://aka.ms/obpipelines/yaml/jobs
+  # - job: packages_osx_arm64
+  #   dependsOn: bicep_osx_arm64
+  #   pool:
+  #     # signing must happen on Windows
+  #     type: windows  # read more about custom job pool types at https://aka.ms/obpipelines/yaml/jobs
     
-    variables:
-      ob_outputDirectory: '$(Build.SourcesDirectory)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
-      # https://aka.ms/obpipelines/sdl
-      ob_sdl_binskim_enabled: true # you can disable sdl tools in non-official build 
-      ob_sdl_binskim_break: false # always break the build on binskim issues. You can disable it by setting to 'false'
-      ob_sdl_binskim_scanOutputDirectoryOnly: true
-      ob_sdl_roslyn_break: true
-      # ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\.gdn\job.gdnsuppress
-    steps:
-    - template: Packages.yml
-      parameters:
-        official: ${{ parameters.official }}
-        rid: osx-arm64
-        artifactSuffix: osx_arm64
+  #   variables:
+  #     ob_outputDirectory: '$(Build.SourcesDirectory)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+  #     # https://aka.ms/obpipelines/sdl
+  #     ob_sdl_binskim_enabled: true # you can disable sdl tools in non-official build 
+  #     ob_sdl_binskim_break: false # always break the build on binskim issues. You can disable it by setting to 'false'
+  #     ob_sdl_binskim_scanOutputDirectoryOnly: true
+  #     ob_sdl_roslyn_break: true
+  #     # ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\.gdn\job.gdnsuppress
+  #   steps:
+  #   - template: Packages.yml
+  #     parameters:
+  #       official: ${{ parameters.official }}
+  #       rid: osx-arm64
+  #       artifactSuffix: osx_arm64
 
   - job: packages_test_windows
     dependsOn: 

--- a/scripts/UploadSignedReleaseArtifacts.ps1
+++ b/scripts/UploadSignedReleaseArtifacts.ps1
@@ -169,15 +169,15 @@ $artifacts = @(
       }
     );
   },
-  @{
-    buildArtifactName = 'drop_build_packages_linux_arm64';
-    assets = @(
-      @{
-        assetName = "Azure.Bicep.CommandLine.linux-arm64.$buildVersion.nupkg";
-        relativePath = "Azure.Bicep.CommandLine.linux-arm64.$buildVersion.nupkg";
-      }
-    );
-  },
+  # @{
+  #   buildArtifactName = 'drop_build_packages_linux_arm64';
+  #   assets = @(
+  #     @{
+  #       assetName = "Azure.Bicep.CommandLine.linux-arm64.$buildVersion.nupkg";
+  #       relativePath = "Azure.Bicep.CommandLine.linux-arm64.$buildVersion.nupkg";
+  #     }
+  #   );
+  # },
   @{
     buildArtifactName = 'drop_build_packages_osx';
     assets = @(
@@ -186,16 +186,16 @@ $artifacts = @(
         relativePath = "Azure.Bicep.CommandLine.osx-x64.$buildVersion.nupkg";
       }
     );
-  },
-  @{
-    buildArtifactName = 'drop_build_packages_osx_arm64';
-    assets = @(
-      @{
-        assetName = "Azure.Bicep.CommandLine.osx-arm64.$buildVersion.nupkg";
-        relativePath = "Azure.Bicep.CommandLine.osx-arm64.$buildVersion.nupkg";
-      }
-    );
-  }
+  }#,
+  # @{
+  #   buildArtifactName = 'drop_build_packages_osx_arm64';
+  #   assets = @(
+  #     @{
+  #       assetName = "Azure.Bicep.CommandLine.osx-arm64.$buildVersion.nupkg";
+  #       relativePath = "Azure.Bicep.CommandLine.osx-arm64.$buildVersion.nupkg";
+  #     }
+  #   );
+  # }
 )
 
 Write-Output "Removing working dir...";


### PR DESCRIPTION
Adding two workarounds for current official build issues:
* Disabled test publishing in ADO
* Disabled the jobs that produces linux-arm64 and osx-arm64 CLI NuGet packages (and corresponding assets in the release script)

Used comments instead of deletions because this should be a temporary state. I expect these issues to be resolved over time.