### PR TITLE
Change telemetry IDs for commands

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             ],
             "env": {
                 "BICEP_TRACING_ENABLED": "true",
-                "DEBUGTELEMETRY": "", // "" or "0" or "false": send telemetry; "1": no telemetry; "verbose": telemetry in console, don't send (defined by vscode-azureextensionui)
+                "DEBUGTELEMETRY": "", // "" or "0" or "false": send telemetry as normal; "1": debug mode (no telemetry sent); "verbose": telemetry in console, don't send (from vscode-azureextensionui)
             },
             "stopOnEntry": false,
             "sourceMaps": true,

--- a/src/vscode-bicep/.vscode/launch.json
+++ b/src/vscode-bicep/.vscode/launch.json
@@ -17,7 +17,8 @@
       "preLaunchTask": "${defaultBuildTask}",
       "env": {
         "BICEP_TRACING_ENABLED": "true",
-        "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll"
+        "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll",
+        "DEBUGTELEMETRY": "", // "" or "0" or "false": send telemetry as normal; "1": debug mode (no telemetry sent); "verbose": telemetry in console, don't send (from vscode-azureextensionui)
       }
     },
     {

--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -17,7 +17,7 @@
         "react-icons": "^4.3.1",
         "styled-components": "^5.3.1",
         "triple-beam": "^1.3.0",
-        "vscode-azureextensionui": "=0.48.0",
+        "vscode-azureextensionui": "^0.49.2",
         "vscode-languageclient": "^7.0.0",
         "winston": "^3.3.3",
         "winston-transport": "^4.4.0"
@@ -86,12 +86,13 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@azure/arm-resources": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
-      "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-4.2.2.tgz",
+      "integrity": "sha512-Oic1OcEwgex3X1KkhP9UM/E/taIaS9oID7PL/CZ8knD7qtVNSRvTxP3uvD3ZpH9NYBYXngJsX5xyRu66iFN+rA==",
       "dependencies": {
-        "@azure/ms-rest-azure-js": "^2.0.1",
-        "@azure/ms-rest-js": "^2.0.4",
+        "@azure/core-auth": "^1.1.4",
+        "@azure/ms-rest-azure-js": "^2.1.0",
+        "@azure/ms-rest-js": "^2.2.0",
         "tslib": "^1.10.0"
       }
     },
@@ -102,6 +103,17 @@
       "dependencies": {
         "@azure/ms-rest-azure-js": "^2.0.1",
         "@azure/ms-rest-js": "^2.0.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/@azure/arm-resources-subscriptions": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
+      "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
+      "dependencies": {
+        "@azure/core-auth": "^1.1.4",
+        "@azure/ms-rest-azure-js": "^2.1.0",
+        "@azure/ms-rest-js": "^2.2.0",
         "tslib": "^1.10.0"
       }
     },
@@ -119,16 +131,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@azure/arm-storage-profile-2020-09-01-hybrid/-/arm-storage-profile-2020-09-01-hybrid-1.0.0.tgz",
       "integrity": "sha512-HNzqGHnrUHpAFVlSR5lG000JNGGI+JNGYOnScaWP2o7oS+OmjiwzyuOkCc0dAV6SJkQEaWnm1NMuQ1wJVvT1GA==",
-      "dependencies": {
-        "@azure/ms-rest-azure-js": "^2.0.1",
-        "@azure/ms-rest-js": "^2.0.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/@azure/arm-subscriptions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
-      "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
       "dependencies": {
         "@azure/ms-rest-azure-js": "^2.0.1",
         "@azure/ms-rest-js": "^2.0.4",
@@ -2081,17 +2083,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/applicationinsights": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
-      "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
-      "dependencies": {
-        "cls-hooked": "^4.2.2",
-        "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "^0.3.3"
-      }
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -2160,37 +2151,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-    },
-    "node_modules/async-hook-jl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "dependencies": {
-        "stack-chain": "^1.3.7"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3"
-      }
-    },
-    "node_modules/async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dependencies": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      },
-      "engines": {
-        "node": "<=0.11.8 || >0.11.10"
-      }
-    },
-    "node_modules/async-listener/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2861,27 +2821,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "dependencies": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
-      }
-    },
-    "node_modules/cls-hooked/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2976,15 +2915,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "node_modules/continuation-local-storage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dependencies": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
@@ -3394,30 +3324,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/diagnostic-channel": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-      "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
-      "dependencies": {
-        "semver": "^5.3.0"
-      }
-    },
-    "node_modules/diagnostic-channel-publishers": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.5.tgz",
-      "integrity": "sha512-AOIjw4T7Nxl0G2BoBPhkQ6i7T4bUd9+xvdYizwvG7vVAM1dvr+SDrcUudlmzwH0kbEwdR2V1EcnKT0wAeYLQNQ==",
-      "peerDependencies": {
-        "diagnostic-channel": "*"
-      }
-    },
-    "node_modules/diagnostic-channel/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -3571,14 +3477,6 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.7.1.tgz",
       "integrity": "sha512-lD86RWdh480/UuRoHhRcnv2IMkIcK6yMDEuT8TPBIbO3db4HfnVF+1lgYdQi99Ck0yb+lg5Eb46JCHI5uOsmAw=="
-    },
-    "node_modules/emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "dependencies": {
-        "shimmer": "^1.2.0"
-      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -7704,11 +7602,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -7834,11 +7727,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "node_modules/stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -8577,6 +8465,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -8779,25 +8668,24 @@
       }
     },
     "node_modules/vscode-azureextensionui": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.48.0.tgz",
-      "integrity": "sha512-8OAeuGZZambaRWB7SAJV9Nv6RpxfoHkEYVRBjICf9UH2g8D6A0viVerm7VEzM8gyFcBYpgqkqXXR9dHwwUgKQg==",
+      "version": "0.49.2",
+      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.2.tgz",
+      "integrity": "sha512-7I2rEmg+qDpZVA9mAkoqFrYWPtfaRQS2FN2es5wy02CvHN7Nk0IIHCTGej4jLgKyLEkv6o/ywO7jyMeQORWmDQ==",
       "dependencies": {
-        "@azure/arm-resources": "^3.0.0",
+        "@azure/arm-resources": "^4.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
+        "@azure/arm-resources-subscriptions": "^1.0.0",
         "@azure/arm-storage": "^15.0.0",
         "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-        "@azure/arm-subscriptions": "^2.0.0",
         "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/ms-rest-js": "^2.2.1",
         "dayjs": "^1.9.3",
         "escape-string-regexp": "^2.0.0",
-        "fs-extra": "^8.0.0",
         "html-to-text": "^5.1.1",
         "open": "^8.0.4",
         "semver": "^5.7.1",
         "uuid": "^8.3.2",
-        "vscode-extension-telemetry": "^0.1.7",
+        "vscode-extension-telemetry": "^0.4.3",
         "vscode-nls": "^4.1.1",
         "vscode-tas-client": "^0.1.22"
       }
@@ -8808,27 +8696,6 @@
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/vscode-azureextensionui/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/vscode-azureextensionui/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/vscode-azureextensionui/node_modules/semver": {
@@ -8848,14 +8715,12 @@
       }
     },
     "node_modules/vscode-extension-telemetry": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.7.tgz",
-      "integrity": "sha512-pZuZTHO9OpsrwlerOKotWBRLRYJ53DobYb7aWiRAXjlqkuqE+YJJaP+2WEy8GrLIF1EnitXTDMaTAKsmLQ5ORQ==",
-      "dependencies": {
-        "applicationinsights": "1.7.4"
-      },
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
+      "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg==",
+      "deprecated": "This package has been renamed to @vscode/extension-telemetry, please update to the new name",
       "engines": {
-        "vscode": "^1.5.0"
+        "vscode": "^1.60.0"
       }
     },
     "node_modules/vscode-jsonrpc": {
@@ -9456,12 +9321,13 @@
       }
     },
     "@azure/arm-resources": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
-      "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-4.2.2.tgz",
+      "integrity": "sha512-Oic1OcEwgex3X1KkhP9UM/E/taIaS9oID7PL/CZ8knD7qtVNSRvTxP3uvD3ZpH9NYBYXngJsX5xyRu66iFN+rA==",
       "requires": {
-        "@azure/ms-rest-azure-js": "^2.0.1",
-        "@azure/ms-rest-js": "^2.0.4",
+        "@azure/core-auth": "^1.1.4",
+        "@azure/ms-rest-azure-js": "^2.1.0",
+        "@azure/ms-rest-js": "^2.2.0",
         "tslib": "^1.10.0"
       }
     },
@@ -9472,6 +9338,17 @@
       "requires": {
         "@azure/ms-rest-azure-js": "^2.0.1",
         "@azure/ms-rest-js": "^2.0.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@azure/arm-resources-subscriptions": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
+      "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
+      "requires": {
+        "@azure/core-auth": "^1.1.4",
+        "@azure/ms-rest-azure-js": "^2.1.0",
+        "@azure/ms-rest-js": "^2.2.0",
         "tslib": "^1.10.0"
       }
     },
@@ -9489,16 +9366,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@azure/arm-storage-profile-2020-09-01-hybrid/-/arm-storage-profile-2020-09-01-hybrid-1.0.0.tgz",
       "integrity": "sha512-HNzqGHnrUHpAFVlSR5lG000JNGGI+JNGYOnScaWP2o7oS+OmjiwzyuOkCc0dAV6SJkQEaWnm1NMuQ1wJVvT1GA==",
-      "requires": {
-        "@azure/ms-rest-azure-js": "^2.0.1",
-        "@azure/ms-rest-js": "^2.0.4",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@azure/arm-subscriptions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
-      "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
       "requires": {
         "@azure/ms-rest-azure-js": "^2.0.1",
         "@azure/ms-rest-js": "^2.0.4",
@@ -11110,17 +10977,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "applicationinsights": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
-      "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
-      "requires": {
-        "cls-hooked": "^4.2.2",
-        "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "^0.3.3"
-      }
-    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -11177,30 +11033,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-    },
-    "async-hook-jl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "requires": {
-        "stack-chain": "^1.3.7"
-      }
-    },
-    "async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "requires": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -11778,23 +11610,6 @@
         "shallow-clone": "^3.0.0"
       }
     },
-    "cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "requires": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -11876,15 +11691,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "continuation-local-storage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "requires": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
-      }
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -12242,27 +12048,6 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
-    "diagnostic-channel": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-      "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
-      "requires": {
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
-    "diagnostic-channel-publishers": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.5.tgz",
-      "integrity": "sha512-AOIjw4T7Nxl0G2BoBPhkQ6i7T4bUd9+xvdYizwvG7vVAM1dvr+SDrcUudlmzwH0kbEwdR2V1EcnKT0wAeYLQNQ==",
-      "requires": {}
-    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -12404,14 +12189,6 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.7.1.tgz",
       "integrity": "sha512-lD86RWdh480/UuRoHhRcnv2IMkIcK6yMDEuT8TPBIbO3db4HfnVF+1lgYdQi99Ck0yb+lg5Eb46JCHI5uOsmAw=="
-    },
-    "emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "requires": {
-        "shimmer": "^1.2.0"
-      }
     },
     "emittery": {
       "version": "0.8.1",
@@ -15627,11 +15404,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -15746,11 +15518,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -16337,7 +16104,8 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unzipper": {
       "version": "0.10.11",
@@ -16513,25 +16281,24 @@
       }
     },
     "vscode-azureextensionui": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.48.0.tgz",
-      "integrity": "sha512-8OAeuGZZambaRWB7SAJV9Nv6RpxfoHkEYVRBjICf9UH2g8D6A0viVerm7VEzM8gyFcBYpgqkqXXR9dHwwUgKQg==",
+      "version": "0.49.2",
+      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.2.tgz",
+      "integrity": "sha512-7I2rEmg+qDpZVA9mAkoqFrYWPtfaRQS2FN2es5wy02CvHN7Nk0IIHCTGej4jLgKyLEkv6o/ywO7jyMeQORWmDQ==",
       "requires": {
-        "@azure/arm-resources": "^3.0.0",
+        "@azure/arm-resources": "^4.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
+        "@azure/arm-resources-subscriptions": "^1.0.0",
         "@azure/arm-storage": "^15.0.0",
         "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-        "@azure/arm-subscriptions": "^2.0.0",
         "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/ms-rest-js": "^2.2.1",
         "dayjs": "^1.9.3",
         "escape-string-regexp": "^2.0.0",
-        "fs-extra": "^8.0.0",
         "html-to-text": "^5.1.1",
         "open": "^8.0.4",
         "semver": "^5.7.1",
         "uuid": "^8.3.2",
-        "vscode-extension-telemetry": "^0.1.7",
+        "vscode-extension-telemetry": "^0.4.3",
         "vscode-nls": "^4.1.1",
         "vscode-tas-client": "^0.1.22"
       },
@@ -16540,24 +16307,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
         },
         "semver": {
           "version": "5.7.1",
@@ -16572,12 +16321,9 @@
       }
     },
     "vscode-extension-telemetry": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.7.tgz",
-      "integrity": "sha512-pZuZTHO9OpsrwlerOKotWBRLRYJ53DobYb7aWiRAXjlqkuqE+YJJaP+2WEy8GrLIF1EnitXTDMaTAKsmLQ5ORQ==",
-      "requires": {
-        "applicationinsights": "1.7.4"
-      }
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
+      "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg=="
     },
     "vscode-jsonrpc": {
       "version": "6.0.0",

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -313,7 +313,7 @@
     "react-icons": "^4.3.1",
     "styled-components": "^5.3.1",
     "triple-beam": "^1.3.0",
-    "vscode-azureextensionui": "=0.48.0",
+    "vscode-azureextensionui": "^0.49.2",
     "vscode-languageclient": "^7.0.0",
     "winston": "^3.3.3",
     "winston-transport": "^4.4.0"

--- a/src/vscode-bicep/src/commands/commandManager.ts
+++ b/src/vscode-bicep/src/commands/commandManager.ts
@@ -31,13 +31,18 @@ export class CommandManager extends Disposable {
   private registerCommand<T extends Command>(command: T): void {
     this.validateCommand(command);
 
+    // Prefix all command telemetry IDs with "command/" so we end up with telemetry IDs like "vscode-bicep/command/bicep.build"
+    const telemetryId = `command/${command.id}`;
+
     // The command will be added to the extension's subscriptions and therefore disposed automatically
     // when the extension is disposed.
     azureextensionui.registerCommand(
       command.id,
       async (context: azureextensionui.IActionContext, ...args: unknown[]) => {
         return await command.execute(context, ...args);
-      }
+      },
+      undefined,
+      telemetryId
     );
   }
 
@@ -58,6 +63,11 @@ export class CommandManager extends Disposable {
     assert(
       !!activation,
       `Code error: Add an entry for '${activationKey}' to package.json's activationEvents array. This ensures that the command will be functional even if the extension is not yet activated.`
+    );
+
+    assert(
+      command.id.startsWith("bicep."),
+      `Command ID doesn't start with 'bicep.': ${command.id}`
     );
   }
 }


### PR DESCRIPTION
Fixes #5433, fixes #5382

Changes telemetry ids from this currently:
```
vscode-bicep/bicep.showVisualizer
vscode-bicep/bicep.showVisualizerToSide
vscode-bicep/bicep.build
etc
```
to this:
```
vscode-bicep/command/bicep.showVisualizer
vscode-bicep/command/bicep.showVisualizerToSide
vscode-bicep/command/bicep.build
```

Reason being to make it easier to group telemetry during queries.