### PR TITLE
Add temp documentation for contributing to Bicep public module

### DIFF
--- a/docs/contributing-to-registry.md
+++ b/docs/contributing-to-registry.md
@@ -2,13 +2,14 @@
 
 # Contributing to Bicep public registry
 
-Currently, we only accept contributions from Microsoft employees. The guide was created to help teams within Microsoft with the development of Bicep public registry modules. External customers can propose a new module by opening an [issue]() in the [Azure/azure-quickstart-templates](https://github.com/Azure/azure-quickstart-templates/tree/master/modules) repository.
+Currently, we only accept contributions from Microsoft employees. The guide was created to help teams within Microsoft with the development of Bicep public registry modules. External customers can propose a new module by opening an [issue]() in the [TBD]() repository.
 
 ## Prerequisite
-- Create a fork of the [Azure/azure-quickstart-templates](https://github.com/Azure/azure-quickstart-templates/tree/master/modules) repository and clone the fork to your local machine.
-<!-- TODO: Add link to Nuget once the tool is published -->
-- Install the [bicep-registry-module]() .NET tool by running:
-  - `dotnet tool install -g bicep-registry-module`
+- Create a fork of the [TBD]() repository and clone the fork to your local machine.
+- Install [.NET 6.0 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0/runtime).
+  <!-- TODO: Add link to Nuget once the tool is published -->
+- Install the [Bicep registry module]() .NET tool by running:
+  - `dotnet tool install -g brm`
 
 ## Creating a new module
 
@@ -18,14 +19,14 @@ Before creating a new module, you must fill out this [issue template](https://gi
 
 ### Creating a directory for the new module
 <!-- TODO: need to discuss the pattern of the module path -->
-Add a new directory under the `modules` folder in your local azure-quickstart-templates repository with the path following the pattern `<ResourceProviderName>/<ModuleName>/<ModuleMajorVersion>.<ModuleMinorVersion>`. For examples: 
-- `Microsoft.Storage/storageAccounts/0.9`
-- `Microsoft.Web/webApplications/1.0`
+Add a new directory under the `modules` folder in your local azure-quickstart-templates repository with the path following the pattern `<ResourceProviderName>/<ModuleName>/<ModuleMajorVersion>.<ModuleMinorVersion>`, and the path must be in lowercase. For examples: 
+- `microsoft.storage/storageaccounts/0.9`
+- `microsoft.web/webapplications/1.0`
 
 ### Generating module files
 Open a terminal and navigate to the newly created folder. From there, run the following command to generate the required files for the Bicep public registry module:
 ```
-bicep-registry-module generate
+brm generate
 ```
 
 You should be able to see these files created in the module folder:
@@ -40,10 +41,10 @@ You should be able to see these files created in the module folder:
 - `README.md`
   - The README file generated based on the contents of `metadata.json` and `main.bicep`. Do not update this file manually.
 - `version.json`
-  - The version file, together with the `azuredeploy.json` file, are used to calculate the patch version of the module automatically when publishing the module to the Bicep public module registry. You should not edit this contents of the file.
+  - The version file, together with the `azuredeploy.json` file, are used to calculate the patch version number of the module. Every time `azuredeploy.json` is changed, the patch version number gets bumped. The full version (`<ModuleMajorVersion>.<ModuleMinorVersion>.<ModulePatchVersion>`) will then be assigned to the module when it gets published to the Bicep public module registry. The process is done by the module publishing CI automatically. You should not edit this contents of the file.
 
 ### Authoring module files
-The only two files that you need to edit are `metadata.json` and  `main.bicep`. When authoring `main.bicep`, make sure to provide a description for each parameter and output. You are free to create other Bicep files and reference them as local modules in `main.bicep` if needed. Once you are done, run `bicep-registry-module generate` again to refresh the other files. You may need to update `azuredeploy.parameters.json` to provide parameter values after the generation if there are changes to the template parameters.
+The only two files that you need to edit are `metadata.json` and  `main.bicep`. When authoring `main.bicep`, make sure to provide a description for each parameter and output. You are free to create other Bicep files and reference them as local modules in `main.bicep` if needed. You can also reference other external modules available in the Bicep public registry to help build your module. Once you are done, run `bicep-registry-module generate` again to refresh the other files. You may need to update `azuredeploy.parameters.json` to provide parameter values after the generation if there are changes to the template parameters.
 
 ## Updating an existing module
 To update an existing module, simply follow the [Authoring module files](#authoring-module-files) section to update and regenerate the module files.
@@ -52,9 +53,9 @@ To update an existing module, simply follow the [Authoring module files](#author
 
 > Before running the command, it is recommended to run `generate` and check `azuredeploy.parameters.json` to ensure all files are up-to-date.
 
-You may use the bicep-registry-module .NET tool to validate files in a registry module. To do so, invoke the follow command from the module folder:
+You may use the Bicep registry module tool to validate files in a registry module. To do so, invoke the follow command from the module folder:
 ```
-bicep-registry-module validate
+brm validate
 ```
 
 ## Submitting a pull request

--- a/docs/contributing-to-registry.md
+++ b/docs/contributing-to-registry.md
@@ -1,0 +1,66 @@
+>**Note**: Please ignore the doc for now as it's a work in progress. We are still working on creating the Bicep public registry, and the tool mentioned in the doc has not been published yet.
+
+# Contributing to Bicep public registry
+
+Currently, we only accept contributions from Microsoft employees. The guide was created to help teams within Microsoft with the development of Bicep public registry modules. External customers can propose a new module by opening an [issue]() in the [Azure/azure-quickstart-templates](https://github.com/Azure/azure-quickstart-templates/tree/master/modules) repository.
+
+## Prerequisite
+- Create a fork of the [Azure/azure-quickstart-templates](https://github.com/Azure/azure-quickstart-templates/tree/master/modules) repository and clone the fork to your local machine.
+<!-- TODO: Add link to Nuget once the tool is published -->
+- Install the [bicep-registry-module]() .NET tool by running:
+  - `dotnet tool install -g bicep-registry-module`
+
+## Creating a new module
+
+### Making a proposal for new module
+<!-- TODO: create an issue template in the quickstart repo -->
+Before creating a new module, you must fill out this [issue template](https://github.com/Azure/azure-quickstart-templates/issues/new) to make a proposal. Once the proposal is approved, proceed with the following steps.
+
+### Creating a directory for the new module
+<!-- TODO: need to discuss the pattern of the module path -->
+Add a new directory under the `modules` folder in your local azure-quickstart-templates repository with the path following the pattern `<ResourceProviderName>/<ModuleName>/<ModuleMajorVersion>.<ModuleMinorVersion>`. For examples: 
+- `Microsoft.Storage/storageAccounts/0.9`
+- `Microsoft.Web/webApplications/1.0`
+
+### Generating module files
+Open a terminal and navigate to the newly created folder. From there, run the following command to generate the required files for the Bicep public registry module:
+```
+bicep-registry-module generate
+```
+
+You should be able to see these files created in the module folder:
+- `metadata.json`
+  - The module manifest file that contains metadata you must provide, such as `description`.
+- `main.bicep`
+  - An empty Bicep file to be updated.
+- `azuredeploy.json`
+  - The ARM template file generated from `main.bicep`. This is the file that will be published to the Bicep public registry. You should not modify this file.
+- `azuredeploy.parameters.json`
+  - The ARM template parameters file for `azuredeploy.json`. The file is generated for running template deployment validation. You must provide values for the required parameters in the file.
+- `README.md`
+  - The README file generated based on the contents of `metadata.json` and `main.bicep`. Do not update this file manually.
+- `version.json`
+  - The version file, together with the `azuredeploy.json` file, are used to calculate the patch version of the module automatically when publishing the module to the Bicep public module registry. You should not edit this contents of the file.
+
+### Authoring module files
+The only two files that you need to edit are `metadata.json` and  `main.bicep`. When authoring `main.bicep`, make sure to provide a description for each parameter and output. You are free to create other Bicep files and reference them as local modules in `main.bicep` if needed. Once you are done, run `bicep-registry-module generate` again to refresh the other files. You may need to update `azuredeploy.parameters.json` to provide parameter values after the generation if there are changes to the template parameters.
+
+## Updating an existing module
+To update an existing module, simply follow the [Authoring module files](#authoring-module-files) section to update and regenerate the module files.
+
+## Validating a module
+
+> Before running the command, it is recommended to run `generate` and check `azuredeploy.parameters.json` to ensure all files are up-to-date.
+
+You may use the bicep-registry-module .NET tool to validate files in a registry module. To do so, invoke the follow command from the module folder:
+```
+bicep-registry-module validate
+```
+
+## Submitting a pull request
+When you are done with editing and validating the module files, you can commit your changes and open a pull request in the [Azure/azure-quickstart-templates](https://github.com/Azure/azure-quickstart-templates/tree/master/modules) repository. You must link the new module proposal in the pull request description if you are trying to add a new module.
+
+## Publishing a module
+Once your pull request is approved and merged to the main, a CI job will be triggered to check if there are changes made to `azuredeploy.json`. If yes, it will automatically bump the version of the module and publish the module to the Bicep public registry.
+
+

--- a/docs/contributing-to-registry.md
+++ b/docs/contributing-to-registry.md
@@ -15,7 +15,7 @@ Currently, we only accept contributions from Microsoft employees. The guide was 
 
 ### Making a proposal for new module
 <!-- TODO: create an issue template in the quickstart repo -->
-Before creating a new module, you must fill out this [issue template](https://github.com/Azure/azure-quickstart-templates/issues/new) to make a proposal. Once the proposal is approved, proceed with the following steps.
+Before creating a new module, you must fill out this [issue template](https://github.com/Azure/azure-quickstart-templates/issues/new) to make a proposal. Once the proposal is approved, proceed with the following steps. You should not send out a pull request to add a module without an associated approval as the pull request will be rejected.
 
 ### Creating a directory for the new module
 <!-- TODO: need to discuss the pattern of the module path -->
@@ -59,7 +59,7 @@ brm validate
 ```
 
 ## Submitting a pull request
-When you are done with editing and validating the module files, you can commit your changes and open a pull request in the [Azure/azure-quickstart-templates](https://github.com/Azure/azure-quickstart-templates/tree/master/modules) repository. You must link the new module proposal in the pull request description if you are trying to add a new module.
+When you are done with editing and validating the module files, you can commit your changes and open a pull request in the [TBD]() repository. You must link the new module proposal in the pull request description if you are trying to add a new module.
 
 ## Publishing a module
 Once your pull request is approved and merged to the main, a CI job will be triggered to check if there are changes made to `azuredeploy.json`. If yes, it will automatically bump the version of the module and publish the module to the Bicep public registry.

--- a/src/Bicep.RegistryModuleTool/Commands/ValidateCommand.cs
+++ b/src/Bicep.RegistryModuleTool/Commands/ValidateCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.Core;
 using Bicep.RegistryModuleTool.Exceptions;
 using Bicep.RegistryModuleTool.Extensions;
 using Bicep.RegistryModuleTool.ModuleFiles;
@@ -9,13 +8,9 @@ using Bicep.RegistryModuleTool.ModuleFileValidators;
 using Bicep.RegistryModuleTool.Proxies;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
-using System.Text;
 
 namespace Bicep.RegistryModuleTool.Commands
 {
@@ -28,17 +23,6 @@ namespace Bicep.RegistryModuleTool.Commands
 
         public sealed class CommandHandler : BaseCommandHandler
         {
-            private readonly static IReadOnlyList<string> AllowedFileNames = new[]
-            {
-                MainBicepFile.FileName,
-                MainArmTemplateFile.FileName,
-                MainArmTemplateParametersFile.FileName,
-                MetadataFile.FileName,
-                ReadmeFile.FileName,
-                VersionFile.FileName,
-                "bicepconfig.json"
-            };
-
             private readonly IEnvironmentProxy environmentProxy;
 
             private readonly IProcessProxy processProxy;
@@ -53,9 +37,6 @@ namespace Bicep.RegistryModuleTool.Commands
             protected override int Invoke(InvocationContext context)
             {
                 var valid = true;
-
-                this.Logger.LogInformation("Validating that no additional files are in the module folder...");
-                valid &= Validate(context.Console, () => this.ValidateNoAdditionalFiles());
 
                 this.Logger.LogInformation("Validating main Bicep file...");
 
@@ -103,46 +84,6 @@ namespace Bicep.RegistryModuleTool.Commands
                 }
 
                 return true;
-            }
-
-            private void ValidateNoAdditionalFiles()
-            {
-                var currentDirectoryPath = this.FileSystem.Directory.GetCurrentDirectory();
-                var filePaths = this.FileSystem.Directory.EnumerateFiles(currentDirectoryPath, "*", SearchOption.AllDirectories);
-                var allowedFilePaths = AllowedFileNames
-                    .Select(fileName => this.FileSystem.Path.Combine(currentDirectoryPath, fileName))
-                    .ToHashSet();
-
-                var notAllowedFilePaths = new List<string>();
-
-                foreach (var filePath in filePaths)
-                {
-                    if (allowedFilePaths.Contains(filePath))
-                    {
-                        continue;
-                    }
-
-                    if (filePath.EndsWith(LanguageConstants.LanguageFileExtension, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Any Bicep file is allowed.
-                        continue;
-                    }
-
-                    notAllowedFilePaths.Add(filePath);
-                }
-
-                if (notAllowedFilePaths.Any())
-                {
-                    var errorMessageBuilder = new StringBuilder();
-                    errorMessageBuilder.AppendLine("The files below are not allowed in the module:");
-
-                    foreach (var filePath in notAllowedFilePaths)
-                    {
-                        errorMessageBuilder.Append("  - ").AppendLine(filePath);
-                    }
-
-                    throw new InvalidModuleFileException(errorMessageBuilder.ToString());
-                }
             }
         }
     }

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
@@ -42,11 +42,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             builder.AppendLine($"# {metadataFile.ItemDisplayName}");
             builder.AppendLine();
 
-            var path = fileSystem.Path.GetFullPath(FileName);
-            var directoryPath = fileSystem.Path.GetDirectoryName(path);
-            var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(directoryPath);
-
-            BuildBadgesAndButtons(builder, directoryInfo);
+            BuildBadgesAndButtons(builder, fileSystem);
 
             builder.AppendLine(metadataFile.Description);
             builder.AppendLine();
@@ -74,12 +70,16 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         protected override void ValidatedBy(IModuleFileValidator validator) => validator.Validate(this);
 
-        private static void BuildBadgesAndButtons(StringBuilder builder, IDirectoryInfo directoryInfo)
+        private static void BuildBadgesAndButtons(StringBuilder builder, IFileSystem fileSystem)
         {
             var stack = new Stack<string>();
 
             try
             {
+                var path = fileSystem.Path.GetFullPath(FileName);
+                var directoryPath = fileSystem.Path.GetDirectoryName(path);
+                var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(directoryPath);
+
                 while (directoryInfo is not null && !directoryInfo.Name.Equals("modules", StringComparison.OrdinalIgnoreCase))
                 {
                     stack.Push(directoryInfo.Name);


### PR DESCRIPTION
Also updated the registry module tool to not check additional files.

Once the registry module tool is published and the module publish CI is set up in the quickstart repo, we'll need to ask Jonathon to polish the documentation and publish it to MS docs.

Closes #5418.
Closes #5608.