### PR TITLE
Remove docs referenced by previous VSCode extension README

### DIFF
--- a/docs/examples/101/aks-vmss-systemassigned-identity/README.md
+++ b/docs/examples/101/aks-vmss-systemassigned-identity/README.md
@@ -4,7 +4,7 @@ This Bicep template deploys a managed **Azure hosted Kubernetes cluster** via **
 
 ## Deployment steps ##
 
-* [Install the Bicep CLI](https://github.com/Azure/bicep/blob/main/docs/installing.md) by following the instruction.
+* [Install the Bicep CLI](https://docs.microsoft.com/azure/azure-resource-manager/bicep/install) by following the instruction.
 * Create Resource Group
 ```
 az group create -n <resource-group-name> -l westus

--- a/docs/examples/101/aks/README.md
+++ b/docs/examples/101/aks/README.md
@@ -4,7 +4,7 @@
 ## Deployment steps ##
 
 ### 0. Optional: Install Bicep ###
-* [Install the Bicep CLI](https://github.com/Azure/bicep/blob/main/docs/installing.md) by following the instruction.
+* [Install the Bicep CLI](https://docs.microsoft.com/azure/azure-resource-manager/bicep/install) by following the instruction.
 
 ### 1. Create Service Principal ###
 ```

--- a/docs/examples/101/basic-batch-account/README.md
+++ b/docs/examples/101/basic-batch-account/README.md
@@ -4,7 +4,7 @@ This Bicep template deploys an Azure Batch account in Batch Service allocation m
 
 ## Deployment steps ##
 
-* [Install the Bicep CLI](https://github.com/Azure/bicep/blob/main/docs/installing.md) by following the instruction.
+* [Install the Bicep CLI](https://docs.microsoft.com/azure/azure-resource-manager/bicep/install) by following the instruction.
 * Build the `main.bicep` file by running the Bicep CLI command:
   
 ```bash

--- a/docs/examples/101/create-managedidentity-rbac/README.md
+++ b/docs/examples/101/create-managedidentity-rbac/README.md
@@ -4,7 +4,7 @@ This Bicep template deploys a user assigned managed identity and associates RBAC
 
 ## Deployment steps ##
 
-* [Install the Bicep CLI](https://github.com/Azure/bicep/blob/main/docs/installing.md) by following the instruction.
+* [Install the Bicep CLI](https://docs.microsoft.com/azure/azure-resource-manager/bicep/install) by following the instruction.
 * Build the `main.bicep` file by running the Bicep CLI command:
   
 ```bash

--- a/docs/examples/201/vm-windows-with-custom-script-extension/README.md
+++ b/docs/examples/201/vm-windows-with-custom-script-extension/README.md
@@ -5,7 +5,7 @@ This sample Bicep file is an extension of [101-vm-simple-windows](https://github
 
 ## Getting Started ##
 
-* [Install the Bicep CLI](https://github.com/Azure/bicep/blob/main/docs/installing.md) by following the instruction.
+* [Install the Bicep CLI](https://docs.microsoft.com/azure/azure-resource-manager/bicep/install) by following the instruction.
 * Build the `main.bicep` file by running the Bicep CLI command:
 
 ```bash

--- a/docs/examples/301/web-app-managed-identity-sql-db/README.md
+++ b/docs/examples/301/web-app-managed-identity-sql-db/README.md
@@ -3,7 +3,7 @@
 A common architecture for Azure customers is Web App + Data + Managed Identity + Monitoring.
 
 **How easy it to deploy this with Bicep?**
-1. [Install Bicep CLI and VS Code extension](https://github.com/Azure/bicep/blob/main/docs/installing.md)
+1. [Install Bicep CLI and VS Code extension](https://docs.microsoft.com/azure/azure-resource-manager/bicep/install)
 2. Use example from [main.bicep](main.bicep)
 3. Arrange/re-order, update variables and params to your preference
 4. Use the Bicep CLI to run Bicep Build command: ``` Bicep Build ./main.bicep ``` to generate ARM Template (main._json_)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,2 +1,0 @@
-# Install the Bicep VS Code extension
-Please refer to our new documentation for installing the Bicep VS code extension on [Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/install#vs-code-and-bicep-extension).

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -1,2 +1,0 @@
-# Bicep Type System
-Please refer to our Microsoft Docs on the [Bicep Type System](https://docs.microsoft.com/azure/azure-resource-manager/bicep/data-types).


### PR DESCRIPTION
Under #4978 we avoided removing `docs/installing.md` & `docs/specs/types.md` because they were referenced by the VSCode extension README.

Now that we've published a new version of the extension (which points to MS Docs), we can remove these files.