### PR TITLE
Implement Kubernetes provider

### DIFF
--- a/docs/examples_extensibility/aks/deploy.sh
+++ b/docs/examples_extensibility/aks/deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# In order to use this functionality, you must first have been enrolled in the extensibility preview.
+# You will also need to ensure you've set the BICEP_IMPORTS_ENABLED_EXPERIMENTAL env var to 'true' in both VSCode and your CLI environment.
+
+baseName="bicepkubedemo"
+adminUsername="anthony"
+
+# end-to-end deployment
+az deployment sub create \
+  -f ./docs/examples/extensibility/aks/main.bicep \
+  --location 'West Central US' \
+  --name $baseName \
+  --parameters \
+    baseName=$baseName \
+    dnsPrefix=$baseName \
+    linuxAdminUsername=$adminUsername \
+    sshRSAPublicKey="$(cat ~/.ssh/id_rsa.pub)" \
+  --query properties.outputs.webUrl
+
+# deploy aks individually
+az deployment group create \
+  -f ./docs/examples/extensibility/aks/modules/aks.bicep \
+  --resource-group $baseName \
+  --parameters \
+    baseName=$baseName \
+    dnsPrefix=$baseName \
+    linuxAdminUsername=$adminUsername \
+    sshRSAPublicKey="$(cat ~/.ssh/id_rsa.pub)" \
+  --query properties.outputs.kubeconfig
+
+# deploy kubernetes individually
+kubeConfig=<base64 encoded kubeconfig>
+az deployment group create \
+  -f ./docs/examples/extensibility/aks/modules/kubernetes.bicep \
+  --resource-group $baseName \
+  --parameters \
+    kubeConfig=$kubeConfig

--- a/docs/examples_extensibility/aks/main.bicep
+++ b/docs/examples_extensibility/aks/main.bicep
@@ -1,0 +1,32 @@
+targetScope = 'subscription'
+
+param baseName string
+param dnsPrefix string
+param linuxAdminUsername string
+param sshRSAPublicKey string
+
+resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: baseName
+  location: deployment().location
+}
+
+module aks './modules/aks.bicep' = {
+  name: 'aks-deploy'
+  scope: rg
+  params: {
+    baseName: baseName
+    sshRSAPublicKey: sshRSAPublicKey
+    linuxAdminUsername: linuxAdminUsername
+    dnsPrefix: dnsPrefix
+  }
+}
+
+module kubernetes './modules/kubernetes.bicep' = {
+  name: 'kubernetes-deploy'
+  scope: rg
+  params: {
+    kubeConfig: aks.outputs.kubeConfig
+  }
+}
+
+// output webUrl string = 'http://${kubernetes.outputs.externalIp}/'

--- a/docs/examples_extensibility/aks/main.bicep
+++ b/docs/examples_extensibility/aks/main.bicep
@@ -29,4 +29,4 @@ module kubernetes './modules/kubernetes.bicep' = {
   }
 }
 
-// output webUrl string = 'http://${kubernetes.outputs.externalIp}/'
+// output webUrl string = 'https://${kubernetes.outputs.externalIp}/'

--- a/docs/examples_extensibility/aks/main.json
+++ b/docs/examples_extensibility/aks/main.json
@@ -1,0 +1,362 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "languageVersion": "1.9-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "3946576466075641134"
+    }
+  },
+  "parameters": {
+    "baseName": {
+      "type": "string"
+    },
+    "dnsPrefix": {
+      "type": "string"
+    },
+    "linuxAdminUsername": {
+      "type": "string"
+    },
+    "sshRSAPublicKey": {
+      "type": "string"
+    }
+  },
+  "resources": {
+    "rg": {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2021-04-01",
+      "name": "[parameters('baseName')]",
+      "location": "[deployment().location]"
+    },
+    "aks": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "aks-deploy",
+      "resourceGroup": "[parameters('baseName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "baseName": {
+            "value": "[parameters('baseName')]"
+          },
+          "sshRSAPublicKey": {
+            "value": "[parameters('sshRSAPublicKey')]"
+          },
+          "linuxAdminUsername": {
+            "value": "[parameters('linuxAdminUsername')]"
+          },
+          "dnsPrefix": {
+            "value": "[parameters('dnsPrefix')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "1.9-experimental",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "6455952491638494487"
+            }
+          },
+          "parameters": {
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "baseName": {
+              "type": "string"
+            },
+            "dnsPrefix": {
+              "type": "string"
+            },
+            "linuxAdminUsername": {
+              "type": "string"
+            },
+            "sshRSAPublicKey": {
+              "type": "string"
+            }
+          },
+          "variables": {
+            "osDiskSizeGB": 0,
+            "agentCount": 3,
+            "agentVMSize": "Standard_DS2_v2"
+          },
+          "resources": {
+            "aks": {
+              "type": "Microsoft.ContainerService/managedClusters",
+              "apiVersion": "2020-09-01",
+              "name": "[parameters('baseName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "dnsPrefix": "[parameters('dnsPrefix')]",
+                "agentPoolProfiles": [
+                  {
+                    "name": "agentpool",
+                    "osDiskSizeGB": "[variables('osDiskSizeGB')]",
+                    "count": "[variables('agentCount')]",
+                    "vmSize": "[variables('agentVMSize')]",
+                    "osType": "Linux",
+                    "mode": "System"
+                  }
+                ],
+                "linuxProfile": {
+                  "adminUsername": "[parameters('linuxAdminUsername')]",
+                  "ssh": {
+                    "publicKeys": [
+                      {
+                        "keyData": "[parameters('sshRSAPublicKey')]"
+                      }
+                    ]
+                  }
+                }
+              },
+              "identity": {
+                "type": "SystemAssigned"
+              }
+            }
+          },
+          "outputs": {
+            "fqdn": {
+              "type": "string",
+              "value": "[reference('aks').fqdn]"
+            },
+            "kubeConfig": {
+              "type": "string",
+              "value": "[listClusterAdminCredential(resourceId('Microsoft.ContainerService/managedClusters', parameters('baseName')), '2020-09-01').kubeconfigs[0].value]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "rg"
+      ]
+    },
+    "kubernetes": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "kubernetes-deploy",
+      "resourceGroup": "[parameters('baseName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "kubeConfig": {
+            "value": "[reference('aks').outputs.kubeConfig.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "1.9-experimental",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "5983176937371621250"
+            }
+          },
+          "parameters": {
+            "kubeConfig": {
+              "type": "secureString"
+            }
+          },
+          "variables": {
+            "backName": "azure-vote-back",
+            "backPort": 6379,
+            "frontName": "azure-vote-front",
+            "frontPort": 80
+          },
+          "imports": {
+            "k8s": {
+              "provider": "Kubernetes",
+              "version": "1.0",
+              "config": {
+                "kubeConfig": "[parameters('kubeConfig')]",
+                "namespace": "default"
+              }
+            }
+          },
+          "resources": {
+            "backDeploy": {
+              "import": "k8s",
+              "type": "apps/Deployment@v1",
+              "properties": {
+                "metadata": {
+                  "name": "[variables('backName')]"
+                },
+                "spec": {
+                  "replicas": 1,
+                  "selector": {
+                    "matchLabels": {
+                      "app": "[variables('backName')]"
+                    }
+                  },
+                  "template": {
+                    "metadata": {
+                      "labels": {
+                        "app": "[variables('backName')]"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "name": "[variables('backName')]",
+                          "image": "mcr.microsoft.com/oss/bitnami/redis:6.0.8",
+                          "env": [
+                            {
+                              "name": "ALLOW_EMPTY_PASSWORD",
+                              "value": "yes"
+                            }
+                          ],
+                          "resources": {
+                            "requests": {
+                              "cpu": "100m",
+                              "memory": "128Mi"
+                            },
+                            "limits": {
+                              "cpu": "250m",
+                              "memory": "256Mi"
+                            }
+                          },
+                          "ports": [
+                            {
+                              "containerPort": "[variables('backPort')]",
+                              "name": "redis"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "metadata": {
+                "description": "Application back-end deployment (redis)"
+              }
+            },
+            "backSvc": {
+              "import": "k8s",
+              "type": "core/Service@v1",
+              "properties": {
+                "metadata": {
+                  "name": "[variables('backName')]"
+                },
+                "spec": {
+                  "ports": [
+                    {
+                      "port": "[variables('backPort')]"
+                    }
+                  ],
+                  "selector": {
+                    "app": "[variables('backName')]"
+                  }
+                }
+              },
+              "metadata": {
+                "description": "Configure back-end service"
+              }
+            },
+            "frontDeploy": {
+              "import": "k8s",
+              "type": "apps/Deployment@v1",
+              "properties": {
+                "metadata": {
+                  "name": "[variables('frontName')]"
+                },
+                "spec": {
+                  "replicas": 1,
+                  "selector": {
+                    "matchLabels": {
+                      "app": "[variables('frontName')]"
+                    }
+                  },
+                  "template": {
+                    "metadata": {
+                      "labels": {
+                        "app": "[variables('frontName')]"
+                      }
+                    },
+                    "spec": {
+                      "nodeSelector": {
+                        "beta.kubernetes.io/os": "linux"
+                      },
+                      "containers": [
+                        {
+                          "name": "[variables('frontName')]",
+                          "image": "mcr.microsoft.com/azuredocs/azure-vote-front:v1",
+                          "resources": {
+                            "requests": {
+                              "cpu": "100m",
+                              "memory": "128Mi"
+                            },
+                            "limits": {
+                              "cpu": "250m",
+                              "memory": "256Mi"
+                            }
+                          },
+                          "ports": [
+                            {
+                              "containerPort": "[variables('frontPort')]"
+                            }
+                          ],
+                          "env": [
+                            {
+                              "name": "REDIS",
+                              "value": "[variables('backName')]"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "metadata": {
+                "description": "Application front-end deployment (website)"
+              }
+            },
+            "frontSvc": {
+              "import": "k8s",
+              "type": "core/Service@v1",
+              "properties": {
+                "metadata": {
+                  "name": "[variables('frontName')]"
+                },
+                "spec": {
+                  "type": "LoadBalancer",
+                  "ports": [
+                    {
+                      "port": "[variables('frontPort')]"
+                    }
+                  ],
+                  "selector": {
+                    "app": "[variables('frontName')]"
+                  }
+                }
+              },
+              "metadata": {
+                "description": "Configure front-end service"
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "aks",
+        "rg"
+      ]
+    }
+  }
+}

--- a/docs/examples_extensibility/aks/modules/aks.bicep
+++ b/docs/examples_extensibility/aks/modules/aks.bicep
@@ -1,0 +1,43 @@
+param location string = resourceGroup().location
+param baseName string
+param dnsPrefix string
+param linuxAdminUsername string
+param sshRSAPublicKey string
+
+var osDiskSizeGB = 0
+var agentCount = 3
+var agentVMSize = 'Standard_DS2_v2'
+
+resource aks 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
+  name: baseName
+  location: location
+  properties: {
+    dnsPrefix: dnsPrefix
+    agentPoolProfiles: [
+      {
+        name: 'agentpool'
+        osDiskSizeGB: osDiskSizeGB
+        count: agentCount
+        vmSize: agentVMSize
+        osType: 'Linux'
+        mode: 'System'
+      }
+    ]
+    linuxProfile: {
+      adminUsername: linuxAdminUsername
+      ssh: {
+        publicKeys: [
+          {
+            keyData: sshRSAPublicKey
+          }
+        ]
+      }
+    }
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+}
+
+output fqdn string = aks.properties.fqdn
+output kubeConfig string = aks.listClusterAdminCredential().kubeconfigs[0].value

--- a/docs/examples_extensibility/aks/modules/aks.json
+++ b/docs/examples_extensibility/aks/modules/aks.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "1.9-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "6455952491638494487"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    },
+    "baseName": {
+      "type": "string"
+    },
+    "dnsPrefix": {
+      "type": "string"
+    },
+    "linuxAdminUsername": {
+      "type": "string"
+    },
+    "sshRSAPublicKey": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "osDiskSizeGB": 0,
+    "agentCount": 3,
+    "agentVMSize": "Standard_DS2_v2"
+  },
+  "resources": {
+    "aks": {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2020-09-01",
+      "name": "[parameters('baseName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+          {
+            "name": "agentpool",
+            "osDiskSizeGB": "[variables('osDiskSizeGB')]",
+            "count": "[variables('agentCount')]",
+            "vmSize": "[variables('agentVMSize')]",
+            "osType": "Linux",
+            "mode": "System"
+          }
+        ],
+        "linuxProfile": {
+          "adminUsername": "[parameters('linuxAdminUsername')]",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "[parameters('sshRSAPublicKey')]"
+              }
+            ]
+          }
+        }
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      }
+    }
+  },
+  "outputs": {
+    "fqdn": {
+      "type": "string",
+      "value": "[reference('aks').fqdn]"
+    },
+    "kubeConfig": {
+      "type": "string",
+      "value": "[listClusterAdminCredential(resourceId('Microsoft.ContainerService/managedClusters', parameters('baseName')), '2020-09-01').kubeconfigs[0].value]"
+    }
+  }
+}

--- a/docs/examples_extensibility/aks/modules/kubernetes.bicep
+++ b/docs/examples_extensibility/aks/modules/kubernetes.bicep
@@ -1,0 +1,154 @@
+@secure()
+param kubeConfig string
+
+import kubernetes as k8s {
+  kubeConfig: kubeConfig
+  namespace: 'default'
+}
+
+var backName = 'azure-vote-back'
+var backPort = 6379
+
+var frontName = 'azure-vote-front'
+var frontPort = 80
+
+@description('Application back-end deployment (redis)')
+resource backDeploy 'apps/Deployment@v1' = {
+  metadata: {
+    name: backName
+  }
+  spec: {
+    replicas: 1
+    selector: {
+      matchLabels: {
+        app: backName
+      }
+    }
+    template: {
+      metadata: {
+        labels: {
+          app: backName
+        }
+      }
+      spec: {
+        containers: [
+          {
+            name: backName
+            image: 'mcr.microsoft.com/oss/bitnami/redis:6.0.8'
+            env: [
+              {
+                name: 'ALLOW_EMPTY_PASSWORD'
+                value: 'yes'
+              }
+            ]
+            resources: {
+              requests: {
+                cpu: '100m'
+                memory: '128Mi'
+              }
+              limits: {
+                cpu: '250m'
+                memory: '256Mi'
+              }
+            }
+            ports: [
+              {
+                containerPort: backPort
+                name: 'redis'
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+
+@description('Configure back-end service')
+resource backSvc 'core/Service@v1' = {
+  metadata: {
+    name: backName
+  }
+  spec: {
+    ports: [
+      {
+        port: backPort
+      }
+    ]
+    selector: {
+      app: backName
+    }
+  }
+}
+
+@description('Application front-end deployment (website)')
+resource frontDeploy 'apps/Deployment@v1' = {
+  metadata: {
+    name: frontName
+  }
+  spec: {
+    replicas: 1
+    selector: {
+      matchLabels: {
+        app: frontName
+      }
+    }
+    template: {
+      metadata: {
+        labels: {
+          app: frontName
+        }
+      }
+      spec: {
+        nodeSelector: {
+          'beta.kubernetes.io/os': 'linux'
+        }
+        containers: [
+          {
+            name: frontName
+            image: 'mcr.microsoft.com/azuredocs/azure-vote-front:v1'
+            resources: {
+              requests: {
+                cpu: '100m'
+                memory: '128Mi'
+              }
+              limits: {
+                cpu: '250m'
+                memory: '256Mi'
+              }
+            }
+            ports: [
+              {
+                containerPort: frontPort
+              }
+            ]
+            env: [
+              {
+                name: 'REDIS'
+                value: backName
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+
+@description('Configure front-end service')
+resource frontSvc 'core/Service@v1' = {
+  metadata: {
+    name: frontName
+  }
+  spec: {
+    type: 'LoadBalancer'
+    ports: [
+      {
+        port: frontPort
+      }
+    ]
+    selector: {
+      app: frontName
+    }
+  }
+}

--- a/docs/examples_extensibility/aks/modules/kubernetes.json
+++ b/docs/examples_extensibility/aks/modules/kubernetes.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "1.9-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "5983176937371621250"
+    }
+  },
+  "parameters": {
+    "kubeConfig": {
+      "type": "secureString"
+    }
+  },
+  "variables": {
+    "backName": "azure-vote-back",
+    "backPort": 6379,
+    "frontName": "azure-vote-front",
+    "frontPort": 80
+  },
+  "imports": {
+    "k8s": {
+      "provider": "Kubernetes",
+      "version": "1.0",
+      "config": {
+        "kubeConfig": "[parameters('kubeConfig')]",
+        "namespace": "default"
+      }
+    }
+  },
+  "resources": {
+    "backDeploy": {
+      "import": "k8s",
+      "type": "apps/Deployment@v1",
+      "properties": {
+        "metadata": {
+          "name": "[variables('backName')]"
+        },
+        "spec": {
+          "replicas": 1,
+          "selector": {
+            "matchLabels": {
+              "app": "[variables('backName')]"
+            }
+          },
+          "template": {
+            "metadata": {
+              "labels": {
+                "app": "[variables('backName')]"
+              }
+            },
+            "spec": {
+              "containers": [
+                {
+                  "name": "[variables('backName')]",
+                  "image": "mcr.microsoft.com/oss/bitnami/redis:6.0.8",
+                  "env": [
+                    {
+                      "name": "ALLOW_EMPTY_PASSWORD",
+                      "value": "yes"
+                    }
+                  ],
+                  "resources": {
+                    "requests": {
+                      "cpu": "100m",
+                      "memory": "128Mi"
+                    },
+                    "limits": {
+                      "cpu": "250m",
+                      "memory": "256Mi"
+                    }
+                  },
+                  "ports": [
+                    {
+                      "containerPort": "[variables('backPort')]",
+                      "name": "redis"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "metadata": {
+        "description": "Application back-end deployment (redis)"
+      }
+    },
+    "backSvc": {
+      "import": "k8s",
+      "type": "core/Service@v1",
+      "properties": {
+        "metadata": {
+          "name": "[variables('backName')]"
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": "[variables('backPort')]"
+            }
+          ],
+          "selector": {
+            "app": "[variables('backName')]"
+          }
+        }
+      },
+      "metadata": {
+        "description": "Configure back-end service"
+      }
+    },
+    "frontDeploy": {
+      "import": "k8s",
+      "type": "apps/Deployment@v1",
+      "properties": {
+        "metadata": {
+          "name": "[variables('frontName')]"
+        },
+        "spec": {
+          "replicas": 1,
+          "selector": {
+            "matchLabels": {
+              "app": "[variables('frontName')]"
+            }
+          },
+          "template": {
+            "metadata": {
+              "labels": {
+                "app": "[variables('frontName')]"
+              }
+            },
+            "spec": {
+              "nodeSelector": {
+                "beta.kubernetes.io/os": "linux"
+              },
+              "containers": [
+                {
+                  "name": "[variables('frontName')]",
+                  "image": "mcr.microsoft.com/azuredocs/azure-vote-front:v1",
+                  "resources": {
+                    "requests": {
+                      "cpu": "100m",
+                      "memory": "128Mi"
+                    },
+                    "limits": {
+                      "cpu": "250m",
+                      "memory": "256Mi"
+                    }
+                  },
+                  "ports": [
+                    {
+                      "containerPort": "[variables('frontPort')]"
+                    }
+                  ],
+                  "env": [
+                    {
+                      "name": "REDIS",
+                      "value": "[variables('backName')]"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "metadata": {
+        "description": "Application front-end deployment (website)"
+      }
+    },
+    "frontSvc": {
+      "import": "k8s",
+      "type": "core/Service@v1",
+      "properties": {
+        "metadata": {
+          "name": "[variables('frontName')]"
+        },
+        "spec": {
+          "type": "LoadBalancer",
+          "ports": [
+            {
+              "port": "[variables('frontPort')]"
+            }
+          ],
+          "selector": {
+            "app": "[variables('frontName')]"
+          }
+        }
+      },
+      "metadata": {
+        "description": "Configure front-end service"
+      }
+    }
+  }
+}

--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -75,6 +75,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -100,8 +108,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -109,20 +117,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -2300,10 +2308,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -75,6 +75,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -100,8 +108,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -109,20 +117,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -1355,10 +1363,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -49,6 +49,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -74,8 +82,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -83,20 +91,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -373,10 +381,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -75,6 +75,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -100,8 +108,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -109,20 +117,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -2290,10 +2298,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.Core.Samples/AssemblyInitializer.cs
+++ b/src/Bicep.Core.Samples/AssemblyInitializer.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Emit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.Samples
+{
+    [TestClass]
+    public static class AssemblyInitializer
+    {
+        [AssemblyInitialize()]
+        public static void AssemblyInitialize(TestContext testContext)
+        {
+            BicepDeploymentsInterop.Initialize();
+        }
+    }
+}

--- a/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
+++ b/src/Bicep.Core.Samples/Bicep.Core.Samples.csproj
@@ -13,6 +13,10 @@
     <!-- Path prefix: docs/examples -->
     <EmbeddedResource Include="../../docs/examples/**/*.json" LogicalName="$([System.String]::new('docs/examples/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" />
     <EmbeddedResource Include="../../docs/examples/**/*.bicep" LogicalName="$([System.String]::new('docs/examples/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" />
+
+    <!-- Path prefix: docs/examples_extensibility -->
+    <EmbeddedResource Include="../../docs/examples_extensibility/**/*.json" LogicalName="$([System.String]::new('docs/examples_extensibility/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" />
+    <EmbeddedResource Include="../../docs/examples_extensibility/**/*.bicep" LogicalName="$([System.String]::new('docs/examples_extensibility/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Core.Samples/ExamplesTests.cs
+++ b/src/Bicep.Core.Samples/ExamplesTests.cs
@@ -15,6 +15,7 @@ using Bicep.Core.PrettyPrint;
 using Bicep.Core.PrettyPrint.Options;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
@@ -61,9 +62,8 @@ namespace Bicep.Core.Samples
         private static string GetParentStreamName(string streamName)
             => Path.GetDirectoryName(streamName)!.Replace('\\', '/');
 
-        private static IEnumerable<object[]> GetExampleData()
+        private static IEnumerable<object[]> GetExampleDataInternal(string pathPrefix)
         {
-            const string pathPrefix = "docs/examples/";
             const string bicepExtension = ".bicep";
 
             foreach (var streamName in typeof(ExamplesTests).Assembly.GetManifestResourceNames().Where(p => p.StartsWith(pathPrefix, StringComparison.Ordinal)))
@@ -84,6 +84,12 @@ namespace Bicep.Core.Samples
                 yield return new object[] { exampleData };
             }
         }
+
+        private static IEnumerable<object[]> GetExampleData()
+            => GetExampleDataInternal("docs/examples/");
+
+        private static IEnumerable<object[]> GetExtensibilityExampleData()
+            => GetExampleDataInternal("docs/examples_extensibility/");
 
         private static bool IsPermittedMissingTypeDiagnostic(IDiagnostic diagnostic)
         {
@@ -223,6 +229,67 @@ namespace Bicep.Core.Samples
                         TestContext,
                         exampleExists ? JToken.Parse(File.ReadAllText(jsonFileName)) : new JObject(),
                         $"src/Bicep.Core.Samples/Files/{relativeJsonStreamName}",
+                        jsonFileName + ".actual");
+
+                    // validate that the template is parseable by the deployment engine
+                    TemplateHelper.TemplateShouldBeValid(generated);
+                }
+            }
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetExtensibilityExampleData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(ExampleData), DynamicDataDisplayName = nameof(ExampleData.GetDisplayName))]
+        [TestCategory(BaselineHelper.BaselineTestCategory)]
+        public void ExtensibilityExampleIsValid(ExampleData example)
+        {
+            // save all the files in the containing directory to disk so that we can test module resolution
+            var parentStream = GetParentStreamName(example.BicepStreamName);
+            var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(TestContext, typeof(ExamplesTests).Assembly, parentStream);
+            var bicepFileName = Path.Combine(outputDirectory, Path.GetFileName(example.BicepStreamName));
+            var jsonFileName = Path.Combine(outputDirectory, Path.GetFileName(example.JsonStreamName));
+
+            var features = BicepTestConstants.CreateFeaturesProvider(TestContext, importsEnabled: true);
+
+            var dispatcher = new ModuleDispatcher(BicepTestConstants.RegistryProvider);
+            var configuration = BicepTestConstants.BuiltInConfigurationWithAnalyzersDisabled;
+            var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFileName), configuration);
+            var compilation = new Compilation(new DefaultNamespaceProvider(BicepTestConstants.AzResourceTypeLoader, features), sourceFileGrouping, configuration, new LinterAnalyzer(configuration));
+            var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel(), new EmitterSettings(features));
+
+            foreach (var (bicepFile, diagnostics) in compilation.GetAllDiagnosticsByBicepFile())
+            {
+                DiagnosticAssertions.DoWithDiagnosticAnnotations(
+                    bicepFile,
+                    diagnostics.Where(x => !IsPermittedMissingTypeDiagnostic(x)),
+                    diagnostics =>
+                    {
+                        diagnostics.Should().BeEmpty("{0} should not have warnings or errors", bicepFile.FileUri.LocalPath);
+                    });
+            }
+
+            // group assertion failures using AssertionScope, rather than reporting the first failure
+            using (new AssertionScope())
+            {
+                var exampleExists = File.Exists(jsonFileName);
+                exampleExists.Should().BeTrue($"Generated example \"{jsonFileName}\" should be checked in");
+
+                using var stream = new MemoryStream();
+                var result = emitter.Emit(stream);
+
+                result.Status.Should().Be(EmitStatus.Succeeded);
+
+                if (result.Status == EmitStatus.Succeeded)
+                {
+                    stream.Position = 0;
+                    var generated = new StreamReader(stream).ReadToEnd();
+
+                    var actual = JToken.Parse(generated);
+                    File.WriteAllText(jsonFileName + ".actual", generated);
+
+                    actual.Should().EqualWithJsonDiffOutput(
+                        TestContext,
+                        exampleExists ? JToken.Parse(File.ReadAllText(jsonFileName)) : new JObject(),
+                        example.JsonStreamName,
                         jsonFileName + ".actual");
 
                     // validate that the template is parseable by the deployment engine

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -75,6 +75,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -100,8 +108,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -109,20 +117,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -2290,10 +2298,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -166,6 +166,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -191,8 +199,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -200,20 +208,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -2282,10 +2290,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -19,11 +19,12 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-		<PackageReference Include="Azure.Deployments.Core" Version="1.0.253" />
-		<PackageReference Include="Azure.Deployments.Templates" Version="1.0.253" />
-		<PackageReference Include="Azure.Deployments.Expression" Version="1.0.253" />
+		<PackageReference Include="Azure.Deployments.Core" Version="1.0.546" />
+		<PackageReference Include="Azure.Deployments.Templates" Version="1.0.546" />
+		<PackageReference Include="Azure.Deployments.Expression" Version="1.0.546" />
 		<PackageReference Include="Azure.Bicep.Types" Version="0.1.331" />
 		<PackageReference Include="Azure.Bicep.Types.Az" Version="0.1.331" />
+		<PackageReference Include="Azure.Bicep.Types.K8s" Version="0.1.11" />
 		<PackageReference Include="System.IO.Abstractions" Version="13.2.47" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/Bicep.Core/Semantics/Namespaces/DefaultNamespaceProvider.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/DefaultNamespaceProvider.cs
@@ -26,6 +26,8 @@ namespace Bicep.Core.Semantics.Namespaces
                     return SystemNamespaceType.Create(aliasName);
                 case AzNamespaceType.BuiltInName:
                     return AzNamespaceType.Create(aliasName, resourceScope, azResourceTypeProvider);
+                case K8sNamespaceType.BuiltInName:
+                    return K8sNamespaceType.Create(aliasName);
             }
 
             return null;

--- a/src/Bicep.Core/Semantics/Namespaces/K8sNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/K8sNamespaceType.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bicep.Core.Extensions;
+using Bicep.Core.Resources;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.K8s;
+
+namespace Bicep.Core.Semantics.Namespaces
+{
+    public static class K8sNamespaceType
+    {
+        public const string BuiltInName = "kubernetes";
+
+        private static readonly IResourceTypeProvider TypeProvider = new K8sResourceTypeProvider(new K8sResourceTypeLoader());
+
+        public static NamespaceSettings Settings { get; } = new(
+            IsSingleton: false,
+            BicepProviderName: BuiltInName,
+            ConfigurationType: GetConfigurationType(),
+            ArmTemplateProviderName: "Kubernetes",
+            ArmTemplateProviderVersion: "1.0");
+
+        private static ObjectType GetConfigurationType()
+        {
+            return new ObjectType("configuration", TypeSymbolValidationFlags.Default, new[]
+            {
+                new TypeProperty("namespace", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("kubeConfig", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("context", LanguageConstants.String),
+            }, null);
+        }
+
+        public static NamespaceType Create(string aliasName)
+        {
+            return new NamespaceType(
+                aliasName,
+                Settings,
+                ImmutableArray<TypeProperty>.Empty,
+                ImmutableArray<FunctionOverload>.Empty,
+                ImmutableArray<BannedFunction>.Empty,
+                ImmutableArray<Decorator>.Empty,
+                TypeProvider);
+        }
+    }
+}

--- a/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeFactory.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Linq;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Bicep.Core.Resources;
+
+namespace Bicep.Core.TypeSystem.K8s
+{
+    public class K8sResourceTypeFactory
+    {
+        private readonly ConcurrentDictionary<Azure.Bicep.Types.Concrete.TypeBase, TypeSymbol> typeCache;
+
+        public K8sResourceTypeFactory()
+        {
+            typeCache = new();
+        }
+
+        public ResourceTypeComponents GetResourceType(Azure.Bicep.Types.Concrete.ResourceType resourceType)
+        {
+            var resourceTypeReference = ResourceTypeReference.Parse(resourceType.Name);
+            var bodyType = GetTypeSymbol(resourceType.Body.Type, true);
+
+            return new ResourceTypeComponents(resourceTypeReference, ToResourceScope(resourceType.ScopeType), bodyType);
+        }
+
+        private TypeSymbol GetTypeSymbol(Azure.Bicep.Types.Concrete.TypeBase serializedType, bool isResourceBodyType)
+            => typeCache.GetOrAdd(serializedType, serializedType => ToTypeSymbol(serializedType, isResourceBodyType));
+
+        private ITypeReference GetTypeReference(Azure.Bicep.Types.Concrete.ITypeReference input)
+            => new DeferredTypeReference(() => GetTypeSymbol(input.Type, false));
+
+        private TypeProperty GetTypeProperty(string name, Azure.Bicep.Types.Concrete.ObjectProperty input)
+        {
+            return new TypeProperty(name, GetTypeReference(input.Type), GetTypePropertyFlags(input), input.Description);
+        }
+
+        private static TypePropertyFlags GetTypePropertyFlags(Azure.Bicep.Types.Concrete.ObjectProperty input)
+        {
+            var flags = TypePropertyFlags.None;
+
+            if (input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.Required))
+            {
+                flags |= TypePropertyFlags.Required;
+            }
+            if (input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.ReadOnly))
+            {
+                flags |= TypePropertyFlags.ReadOnly;
+            }
+            if (input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.WriteOnly))
+            {
+                flags |= TypePropertyFlags.WriteOnly;
+            }
+            if (input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.DeployTimeConstant))
+            {
+                flags |= TypePropertyFlags.DeployTimeConstant;
+            }
+            if(!input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.Required) && !input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.ReadOnly))
+            {
+                // for non-required and non-readonly resource properties, we allow null assignment
+                flags |= TypePropertyFlags.AllowImplicitNull;
+            }
+
+            return flags;
+        }
+
+        private TypeSymbol ToTypeSymbol(Azure.Bicep.Types.Concrete.TypeBase typeBase, bool isResourceBodyType)
+        {
+            switch (typeBase)
+            {
+                case Azure.Bicep.Types.Concrete.BuiltInType builtInType:
+                    return builtInType.Kind switch {
+                        Azure.Bicep.Types.Concrete.BuiltInTypeKind.Any => LanguageConstants.Any,
+                        Azure.Bicep.Types.Concrete.BuiltInTypeKind.Null => LanguageConstants.Null,
+                        Azure.Bicep.Types.Concrete.BuiltInTypeKind.Bool => LanguageConstants.Bool,
+                        Azure.Bicep.Types.Concrete.BuiltInTypeKind.Int => LanguageConstants.Int,
+                        Azure.Bicep.Types.Concrete.BuiltInTypeKind.String => LanguageConstants.String,
+                        Azure.Bicep.Types.Concrete.BuiltInTypeKind.Object => LanguageConstants.Object,
+                        Azure.Bicep.Types.Concrete.BuiltInTypeKind.Array => LanguageConstants.Array,
+                        Azure.Bicep.Types.Concrete.BuiltInTypeKind.ResourceRef => LanguageConstants.ResourceRef,
+                        _ => throw new ArgumentException(),
+                    };
+                case Azure.Bicep.Types.Concrete.ObjectType objectType:
+                {
+                    var additionalProperties = objectType.AdditionalProperties != null ? GetTypeReference(objectType.AdditionalProperties) : null;
+                    var properties = objectType.Properties.Select(kvp => GetTypeProperty(kvp.Key, kvp.Value));
+
+                    return new ObjectType(objectType.Name, GetValidationFlags(isResourceBodyType), properties, additionalProperties, TypePropertyFlags.None);
+                }
+                case Azure.Bicep.Types.Concrete.ArrayType arrayType:
+                {
+                    return new TypedArrayType(GetTypeReference(arrayType.ItemType), GetValidationFlags(isResourceBodyType));
+                }
+                case Azure.Bicep.Types.Concrete.UnionType unionType:
+                {
+                    return TypeHelper.CreateTypeUnion(unionType.Elements.Select(x => GetTypeReference(x)));
+                }
+                case Azure.Bicep.Types.Concrete.StringLiteralType stringLiteralType:
+                    return new StringLiteralType(stringLiteralType.Value);
+                case Azure.Bicep.Types.Concrete.DiscriminatedObjectType discriminatedObjectType:
+                {
+                    var elementReferences = discriminatedObjectType.Elements.Select(kvp => new DeferredTypeReference(() => ToCombinedType(discriminatedObjectType.BaseProperties, kvp.Key, kvp.Value, isResourceBodyType)));
+
+                    return new DiscriminatedObjectType(discriminatedObjectType.Name, GetValidationFlags(isResourceBodyType), discriminatedObjectType.Discriminator, elementReferences);
+                }
+                default:
+                    throw new ArgumentException();
+            }
+        }
+
+        private ObjectType ToCombinedType(IEnumerable<KeyValuePair<string, Azure.Bicep.Types.Concrete.ObjectProperty>> baseProperties, string name, Azure.Bicep.Types.Concrete.ITypeReference extendedType, bool isResourceBodyType)
+        {
+            if (!(extendedType.Type is Azure.Bicep.Types.Concrete.ObjectType objectType))
+            {
+                throw new ArgumentException();
+            }
+
+            var additionalProperties = objectType.AdditionalProperties != null ? GetTypeReference(objectType.AdditionalProperties) : null;
+
+            var extendedProperties = objectType.Properties.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
+            foreach (var property in baseProperties.Where(x => !extendedProperties.ContainsKey(x.Key)))
+            {
+                extendedProperties[property.Key] = property.Value;
+            }
+
+            return new ObjectType(name, GetValidationFlags(isResourceBodyType), extendedProperties.Select(kvp => GetTypeProperty(kvp.Key, kvp.Value)), additionalProperties, TypePropertyFlags.None);
+        }
+
+        private static TypeSymbolValidationFlags GetValidationFlags(bool isResourceBodyType)
+        {
+            if (isResourceBodyType)
+            {
+                // strict validation on top-level resource properties, as 'custom' top-level properties are not supported by the platform
+                return TypeSymbolValidationFlags.Default;
+            }
+
+            // in all other places, we should allow some wiggle room so that we don't block compilation if there are any swagger inaccuracies
+            return TypeSymbolValidationFlags.WarnOnTypeMismatch;
+        }
+
+        private static ResourceScope ToResourceScope(Azure.Bicep.Types.Concrete.ScopeType input)
+        {
+            if (input == Azure.Bicep.Types.Concrete.ScopeType.Unknown)
+            {
+                return ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup | ResourceScope.Resource;
+            }
+
+            var output = ResourceScope.None;
+            output |= input.HasFlag(Azure.Bicep.Types.Concrete.ScopeType.Extension) ? ResourceScope.Resource : ResourceScope.None;
+            output |= input.HasFlag(Azure.Bicep.Types.Concrete.ScopeType.Tenant) ? ResourceScope.Tenant : ResourceScope.None;
+            output |= input.HasFlag(Azure.Bicep.Types.Concrete.ScopeType.ManagementGroup) ? ResourceScope.ManagementGroup : ResourceScope.None;
+            output |= input.HasFlag(Azure.Bicep.Types.Concrete.ScopeType.Subscription) ? ResourceScope.Subscription : ResourceScope.None;
+            output |= input.HasFlag(Azure.Bicep.Types.Concrete.ScopeType.ResourceGroup) ? ResourceScope.ResourceGroup : ResourceScope.None;
+
+            return output;
+        }
+    }
+}

--- a/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeLoader.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Azure.Bicep.Types.K8s;
+using Bicep.Core.Resources;
+
+namespace Bicep.Core.TypeSystem.K8s
+{
+    public class K8sResourceTypeLoader
+    {
+        private readonly ITypeLoader typeLoader;
+        private readonly K8sResourceTypeFactory resourceTypeFactory;
+        private readonly ImmutableDictionary<ResourceTypeReference, TypeLocation> availableTypes;
+
+        public K8sResourceTypeLoader()
+        {
+            this.typeLoader = new TypeLoader();
+            this.resourceTypeFactory = new K8sResourceTypeFactory();
+            this.availableTypes = typeLoader.GetIndexedTypes().Types.ToImmutableDictionary(
+                kvp => ResourceTypeReference.Parse(kvp.Key),
+                kvp => kvp.Value,
+                ResourceTypeReferenceComparer.Instance);
+        }
+
+        public IEnumerable<ResourceTypeReference> GetAvailableTypes()
+            => availableTypes.Keys;
+
+        public ResourceTypeComponents LoadType(ResourceTypeReference reference)
+        {
+            var typeLocation = availableTypes[reference];
+
+            var serializedResourceType = typeLoader.LoadResourceType(typeLocation);
+            return resourceTypeFactory.GetResourceType(serializedResourceType);
+        }
+    }
+}

--- a/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeProvider.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bicep.Core.Resources;
+using Bicep.Core.Semantics;
+using System.Collections.Immutable;
+using System.Collections.Concurrent;
+using Bicep.Core.Emit;
+using System.Text.RegularExpressions;
+
+namespace Bicep.Core.TypeSystem.K8s
+{
+    public class K8sResourceTypeProvider : IResourceTypeProvider
+    {
+        private class ResourceTypeCache
+        {
+            private class KeyComparer : IEqualityComparer<(ResourceTypeGenerationFlags flags, ResourceTypeReference type)>
+            {
+                public static IEqualityComparer<(ResourceTypeGenerationFlags flags, ResourceTypeReference type)> Instance { get; }
+                    = new KeyComparer();
+
+                public bool Equals((ResourceTypeGenerationFlags flags, ResourceTypeReference type) x, (ResourceTypeGenerationFlags flags, ResourceTypeReference type) y)
+                    => x.flags == y.flags &&
+                        ResourceTypeReferenceComparer.Instance.Equals(x.type, y.type);
+
+                public int GetHashCode((ResourceTypeGenerationFlags flags, ResourceTypeReference type) x)
+                    => x.flags.GetHashCode() ^
+                        ResourceTypeReferenceComparer.Instance.GetHashCode(x.type);
+            }
+
+            private readonly ConcurrentDictionary<(ResourceTypeGenerationFlags flags, ResourceTypeReference type), ResourceTypeComponents> cache
+                = new ConcurrentDictionary<(ResourceTypeGenerationFlags flags, ResourceTypeReference type), ResourceTypeComponents>(KeyComparer.Instance);
+
+            public ResourceTypeComponents GetOrAdd(ResourceTypeGenerationFlags flags, ResourceTypeReference typeReference, Func<ResourceTypeComponents> buildFunc)
+            {
+                var cacheKey = (flags, typeReference);
+
+                return cache.GetOrAdd(cacheKey, cacheKey => buildFunc());
+            }
+        }
+
+        public const string ResourceNamePropertyName = "name";
+
+        public static readonly TypeSymbol Tags = new ObjectType(nameof(Tags), TypeSymbolValidationFlags.Default, Enumerable.Empty<TypeProperty>(), LanguageConstants.String, TypePropertyFlags.None);
+
+        private readonly K8sResourceTypeLoader resourceTypeLoader;
+        private readonly ImmutableHashSet<ResourceTypeReference> availableResourceTypes;
+        private readonly ResourceTypeCache definedTypeCache;
+        private readonly ResourceTypeCache generatedTypeCache;
+
+        public static readonly ImmutableHashSet<string> UniqueIdentifierProperties = new[]
+        {
+            ResourceNamePropertyName,
+        }.ToImmutableHashSet();
+
+        public K8sResourceTypeProvider(K8sResourceTypeLoader resourceTypeLoader)
+        {
+            this.resourceTypeLoader = resourceTypeLoader;
+            this.availableResourceTypes = resourceTypeLoader.GetAvailableTypes().ToImmutableHashSet(ResourceTypeReferenceComparer.Instance);
+            this.definedTypeCache = new ResourceTypeCache();
+            this.generatedTypeCache = new ResourceTypeCache();
+        }
+
+        private static ResourceTypeComponents SetBicepResourceProperties(ResourceTypeComponents resourceType, ResourceTypeGenerationFlags flags)
+        {
+            var bodyType = resourceType.Body.Type;
+
+            switch (bodyType)
+            {
+                case ObjectType bodyObjectType:
+                    if (bodyObjectType.Properties.TryGetValue(ResourceNamePropertyName, out var nameProperty) &&
+                        nameProperty.TypeReference.Type is not PrimitiveType { Name: LanguageConstants.TypeNameString })
+                    {
+                        // The 'name' property doesn't support fixed value names (e.g. we're in a top-level child resource declaration).
+                        // Best we can do is return a regular 'string' field for it as we have no good way to reliably evaluate complex expressions (e.g. to check whether it terminates with '/<constantType>').
+                        // Keep it simple for now - we eventually plan to phase out the 'top-level child' syntax.
+                        bodyObjectType = new ObjectType(
+                            bodyObjectType.Name,
+                            bodyObjectType.ValidationFlags,
+                            bodyObjectType.Properties.SetItem(ResourceNamePropertyName, new TypeProperty(nameProperty.Name, LanguageConstants.String, nameProperty.Flags)).Values,
+                            bodyObjectType.AdditionalPropertiesType,
+                            bodyObjectType.AdditionalPropertiesFlags,
+                            bodyObjectType.MethodResolver.CopyToObject);
+
+                        bodyType = SetBicepResourceProperties(bodyObjectType, resourceType.ValidParentScopes, resourceType.TypeReference, flags);
+                        break;
+                    }
+
+                    bodyType = SetBicepResourceProperties(bodyObjectType, resourceType.ValidParentScopes, resourceType.TypeReference, flags);
+                    break;
+                default:
+                    // we exhaustively test deserialization of every resource type during CI, and this happens in a deterministic fashion,
+                    // so this exception should never occur in the released product
+                    throw new ArgumentException($"Resource {resourceType.TypeReference.FormatName()} has unexpected body type {bodyType.GetType()}");
+            }
+
+            return new ResourceTypeComponents(resourceType.TypeReference, resourceType.ValidParentScopes, bodyType);
+        }
+
+        private static ObjectType SetBicepResourceProperties(ObjectType objectType, ResourceScope validParentScopes, ResourceTypeReference typeReference, ResourceTypeGenerationFlags flags)
+        {
+            // Local function.
+            static TypeProperty UpdateFlags(TypeProperty typeProperty, TypePropertyFlags flags) =>
+                new(typeProperty.Name, typeProperty.TypeReference, flags, typeProperty.Description);
+
+            var properties = objectType.Properties;
+            var isExistingResource = flags.HasFlag(ResourceTypeGenerationFlags.ExistingResource);
+
+            if (isExistingResource)
+            {
+            }
+            else
+            {
+                // TODO: remove 'dependsOn' from the type library
+                properties = properties.SetItem(LanguageConstants.ResourceDependsOnPropertyName, new TypeProperty(LanguageConstants.ResourceDependsOnPropertyName, LanguageConstants.ResourceOrResourceCollectionRefArray, TypePropertyFlags.WriteOnly | TypePropertyFlags.DisallowAny));
+            }
+
+            // add the loop variant flag to the name property (if it exists)
+            if (properties.TryGetValue(ResourceNamePropertyName, out var nameProperty))
+            {
+                // TODO apply this to all unique properties
+                properties = properties.SetItem(ResourceNamePropertyName, UpdateFlags(nameProperty, nameProperty.Flags | TypePropertyFlags.LoopVariant));
+            }
+
+            return new ObjectType(
+                objectType.Name,
+                objectType.ValidationFlags,
+                isExistingResource ? ConvertToReadOnly(properties.Values) : properties.Values,
+                objectType.AdditionalPropertiesType,
+                isExistingResource ? ConvertToReadOnly(objectType.AdditionalPropertiesFlags) : objectType.AdditionalPropertiesFlags,
+                functions: null);
+        }
+
+        private static IEnumerable<TypeProperty> ConvertToReadOnly(IEnumerable<TypeProperty> properties)
+        {
+            foreach (var property in properties)
+            {
+                // "name", "scope" & "parent" can be set for existing resources - everything else should be read-only
+                if (UniqueIdentifierProperties.Contains(property.Name))
+                {
+                    yield return property;
+                }
+                else
+                {
+                    yield return new TypeProperty(property.Name, property.TypeReference, ConvertToReadOnly(property.Flags));
+                }
+            }
+        }
+
+        private static TypePropertyFlags ConvertToReadOnly(TypePropertyFlags typePropertyFlags)
+            => (typePropertyFlags | TypePropertyFlags.ReadOnly) & ~TypePropertyFlags.Required;
+
+        public ResourceType? TryGetDefinedType(NamespaceType declaringNamespace, ResourceTypeReference typeReference, ResourceTypeGenerationFlags flags)
+        {
+            if (!HasDefinedType(typeReference))
+            {
+                return null;
+            }
+
+            // It's important to cache this result because generating the resource type is an expensive operation
+            var resourceType =  definedTypeCache.GetOrAdd(flags, typeReference, () =>
+            {
+                var resourceType = this.resourceTypeLoader.LoadType(typeReference);
+
+                return SetBicepResourceProperties(resourceType, flags);
+            });
+
+            return new(declaringNamespace, resourceType.TypeReference, resourceType.ValidParentScopes, resourceType.Body, UniqueIdentifierProperties);
+        }
+
+        public ResourceType? TryGenerateFallbackType(NamespaceType declaringNamespace, ResourceTypeReference typeReference, ResourceTypeGenerationFlags flags)
+            => null;
+
+        public bool HasDefinedType(ResourceTypeReference typeReference)
+            => availableResourceTypes.Contains(typeReference);
+
+        public IEnumerable<ResourceTypeReference> GetAvailableTypes()
+            => availableResourceTypes;
+    }
+}

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -20,6 +20,15 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Direct",
+        "requested": "[0.1.11, )",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Direct",
         "requested": "[1.1.0-beta.3, )",
@@ -32,9 +41,9 @@
       },
       "Azure.Deployments.Core": {
         "type": "Direct",
-        "requested": "[1.0.253, )",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "requested": "[1.0.546, )",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -42,22 +51,22 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Direct",
-        "requested": "[1.0.253, )",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "requested": "[1.0.546, )",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Direct",
-        "requested": "[1.0.253, )",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "requested": "[1.0.546, )",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -75,6 +75,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -100,8 +108,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -109,20 +117,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -2275,10 +2283,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -75,6 +75,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -100,8 +108,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -109,20 +117,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -2275,10 +2283,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -45,6 +45,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -70,8 +78,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -79,20 +87,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -330,10 +338,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -97,6 +97,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -122,8 +130,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -131,20 +139,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -2303,10 +2311,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -97,6 +97,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -122,8 +130,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -131,20 +139,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -2303,10 +2311,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -42,6 +42,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -67,8 +75,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -76,20 +84,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -605,10 +613,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -75,6 +75,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -100,8 +108,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -109,20 +117,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -1744,10 +1752,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -74,6 +74,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -99,8 +107,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -108,20 +116,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -1666,10 +1674,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -75,6 +75,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -100,8 +108,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -109,20 +117,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -1744,10 +1752,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -154,6 +154,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -179,8 +187,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -188,20 +196,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -695,10 +703,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -52,6 +52,14 @@
           "Azure.Bicep.Types": "0.1.331"
         }
       },
+      "Azure.Bicep.Types.K8s": {
+        "type": "Transitive",
+        "resolved": "0.1.11",
+        "contentHash": "pKBzr7xjTS7+fj0Fh83T40rnrpGh0JLVV4gErcJCbr+4AAYS/O6Tpu3DCPu8ZlSgHGcuCzGMWYarkSO5VDsf9w==",
+        "dependencies": {
+          "Azure.Bicep.Types": "0.1.304"
+        }
+      },
       "Azure.Containers.ContainerRegistry": {
         "type": "Transitive",
         "resolved": "1.1.0-beta.3",
@@ -77,8 +85,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "bF/scScUsZkrYWy6GVYQlUmSuPpbja081N91uqXwv9N/PU1wnh7pXI2JuYO/xYtb52uZGYaaZJPQBsFkfdrPAQ==",
+        "resolved": "1.0.546",
+        "contentHash": "pm2/h4e6b0iCRhSXMdbLtMNJzhbQA+PwiEhW5PuFvXm3J7Cvujj0q4vpw+WdQb3JSD/uHKRcx5fgJgZCi8NtbA==",
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -86,20 +94,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "NdMIPL7XoxphLGV2gyxEzaV5tgPJr3VHMe4bAAJsvQ4HYnZMMIauNIXEYiES/4Jd1erfBshJc0UMh01D/9pgMw==",
+        "resolved": "1.0.546",
+        "contentHash": "FzjcKUGvgwXBhkAH9QjeCDxR3iyGR4Lsor3g80Umlh3+y3ejOQQ7iBBTJ3UOUFlfUZ7M8MdovF73mWzqGY/Dew==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.253",
-        "contentHash": "kh+GCwSurLDbf7HRr0S5dI7E1m7fmk5SSUfmmzDAUKpEa62KpPR8eycK6xUGlJXv81KBvmqRth2cWGIjzJDl9g==",
+        "resolved": "1.0.546",
+        "contentHash": "AOFJJYT5D1BYVNJ9lusw3i0JY06OqKrm1LkISot9glmdzO7q0dfwtQ1HcX3Te1kQn4ySbnpTqixLi3/VlEKPHQ==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -460,10 +468,11 @@
         "dependencies": {
           "Azure.Bicep.Types": "0.1.331",
           "Azure.Bicep.Types.Az": "0.1.331",
+          "Azure.Bicep.Types.K8s": "0.1.11",
           "Azure.Containers.ContainerRegistry": "1.1.0-beta.3",
-          "Azure.Deployments.Core": "1.0.253",
-          "Azure.Deployments.Expression": "1.0.253",
-          "Azure.Deployments.Templates": "1.0.253",
+          "Azure.Deployments.Core": "1.0.546",
+          "Azure.Deployments.Expression": "1.0.546",
+          "Azure.Deployments.Templates": "1.0.546",
           "Azure.Identity": "1.5.0",
           "Azure.ResourceManager.Resources": "1.0.0-beta.3",
           "Microsoft.Extensions.Configuration": "6.0.0",


### PR DESCRIPTION
This PR adds the Kubernetes type provider, behind the `BICEP_IMPORTS_ENABLED_EXPERIMENTAL` flag.

Note that this functionality will only be usable if you have been enrolled in the extensibility preview.