### PR TITLE
Fix code signing for registry module tool (2nd trial)

### DIFF
--- a/.pipelines/Bicep.yml
+++ b/.pipelines/Bicep.yml
@@ -113,6 +113,18 @@ steps:
         files_to_sign: '**/*.dll'
         search_root: '$(Build.SourcesDirectory)/src/Bicep.MSBuild/bin/$(BuildConfiguration)/netstandard2.0/'
 
+  - task: DotNetCoreCLI@2
+    displayName: Pack
+    inputs:
+      command: custom
+      custom: pack
+      projects: $(BuildSolution)
+      arguments: '--configuration $(BuildConfiguration) --no-build /p:PublicRelease=${{ parameters.official }}'
+
+  # dotnet pack publishes the registry module tool on the fly and always copies the latest binaries to a publish folder.
+  # In order to sign the publish folder, nuget package generation is disabled in the pack step above (see the DisablePacking target
+  # in Bicep.RegistryModuleTool.csproj). The publish folder is packed using the Bicep.RegistryModuleTool.Nuget project.
+  - ${{ if eq(parameters.enableSigning, true) }}:
     - task: onebranch.pipeline.signing@1
       displayName: Sign Bicep.RegistryModuleTool bin
       inputs:
@@ -121,13 +133,21 @@ steps:
         files_to_sign: '**/*.exe;**/*.dll'
         search_root: '$(Build.SourcesDirectory)/src/Bicep.RegistryModuleTool/bin/$(BuildConfiguration)/net6.0/'
 
-  - task: DotNetCoreCLI@2
-    displayName: Pack
-    inputs:
-      command: custom
-      custom: pack
-      projects: $(BuildSolution)
-      arguments: '--configuration $(BuildConfiguration) /p:BuildProjectReferences=false /p:NoBuild=true /p:PublicRelease=${{ parameters.official }}'
+    - task: DotNetCoreCLI@2
+      displayName: Build Bicep registry module tool package
+      inputs:
+        command: build
+        projects: $(Build.SourcesDirectory)/src/Bicep.RegistryModuleTool.Nuget/nuget.proj
+        arguments: '--configuration $(BuildConfiguration) /p:PublicRelease=${{ parameters.official }}'
+
+    - task: CopyFiles@2
+      displayName: Copy Bicep registry module tool package to output
+      inputs:
+        sourceFolder: '$(Build.SourcesDirectory)/src/Bicep.RegistryModuleTool.Nuget/'
+        contents: |
+          *.nupkg
+          *.snupkg
+        targetFolder: '$(Build.SourcesDirectory)/out/'
 
   # test signing fails on .nupkg files and .snupkg files are completely unsupported for signing
   - ${{ if and(eq(parameters.official, true), eq(parameters.enableSigning, true)) }}:

--- a/src/Bicep.RegistryModuleTool.Nuget/nuget.proj
+++ b/src/Bicep.RegistryModuleTool.Nuget/nuget.proj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <!-- NoTargets SDK no longer sets Language, which is required by NerdBank.GitVersioning -->
+    <Language>C#</Language>
+
+    <NugetExePath>$(PkgNuGet_CommandLine)\tools\NuGet.exe</NugetExePath>
+    <NugetExePath Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">mono $(NugetExePath)</NugetExePath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.CommandLine" Version="5.8.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <Target Name="RunTool" AfterTargets="Build" DependsOnTargets="GetBuildVersion">
+    <ItemGroup>
+      <NuSpec Include="$(BUILD_SOURCESDIRECTORY)/src/Bicep.RegistryModuleTool/obj/$(BUILDCONFIGURATION)/Bicep.RegistryModuleTool.$(NugetPackageVersion).nuspec" />
+    </ItemGroup>
+
+    <Exec Command="$(NugetExePath) pack @(NuSpec) -Version $(NuGetPackageVersion) -Symbols -SymbolPackageFormat snupkg -NonInteractive"
+          WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/src/Bicep.RegistryModuleTool.Nuget/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.Nuget/packages.lock.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.3, )",
+        "resolved": "3.3.3",
+        "contentHash": "vvz3XCHVrd/Ks4xPoutLmL/T2+8JcOk/OMs3ngwQqnzokQCGEDsY+WjK/txCsDWU29sX3fGzH/FnYwNV93O1mA=="
+      },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.4.231, )",
+        "resolved": "3.4.231",
+        "contentHash": "ifpSbv0sySgIVymTQQz0pjI6O7o/JxnIQMlj28JF5Ybr1LoUTcMfoKnAKwteRlhpQM9qJmONGy9M8BgrEcOteg=="
+      },
+      "NuGet.CommandLine": {
+        "type": "Direct",
+        "requested": "[5.8.1, )",
+        "resolved": "5.8.1",
+        "contentHash": "75mXXZr2IfK5aux/f2Axbt/P9baVK9ICws1ezEJ692r05VGX7u+8jrhZyp2meZTFpRZG9CjC29z/KZ1Y5LJFGw=="
+      }
+    },
+    ".NETFramework,Version=v4.7.2/linux-arm64": {},
+    ".NETFramework,Version=v4.7.2/linux-musl-x64": {},
+    ".NETFramework,Version=v4.7.2/linux-x64": {},
+    ".NETFramework,Version=v4.7.2/osx-arm64": {},
+    ".NETFramework,Version=v4.7.2/osx-x64": {},
+    ".NETFramework,Version=v4.7.2/win-arm64": {},
+    ".NETFramework,Version=v4.7.2/win-x64": {}
+  }
+}

--- a/src/Bicep.RegistryModuleTool/Bicep.RegistryModuleTool.csproj
+++ b/src/Bicep.RegistryModuleTool/Bicep.RegistryModuleTool.csproj
@@ -31,5 +31,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Bicep.Core\Bicep.Core.csproj" />
   </ItemGroup>
+  
+  <!-- TF_BUILD is a read-only predefined variable in ADO. It is set to True when starting a build task. -->
+  <Target Name="DisablePacking" BeforeTargets="GenerateNuspec" Condition=" '$(TF_BUILD)' == 'True' ">
+    <PropertyGroup>
+      <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
+    </PropertyGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
Verified Digital Signatures of `Bicep.RegistryModuleTool.dll` this time.
![image](https://user-images.githubusercontent.com/16367959/148626478-2701eebe-d1bd-4498-870d-f524b494834b.png)
