### PR TITLE
[WIP] Use an IR for Bicep code generation

### DIFF
--- a/docs/examples/201/policy-with-initiative-definition-and-assignment/main.json
+++ b/docs/examples/201/policy-with-initiative-definition-and-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16725308854916544444"
+      "templateHash": "2187496986171293588"
     }
   },
   "parameters": {
@@ -51,7 +51,11 @@
         "parameters": {
           "listOfAllowedLocations": {
             "type": "Array",
-            "metadata": "[createObject('description', 'The List of Allowed Locations for Resource Groups and Resources.', 'strongtype', 'location', 'displayName', 'Allowed Locations')]"
+            "metadata": {
+              "description": "The List of Allowed Locations for Resource Groups and Resources.",
+              "strongtype": "location",
+              "displayName": "Allowed Locations"
+            }
           },
           "listOfAllowedSKUs": {
             "type": "Array",

--- a/docs/examples/201/wvd-create-hostpool/main.json
+++ b/docs/examples/201/wvd-create-hostpool/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4658160886334966548"
+      "templateHash": "335440428036226939"
     }
   },
   "parameters": {
@@ -84,8 +84,8 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
       "defaultValue": "",
+      "type": "secureString",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -98,8 +98,8 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
       "defaultValue": "",
+      "type": "secureString",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
       }
@@ -970,8 +970,8 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
               "defaultValue": "",
+              "type": "secureString",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
               }
@@ -1656,8 +1656,8 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
               "defaultValue": "",
+              "type": "secureString",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
               }
@@ -2327,8 +2327,8 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
               "defaultValue": "",
+              "type": "secureString",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
               }
@@ -2994,8 +2994,8 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
               "defaultValue": "",
+              "type": "secureString",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
               }

--- a/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/main.json
+++ b/docs/examples/301/modules-vwan-to-vnet-s2s-with-fw/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7935120756355915845"
+      "templateHash": "10649734997133352779"
     }
   },
   "parameters": {
@@ -31,11 +31,11 @@
       }
     },
     "psk": {
-      "type": "secureString",
       "defaultValue": "[uniqueString(subscription().id)]",
       "metadata": {
         "description": "Pre-Shared Key used to establish the site to site tunnel between the Virtual Hub and On-Prem VNet"
-      }
+      },
+      "type": "secureString"
     }
   },
   "variables": {
@@ -1648,10 +1648,10 @@
               "type": "string"
             },
             "psk": {
-              "type": "secureString",
               "metadata": {
                 "description": "Specifies the pre-shared key to use for the VPN Connection"
-              }
+              },
+              "type": "secureString"
             },
             "vpnsiteid": {
               "type": "string",
@@ -1771,10 +1771,10 @@
               }
             },
             "psk": {
-              "type": "secureString",
               "metadata": {
                 "description": "Specifies the pre-shared key to use for the VPN Connection"
-              }
+              },
+              "type": "secureString"
             },
             "remotesiteasn": {
               "type": "int",

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -2677,7 +2677,7 @@ var myValue = -9223372036854775808
 ");
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
-            result.Template.Should().HaveValueAtPath("$.variables.myValue", "[json('-9223372036854775808')]");
+            result.Template.Should().HaveValueAtPath("$.variables.myValue", -9223372036854775808);
         }
 
         [TestMethod]

--- a/src/Bicep.Core.IntegrationTests/Scenarios/LoadFunctionsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/LoadFunctionsTests.cs
@@ -522,7 +522,7 @@ output out string = script
   ""propInt"": 1073741824,
   ""propIntNegative"": -1073741824,
   ""propBigInt"": 4611686018427387904,
-  ""propBigIntNegative"": ""[json('-4611686018427387904')]"",
+  ""propBigIntNegative"": -4611686018427387904,
   ""propFloat"": ""[json('1.618033988749894')]"",
   ""propFloatNegative"": ""[json('-1.618033988749894')]"",
   ""propArrayString"": [

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10244203654925270193"
+      "templateHash": "9036125375840019027"
     }
   },
   "parameters": {
@@ -1744,8 +1744,8 @@
               "type": "secureString"
             },
             "secureStringParam2": {
-              "type": "secureString",
-              "defaultValue": ""
+              "defaultValue": "",
+              "type": "secureString"
             }
           },
           "resources": [],
@@ -1801,8 +1801,8 @@
               "type": "secureString"
             },
             "secureStringParam2": {
-              "type": "secureString",
-              "defaultValue": ""
+              "defaultValue": "",
+              "type": "secureString"
             }
           },
           "resources": [],
@@ -1862,8 +1862,8 @@
               "type": "secureString"
             },
             "secureStringParam2": {
-              "type": "secureString",
-              "defaultValue": ""
+              "defaultValue": "",
+              "type": "secureString"
             }
           },
           "resources": [],

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10105950490850461524"
+      "templateHash": "2103890999352132411"
     }
   },
   "parameters": {
@@ -1809,8 +1809,8 @@
               "type": "secureString"
             },
             "secureStringParam2": {
-              "type": "secureString",
-              "defaultValue": ""
+              "defaultValue": "",
+              "type": "secureString"
             }
           },
           "resources": {},
@@ -1868,8 +1868,8 @@
               "type": "secureString"
             },
             "secureStringParam2": {
-              "type": "secureString",
-              "defaultValue": ""
+              "defaultValue": "",
+              "type": "secureString"
             }
           },
           "resources": {},
@@ -1931,8 +1931,8 @@
               "type": "secureString"
             },
             "secureStringParam2": {
-              "type": "secureString",
-              "defaultValue": ""
+              "defaultValue": "",
+              "type": "secureString"
             }
           },
           "resources": {},

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5474777074424075084"
+      "templateHash": "10322473353118594870"
     }
   },
   "parameters": {
@@ -56,12 +56,12 @@
       {
         "name": "arrayOfHardCodedNumbers",
         "count": "[length(range(0, 10))]",
-        "input": "[int(3)]"
+        "input": 3
       },
       {
         "name": "arrayOfHardCodedBools",
         "count": "[length(range(0, 10))]",
-        "input": "[false()]"
+        "input": false
       },
       {
         "name": "arrayOfHardCodedStrings",
@@ -218,8 +218,8 @@
     "isFalse": "[not(variables('isTrue'))]",
     "someText": "[if(variables('isTrue'), concat('a', concat('b', 'c')), 'someText')]",
     "scopesWithoutArmRepresentation": {
-      "subscription": "[createObject()]",
-      "resourceGroup": "[createObject()]"
+      "subscription": {},
+      "resourceGroup": {}
     },
     "scopesWithArmRepresentation": {
       "tenant": "[tenant()]",

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12480395712152468332"
+      "templateHash": "6394383558549354215"
     }
   },
   "parameters": {
@@ -58,12 +58,12 @@
       {
         "name": "arrayOfHardCodedNumbers",
         "count": "[length(range(0, 10))]",
-        "input": "[int(3)]"
+        "input": 3
       },
       {
         "name": "arrayOfHardCodedBools",
         "count": "[length(range(0, 10))]",
-        "input": "[false()]"
+        "input": false
       },
       {
         "name": "arrayOfHardCodedStrings",
@@ -220,8 +220,8 @@
     "isFalse": "[not(variables('isTrue'))]",
     "someText": "[if(variables('isTrue'), concat('a', concat('b', 'c')), 'someText')]",
     "scopesWithoutArmRepresentation": {
-      "subscription": "[createObject()]",
-      "resourceGroup": "[createObject()]"
+      "subscription": {},
+      "resourceGroup": {}
     },
     "scopesWithArmRepresentation": {
       "tenant": "[tenant()]",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-with-initiative-definition-and-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/policy-with-initiative-definition-and-assignment/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9860965441495139106"
+      "templateHash": "7748981375394151951"
     }
   },
   "parameters": {
@@ -53,7 +53,11 @@
         "parameters": {
           "listOfAllowedLocations": {
             "type": "Array",
-            "metadata": "[createObject('description', 'The List of Allowed Locations for Resource Groups and Resources.', 'strongtype', 'location', 'displayName', 'Allowed Locations')]"
+            "metadata": {
+              "description": "The List of Allowed Locations for Resource Groups and Resources.",
+              "strongtype": "location",
+              "displayName": "Allowed Locations"
+            }
           },
           "listOfAllowedSKUs": {
             "type": "Array",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/wvd-create-hostpool/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6570365507497931924"
+      "templateHash": "8642390233699218744"
     }
   },
   "parameters": {
@@ -86,8 +86,8 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
       "defaultValue": "",
+      "type": "secureString",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -100,8 +100,8 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
       "defaultValue": "",
+      "type": "secureString",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
       }
@@ -978,8 +978,8 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
               "defaultValue": "",
+              "type": "secureString",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
               }
@@ -1668,8 +1668,8 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
               "defaultValue": "",
+              "type": "secureString",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
               }
@@ -2343,8 +2343,8 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
               "defaultValue": "",
+              "type": "secureString",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
               }
@@ -3014,8 +3014,8 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
               "defaultValue": "",
+              "type": "secureString",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
               }

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/modules-vwan-to-vnet-s2s-with-fw/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5484437357573305551"
+      "templateHash": "13427545110239540962"
     }
   },
   "parameters": {
@@ -33,11 +33,11 @@
       }
     },
     "psk": {
-      "type": "secureString",
       "defaultValue": "[uniqueString(subscription().id)]",
       "metadata": {
         "description": "Pre-Shared Key used to establish the site to site tunnel between the Virtual Hub and On-Prem VNet"
-      }
+      },
+      "type": "secureString"
     }
   },
   "variables": {
@@ -1674,10 +1674,10 @@
               "type": "string"
             },
             "psk": {
-              "type": "secureString",
               "metadata": {
                 "description": "Specifies the pre-shared key to use for the VPN Connection"
-              }
+              },
+              "type": "secureString"
             },
             "vpnsiteid": {
               "type": "string",
@@ -1799,10 +1799,10 @@
               }
             },
             "psk": {
-              "type": "secureString",
               "metadata": {
                 "description": "Specifies the pre-shared key to use for the VPN Connection"
-              }
+              },
+              "type": "secureString"
             },
             "remotesiteasn": {
               "type": "int",

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -3,12 +3,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using Azure.Deployments.Expression.Expressions;
 using Bicep.Core.DataFlow;
 using Bicep.Core.Extensions;
+using Bicep.Core.Intermediate;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
@@ -22,478 +21,218 @@ namespace Bicep.Core.Emit
     {
         private readonly EmitterContext context;
 
-        private readonly ImmutableDictionary<LocalVariableSymbol, LanguageExpression> localReplacements;
+        private readonly ImmutableDictionary<LocalVariableSymbol, Operation> localReplacements;
+
+        private readonly OperationConverter operationConverter;
 
         public ExpressionConverter(EmitterContext context)
-            : this(context, ImmutableDictionary<LocalVariableSymbol, LanguageExpression>.Empty)
+            : this(context, ImmutableDictionary<LocalVariableSymbol, Operation>.Empty)
         {
         }
 
-        private ExpressionConverter(EmitterContext context, ImmutableDictionary<LocalVariableSymbol, LanguageExpression> localReplacements)
+        private ExpressionConverter(EmitterContext context, ImmutableDictionary<LocalVariableSymbol, Operation> localReplacements)
         {
             this.context = context;
             this.localReplacements = localReplacements;
+            this.operationConverter = new OperationConverter(context, localReplacements);
         }
 
-        public ExpressionConverter AppendReplacement(LocalVariableSymbol symbol, LanguageExpression replacement)
-        {
-            // Allow local variable symbol replacements to be overwritten, as there are scenarios where we recursively generate expressions for the same index symbol
-            return new(this.context, this.localReplacements.SetItem(symbol, replacement));
-        }
+        public LanguageExpression ConvertExpression(SyntaxBase syntax)
+            => ConvertOperation(operationConverter.ConvertSyntax(syntax));
 
-        /// <summary>
-        /// Converts the specified bicep expression tree into an ARM template expression tree.
-        /// The returned tree may be rooted at either a function expression or jtoken expression.
-        /// </summary>
-        /// <param name="expression">The expression</param>
-        public LanguageExpression ConvertExpression(SyntaxBase expression)
+        private ExpressionConverter GetConverter(IndexReplacementContext? replacementContext)
         {
-            switch (expression)
+            if (replacementContext is not null)
             {
-                case BooleanLiteralSyntax boolSyntax:
-                    return CreateFunction(boolSyntax.Value ? "true" : "false");
-
-                case IntegerLiteralSyntax integerSyntax:
-                    return ConvertInteger(integerSyntax, false);
-
-                case StringSyntax stringSyntax:
-                    // using the throwing method to get semantic value of the string because
-                    // error checking should have caught any errors by now
-                    return ConvertString(stringSyntax);
-
-                case NullLiteralSyntax _:
-                    return CreateFunction("null");
-
-                case ObjectSyntax @object:
-                    return ConvertObject(@object);
-
-                case ArraySyntax array:
-                    return ConvertArray(array);
-
-                case ParenthesizedExpressionSyntax parenthesized:
-                    // template expressions do not have operators so parentheses are irrelevant
-                    return ConvertExpression(parenthesized.Expression);
-
-                case UnaryOperationSyntax unary:
-                    return ConvertUnary(unary);
-
-                case BinaryOperationSyntax binary:
-                    return ConvertBinary(binary);
-
-                case TernaryOperationSyntax ternary:
-                    return CreateFunction(
-                        "if",
-                        ConvertExpression(ternary.ConditionExpression),
-                        ConvertExpression(ternary.TrueExpression),
-                        ConvertExpression(ternary.FalseExpression));
-
-                case FunctionCallSyntaxBase functionCall:
-                    return ConvertFunction(functionCall);
-
-                case ArrayAccessSyntax arrayAccess:
-                    return ConvertArrayAccess(arrayAccess);
-
-                case ResourceAccessSyntax resourceAccess:
-                    return ConvertResourceAccess(resourceAccess);
-
-                case PropertyAccessSyntax propertyAccess:
-                    return ConvertPropertyAccess(propertyAccess);
-
-                case VariableAccessSyntax variableAccess:
-                    return ConvertVariableAccess(variableAccess);
-
-                default:
-                    throw new NotImplementedException($"Cannot emit unexpected expression of type {expression.GetType().Name}");
-            }
-        }
-
-        private LanguageExpression ConvertFunction(FunctionCallSyntaxBase functionCall)
-        {
-            var symbol = context.SemanticModel.GetSymbolInfo(functionCall);
-            if (symbol is FunctionSymbol &&
-                context.SemanticModel.TypeManager.GetMatchedFunctionOverload(functionCall) is { Evaluator: { } } functionOverload)
-            {
-                return ConvertExpression(functionOverload.Evaluator(functionCall,
-                    symbol,
-                    context.SemanticModel.GetTypeInfo(functionCall),
-                    context.FunctionVariables.GetValueOrDefault(functionCall),
-                    context.SemanticModel.TypeManager.GetMatchedFunctionResultValue(functionCall)));
+                return new(this.context, replacementContext.LocalReplacements);
             }
 
-            switch (functionCall)
-            {
-                case FunctionCallSyntax function:
-                    return CreateFunction(
-                        function.Name.IdentifierName,
-                        function.Arguments.Select(a => ConvertExpression(a.Expression)));
-
-                case InstanceFunctionCallSyntax instanceFunctionCall:
-                    var (baseExpression, indexExpression) = SyntaxHelper.UnwrapArrayAccessSyntax(instanceFunctionCall.BaseExpression);
-                    var baseSymbol = context.SemanticModel.GetSymbolInfo(baseExpression);
-
-                    switch (baseSymbol)
-                    {
-                        case INamespaceSymbol namespaceSymbol:
-                            Debug.Assert(indexExpression is null, "Indexing into a namespace should have been blocked by type analysis");
-                            return CreateFunction(
-                                instanceFunctionCall.Name.IdentifierName,
-                                instanceFunctionCall.Arguments.Select(a => ConvertExpression(a.Expression)));
-                        case DeclaredSymbol declaredSymbol when context.SemanticModel.ResourceMetadata.TryLookup(declaredSymbol.DeclaringSyntax) is DeclaredResourceMetadata resource:
-                            if (instanceFunctionCall.Name.IdentifierName.StartsWithOrdinalInsensitively("list"))
-                            {
-                                var converter = indexExpression is not null ?
-                                    CreateConverterForIndexReplacement(resource.NameSyntax, indexExpression, instanceFunctionCall) :
-                                    this;
-
-                                // Handle list<method_name>(...) method on resource symbol - e.g. stgAcc.listKeys()
-                                var convertedArgs = instanceFunctionCall.Arguments.SelectArray(a => ConvertExpression(a.Expression));
-                                var resourceIdExpression = converter.GetFullyQualifiedResourceId(resource);
-
-                                var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
-                                var apiVersionExpression = new JTokenExpression(apiVersion);
-
-                                var listArgs = convertedArgs.Length switch
-                                {
-                                    0 => new LanguageExpression[] { resourceIdExpression, apiVersionExpression, },
-                                    _ => new LanguageExpression[] { resourceIdExpression, }.Concat(convertedArgs),
-                                };
-
-                                return CreateFunction(instanceFunctionCall.Name.IdentifierName, listArgs);
-                            }
-
-                            break;
-                    }
-                    throw new InvalidOperationException($"Unrecognized base expression {baseSymbol?.Kind}");
-                default:
-                    throw new NotImplementedException($"Cannot emit unexpected expression of type {functionCall.GetType().Name}");
-            }
+            return this;
         }
 
         public ExpressionConverter CreateConverterForIndexReplacement(SyntaxBase nameSyntax, SyntaxBase? indexExpression, SyntaxBase newContext)
+            => GetConverter(
+                TryGetReplacementContext(nameSyntax, indexExpression, newContext));
+
+        public IndexReplacementContext? TryGetReplacementContext(DeclaredResourceMetadata resource, SyntaxBase? indexExpression, SyntaxBase newContext)
+            => operationConverter.TryGetReplacementContext(resource, indexExpression, newContext);
+
+        public IndexReplacementContext? TryGetReplacementContext(SyntaxBase nameSyntax, SyntaxBase? indexExpression, SyntaxBase newContext)
+            => operationConverter.TryGetReplacementContext(nameSyntax, indexExpression, newContext);
+
+        public Operation GetExpressionOperation(SyntaxBase syntax)
+            => operationConverter.ConvertSyntax(syntax);
+
+        public ProgramOperation ConvertProgram(FileSymbol fileSymbol)
+            => operationConverter.ConvertProgram(fileSymbol);
+
+        public IEnumerable<ObjectPropertyOperation> GetDecorators(StatementSyntax statement, TypeSymbol targetType)
+            => operationConverter.GetDecorators(statement, targetType);
+
+        public LanguageExpression ConvertOperation(Operation operation)
         {
-            var inaccessibleLocals = this.context.DataFlowAnalyzer.GetInaccessibleLocalsAfterSyntaxMove(nameSyntax, newContext);
-            var inaccessibleLocalLoops = inaccessibleLocals.Select(local => GetEnclosingForExpression(local)).Distinct().ToList();
-
-            switch (inaccessibleLocalLoops.Count)
+            switch (operation)
             {
-                case 0:
-                    // moving the name expression does not produce any inaccessible locals (no locals means no loops)
-                    // regardless if there is an index expression or not, we don't need to append replacements
-                    return this;
-
-                case 1 when indexExpression is not null:
-                    // TODO: Run data flow analysis on the array expression as well. (Will be needed for nested resource loops)
-                    var @for = inaccessibleLocalLoops.Single();
-                    var current = this;
-                    foreach (var local in inaccessibleLocals)
+                case ConstantValueOperation op:
                     {
-                        var replacementValue = GetLoopVariableExpression(local, @for, this.ConvertExpression(indexExpression));
-                        current = current.AppendReplacement(local, replacementValue);
+                        return op.Value switch
+                        {
+                            string value => new JTokenExpression(value),
+                            long value when value <= int.MaxValue && value >= int.MinValue => new JTokenExpression((int)value),
+                            long value => CreateFunction("json", new JTokenExpression(value.ToInvariantString())),
+                            bool value => CreateFunction(value ? "true" : "false"),
+                            _ => throw new NotImplementedException($"Cannot convert constant type {op.Value?.GetType()}"),
+                        };
                     }
+                case ArrayOperation op:
+                    {
+                        return CreateFunction(
+                            "createArray",
+                            op.Items.SelectArray(ConvertOperation));
+                    }
+                case ObjectOperation op:
+                    {
+                        return CreateFunction(
+                            "createObject",
+                            op.Properties.SelectMany(x => new [] { ConvertOperation(x.Key), ConvertOperation(x.Value) }).ToArray());
+                    }
+                case NullValueOperation op:
+                    {
+                        return CreateFunction("null");
+                    }
+                case PropertyAccessOperation op:
+                    {
+                        return AppendProperties(
+                            ToFunctionExpression(ConvertOperation(op.Base)),
+                            new JTokenExpression(op.PropertyName));
+                    }
+                case ArrayAccessOperation op:
+                    {
+                        return AppendProperties(
+                            ToFunctionExpression(ConvertOperation(op.Base)),
+                            ConvertOperation(op.Access));
+                    }
+                case ResourceIdOperation op:
+                    {
+                        return GetConverter(op.IndexContext).GetFullyQualifiedResourceId(op.Metadata);
+                    }
+                case ResourceNameOperation op:
+                    {
+                        return op.FullyQualified switch {
+                            true => GetConverter(op.IndexContext).GetFullyQualifiedResourceName(op.Metadata),
+                            false => GetConverter(op.IndexContext).GetUnqualifiedResourceName(op.Metadata),
+                        };
+                    }
+                case ResourceTypeOperation op:
+                    {
+                        return new JTokenExpression(op.Metadata.TypeReference.FormatType());
+                    }
+                case ResourceApiVersionOperation op:
+                    {
+                        return op.Metadata.TypeReference.ApiVersion switch
+                        {
+                            { } apiVersion => new JTokenExpression(apiVersion),
+                            _ => throw new NotImplementedException(""),
+                        };
+                    }
+                case ResourceInfoOperation op:
+                    {
+                        return CreateFunction(
+                            "resourceInfo",
+                            GenerateSymbolicReference(op.Metadata.Symbol.Name, op.IndexContext));
+                    }
+                case ResourceReferenceOperation op:
+                    {
+                        return (op.Full, op.ShouldIncludeApiVersion) switch
+                        {
+                            (true, _) => CreateFunction(
+                                "reference",
+                                ConvertOperation(op.ResourceId),
+                                new JTokenExpression(op.Metadata.TypeReference.ApiVersion!),
+                                new JTokenExpression("full")),
+                            (false, false) => CreateFunction(
+                                "reference",
+                                ConvertOperation(op.ResourceId)),
+                            (false, true) => CreateFunction(
+                                "reference",
+                                ConvertOperation(op.ResourceId),
+                                new JTokenExpression(op.Metadata.TypeReference.ApiVersion!)),
+                        };
+                    }
+                case SymbolicResourceReferenceOperation op:
+                    {
+                        return (op.Full, op.Metadata.IsAzResource) switch
+                        {
+                            (true, true) => CreateFunction(
+                                "reference",
+                                GenerateSymbolicReference(op.Metadata.Symbol.Name, op.IndexContext),
+                                new JTokenExpression(op.Metadata.TypeReference.ApiVersion!),
+                                new JTokenExpression("full")),
+                            _ => CreateFunction(
+                                "reference",
+                                GenerateSymbolicReference(op.Metadata.Symbol.Name, op.IndexContext)),
+                        };
+                    }
+                case ModuleNameOperation op:
+                    {
+                        return GetConverter(op.IndexContext).GetModuleNameExpression(op.Symbol);
+                    }
+                case VariableAccessOperation op:
+                    {
+                        return CreateFunction(
+                            "variables",
+                            new JTokenExpression(op.Symbol.Name));
+                    }
+                case ExplicitVariableAccessOperation op:
+                    {
+                        return CreateFunction(
+                            "variables",
+                            new JTokenExpression(op.Name));
+                    }
+                case ParameterAccessOperation op:
+                    {
+                        return CreateFunction(
+                            "parameters",
+                            new JTokenExpression(op.Symbol.Name));
+                    }
+                case ModuleOutputOperation op:
+                    {
+                        var reference = ConvertOperation(new ModuleReferenceOperation(op.Symbol, op.IndexContext));
 
-                    return current;
+                        return AppendProperties(
+                            ToFunctionExpression(reference),
+                            new JTokenExpression("outputs"),
+                            ConvertOperation(op.PropertyName),
+                            new JTokenExpression("value"));
+                    }
+                case ModuleReferenceOperation op:
+                    {
+                        // See https://github.com/Azure/bicep/issues/6008 for more info
+                        var shouldIncludeApiVersion = op.Symbol.DeclaringModule.HasCondition();
 
+                        return (context.Settings.EnableSymbolicNames, shouldIncludeApiVersion) switch
+                        {
+                            (true, _) => CreateFunction(
+                                "reference",
+                                GenerateSymbolicReference(op.Symbol.Name, op.IndexContext)),
+                            (false, false) => CreateFunction(
+                                "reference",
+                                GetConverter(op.IndexContext).GetFullyQualifiedResourceId(op.Symbol)),
+                            (false, true) => CreateFunction(
+                                "reference",
+                                GetConverter(op.IndexContext).GetFullyQualifiedResourceId(op.Symbol),
+                                new JTokenExpression(TemplateWriter.NestedDeploymentResourceApiVersion)),
+                        };
+                    }
+                case FunctionCallOperation op:
+                    {
+                        return CreateFunction(
+                            op.Name,
+                            op.Parameters.Select(p => ConvertOperation(p)));
+                    }
                 default:
-                    throw new NotImplementedException("Mismatch between count of index expressions and inaccessible symbols during array access index replacement.");
-            }
-        }
-
-        private LanguageExpression ConvertArrayAccess(ArrayAccessSyntax arrayAccess)
-        {
-            // if there is an array access on a resource/module reference, we have to generate differently
-            // when constructing the reference() function call, the resource name expression needs to have its local
-            // variable replaced with <loop array expression>[this array access' index expression]
-            if (arrayAccess.BaseExpression is VariableAccessSyntax || arrayAccess.BaseExpression is ResourceAccessSyntax)
-            {
-                if (context.SemanticModel.ResourceMetadata.TryLookup(arrayAccess.BaseExpression) is DeclaredResourceMetadata resource &&
-                    resource.Symbol.IsCollection)
-                {
-                    var movedSyntax = context.Settings.EnableSymbolicNames ? resource.Symbol.NameSyntax : resource.NameSyntax;
-
-                    return this.CreateConverterForIndexReplacement(movedSyntax, arrayAccess.IndexExpression, arrayAccess)
-                        .GetReferenceExpression(resource, arrayAccess.IndexExpression, true);
-                }
-
-                switch (this.context.SemanticModel.GetSymbolInfo(arrayAccess.BaseExpression))
-                {
-                    case ModuleSymbol { IsCollection: true } moduleSymbol:
-                        var moduleConverter = this.CreateConverterForIndexReplacement(ExpressionConverter.GetModuleNameSyntax(moduleSymbol), arrayAccess.IndexExpression, arrayAccess);
-
-                        // TODO: Can this return a language expression?
-                        return moduleConverter.ToFunctionExpression(arrayAccess.BaseExpression);
-                }
-            }
-
-            return AppendProperties(
-                ToFunctionExpression(arrayAccess.BaseExpression),
-                ConvertExpression(arrayAccess.IndexExpression));
-        }
-
-        private LanguageExpression ConvertResourcePropertyAccess(ResourceMetadata resource, SyntaxBase? indexExpression, string propertyName)
-        {
-            if (!resource.IsAzResource)
-            {
-                // For an extensible resource, always generate a 'reference' statement.
-                // User-defined properties appear inside "properties", so use a non-full reference.
-                return AppendProperties(
-                    GetReferenceExpression(resource, indexExpression, false),
-                    new JTokenExpression(propertyName));
-            }
-
-            // The cases for a parameter resource are much simpler and can be handled up front. These do not
-            // support symbolic names they are somewhat different from the declared resource case since we just have an
-            // ID and type.
-            if (resource is ParameterResourceMetadata parameter)
-            {
-                switch (propertyName)
-                {
-                    case "id":
-                        return GetFullyQualifiedResourceId(parameter);
-                    case "type":
-                        return new JTokenExpression(resource.TypeReference.FormatType());
-                    case "apiVersion":
-                        return new JTokenExpression(resource.TypeReference.ApiVersion);
-                    case "name":
-                        // create an expression like: `last(split(<resource id>, '/'))`
-                        return new FunctionExpression(
-                                "last",
-                                new LanguageExpression[]
-                                {
-                                    new FunctionExpression(
-                                        "split",
-                                        new LanguageExpression[]
-                                        {
-                                            GetFullyQualifiedResourceId(parameter),
-                                            new JTokenExpression("/"),
-                                        },
-                                        Array.Empty<LanguageExpression>())
-                                },
-                                Array.Empty<LanguageExpression>());
-                    case "properties":
-                        // use the reference() overload without "full" to generate a shorter expression
-                        // this is dependent on the name expression which could involve locals in case of a resource collection
-                        return GetReferenceExpression(resource, indexExpression, false);
-                    default:
-                        return AppendProperties(
-                            GetReferenceExpression(resource, indexExpression, true),
-                            new JTokenExpression(propertyName));
-                }
-            }
-            else if (resource is ModuleOutputResourceMetadata output)
-            {
-                switch (propertyName)
-                {
-                    case "id":
-                        return GetFullyQualifiedResourceId(output);
-                    case "type":
-                        return new JTokenExpression(resource.TypeReference.FormatType());
-                    case "apiVersion":
-                        return new JTokenExpression(resource.TypeReference.ApiVersion);
-                    case "name":
-                        // create an expression like: `last(split(<resource id>, '/'))`
-                        return new FunctionExpression(
-                                "last",
-                                new LanguageExpression[]
-                                {
-                                    new FunctionExpression(
-                                        "split",
-                                        new LanguageExpression[]
-                                        {
-                                            GetFullyQualifiedResourceId(output),
-                                            new JTokenExpression("/"),
-                                        },
-                                        Array.Empty<LanguageExpression>())
-                                },
-                                Array.Empty<LanguageExpression>());
-                    case "properties":
-                        // use the reference() overload without "full" to generate a shorter expression
-                        // this is dependent on the name expression which could involve locals in case of a resource collection
-                        return GetReferenceExpression(resource, indexExpression, false);
-                    default:
-                        // For a module output we have to handle all possible cases here, because otherwise
-                        // this case would be handled like any old property access rather than access to a resource's property.
-                        return AppendProperties(GetReferenceExpression(resource, indexExpression, true), new JTokenExpression(propertyName));
-                }
-            }
-            else if (resource is DeclaredResourceMetadata declaredResource)
-            {
-                switch ((propertyName, context.Settings.EnableSymbolicNames))
-                {
-                    case ("id", true):
-                    case ("name", true):
-                    case ("type", true):
-                    case ("apiVersion", true):
-                        var symbolExpression = GenerateSymbolicReference(declaredResource.Symbol.Name, indexExpression);
-
-                        return AppendProperties(
-                            CreateFunction("resourceInfo", symbolExpression),
-                            new JTokenExpression(propertyName));
-                    case ("id", false):
-                        // the ID is dependent on the name expression which could involve locals in case of a resource collection
-                        return GetFullyQualifiedResourceId(resource);
-                    case ("name", false):
-                        // the name is dependent on the name expression which could involve locals in case of a resource collection
-
-                        // Note that we don't want to return the fully-qualified resource name in the case of name property access.
-                        // we should return whatever the user has set as the value of the 'name' property for a predictable user experience.
-                        return ConvertExpression(declaredResource.NameSyntax);
-                    case ("type", false):
-                        return new JTokenExpression(resource.TypeReference.FormatType());
-                    case ("apiVersion", false):
-                        var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
-                        return new JTokenExpression(apiVersion);
-                    case ("properties", _):
-                        // use the reference() overload without "full" to generate a shorter expression
-                        // this is dependent on the name expression which could involve locals in case of a resource collection
-                        return GetReferenceExpression(resource, indexExpression, false);
-                    default:
-                        return AppendProperties(
-                            GetReferenceExpression(resource, indexExpression, true),
-                            new JTokenExpression(propertyName));
-                }
-            }
-            else
-            {
-                throw new InvalidOperationException($"Unsupported resource metadata type: {resource.GetType()}");
-            }
-        }
-
-        private LanguageExpression? ConvertModulePropertyAccess(ModuleSymbol moduleSymbol, string propertyName)
-        {
-            switch (propertyName)
-            {
-                case "name":
-                    // the name is dependent on the name expression which could involve locals in case of a resource collection
-                    return GetModuleNameExpression(moduleSymbol);
-            }
-
-            return null;
-        }
-
-        private LanguageExpression ConvertPropertyAccess(PropertyAccessSyntax propertyAccess)
-        {
-            if (context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is DeclaredResourceMetadata resource)
-            {
-                var movedSyntax = context.Settings.EnableSymbolicNames ? resource.Symbol.NameSyntax : resource.NameSyntax;
-
-                // we are doing property access on a single resource
-                return CreateConverterForIndexReplacement(movedSyntax, null, propertyAccess)
-                    .ConvertResourcePropertyAccess(resource, null, propertyAccess.PropertyName.IdentifierName);
-            }
-
-            if ((propertyAccess.BaseExpression is VariableAccessSyntax || propertyAccess.BaseExpression is ResourceAccessSyntax) &&
-                context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is ParameterResourceMetadata parameter &&
-                    this.ConvertResourcePropertyAccess(parameter, null, propertyAccess.PropertyName.IdentifierName) is { } convertedSingleParameter)
-            {
-                // we are doing property access on a single resource
-                // and we are dealing with special case properties
-                return convertedSingleParameter;
-            }
-
-            if (propertyAccess.BaseExpression is ArrayAccessSyntax propArrayAccess &&
-                context.SemanticModel.ResourceMetadata.TryLookup(propArrayAccess.BaseExpression) is DeclaredResourceMetadata resourceCollection)
-            {
-                var movedSyntax = context.Settings.EnableSymbolicNames ? resourceCollection.Symbol.NameSyntax : resourceCollection.NameSyntax;
-
-                // we are doing property access on an array access of a resource collection
-                return CreateConverterForIndexReplacement(movedSyntax, propArrayAccess.IndexExpression, propertyAccess)
-                    .ConvertResourcePropertyAccess(resourceCollection, propArrayAccess.IndexExpression, propertyAccess.PropertyName.IdentifierName);
-            }
-
-            if (propertyAccess.BaseExpression is PropertyAccessSyntax &&
-                context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is ModuleOutputResourceMetadata moduleOutput &&
-                !moduleOutput.Module.IsCollection &&
-                this.ConvertResourcePropertyAccess(moduleOutput, null, propertyAccess.PropertyName.IdentifierName) is { } convertedSingleModuleOutput)
-            {
-                // we are doing property access on an output of a non-collection module.
-                // and we are dealing with special case properties
-                return convertedSingleModuleOutput;
-            }
-
-            if (propertyAccess.BaseExpression is PropertyAccessSyntax moduleCollectionOutputProperty &&
-                moduleCollectionOutputProperty.BaseExpression is PropertyAccessSyntax moduleCollectionOutputs &&
-                moduleCollectionOutputs.BaseExpression is ArrayAccessSyntax moduleArrayAccess &&
-                context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is ModuleOutputResourceMetadata moduleCollectionOutputMetadata &&
-                moduleCollectionOutputMetadata.Module.IsCollection &&
-                CreateConverterForIndexReplacement(moduleCollectionOutputMetadata.NameSyntax, moduleArrayAccess.IndexExpression, propertyAccess)
-                    .ConvertResourcePropertyAccess(moduleCollectionOutputMetadata, null, propertyAccess.PropertyName.IdentifierName) is { } convertedCollectionModuleOutput)
-            {
-                // we are doing property access on an output of an array of modules.
-                // and we are dealing with special case properties
-                return convertedCollectionModuleOutput;
-            }
-
-            if (propertyAccess.BaseExpression is VariableAccessSyntax modulePropVariableAccess &&
-                context.SemanticModel.GetSymbolInfo(modulePropVariableAccess) is ModuleSymbol moduleSymbol &&
-                CreateConverterForIndexReplacement(GetModuleNameSyntax(moduleSymbol), null, propertyAccess)
-                    .ConvertModulePropertyAccess(moduleSymbol, propertyAccess.PropertyName.IdentifierName) is { } moduleConvertedSingle)
-            {
-                // we are doing property access on a single module
-                // and we are dealing with special case properties
-                return moduleConvertedSingle;
-            }
-
-            if (propertyAccess.BaseExpression is ArrayAccessSyntax modulePropArrayAccess &&
-                modulePropArrayAccess.BaseExpression is VariableAccessSyntax moduleArrayVariableAccess &&
-                context.SemanticModel.GetSymbolInfo(moduleArrayVariableAccess) is ModuleSymbol moduleCollectionSymbol &&
-                CreateConverterForIndexReplacement(GetModuleNameSyntax(moduleCollectionSymbol), modulePropArrayAccess.IndexExpression, propertyAccess)
-                    .ConvertModulePropertyAccess(moduleCollectionSymbol, propertyAccess.PropertyName.IdentifierName) is { } moduleConvertedCollection)
-            {
-
-                // we are doing property access on an array access of a module collection
-                // and we are dealing with special case properties
-                return moduleConvertedCollection;
-            }
-
-            // is this a (<child>.outputs).<prop> propertyAccess?
-            if (propertyAccess.BaseExpression is PropertyAccessSyntax childPropertyAccess && childPropertyAccess.PropertyName.IdentifierName == LanguageConstants.ModuleOutputsPropertyName)
-            {
-                switch (childPropertyAccess.BaseExpression)
-                {
-                    // is <child> a variable which points to a variable that requires in-lining?
-                    case VariableAccessSyntax grandChildVariableAccess
-                        when context.SemanticModel.GetSymbolInfo(grandChildVariableAccess) is VariableSymbol variableSymbol &&
-                            context.VariablesToInline.Contains(variableSymbol):
-                        {
-                            //execute variable in-lining
-                            if (ConvertVariableAccess(grandChildVariableAccess) is FunctionExpression moduleReferenceExpression)
-                            {
-                                // we assume that this will generate a proper reference function to a deployment resource.
-                                // If not then the deployment will fail as the template will be malformed but that should have been caught before
-
-                                return AppendProperties(moduleReferenceExpression,
-                                    new JTokenExpression(propertyAccess.PropertyName.IdentifierName),
-                                    new JTokenExpression("value"));
-                            }
-                            break;
-                        }
-
-                    // is <child> a variable which points to a non-collection module symbol?
-                    case VariableAccessSyntax grandChildVariableAccess
-                        when context.SemanticModel.GetSymbolInfo(grandChildVariableAccess) is ModuleSymbol { IsCollection: false } outputsModuleSymbol:
-                        {
-                            return AppendProperties(
-                                this.GetModuleOutputsReferenceExpression(outputsModuleSymbol, null),
-                                new JTokenExpression(propertyAccess.PropertyName.IdentifierName),
-                                new JTokenExpression("value"));
-                        }
-
-                    // is <child> an array access operating on a module collection
-                    case ArrayAccessSyntax { BaseExpression: VariableAccessSyntax grandGrandChildVariableAccess } grandChildArrayAccess
-                        when context.SemanticModel.GetSymbolInfo(grandGrandChildVariableAccess) is ModuleSymbol { IsCollection: true } outputsModuleCollectionSymbol:
-                        {
-                            var updatedConverter = this.CreateConverterForIndexReplacement(GetModuleNameSyntax(outputsModuleCollectionSymbol), grandChildArrayAccess.IndexExpression, propertyAccess);
-                            return AppendProperties(
-                                updatedConverter.GetModuleOutputsReferenceExpression(outputsModuleCollectionSymbol, grandChildArrayAccess.IndexExpression),
-                                new JTokenExpression(propertyAccess.PropertyName.IdentifierName),
-                                new JTokenExpression("value"));
-                        }
-                }
-            }
-
-            return AppendProperties(
-                ToFunctionExpression(propertyAccess.BaseExpression),
-                new JTokenExpression(propertyAccess.PropertyName.IdentifierName));
+                    throw new NotImplementedException($"Cannot convert operation of type {operation.GetType().Name}");
+            };
         }
 
         public IEnumerable<LanguageExpression> GetResourceNameSegments(DeclaredResourceMetadata resource)
@@ -614,7 +353,7 @@ namespace Bicep.Core.Emit
                 var newContext = i < ancestors.Length - 1 ? ancestors[i + 1].Resource : resource;
 
                 var inaccessibleLocals = this.context.DataFlowAnalyzer.GetInaccessibleLocalsAfterSyntaxMove(rewritten, newContext.Symbol.NameSyntax);
-                var inaccessibleLocalLoops = inaccessibleLocals.Select(local => GetEnclosingForExpression(local)).Distinct().ToList();
+                var inaccessibleLocalLoops = inaccessibleLocals.Select(local => operationConverter.GetEnclosingForExpression(local)).Distinct().ToList();
 
                 switch (inaccessibleLocalLoops.Count)
                 {
@@ -635,7 +374,7 @@ namespace Bicep.Core.Emit
                         {
                             // rewrite the straggler from previous iteration
                             // TODO: Nested loops will require DFA on the ForSyntax.Expression
-                            rewritten = SymbolReplacer.Replace(this.context.SemanticModel, new Dictionary<Symbol, SyntaxBase> { [loopItemSymbol] = SyntaxFactory.CreateArrayAccess(GetEnclosingForExpression(loopItemSymbol).Expression, ancestor.IndexExpression) }, rewritten);
+                            rewritten = SymbolReplacer.Replace(this.context.SemanticModel, new Dictionary<Symbol, SyntaxBase> { [loopItemSymbol] = SyntaxFactory.CreateArrayAccess(operationConverter.GetEnclosingForExpression(loopItemSymbol).Expression, ancestor.IndexExpression) }, rewritten);
                         }
 
                         // TODO: Run data flow analysis on the array expression as well. (Will be needed for nested resource loops)
@@ -660,41 +399,66 @@ namespace Bicep.Core.Emit
             return rewritten;
         }
 
-        public LanguageExpression GetFullyQualifiedResourceName(DeclaredResourceMetadata resource)
+        public LanguageExpression GetFullyQualifiedResourceName(ResourceMetadata resource)
         {
-            var nameValueSyntax = resource.NameSyntax;
-
-            // For a nested resource we need to compute the name
-            var ancestors = this.context.SemanticModel.ResourceAncestors.GetAncestors(resource);
-            if (ancestors.Length == 0)
+            switch (resource)
             {
-                return ConvertExpression(nameValueSyntax);
+                case DeclaredResourceMetadata declaredResource:
+                    var nameValueSyntax = declaredResource.NameSyntax;
+
+                    // For a nested resource we need to compute the name
+                    var ancestors = this.context.SemanticModel.ResourceAncestors.GetAncestors(declaredResource);
+                    if (ancestors.Length == 0)
+                    {
+                        return ConvertExpression(nameValueSyntax);
+                    }
+
+                    // Build an expression like '${parent.name}/${child.name}'
+                    //
+                    // This is a call to the `format` function with the first arg as a format string
+                    // and the remaining args the actual name segments.
+                    //
+                    // args.Length = 1 (format string) + N (ancestor names) + 1 (resource name)
+
+                    var nameSegments = GetResourceNameSegments(declaredResource);
+                    // {0}/{1}/{2}....
+                    var formatString = string.Join("/", nameSegments.Select((_, i) => $"{{{i}}}"));
+
+                    return CreateFunction("format", new JTokenExpression(formatString).AsEnumerable().Concat(nameSegments));
+                case ModuleOutputResourceMetadata:
+                case ParameterResourceMetadata:
+                    // TODO(antmarti): Can we come up with an expression to get the fully-qualified name here?
+                    return GetUnqualifiedResourceName(resource);
+                default:
+                    throw new InvalidOperationException($"Unsupported resource metadata type: {resource}");
             }
 
-            // Build an expression like '${parent.name}/${child.name}'
-            //
-            // This is a call to the `format` function with the first arg as a format string
-            // and the remaining args the actual name segments.
-            //
-            // args.Length = 1 (format string) + N (ancestor names) + 1 (resource name)
+        }
 
-            var nameSegments = GetResourceNameSegments(resource);
-            // {0}/{1}/{2}....
-            var formatString = string.Join("/", nameSegments.Select((_, i) => $"{{{i}}}"));
-
-            return CreateFunction("format", new JTokenExpression(formatString).AsEnumerable().Concat(nameSegments));
+        public LanguageExpression GetUnqualifiedResourceName(ResourceMetadata resource)
+        {
+            switch (resource)
+            {
+                case DeclaredResourceMetadata declaredResource:
+                    return ConvertExpression(declaredResource.NameSyntax);
+                case ModuleOutputResourceMetadata:
+                case ParameterResourceMetadata:
+                    // create an expression like: `last(split(<resource id>, '/'))`
+                    return CreateFunction(
+                        "last",
+                        CreateFunction(
+                            "split",
+                            GetFullyQualifiedResourceId(resource),
+                            new JTokenExpression("/")));
+                default:
+                    throw new InvalidOperationException($"Unsupported resource metadata type: {resource}");
+            }
         }
 
         private LanguageExpression GetModuleNameExpression(ModuleSymbol moduleSymbol)
         {
-            SyntaxBase nameValueSyntax = GetModuleNameSyntax(moduleSymbol);
+            SyntaxBase nameValueSyntax = OperationConverter.GetModuleNameSyntax(moduleSymbol);
             return ConvertExpression(nameValueSyntax);
-        }
-
-        public static SyntaxBase GetModuleNameSyntax(ModuleSymbol moduleSymbol)
-        {
-            // this condition should have already been validated by the type checker
-            return moduleSymbol.TryGetBodyPropertyValue(LanguageConstants.ModuleNamePropertyName) ?? throw new ArgumentException($"Expected module syntax body to contain property 'name'");
         }
 
         public LanguageExpression GetUnqualifiedResourceId(DeclaredResourceMetadata resource)
@@ -709,34 +473,17 @@ namespace Bicep.Core.Emit
 
         public LanguageExpression GetFullyQualifiedResourceId(ResourceMetadata resource)
         {
-            if (resource is ParameterResourceMetadata parameter)
-            {
-                return new FunctionExpression(
-                    "parameters",
-                    new LanguageExpression[] { new JTokenExpression(parameter.Symbol.Name), },
-                    new LanguageExpression[] { });
-            }
-            else if (resource is ModuleOutputResourceMetadata output)
-            {
-                return AppendProperties(
-                    GetModuleOutputsReferenceExpression(output.Module, null),
-                    new JTokenExpression(output.OutputName),
-                    new JTokenExpression("value"));
-            }
-            else if (resource is DeclaredResourceMetadata declared)
-            {
-                var nameSegments = GetResourceNameSegments(declared);
-                return ScopeHelper.FormatFullyQualifiedResourceId(
+            return resource switch {
+                ParameterResourceMetadata parameter => ConvertOperation(new ParameterAccessOperation(parameter.Symbol)),
+                ModuleOutputResourceMetadata output => ConvertOperation(new ModuleOutputOperation(output.Module, null, new ConstantValueOperation(output.OutputName))),
+                DeclaredResourceMetadata declared => ScopeHelper.FormatFullyQualifiedResourceId(
                     context,
                     this,
                     context.ResourceScopeData[declared],
                     resource.TypeReference.FormatType(),
-                    nameSegments);
-            }
-            else
-            {
-                throw new InvalidOperationException($"Unsupported resource metadata type: {resource}");
-            }
+                    GetResourceNameSegments(declared)),
+                _ => throw new InvalidOperationException($"Unsupported resource metadata type: {resource}"),
+            };
         }
 
         public LanguageExpression GetFullyQualifiedResourceId(ModuleSymbol moduleSymbol)
@@ -749,276 +496,11 @@ namespace Bicep.Core.Emit
                 GetModuleNameExpression(moduleSymbol).AsEnumerable());
         }
 
-        public FunctionExpression GetModuleOutputsReferenceExpression(ModuleSymbol moduleSymbol, SyntaxBase? indexExpression)
-        {
-            if (context.Settings.EnableSymbolicNames)
-            {
-                return AppendProperties(
-                    CreateFunction(
-                        "reference",
-                        GenerateSymbolicReference(moduleSymbol.Name, indexExpression)),
-                    new JTokenExpression("outputs"));
-            }
-
-            if (moduleSymbol.DeclaringModule.HasCondition())
-            {
-                return AppendProperties(
-                    CreateFunction(
-                        "reference",
-                        GetFullyQualifiedResourceId(moduleSymbol),
-                        new JTokenExpression(TemplateWriter.NestedDeploymentResourceApiVersion)),
-                    new JTokenExpression("outputs"));
-            }
-
-            return AppendProperties(
-                CreateFunction(
-                    "reference",
-                    GetFullyQualifiedResourceId(moduleSymbol)),
-                new JTokenExpression("outputs"));
-        }
-
-        public FunctionExpression GetReferenceExpression(ResourceMetadata resource, SyntaxBase? indexExpression, bool full)
-        {
-            var referenceExpression = resource switch
-            {
-                ParameterResourceMetadata parameter => new FunctionExpression(
-                    "parameters",
-                    new LanguageExpression[] { new JTokenExpression(parameter.Symbol.Name), },
-                    Array.Empty<LanguageExpression>()),
-
-                ModuleOutputResourceMetadata output => AppendProperties(
-                    GetModuleOutputsReferenceExpression(output.Module, null),
-                    new JTokenExpression(output.OutputName),
-                    new JTokenExpression("value")),
-
-                DeclaredResourceMetadata declared when context.Settings.EnableSymbolicNames =>
-                    GenerateSymbolicReference(declared.Symbol.Name, indexExpression),
-                DeclaredResourceMetadata => GetFullyQualifiedResourceId(resource),
-
-                _ => throw new InvalidOperationException($"Unexpected resource metadata type: {resource.GetType()}"),
-            };
-
-            if (!resource.IsAzResource)
-            {
-                // For an extensible resource, always generate a 'reference' statement.
-                // User-defined properties appear inside "properties", so use a non-full reference.
-                return CreateFunction(
-                    "reference",
-                    referenceExpression);
-            }
-
-            // full gives access to top-level resource properties, but generates a longer statement
-            if (full)
-            {
-                var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
-
-                return CreateFunction(
-                    "reference",
-                    referenceExpression,
-                    new JTokenExpression(apiVersion),
-                    new JTokenExpression("full"));
-            }
-
-            var shouldIncludeApiVersion =
-                !context.Settings.EnableSymbolicNames &&
-                (resource.IsExistingResource ||
-                (resource is DeclaredResourceMetadata { Symbol.DeclaringResource: var declaringResource } && declaringResource.HasCondition()));
-
-            if (shouldIncludeApiVersion)
-            {
-                var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
-
-                // we must include an API version for an existing resource, because it cannot be inferred from any deployed template resource
-                return CreateFunction(
-                    "reference",
-                    referenceExpression,
-                    new JTokenExpression(apiVersion));
-            }
-
-            return CreateFunction(
-                "reference",
-                referenceExpression);
-        }
-
-        private LanguageExpression GetLocalVariableExpression(LocalVariableSymbol localVariableSymbol)
-        {
-            if (this.localReplacements.TryGetValue(localVariableSymbol, out var replacement))
-            {
-                // the current context has specified an expression to be used for this local variable symbol
-                // to override the regular conversion
-                return replacement;
-            }
-
-            var @for = GetEnclosingForExpression(localVariableSymbol);
-            return GetLoopVariableExpression(localVariableSymbol, @for, CreateCopyIndexFunction(@for));
-        }
-
-        private LanguageExpression GetLoopVariableExpression(LocalVariableSymbol localVariableSymbol, ForSyntax @for, LanguageExpression indexExpression)
-        {
-            return localVariableSymbol.LocalKind switch
-            {
-                // this is the "item" variable of a for-expression
-                // to emit this, we need to index the array expression by the copyIndex() function
-                LocalKind.ForExpressionItemVariable => GetLoopItemVariableExpression(@for, indexExpression),
-
-                // this is the "index" variable of a for-expression inside a variable block
-                // to emit this, we need to return a copyIndex(...) function
-                LocalKind.ForExpressionIndexVariable => indexExpression,
-
-                _ => throw new NotImplementedException($"Unexpected local variable kind '{localVariableSymbol.LocalKind}'."),
-            };
-        }
-
-        private ForSyntax GetEnclosingForExpression(LocalVariableSymbol localVariable)
-        {
-            // we're following the symbol hierarchy rather than syntax hierarchy because
-            // this guarantees a single hop in all cases
-            var symbolParent = this.context.SemanticModel.GetSymbolParent(localVariable);
-            if (symbolParent is not LocalScope localScope)
-            {
-                throw new NotImplementedException($"{nameof(LocalVariableSymbol)} has un unexpected parent of type '{symbolParent?.GetType().Name}'.");
-            }
-
-            if (localScope.DeclaringSyntax is ForSyntax @for)
-            {
-                return @for;
-            }
-
-            throw new NotImplementedException($"{nameof(LocalVariableSymbol)} was declared by an unexpected syntax type '{localScope.DeclaringSyntax?.GetType().Name}'.");
-        }
-
-        private string? GetCopyIndexName(ForSyntax @for)
-        {
-            return this.context.SemanticModel.Binder.GetParent(@for) switch
-            {
-                // copyIndex without name resolves to module/resource loop index in the runtime
-                ResourceDeclarationSyntax => null,
-                ModuleDeclarationSyntax => null,
-
-                // variable copy index has the name of the variable
-                VariableDeclarationSyntax variable when variable.Name.IsValid => variable.Name.IdentifierName,
-
-                // output loops are only allowed at the top level and don't have names, either
-                OutputDeclarationSyntax => null,
-
-                // the property copy index has the name of the property
-                ObjectPropertySyntax property when property.TryGetKeyText() is { } key && ReferenceEquals(property.Value, @for) => key,
-
-                _ => throw new NotImplementedException("Unexpected for-expression grandparent.")
-            };
-        }
-
-        private FunctionExpression CreateCopyIndexFunction(ForSyntax @for)
-        {
-            var copyIndexName = GetCopyIndexName(@for);
-            return copyIndexName is null
-                ? CreateFunction("copyIndex")
-                : CreateFunction("copyIndex", new JTokenExpression(copyIndexName));
-        }
-
-        private FunctionExpression GetLoopItemVariableExpression(ForSyntax @for, LanguageExpression indexExpression)
-        {
-            // loop item variable should be replaced with <array expression>[<index expression>]
-            var arrayExpression = ToFunctionExpression(@for.Expression);
-
-            return AppendProperties(arrayExpression, indexExpression);
-        }
-
-        private LanguageExpression ConvertVariableAccess(VariableAccessSyntax variableAccessSyntax)
-        {
-            var name = variableAccessSyntax.Name.IdentifierName;
-
-            if (variableAccessSyntax is ExplicitVariableAccessSyntax)
-            {
-                //just return a call to variables.
-                return CreateFunction("variables", new JTokenExpression(name));
-            }
-
-            var symbol = context.SemanticModel.GetSymbolInfo(variableAccessSyntax);
-
-            switch (symbol)
-            {
-                case ParameterSymbol parameterSymbol when parameterSymbol.Type is ResourceType resourceType:
-                    // This is a reference to a pre-existing resource where the resource ID was passed in as a
-                    // string. Generate a call to reference().
-                    return CreateFunction(
-                        "reference",
-                        CreateFunction("parameters", new JTokenExpression(name)),
-                        new JTokenExpression(resourceType.TypeReference.ApiVersion),
-                        new JTokenExpression("full"));
-
-                case ParameterSymbol parameterSymbol when parameterSymbol.Type is ResourceType:
-                    return CreateFunction("parameters", new JTokenExpression(name));
-
-                case ParameterSymbol _:
-                    return CreateFunction("parameters", new JTokenExpression(name));
-
-                case VariableSymbol variableSymbol:
-                    if (context.VariablesToInline.Contains(variableSymbol))
-                    {
-                        // we've got a runtime dependency, so we have to inline the variable usage
-                        return ConvertExpression(variableSymbol.DeclaringVariable.Value);
-                    }
-                    return CreateFunction("variables", new JTokenExpression(name));
-
-                case ResourceSymbol when context.SemanticModel.ResourceMetadata.TryLookup(variableAccessSyntax) is { } resource:
-                    return GetReferenceExpression(resource, null, true);
-
-                case ModuleSymbol moduleSymbol:
-                    return GetModuleOutputsReferenceExpression(moduleSymbol, null);
-
-                case LocalVariableSymbol localVariableSymbol:
-                    return GetLocalVariableExpression(localVariableSymbol);
-
-                default:
-                    throw new NotImplementedException($"Encountered an unexpected symbol kind '{symbol?.Kind}' when generating a variable access expression.");
-
-            }
-        }
-
-        private LanguageExpression ConvertResourceAccess(ResourceAccessSyntax resourceAccessSyntax)
-        {
-            if (context.SemanticModel.ResourceMetadata.TryLookup(resourceAccessSyntax) is { } resource)
-            {
-                return GetReferenceExpression(resource, null, true);
-            }
-
-            throw new NotImplementedException($"Unable to obtain resource metadata when generating a resource access expression.");
-        }
-
-        private LanguageExpression ConvertString(StringSyntax syntax)
-        {
-            if (syntax.TryGetLiteralValue() is string literalStringValue)
-            {
-                // no need to build a format string
-                return new JTokenExpression(literalStringValue);
-            }
-
-            var formatArgs = new LanguageExpression[syntax.Expressions.Length + 1];
-
-            var formatString = StringFormatConverter.BuildFormatString(syntax);
-            formatArgs[0] = new JTokenExpression(formatString);
-
-            for (var i = 0; i < syntax.Expressions.Length; i++)
-            {
-                formatArgs[i + 1] = ConvertExpression(syntax.Expressions[i]);
-            }
-
-            return CreateFunction("format", formatArgs);
-        }
-
         /// <summary>
-        /// Converts the specified bicep expression tree into an ARM template expression tree.
+        /// Converts a given language expression into an ARM template expression tree.
         /// This always returns a function expression, which is useful when converting property access or array access
         /// on literals.
         /// </summary>
-        /// <param name="expression">The expression</param>
-        public FunctionExpression ToFunctionExpression(SyntaxBase expression)
-        {
-            var converted = ConvertExpression(expression);
-            return ToFunctionExpression(converted);
-        }
-
         public static FunctionExpression ToFunctionExpression(LanguageExpression converted)
         {
             switch (converted)
@@ -1046,136 +528,9 @@ namespace Bicep.Core.Emit
             throw new NotImplementedException($"Unexpected expression type '{converted.GetType().Name}'.");
         }
 
-        private FunctionExpression ConvertArray(ArraySyntax syntax)
+        public LanguageExpression GenerateSymbolicReference(string symbolName, IndexReplacementContext? indexContext)
         {
-            // we are using the createArray() function as a proxy for an array literal
-            return CreateFunction(
-                "createArray",
-                syntax.Items.Select(item => ConvertExpression(item.Value)));
-        }
-
-        private FunctionExpression ConvertObject(ObjectSyntax syntax)
-        {
-            // need keys and values in one array of parameters
-            var parameters = new LanguageExpression[syntax.Properties.Count() * 2];
-
-            int index = 0;
-            foreach (var propertySyntax in syntax.Properties)
-            {
-                parameters[index] = propertySyntax.Key switch
-                {
-                    IdentifierSyntax identifier => new JTokenExpression(identifier.IdentifierName),
-                    StringSyntax @string => ConvertString(@string),
-                    _ => throw new NotImplementedException($"Encountered an unexpected type '{propertySyntax.Key.GetType().Name}' when generating object's property name.")
-                };
-                index++;
-
-                parameters[index] = ConvertExpression(propertySyntax.Value);
-                index++;
-            }
-
-            // we are using the createObject() function as a proxy for an object literal
-            return GetCreateObjectExpression(parameters);
-        }
-
-        private static FunctionExpression GetCreateObjectExpression(params LanguageExpression[] parameters)
-            => CreateFunction("createObject", parameters);
-
-        private LanguageExpression ConvertBinary(BinaryOperationSyntax syntax)
-        {
-            LanguageExpression operand1 = ConvertExpression(syntax.LeftExpression);
-            LanguageExpression operand2 = ConvertExpression(syntax.RightExpression);
-
-            return syntax.Operator switch
-            {
-                BinaryOperator.LogicalOr => CreateFunction("or", operand1, operand2),
-                BinaryOperator.LogicalAnd => CreateFunction("and", operand1, operand2),
-                BinaryOperator.Equals => CreateFunction("equals", operand1, operand2),
-                BinaryOperator.NotEquals => CreateFunction("not",
-                    CreateFunction("equals", operand1, operand2)),
-                BinaryOperator.EqualsInsensitive => CreateFunction("equals",
-                    CreateFunction("toLower", operand1),
-                    CreateFunction("toLower", operand2)),
-                BinaryOperator.NotEqualsInsensitive => CreateFunction("not",
-                    CreateFunction("equals",
-                        CreateFunction("toLower", operand1),
-                        CreateFunction("toLower", operand2))),
-                BinaryOperator.LessThan => CreateFunction("less", operand1, operand2),
-                BinaryOperator.LessThanOrEqual => CreateFunction("lessOrEquals", operand1, operand2),
-                BinaryOperator.GreaterThan => CreateFunction("greater", operand1, operand2),
-                BinaryOperator.GreaterThanOrEqual => CreateFunction("greaterOrEquals", operand1, operand2),
-                BinaryOperator.Add => CreateFunction("add", operand1, operand2),
-                BinaryOperator.Subtract => CreateFunction("sub", operand1, operand2),
-                BinaryOperator.Multiply => CreateFunction("mul", operand1, operand2),
-                BinaryOperator.Divide => CreateFunction("div", operand1, operand2),
-                BinaryOperator.Modulo => CreateFunction("mod", operand1, operand2),
-                BinaryOperator.Coalesce => CreateFunction("coalesce", operand1, operand2),
-                _ => throw new NotImplementedException($"Cannot emit unexpected binary operator '{syntax.Operator}'."),
-            };
-        }
-
-        private LanguageExpression ConvertUnary(UnaryOperationSyntax syntax)
-        {
-            switch (syntax.Operator)
-            {
-                case UnaryOperator.Not:
-                    LanguageExpression convertedOperand = ConvertExpression(syntax.Expression);
-                    return CreateFunction("not", convertedOperand);
-
-                case UnaryOperator.Minus:
-                    if (syntax.Expression is IntegerLiteralSyntax integerLiteral)
-                    {
-                        // shortcutting the integer parsing logic here because we need to return either the literal 32 bit integer or the FunctionExpression of an integer outside the 32 bit range
-                        return ConvertInteger(integerLiteral, true);
-                    }
-
-                    return CreateFunction(
-                        "sub",
-                        new JTokenExpression(0),
-                        ConvertExpression(syntax.Expression));
-
-                default:
-                    throw new NotImplementedException($"Cannot emit unexpected unary operator '{syntax.Operator}.");
-            }
-        }
-
-        // the deployment engine can only handle 32 bit integers expressed as literal values, so for 32 bit integers, we return the literal integer value
-        // for values outside that signed 32 bit integer range, we return the FunctionExpression
-        private LanguageExpression ConvertInteger(IntegerLiteralSyntax integerSyntax, bool minus)
-        {
-            if (minus)
-            {
-                // integerSyntax.Value is always positive, so for the most negative signed 32 bit integer -2,147,483,648
-                // we would compare its positive token (2,147,483,648) to int.MaxValue (2,147,483,647) + 1
-                if (integerSyntax.Value > (ulong)int.MaxValue + 1)
-                {
-                    return CreateFunction("json", new JTokenExpression($"-{integerSyntax.Value.ToString(CultureInfo.InvariantCulture)}"));
-                }
-                else
-                {
-                    // the integerSyntax.Value is a valid negative 32 bit integer.
-                    // because integerSyntax.Value is a ulong type, it is always positive. we need to first cast it to a long in order to negate it.
-                    // after negating, cast it to a int type because that is what represents a signed 32 bit integer.
-                    var longValue = -(long)integerSyntax.Value;
-                    return new JTokenExpression((int)longValue);
-                }
-            }
-            else
-            {
-                if (integerSyntax.Value > int.MaxValue)
-                {
-                    return CreateFunction("json", new JTokenExpression(integerSyntax.Value.ToString(CultureInfo.InvariantCulture)));
-                }
-                else
-                {
-                    return new JTokenExpression((int)integerSyntax.Value);
-                }
-            }
-        }
-
-        public LanguageExpression GenerateSymbolicReference(string symbolName, SyntaxBase? indexExpression)
-        {
-            if (indexExpression is null)
+            if (indexContext is null)
             {
                 return new JTokenExpression(symbolName);
             }
@@ -1183,7 +538,7 @@ namespace Bicep.Core.Emit
             return CreateFunction(
                 "format",
                 new JTokenExpression($"{symbolName}[{{0}}]"),
-                ConvertExpression(indexExpression));
+                ConvertOperation(indexContext.Index));
         }
 
         public static LanguageExpression GenerateUnqualifiedResourceId(string fullyQualifiedType, IEnumerable<LanguageExpression> nameSegments)
@@ -1254,15 +609,6 @@ namespace Bicep.Core.Emit
 
         public static FunctionExpression AppendProperties(FunctionExpression function, IEnumerable<LanguageExpression> properties)
             => new(function.Function, function.Parameters, function.Properties.Concat(properties).ToArray());
-
-        protected static void Assert(bool predicate, string message)
-        {
-            if (predicate == false)
-            {
-                // we have a code defect - use the exception stack to debug
-                throw new ArgumentException(message);
-            }
-        }
     }
 }
 

--- a/src/Bicep.Core/Emit/OperationConverter.cs
+++ b/src/Bicep.Core/Emit/OperationConverter.cs
@@ -1,0 +1,941 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Bicep.Core.Extensions;
+using Bicep.Core.Intermediate;
+using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Metadata;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+
+namespace Bicep.Core.Emit
+{
+    public class OperationConverter
+    {
+        private readonly EmitterContext context;
+        private readonly ImmutableDictionary<LocalVariableSymbol, Operation> localReplacements;
+
+        public OperationConverter(EmitterContext context, ImmutableDictionary<LocalVariableSymbol, Operation> localReplacements)
+        {
+            this.context = context;
+            this.localReplacements = localReplacements;
+        }
+
+        public ProgramOperation ConvertProgram(FileSymbol fileSymbol)
+        {
+            var parameters = fileSymbol.ParameterDeclarations.Select(ConvertParameter);
+            var outputs = fileSymbol.OutputDeclarations.Select(ConvertOutput);
+            var imports = fileSymbol.ImportDeclarations.Select(ConvertImport);
+            var variables = ConvertVariables(fileSymbol);
+
+            return new ProgramOperation(
+                parameters.ToImmutableArray(),
+                outputs.ToImmutableArray(),
+                imports.ToImmutableArray(),
+                variables.ToImmutableArray());
+        }
+
+        private IEnumerable<VariableOperation> ConvertVariables(FileSymbol fileSymbol)
+        {
+            //emit internal variables
+            foreach (var functionVariable in context.FunctionVariables.Values.OrderBy(x => x.Name, LanguageConstants.IdentifierComparer))
+            {
+                yield return new VariableOperation(
+                    functionVariable.Name,
+                    ConvertSyntax(functionVariable.Value));
+            }
+
+            var nonInlinedVariables = fileSymbol.VariableDeclarations.Where(x => !context.VariablesToInline.Contains(x));
+            foreach (var variable in nonInlinedVariables)
+            {
+                yield return new VariableOperation(
+                    variable.Name,
+                    ConvertSyntax(variable.Value));
+            }
+        }
+
+        private ParameterOperation ConvertParameter(ParameterSymbol parameterSymbol)
+        {
+            TypeSymbol targetType;
+
+            var properties = new List<ObjectPropertyOperation>();
+            if (parameterSymbol.Type is ResourceType resourceType)
+            {
+                // Encode a resource type as a string parameter with a metadata for the resource type.
+                targetType = resourceType;
+                properties.Add(new ObjectPropertyOperation(
+                    new ConstantValueOperation("type"),
+                    new ConstantValueOperation(LanguageConstants.String.Name)));
+                properties.Add(new ObjectPropertyOperation(
+                    new ConstantValueOperation(LanguageConstants.ParameterMetadataPropertyName),
+                    new ObjectOperation(new [] {
+                        new ObjectPropertyOperation(
+                            new ConstantValueOperation(LanguageConstants.MetadataResourceTypePropertyName),
+                            new ConstantValueOperation(resourceType.TypeReference.FormatName())),
+                    }.ToImmutableArray())));
+            }
+            else if (SyntaxHelper.TryGetPrimitiveType(parameterSymbol.DeclaringParameter) is TypeSymbol primitiveType)
+            {
+                targetType = primitiveType;
+                properties.Add(new ObjectPropertyOperation(
+                    new ConstantValueOperation("type"),
+                    new ConstantValueOperation(primitiveType.Name)));
+            }
+            else
+            {
+                // this should have been caught by the type checker long ago
+                throw new ArgumentException($"Unable to find primitive type for parameter {parameterSymbol.Name}");
+            }
+
+            if (parameterSymbol.DeclaringParameter.Modifier is ParameterDefaultValueSyntax defaultValueSyntax)
+            {
+                properties.Add(new ObjectPropertyOperation(
+                    new ConstantValueOperation("defaultValue"),
+                    ConvertSyntax(defaultValueSyntax.DefaultValue)));
+            }
+
+            properties.AddRange(GetDecorators(parameterSymbol.DeclaringParameter, targetType));
+
+            return new ParameterOperation(
+                parameterSymbol.Name,
+                properties.ToImmutableArray());
+        }
+
+        private OutputOperation ConvertOutput(OutputSymbol outputSymbol)
+        {
+            TypeSymbol targetType;
+
+            ObjectSyntax objectWithDecorators;
+            Operation value;
+            var properties = new List<ObjectPropertyOperation>();
+            if (outputSymbol.Type is ResourceType resourceType)
+            {
+                // TODO(antmarti): Handle array access here
+                if (context.SemanticModel.ResourceMetadata.TryLookup(outputSymbol.Value) is not {} resourceMetadata)
+                {
+                    throw new InvalidOperationException($"Failed to find resource metadata for resource output {outputSymbol.Name}");
+                }
+
+                // Resource-typed outputs are encoded as strings
+                targetType = LanguageConstants.String;
+                properties.Add(new ObjectPropertyOperation(
+                    new ConstantValueOperation(LanguageConstants.ParameterMetadataPropertyName),
+                    new ObjectOperation(new [] {
+                        new ObjectPropertyOperation(
+                            new ConstantValueOperation(LanguageConstants.MetadataResourceTypePropertyName),
+                            new ConstantValueOperation(resourceType.TypeReference.FormatName())),
+                    }.ToImmutableArray())));
+
+                // Resource-typed outputs are serialized using the resource id.
+                value = new ResourceIdOperation(resourceMetadata, null);
+            }
+            else
+            {
+                targetType = outputSymbol.Type;
+                objectWithDecorators = SyntaxFactory.CreateObject(Enumerable.Empty<ObjectPropertySyntax>());
+                value = ConvertSyntax(outputSymbol.Value);
+            }
+
+            properties.AddRange(GetDecorators(outputSymbol.DeclaringOutput, targetType));
+
+            return new OutputOperation(
+                outputSymbol.Name,
+                targetType.Name,
+                value,
+                properties.ToImmutableArray());
+        }
+
+        private ImportOperation ConvertImport(ImportedNamespaceSymbol import)
+        {
+            var namespaceType = context.SemanticModel.GetTypeInfo(import.DeclaringSyntax) as NamespaceType
+                ?? throw new ArgumentException("Imported namespace does not have namespace type");
+
+            return new ImportOperation(
+                import.DeclaringImport.AliasName.IdentifierName,
+                namespaceType,
+                import.DeclaringImport.Config is null ? null : ConvertSyntax(import.DeclaringImport.Config));
+        }
+
+        public IEnumerable<ObjectPropertyOperation> GetDecorators(StatementSyntax statement, TypeSymbol targetType)
+        {
+            var result = SyntaxFactory.CreateObject(Enumerable.Empty<ObjectPropertySyntax>());
+            foreach (var decoratorSyntax in statement.Decorators.Reverse())
+            {
+                var symbol = this.context.SemanticModel.GetSymbolInfo(decoratorSyntax.Expression);
+
+                if (symbol is FunctionSymbol decoratorSymbol &&
+                    decoratorSymbol.DeclaringObject is NamespaceType namespaceType &&
+                    TemplateWriter.DecoratorsToEmitAsResourceProperties.Contains(decoratorSymbol.Name))
+                {
+                    var argumentTypes = decoratorSyntax.Arguments
+                        .Select(argument => this.context.SemanticModel.TypeManager.GetTypeInfo(argument))
+                        .ToArray();
+
+                    // There should be exact one matching decorator since there's no errors.
+                    var decorator = namespaceType.DecoratorResolver.GetMatches(decoratorSymbol, argumentTypes).Single();
+
+                    var evaluated = decorator.Evaluate(decoratorSyntax, targetType, result);
+                    if (evaluated is not null)
+                    {
+                        result = evaluated;
+                    }
+                }
+            }
+
+            foreach (var property in result.Properties)
+            {
+                yield return new ObjectPropertyOperation(
+                    property.TryGetKeyText() is { } keyName ? new ConstantValueOperation(keyName) : ConvertSyntax(property.Key),
+                    ConvertSyntax(property.Value));
+            }
+        }
+
+        public Operation ConvertSyntax(SyntaxBase syntax)
+        {
+            var symbol = context.SemanticModel.GetSymbolInfo(syntax);
+            if (symbol is VariableSymbol variableSymbol && context.VariablesToInline.Contains(variableSymbol))
+            {
+                return ConvertSyntax(variableSymbol.Value);
+            }
+
+            if (syntax is FunctionCallSyntax functionCall &&
+                symbol is FunctionSymbol functionSymbol &&
+                string.Equals(functionSymbol.Name, LanguageConstants.AnyFunction, LanguageConstants.IdentifierComparison))
+            {
+                // the outermost function in the current syntax node is the "any" function
+                // we should emit its argument directly
+                // otherwise, they'd get wrapped in a json() template function call in the converted expression
+
+                // we have checks for function parameter count mismatch, which should prevent an exception from being thrown
+                return ConvertSyntax(functionCall.Arguments.Single().Expression);
+            }
+
+            switch (syntax)
+            {
+                case BooleanLiteralSyntax boolSyntax:
+                    return new ConstantValueOperation(boolSyntax.Value);
+
+                case IntegerLiteralSyntax integerSyntax:
+                    var longValue = integerSyntax.Value switch {
+                        <= long.MaxValue => (long)integerSyntax.Value,
+                        _ => throw new InvalidOperationException($"Integer syntax hs value {integerSyntax.Value} which will overflow"),
+                    };
+
+                    return new ConstantValueOperation(longValue);
+
+                case NullLiteralSyntax _:
+                    return new NullValueOperation();
+
+                case ObjectSyntax objectSyntax:
+                    var properties = objectSyntax.Properties.Select(prop => new ObjectPropertyOperation(
+                        prop.TryGetKeyText() is { } keyName ? new ConstantValueOperation(keyName) : ConvertSyntax(prop.Key),
+                        ConvertSyntax(prop.Value)));
+                    return new ObjectOperation(properties.ToImmutableArray());
+
+                case ObjectPropertySyntax prop:
+                    return new ObjectPropertyOperation(
+                        prop.TryGetKeyText() is { } keyName ? new ConstantValueOperation(keyName) : ConvertSyntax(prop.Key),
+                        ConvertSyntax(prop.Value));
+
+                case ArraySyntax arraySyntax:
+                    var items = arraySyntax.Items.Select(x => ConvertSyntax(x.Value));
+                    return new ArrayOperation(items.ToImmutableArray());
+
+                case ArrayItemSyntax arrayItemSyntax:
+                    return ConvertSyntax(arrayItemSyntax.Value);
+
+                case ForSyntax forSyntax:
+                    return new ForLoopOperation(
+                        ConvertSyntax(forSyntax.Expression),
+                        ConvertSyntax(forSyntax.Body));
+
+                case ParenthesizedExpressionSyntax _:
+                case UnaryOperationSyntax _:
+                case BinaryOperationSyntax _:
+                case TernaryOperationSyntax _:
+                case StringSyntax _:
+                case InstanceFunctionCallSyntax _:
+                case FunctionCallSyntax _:
+                case ArrayAccessSyntax _:
+                case PropertyAccessSyntax _:
+                case ResourceAccessSyntax _:
+                case VariableAccessSyntax _:
+                    return ConvertExpressionSyntax(syntax);
+
+                default:
+                    throw new NotImplementedException($"Cannot emit unexpected expression of type {syntax.GetType().Name}");
+            }
+        }
+
+        public Operation ConvertExpressionSyntax(SyntaxBase expression)
+        {
+            switch (expression)
+            {
+                case BooleanLiteralSyntax boolSyntax:
+                    return new ConstantValueOperation(boolSyntax.Value);
+
+                case IntegerLiteralSyntax integerSyntax:
+                    var longValue = integerSyntax.Value switch {
+                        <= long.MaxValue => (long)integerSyntax.Value,
+                        _ => throw new InvalidOperationException($"Integer syntax hs value {integerSyntax.Value} which will overflow"),
+                    };
+
+                    return new ConstantValueOperation(longValue);
+
+                case StringSyntax stringSyntax:
+                    // using the throwing method to get semantic value of the string because
+                    // error checking should have caught any errors by now
+                    return ConvertString(stringSyntax);
+
+                case NullLiteralSyntax _:
+                    return new NullValueOperation();
+
+                case ObjectSyntax @object:
+                    return ConvertObject(@object);
+
+                case ArraySyntax array:
+                    return ConvertArray(array);
+
+                case ParenthesizedExpressionSyntax parenthesized:
+                    // template expressions do not have operators so parentheses are irrelevant
+                    return ConvertExpressionSyntax(parenthesized.Expression);
+
+                case UnaryOperationSyntax unary:
+                    return ConvertUnary(unary);
+
+                case BinaryOperationSyntax binary:
+                    return ConvertBinary(binary);
+
+                case TernaryOperationSyntax ternary:
+                    return new FunctionCallOperation(
+                        "if",
+                        ConvertExpressionSyntax(ternary.ConditionExpression),
+                        ConvertExpressionSyntax(ternary.TrueExpression),
+                        ConvertExpressionSyntax(ternary.FalseExpression));
+
+                case FunctionCallSyntaxBase functionCall:
+                    return ConvertFunction(functionCall);
+
+                case ArrayAccessSyntax arrayAccess:
+                    return ConvertArrayAccess(arrayAccess);
+
+                case ResourceAccessSyntax resourceAccess:
+                    return ConvertResourceAccess(resourceAccess);
+
+                case PropertyAccessSyntax propertyAccess:
+                    return ConvertPropertyAccess(propertyAccess);
+
+                case VariableAccessSyntax variableAccess:
+                    return ConvertVariableAccess(variableAccess);
+
+                default:
+                    throw new NotImplementedException($"Cannot emit unexpected expression of type {expression.GetType().Name}");
+            }
+        }
+
+        private Operation ConvertArray(ArraySyntax syntax)
+        {
+            var items = syntax.Items.Select(ConvertSyntax);
+
+            return new ArrayOperation(items.ToImmutableArray());
+        }
+
+        private Operation ConvertObject(ObjectSyntax syntax)
+        {
+            var properties = syntax.Properties.Select(prop => new ObjectPropertyOperation(
+                prop.TryGetKeyText() is { } keyName ? new ConstantValueOperation(keyName) : ConvertSyntax(prop.Key),
+                ConvertSyntax(prop.Value)));
+
+            return new ObjectOperation(properties.ToImmutableArray());
+        }
+
+        private Operation ConvertBinary(BinaryOperationSyntax syntax)
+        {
+            var operand1 = ConvertExpressionSyntax(syntax.LeftExpression);
+            var operand2 = ConvertExpressionSyntax(syntax.RightExpression);
+
+            return syntax.Operator switch
+            {
+                BinaryOperator.LogicalOr => new FunctionCallOperation("or", operand1, operand2),
+                BinaryOperator.LogicalAnd => new FunctionCallOperation("and", operand1, operand2),
+                BinaryOperator.Equals => new FunctionCallOperation("equals", operand1, operand2),
+                BinaryOperator.NotEquals => new FunctionCallOperation("not",
+                    new FunctionCallOperation("equals", operand1, operand2)),
+                BinaryOperator.EqualsInsensitive => new FunctionCallOperation("equals",
+                    new FunctionCallOperation("toLower", operand1),
+                    new FunctionCallOperation("toLower", operand2)),
+                BinaryOperator.NotEqualsInsensitive => new FunctionCallOperation("not",
+                    new FunctionCallOperation("equals",
+                        new FunctionCallOperation("toLower", operand1),
+                        new FunctionCallOperation("toLower", operand2))),
+                BinaryOperator.LessThan => new FunctionCallOperation("less", operand1, operand2),
+                BinaryOperator.LessThanOrEqual => new FunctionCallOperation("lessOrEquals", operand1, operand2),
+                BinaryOperator.GreaterThan => new FunctionCallOperation("greater", operand1, operand2),
+                BinaryOperator.GreaterThanOrEqual => new FunctionCallOperation("greaterOrEquals", operand1, operand2),
+                BinaryOperator.Add => new FunctionCallOperation("add", operand1, operand2),
+                BinaryOperator.Subtract => new FunctionCallOperation("sub", operand1, operand2),
+                BinaryOperator.Multiply => new FunctionCallOperation("mul", operand1, operand2),
+                BinaryOperator.Divide => new FunctionCallOperation("div", operand1, operand2),
+                BinaryOperator.Modulo => new FunctionCallOperation("mod", operand1, operand2),
+                BinaryOperator.Coalesce => new FunctionCallOperation("coalesce", operand1, operand2),
+                _ => throw new NotImplementedException($"Cannot emit unexpected binary operator '{syntax.Operator}'."),
+            };
+        }
+
+        private Operation ConvertUnary(UnaryOperationSyntax syntax)
+        {
+            switch (syntax.Operator)
+            {
+                case UnaryOperator.Not:
+                    return new FunctionCallOperation("not", ConvertExpressionSyntax(syntax.Expression));
+
+                case UnaryOperator.Minus:
+                    if (syntax.Expression is IntegerLiteralSyntax integerLiteral)
+                    {
+                        var integerValue = integerLiteral.Value switch {
+                            <= long.MaxValue => -(long)integerLiteral.Value,
+                            (ulong)long.MaxValue + 1 => long.MinValue,
+                            _ => throw new InvalidOperationException($"Integer syntax hs value {integerLiteral.Value} which will overflow"),
+                        };
+
+                        return new ConstantValueOperation(integerValue);
+                    }
+
+                    return new FunctionCallOperation(
+                        "sub",
+                        new[] {
+                            new ConstantValueOperation(0),
+                            ConvertExpressionSyntax(syntax.Expression),
+                        });
+
+                default:
+                    throw new NotImplementedException($"Cannot emit unexpected unary operator '{syntax.Operator}.");
+            }
+        }
+
+        private Operation ConvertFunction(FunctionCallSyntaxBase functionCall)
+        {
+            var symbol = context.SemanticModel.GetSymbolInfo(functionCall);
+            if (symbol is FunctionSymbol &&
+                context.SemanticModel.TypeManager.GetMatchedFunctionOverload(functionCall) is { Evaluator: { } } functionOverload)
+            {
+                return ConvertExpressionSyntax(functionOverload.Evaluator(
+                    functionCall,
+                    symbol,
+                    context.SemanticModel.GetTypeInfo(functionCall),
+                    context.FunctionVariables.GetValueOrDefault(functionCall),
+                    context.SemanticModel.TypeManager.GetMatchedFunctionResultValue(functionCall)));
+            }
+
+            switch (functionCall)
+            {
+                case FunctionCallSyntax function:
+                    return new FunctionCallOperation(
+                        function.Name.IdentifierName,
+                        function.Arguments.Select(a => ConvertExpressionSyntax(a.Expression)).ToImmutableArray());
+
+                case InstanceFunctionCallSyntax method:
+                    var (baseSyntax, indexExpression) = SyntaxHelper.UnwrapArrayAccessSyntax(method.BaseExpression);
+                    var baseSymbol = context.SemanticModel.GetSymbolInfo(baseSyntax);
+
+                    switch (baseSymbol)
+                    {
+                        case INamespaceSymbol namespaceSymbol:
+                            Debug.Assert(indexExpression is null, "Indexing into a namespace should have been blocked by type analysis");
+                            return new FunctionCallOperation(
+                                method.Name.IdentifierName,
+                                method.Arguments.Select(a => ConvertExpressionSyntax(a.Expression)).ToImmutableArray());
+                        case { } _ when context.SemanticModel.ResourceMetadata.TryLookup(baseSyntax) is DeclaredResourceMetadata resource:
+                            if (method.Name.IdentifierName.StartsWithOrdinalInsensitively("list"))
+                            {
+                                // Handle list<method_name>(...) method on resource symbol - e.g. stgAcc.listKeys()
+                                var indexContext = TryGetReplacementContext(resource.NameSyntax, indexExpression, method);
+                                var resourceIdOperation = new ResourceIdOperation(resource, indexContext);
+
+                                var convertedArgs = method.Arguments.SelectArray(a => ConvertExpressionSyntax(a.Expression));
+
+                                var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
+                                var apiVersionOperation = new ConstantValueOperation(apiVersion);
+
+                                var listArgs = convertedArgs.Length switch
+                                {
+                                    0 => new Operation[] { resourceIdOperation, apiVersionOperation, },
+                                    _ => new Operation[] { resourceIdOperation, }.Concat(convertedArgs),
+                                };
+
+                                return new FunctionCallOperation(
+                                    method.Name.IdentifierName,
+                                    listArgs.ToImmutableArray());
+                            }
+
+                            if (LanguageConstants.IdentifierComparer.Equals(method.Name.IdentifierName, "getSecret"))
+                            {
+                                var indexContext = TryGetReplacementContext(resource.NameSyntax, indexExpression, method);
+                                var resourceIdOperation = new ResourceIdOperation(resource, indexContext);
+
+                                var convertedArgs = method.Arguments.SelectArray(a => ConvertExpressionSyntax(a.Expression));
+
+                                return new GetKeyVaultSecretOperation(
+                                    resourceIdOperation,
+                                    convertedArgs[0],
+                                    convertedArgs.Length > 1 ? convertedArgs[1] : null);
+                            }
+
+                            break;
+                    }
+                    throw new InvalidOperationException($"Unrecognized base expression {baseSymbol?.Kind}");
+                default:
+                    throw new NotImplementedException($"Cannot emit unexpected expression of type {functionCall.GetType().Name}");
+            }
+        }
+
+        private Operation ConvertArrayAccess(ArrayAccessSyntax arrayAccess)
+        {
+            // if there is an array access on a resource/module reference, we have to generate differently
+            // when constructing the reference() function call, the resource name expression needs to have its local
+            // variable replaced with <loop array expression>[this array access' index expression]
+            if (arrayAccess.BaseExpression is VariableAccessSyntax || arrayAccess.BaseExpression is ResourceAccessSyntax)
+            {
+                if (context.SemanticModel.ResourceMetadata.TryLookup(arrayAccess.BaseExpression) is DeclaredResourceMetadata resource &&
+                    resource.Symbol.IsCollection)
+                {
+                    var indexContent = TryGetReplacementContext(resource, arrayAccess.IndexExpression, arrayAccess);
+                    return GetResourceReference(resource, indexContent, full: true);
+                }
+
+                if (context.SemanticModel.GetSymbolInfo(arrayAccess.BaseExpression) is ModuleSymbol { IsCollection: true } moduleSymbol)
+                {
+                    var indexContent = TryGetReplacementContext(GetModuleNameSyntax(moduleSymbol), arrayAccess.IndexExpression, arrayAccess);
+                    return GetModuleOutputsReference(moduleSymbol, indexContent);
+                }
+            }
+
+            return new ArrayAccessOperation(
+                ConvertExpressionSyntax(arrayAccess.BaseExpression),
+                ConvertExpressionSyntax(arrayAccess.IndexExpression));
+        }
+
+        private Operation ConvertResourcePropertyAccess(ResourceMetadata resource, IndexReplacementContext? indexContext, string propertyName)
+        {
+            if (context.Settings.EnableSymbolicNames &&
+                resource is DeclaredResourceMetadata declaredResource)
+            {
+                if (!resource.IsAzResource)
+                {
+                    // For an extensible resource, always generate a 'reference' statement.
+                    // User-defined properties appear inside "properties", so use a non-full reference.
+                    return new PropertyAccessOperation(
+                        new SymbolicResourceReferenceOperation(declaredResource, indexContext, false),
+                        propertyName);
+                }
+
+                if (context.Settings.EnableSymbolicNames)
+                {
+                    switch (propertyName)
+                    {
+                        case "id":
+                        case "name":
+                        case "type":
+                        case "apiVersion":
+                            return new PropertyAccessOperation(
+                                new ResourceInfoOperation(declaredResource, indexContext),
+                                propertyName);
+                        case "properties":
+                            return new SymbolicResourceReferenceOperation(declaredResource, indexContext, false);
+                        default:
+                            return new PropertyAccessOperation(
+                                new SymbolicResourceReferenceOperation(declaredResource, indexContext, true),
+                                propertyName);
+                    }
+                }
+            }
+
+            switch (propertyName)
+            {
+                case "id":
+                    // the ID is dependent on the name expression which could involve locals in case of a resource collection
+                    return new ResourceIdOperation(resource, indexContext);
+                case "name":
+                    // the name is dependent on the name expression which could involve locals in case of a resource collection
+
+                    // Note that we don't want to return the fully-qualified resource name in the case of name property access.
+                    // we should return whatever the user has set as the value of the 'name' property for a predictable user experience.
+                    return new ResourceNameOperation(resource, indexContext, FullyQualified: false);
+                case "type":
+                    return new ResourceTypeOperation(resource);
+                case "apiVersion":
+                    return new ResourceApiVersionOperation(resource);
+                case "properties":
+                    var shouldIncludeApiVersion = resource.IsExistingResource ||
+                        (resource is DeclaredResourceMetadata { Symbol.DeclaringResource: var declaringResource } && declaringResource.HasCondition());
+
+                    return new ResourceReferenceOperation(
+                        resource,
+                        new ResourceIdOperation(resource, indexContext),
+                        Full: false,
+                        ShouldIncludeApiVersion: shouldIncludeApiVersion);
+                default:
+                    return new PropertyAccessOperation(
+                        new ResourceReferenceOperation(
+                            resource,
+                            new ResourceIdOperation(resource, indexContext),
+                            Full: true,
+                            ShouldIncludeApiVersion: true),
+                        propertyName);
+            }
+        }
+
+        private Operation ConvertModuleOutput(ModuleSymbol moduleSymbol, IndexReplacementContext? indexContext, string propertyName)
+        {
+            return new ModuleOutputOperation(
+                moduleSymbol,
+                indexContext,
+                new ConstantValueOperation(propertyName));
+        }
+
+        private Operation ConvertModulePropertyAccess(ModuleSymbol moduleSymbol, string propertyName, IndexReplacementContext? indexContext)
+        {
+            switch (propertyName)
+            {
+                case LanguageConstants.ModuleNamePropertyName:
+                    // the name is dependent on the name expression which could involve locals in case of a resource collection
+                    return new ModuleNameOperation(moduleSymbol, indexContext);
+                default:
+                    throw new NotImplementedException("Property access is only implemented for module name");
+            }
+        }
+
+        private Operation ConvertPropertyAccess(PropertyAccessSyntax propertyAccess)
+        {
+            if (context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is DeclaredResourceMetadata resource)
+            {
+                // we are doing property access on a single resource
+                var indexContext = TryGetReplacementContext(resource, null, propertyAccess);
+                return ConvertResourcePropertyAccess(resource, indexContext, propertyAccess.PropertyName.IdentifierName);
+            }
+
+            if ((propertyAccess.BaseExpression is VariableAccessSyntax || propertyAccess.BaseExpression is ResourceAccessSyntax) &&
+                context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is ResourceMetadata parameter)
+            {
+                // we are doing property access on a single resource
+                // and we are dealing with special case properties
+                return ConvertResourcePropertyAccess(parameter, null, propertyAccess.PropertyName.IdentifierName);
+            }
+
+            if (propertyAccess.BaseExpression is ArrayAccessSyntax propArrayAccess &&
+                context.SemanticModel.ResourceMetadata.TryLookup(propArrayAccess.BaseExpression) is DeclaredResourceMetadata resourceCollection)
+            {
+                // we are doing property access on an array access of a resource collection
+                var indexContext = TryGetReplacementContext(resourceCollection, propArrayAccess.IndexExpression, propertyAccess);
+                return ConvertResourcePropertyAccess(resourceCollection, indexContext, propertyAccess.PropertyName.IdentifierName);
+            }
+
+            if (propertyAccess.BaseExpression is PropertyAccessSyntax &&
+                context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is ModuleOutputResourceMetadata moduleOutput &&
+                !moduleOutput.Module.IsCollection)
+            {
+                // we are doing property access on an output of a non-collection module.
+                // and we are dealing with special case properties
+                return this.ConvertResourcePropertyAccess(moduleOutput, null, propertyAccess.PropertyName.IdentifierName);
+            }
+
+            if (propertyAccess.BaseExpression is PropertyAccessSyntax moduleCollectionOutputProperty &&
+                moduleCollectionOutputProperty.BaseExpression is PropertyAccessSyntax moduleCollectionOutputs &&
+                moduleCollectionOutputs.BaseExpression is ArrayAccessSyntax moduleArrayAccess &&
+                context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is ModuleOutputResourceMetadata moduleCollectionOutputMetadata &&
+                moduleCollectionOutputMetadata.Module.IsCollection)
+            {
+                // we are doing property access on an output of an array of modules.
+                // and we are dealing with special case properties
+                var indexContext = TryGetReplacementContext(moduleCollectionOutputMetadata.NameSyntax, moduleArrayAccess.IndexExpression, propertyAccess);
+                return ConvertResourcePropertyAccess(moduleCollectionOutputMetadata, indexContext, propertyAccess.PropertyName.IdentifierName);
+            }
+
+            if (context.SemanticModel.GetSymbolInfo(propertyAccess.BaseExpression) is ModuleSymbol moduleSymbol)
+            {
+                // we are doing property access on a single module
+                var indexContext = TryGetReplacementContext(GetModuleNameSyntax(moduleSymbol), null, propertyAccess);
+                return ConvertModulePropertyAccess(moduleSymbol, propertyAccess.PropertyName.IdentifierName, indexContext);
+            }
+
+            if (propertyAccess.BaseExpression is ArrayAccessSyntax modulePropArrayAccess &&
+                context.SemanticModel.GetSymbolInfo(modulePropArrayAccess.BaseExpression) is ModuleSymbol moduleCollectionSymbol)
+            {
+                // we are doing property access on an array access of a module collection
+                var indexContext = TryGetReplacementContext(GetModuleNameSyntax(moduleCollectionSymbol), modulePropArrayAccess.IndexExpression, propertyAccess);
+                return ConvertModulePropertyAccess(moduleCollectionSymbol, propertyAccess.PropertyName.IdentifierName, indexContext);
+            }
+
+            if (propertyAccess.BaseExpression is PropertyAccessSyntax childPropertyAccess &&
+                childPropertyAccess.PropertyName.NameEquals(LanguageConstants.ModuleOutputsPropertyName))
+            {
+                if (childPropertyAccess.BaseExpression is VariableAccessSyntax grandChildVariableAccess &&
+                    context.SemanticModel.GetSymbolInfo(grandChildVariableAccess) is VariableSymbol variableSymbol &&
+                    context.VariablesToInline.Contains(variableSymbol))
+                {
+                    // This is imprecise as we don't check that that variable being accessed is solely composed of modules. We'd end up generating incorrect code for:
+                    // var foo = false ? mod1 : varWithOutputs
+                    // var bar = foo.outputs.someProp
+                    return new PropertyAccessOperation(
+                        new PropertyAccessOperation(
+                            ConvertVariableAccess(grandChildVariableAccess),
+                            propertyAccess.PropertyName.IdentifierName),
+                        "value");
+                }
+
+                if (context.SemanticModel.GetSymbolInfo(childPropertyAccess.BaseExpression) is ModuleSymbol outputModuleSymbol)
+                {
+                    var indexContext = TryGetReplacementContext(GetModuleNameSyntax(outputModuleSymbol), null, propertyAccess);
+                    return ConvertModuleOutput(outputModuleSymbol, indexContext, propertyAccess.PropertyName.IdentifierName);
+                }
+
+                if (childPropertyAccess.BaseExpression is ArrayAccessSyntax outputModulePropArrayAccess &&
+                    context.SemanticModel.GetSymbolInfo(outputModulePropArrayAccess.BaseExpression) is ModuleSymbol outputArrayModuleSymbol)
+                {
+                    var indexContext = TryGetReplacementContext(GetModuleNameSyntax(outputArrayModuleSymbol), outputModulePropArrayAccess.IndexExpression, propertyAccess);
+                    return ConvertModuleOutput(outputArrayModuleSymbol, indexContext, propertyAccess.PropertyName.IdentifierName);
+                }
+            }
+
+            return new PropertyAccessOperation(
+                ConvertExpressionSyntax(propertyAccess.BaseExpression),
+                propertyAccess.PropertyName.IdentifierName);
+        }
+
+        private Operation ConvertVariableAccess(VariableAccessSyntax variableAccessSyntax)
+        {
+            var name = variableAccessSyntax.Name.IdentifierName;
+
+            if (variableAccessSyntax is ExplicitVariableAccessSyntax)
+            {
+                //just return a call to variables.
+                return new ExplicitVariableAccessOperation(name);
+            }
+
+            var symbol = context.SemanticModel.GetSymbolInfo(variableAccessSyntax);
+
+            switch (symbol)
+            {
+                case ParameterSymbol parameterSymbol when context.SemanticModel.ResourceMetadata.TryLookup(parameterSymbol.DeclaringSyntax) is {} resource:
+                    // This is a reference to a pre-existing resource where the resource ID was passed in as a
+                    // string. Generate a call to reference().
+                    return GetResourceReference(resource, null, true);
+                case ParameterSymbol parameterSymbol:
+                    return new ParameterAccessOperation(parameterSymbol);
+
+                case VariableSymbol variableSymbol:
+                    if (context.VariablesToInline.Contains(variableSymbol))
+                    {
+                        // we've got a runtime dependency, so we have to inline the variable usage
+                        return ConvertExpressionSyntax(variableSymbol.DeclaringVariable.Value);
+                    }
+
+                    return new VariableAccessOperation(variableSymbol);
+
+                case ResourceSymbol when context.SemanticModel.ResourceMetadata.TryLookup(variableAccessSyntax) is { } resource:
+                    return GetResourceReference(resource, null, true);
+
+                case ModuleSymbol moduleSymbol:
+                    return GetModuleOutputsReference(moduleSymbol, null);
+
+                case LocalVariableSymbol localVariableSymbol:
+                    return GetLocalVariable(localVariableSymbol);
+
+                default:
+                    throw new NotImplementedException($"Encountered an unexpected symbol kind '{symbol?.Kind}' when generating a variable access expression.");
+
+            }
+        }
+
+        private Operation ConvertResourceAccess(ResourceAccessSyntax resourceAccessSyntax)
+        {
+            if (context.SemanticModel.ResourceMetadata.TryLookup(resourceAccessSyntax) is { } resource)
+            {
+                return GetResourceReference(resource, null, true);
+            }
+
+            throw new NotImplementedException($"Unable to obtain resource metadata when generating a resource access expression.");
+        }
+
+        private Operation ConvertString(StringSyntax syntax)
+        {
+            if (syntax.TryGetLiteralValue() is string literalStringValue)
+            {
+                // no need to build a format string
+                return new ConstantValueOperation(literalStringValue);
+            }
+
+            var formatArgs = new Operation[syntax.Expressions.Length + 1];
+
+            var formatString = StringFormatConverter.BuildFormatString(syntax);
+            formatArgs[0] = new ConstantValueOperation(formatString);
+
+            for (var i = 0; i < syntax.Expressions.Length; i++)
+            {
+                formatArgs[i + 1] = ConvertExpressionSyntax(syntax.Expressions[i]);
+            }
+
+            return new FunctionCallOperation("format", formatArgs);
+        }
+
+        private Operation GetModuleOutputsReference(ModuleSymbol moduleSymbol, IndexReplacementContext? indexContext)
+        {
+            return new PropertyAccessOperation(
+                new ModuleReferenceOperation(
+                    moduleSymbol,
+                    indexContext),
+                "outputs");
+        }
+
+        private Operation GetResourceReference(ResourceMetadata resource, IndexReplacementContext? indexContext, bool full)
+        {
+            return (context.Settings.EnableSymbolicNames, resource) switch {
+                (true, DeclaredResourceMetadata declaredResource) => new SymbolicResourceReferenceOperation(declaredResource, indexContext, true),
+                _ => new ResourceReferenceOperation(
+                    resource,
+                    new ResourceIdOperation(resource, indexContext),
+                    Full: true,
+                    ShouldIncludeApiVersion: true),
+            };
+        }
+
+        private Operation GetLocalVariable(LocalVariableSymbol localVariableSymbol)
+        {
+            if (this.localReplacements.TryGetValue(localVariableSymbol, out var replacement))
+            {
+                // the current context has specified an expression to be used for this local variable symbol
+                // to override the regular conversion
+                return replacement;
+            }
+
+            var @for = GetEnclosingForExpression(localVariableSymbol);
+            return GetLoopVariable(localVariableSymbol, @for, CreateCopyIndexFunction(@for));
+        }
+
+        private Operation GetLoopVariable(LocalVariableSymbol localVariableSymbol, ForSyntax @for, Operation indexOperation)
+        {
+            return localVariableSymbol.LocalKind switch
+            {
+                // this is the "item" variable of a for-expression
+                // to emit this, we need to index the array expression by the copyIndex() function
+                LocalKind.ForExpressionItemVariable => GetLoopItemVariable(@for, indexOperation),
+
+                // this is the "index" variable of a for-expression inside a variable block
+                // to emit this, we need to return a copyIndex(...) function
+                LocalKind.ForExpressionIndexVariable => indexOperation,
+
+                _ => throw new NotImplementedException($"Unexpected local variable kind '{localVariableSymbol.LocalKind}'."),
+            };
+        }
+
+        public ForSyntax GetEnclosingForExpression(LocalVariableSymbol localVariable)
+        {
+            // we're following the symbol hierarchy rather than syntax hierarchy because
+            // this guarantees a single hop in all cases
+            var symbolParent = this.context.SemanticModel.GetSymbolParent(localVariable);
+            if (symbolParent is not LocalScope localScope)
+            {
+                throw new NotImplementedException($"{nameof(LocalVariableSymbol)} has un unexpected parent of type '{symbolParent?.GetType().Name}'.");
+            }
+
+            if (localScope.DeclaringSyntax is ForSyntax @for)
+            {
+                return @for;
+            }
+
+            throw new NotImplementedException($"{nameof(LocalVariableSymbol)} was declared by an unexpected syntax type '{localScope.DeclaringSyntax?.GetType().Name}'.");
+        }
+
+        private string? GetCopyIndexName(ForSyntax @for)
+        {
+            return this.context.SemanticModel.Binder.GetParent(@for) switch
+            {
+                // copyIndex without name resolves to module/resource loop index in the runtime
+                ResourceDeclarationSyntax => null,
+                ModuleDeclarationSyntax => null,
+
+                // variable copy index has the name of the variable
+                VariableDeclarationSyntax variable when variable.Name.IsValid => variable.Name.IdentifierName,
+
+                // output loops are only allowed at the top level and don't have names, either
+                OutputDeclarationSyntax => null,
+
+                // the property copy index has the name of the property
+                ObjectPropertySyntax property when property.TryGetKeyText() is { } key && ReferenceEquals(property.Value, @for) => key,
+
+                _ => throw new NotImplementedException("Unexpected for-expression grandparent.")
+            };
+        }
+
+        private Operation CreateCopyIndexFunction(ForSyntax @for)
+        {
+            var copyIndexName = GetCopyIndexName(@for);
+            return copyIndexName is null
+                ? new FunctionCallOperation("copyIndex")
+                : new FunctionCallOperation("copyIndex", new ConstantValueOperation(copyIndexName));
+        }
+
+        private Operation GetLoopItemVariable(ForSyntax @for, Operation indexOperation)
+        {
+            // loop item variable should be replaced with <array expression>[<index expression>]
+            var forOperation = ConvertExpressionSyntax(@for.Expression);
+
+            return new ArrayAccessOperation(forOperation, indexOperation);
+        }
+
+        public IndexReplacementContext? TryGetReplacementContext(DeclaredResourceMetadata resource, SyntaxBase? indexExpression, SyntaxBase newContext)
+        {
+            var movedSyntax = context.Settings.EnableSymbolicNames ? resource.Symbol.NameSyntax : resource.NameSyntax;
+
+            return TryGetReplacementContext(movedSyntax, indexExpression, newContext);
+        }
+
+        public IndexReplacementContext? TryGetReplacementContext(SyntaxBase nameSyntax, SyntaxBase? indexExpression, SyntaxBase newContext)
+        {
+            var inaccessibleLocals = this.context.DataFlowAnalyzer.GetInaccessibleLocalsAfterSyntaxMove(nameSyntax, newContext);
+            var inaccessibleLocalLoops = inaccessibleLocals.Select(local => GetEnclosingForExpression(local)).Distinct().ToList();
+
+            switch (inaccessibleLocalLoops.Count)
+            {
+                case 0:
+                    // moving the name expression does not produce any inaccessible locals (no locals means no loops)
+                    // regardless if there is an index expression or not, we don't need to append replacements
+                    if (indexExpression is null)
+                    {
+                        return null;
+                    }
+
+                    return new(this.localReplacements, ConvertExpressionSyntax(indexExpression));
+
+                case 1 when indexExpression is not null:
+                    // TODO: Run data flow analysis on the array expression as well. (Will be needed for nested resource loops)
+                    var @for = inaccessibleLocalLoops.Single();
+                    var localReplacements = this.localReplacements;
+                    var converter = new OperationConverter(this.context, localReplacements);
+                    foreach (var local in inaccessibleLocals)
+                    {
+                        // Allow local variable symbol replacements to be overwritten, as there are scenarios where we recursively generate expressions for the same index symbol
+                        var replacementValue = GetLoopVariable(local, @for, converter.ConvertExpressionSyntax(indexExpression));
+                        localReplacements = localReplacements.SetItem(local, replacementValue);
+                    }
+
+                    return new(localReplacements, converter.ConvertExpressionSyntax(indexExpression));
+
+                default:
+                    throw new NotImplementedException("Mismatch between count of index expressions and inaccessible symbols during array access index replacement.");
+            }
+        }
+
+        public static SyntaxBase GetModuleNameSyntax(ModuleSymbol moduleSymbol)
+        {
+            // this condition should have already been validated by the type checker
+            return moduleSymbol.TryGetBodyPropertyValue(LanguageConstants.ModuleNamePropertyName) ?? throw new ArgumentException($"Expected module syntax body to contain property 'name'");
+        }
+    }
+}
+

--- a/src/Bicep.Core/Emit/ScopeHelper.cs
+++ b/src/Bicep.Core/Emit/ScopeHelper.cs
@@ -66,16 +66,8 @@ namespace Bicep.Core.Emit
                 return null;
             }
 
-            var (scopeSymbol, indexExpression) = scopeValue switch
-            {
-                // scope indexing can only happen with references to module or resource collections
-                ArrayAccessSyntax { BaseExpression: VariableAccessSyntax baseVariableAccess } arrayAccess => (semanticModel.GetSymbolInfo(baseVariableAccess), arrayAccess.IndexExpression),
-                ArrayAccessSyntax { BaseExpression: ResourceAccessSyntax baseVariableAccess } arrayAccess => (semanticModel.GetSymbolInfo(baseVariableAccess), arrayAccess.IndexExpression),
-
-                // all other scope expressions
-                _ => (semanticModel.GetSymbolInfo(scopeValue), null)
-            };
-
+            var (baseSyntax, indexExpression) = SyntaxHelper.UnwrapArrayAccessSyntax(scopeValue);
+            var scopeSymbol = semanticModel.GetSymbolInfo(baseSyntax);
             var scopeType = semanticModel.GetTypeInfo(scopeValue);
 
             switch (scopeType)

--- a/src/Bicep.Core/Intermediate/ArrayAccessOperation.cs
+++ b/src/Bicep.Core/Intermediate/ArrayAccessOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public record ArrayAccessOperation(
+        Operation Base,
+        Operation Access) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitArrayAccessOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ArrayOperation.cs
+++ b/src/Bicep.Core/Intermediate/ArrayOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ArrayOperation(
+        ImmutableArray<Operation> Items) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitArrayOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ConstantValueOperation.cs
+++ b/src/Bicep.Core/Intermediate/ConstantValueOperation.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public record ConstantValueOperation : Operation
+    {
+        public ConstantValueOperation(string value)
+        {
+            Value = value;
+        }
+
+        public ConstantValueOperation(long value)
+        {
+            Value = value;
+        }
+
+        public ConstantValueOperation(bool value)
+        {
+            Value = value;
+        }
+
+        public object Value { get; }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitConstantValueOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ExplicitVariableAccessOperation.cs
+++ b/src/Bicep.Core/Intermediate/ExplicitVariableAccessOperation.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public record ExplicitVariableAccessOperation(
+        string Name) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitExplicitVariableAccessOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ForLoopOperation.cs
+++ b/src/Bicep.Core/Intermediate/ForLoopOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public record ForLoopOperation(
+        Operation Expression,
+        Operation Body) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitForLoopOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/FunctionCallOperation.cs
+++ b/src/Bicep.Core/Intermediate/FunctionCallOperation.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Intermediate
+{
+    public record FunctionCallOperation(
+        string Name,
+        ImmutableArray<Operation> Parameters) : Operation
+    {
+        public FunctionCallOperation(string name, params Operation[] parameters)
+            : this(name, parameters.ToImmutableArray())
+        {
+        }
+
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitFunctionCallOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/GetKeyVaultSecretOperation.cs
+++ b/src/Bicep.Core/Intermediate/GetKeyVaultSecretOperation.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public record GetKeyVaultSecretOperation(
+        ResourceIdOperation KeyVaultId,
+        Operation SecretName,
+        Operation? SecretVersion) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitGetKeyVaultSecretOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/IOperationVisitor.cs
+++ b/src/Bicep.Core/Intermediate/IOperationVisitor.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public interface IOperationVisitor
+    {
+        void VisitConstantValueOperation(ConstantValueOperation operation);
+
+        void VisitPropertyAccessOperation(PropertyAccessOperation operation);
+
+        void VisitArrayAccessOperation(ArrayAccessOperation operation);
+
+        void VisitResourceIdOperation(ResourceIdOperation operation);
+
+        void VisitResourceNameOperation(ResourceNameOperation operation);
+
+        void VisitResourceTypeOperation(ResourceTypeOperation operation);
+
+        void VisitResourceApiVersionOperation(ResourceApiVersionOperation operation);
+
+        void VisitResourceReferenceOperation(ResourceReferenceOperation operation);
+
+        void VisitSymbolicResourceReferenceOperation(SymbolicResourceReferenceOperation operation);
+
+        void VisitResourceInfoOperation(ResourceInfoOperation operation);
+
+        void VisitModuleNameOperation(ModuleNameOperation operation);
+
+        void VisitModuleOutputOperation(ModuleOutputOperation operation);
+
+        void VisitVariableAccessOperation(VariableAccessOperation operation);
+
+        void VisitExplicitVariableAccessOperation(ExplicitVariableAccessOperation operation);
+
+        void VisitParameterAccessOperation(ParameterAccessOperation operation);
+
+        void VisitModuleReferenceOperation(ModuleReferenceOperation operation);
+
+        void VisitFunctionCallOperation(FunctionCallOperation operation);
+
+        void VisitArrayOperation(ArrayOperation operation);
+
+        void VisitForLoopOperation(ForLoopOperation operation);
+
+        void VisitGetKeyVaultSecretOperation(GetKeyVaultSecretOperation operation);
+
+        void VisitNullValueOperation(NullValueOperation operation);
+
+        void VisitObjectOperation(ObjectOperation operation);
+
+        void VisitObjectPropertyOperation(ObjectPropertyOperation operation);
+
+        void VisitOutputOperation(OutputOperation operation);
+
+        void VisitParameterOperation(ParameterOperation operation);
+
+        void VisitImportOperation(ImportOperation operation);
+
+        void VisitVariableOperation(VariableOperation operation);
+
+        void VisitProgramOperation(ProgramOperation operation);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ImportOperation.cs
+++ b/src/Bicep.Core/Intermediate/ImportOperation.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.TypeSystem;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ImportOperation(
+        string AliasName,
+        NamespaceType NamespaceType,
+        Operation? Config) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitImportOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/IndexReplacementContext.cs
+++ b/src/Bicep.Core/Intermediate/IndexReplacementContext.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.Intermediate
+{
+    public record IndexReplacementContext(
+        ImmutableDictionary<LocalVariableSymbol, Operation> LocalReplacements,
+        Operation Index);
+}

--- a/src/Bicep.Core/Intermediate/ModuleNameOperation.cs
+++ b/src/Bicep.Core/Intermediate/ModuleNameOperation.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ModuleNameOperation(
+        ModuleSymbol Symbol,
+        IndexReplacementContext? IndexContext) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitModuleNameOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ModuleOutputOperation.cs
+++ b/src/Bicep.Core/Intermediate/ModuleOutputOperation.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ModuleOutputOperation(
+        ModuleSymbol Symbol,
+        IndexReplacementContext? IndexContext,
+        Operation PropertyName) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitModuleOutputOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ModuleReferenceOperation.cs
+++ b/src/Bicep.Core/Intermediate/ModuleReferenceOperation.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ModuleReferenceOperation(
+        ModuleSymbol Symbol,
+        IndexReplacementContext? IndexContext) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitModuleReferenceOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/NullValueOperation.cs
+++ b/src/Bicep.Core/Intermediate/NullValueOperation.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public record NullValueOperation() : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitNullValueOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ObjectOperation.cs
+++ b/src/Bicep.Core/Intermediate/ObjectOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ObjectOperation(
+        ImmutableArray<ObjectPropertyOperation> Properties) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitObjectOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ObjectPropertyOperation.cs
+++ b/src/Bicep.Core/Intermediate/ObjectPropertyOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public record ObjectPropertyOperation(
+        Operation Key,
+        Operation Value) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitObjectPropertyOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/Operation.cs
+++ b/src/Bicep.Core/Intermediate/Operation.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public abstract record Operation()
+    {
+        public abstract void Accept(IOperationVisitor visitor);
+    }
+}

--- a/src/Bicep.Core/Intermediate/OutputOperation.cs
+++ b/src/Bicep.Core/Intermediate/OutputOperation.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Intermediate
+{
+    public record OutputOperation(
+        string Name,
+        string Type,
+        Operation Value,
+        ImmutableArray<ObjectPropertyOperation> AdditionalProperties) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitOutputOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ParameterAccessOperation.cs
+++ b/src/Bicep.Core/Intermediate/ParameterAccessOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ParameterAccessOperation(
+        ParameterSymbol Symbol) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitParameterAccessOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ParameterOperation.cs
+++ b/src/Bicep.Core/Intermediate/ParameterOperation.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ParameterOperation(
+        string Name,
+        ImmutableArray<ObjectPropertyOperation> AdditionalProperties) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitParameterOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ProgramOperation.cs
+++ b/src/Bicep.Core/Intermediate/ProgramOperation.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ProgramOperation(
+        ImmutableArray<ParameterOperation> Parameters,
+        ImmutableArray<OutputOperation> Outputs,
+        ImmutableArray<ImportOperation> Imports,
+        ImmutableArray<VariableOperation> Variables) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitProgramOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/PropertyAccessOperation.cs
+++ b/src/Bicep.Core/Intermediate/PropertyAccessOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public record PropertyAccessOperation(
+        Operation Base,
+        string PropertyName) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitPropertyAccessOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ResourceApiVersionOperation.cs
+++ b/src/Bicep.Core/Intermediate/ResourceApiVersionOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ResourceApiVersionOperation(
+        ResourceMetadata Metadata) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceApiVersionOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ResourceIdOperation.cs
+++ b/src/Bicep.Core/Intermediate/ResourceIdOperation.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ResourceIdOperation(
+        ResourceMetadata Metadata,
+        IndexReplacementContext? IndexContext) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceIdOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ResourceInfoOperation.cs
+++ b/src/Bicep.Core/Intermediate/ResourceInfoOperation.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ResourceInfoOperation(
+        DeclaredResourceMetadata Metadata,
+        IndexReplacementContext? IndexContext) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceInfoOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ResourceNameOperation.cs
+++ b/src/Bicep.Core/Intermediate/ResourceNameOperation.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ResourceNameOperation(
+        ResourceMetadata Metadata,
+        IndexReplacementContext? IndexContext,
+        bool FullyQualified) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceNameOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ResourceReferenceOperation.cs
+++ b/src/Bicep.Core/Intermediate/ResourceReferenceOperation.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ResourceReferenceOperation(
+        ResourceMetadata Metadata,
+        ResourceIdOperation ResourceId,
+        bool Full,
+        bool ShouldIncludeApiVersion) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceReferenceOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/ResourceTypeOperation.cs
+++ b/src/Bicep.Core/Intermediate/ResourceTypeOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.Intermediate
+{
+    public record ResourceTypeOperation(
+        ResourceMetadata Metadata) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitResourceTypeOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/SymbolicResourceReferenceOperation.cs
+++ b/src/Bicep.Core/Intermediate/SymbolicResourceReferenceOperation.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics.Metadata;
+
+namespace Bicep.Core.Intermediate
+{
+    public record SymbolicResourceReferenceOperation(
+        DeclaredResourceMetadata Metadata,
+        IndexReplacementContext? IndexContext,
+        bool Full) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitSymbolicResourceReferenceOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/VariableAccessOperation.cs
+++ b/src/Bicep.Core/Intermediate/VariableAccessOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.Intermediate
+{
+    public record VariableAccessOperation(
+        VariableSymbol Symbol) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitVariableAccessOperation(this);
+    }
+}

--- a/src/Bicep.Core/Intermediate/VariableOperation.cs
+++ b/src/Bicep.Core/Intermediate/VariableOperation.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate
+{
+    public record VariableOperation(
+        string Name,
+        Operation Value) : Operation
+    {
+        public override void Accept(IOperationVisitor visitor)
+            => visitor.VisitVariableOperation(this);
+    }
+}

--- a/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs
@@ -115,15 +115,10 @@ namespace Bicep.Core.Semantics.Metadata
                         }
                         else if (symbol.TryGetBodyPropertyValue(LanguageConstants.ResourceParentPropertyName) is { } referenceParentSyntax)
                         {
-                            SyntaxBase? indexExpression = null;
-                            if (referenceParentSyntax is ArrayAccessSyntax arrayAccess)
-                            {
-                                referenceParentSyntax = arrayAccess.BaseExpression;
-                                indexExpression = arrayAccess.IndexExpression;
-                            }
+                            var (baseSyntax, indexExpression) = SyntaxHelper.UnwrapArrayAccessSyntax(referenceParentSyntax);
 
                             // parent property reference syntax
-                            if (TryLookup(referenceParentSyntax) is { } parentMetadata)
+                            if (TryLookup(baseSyntax) is { } parentMetadata)
                             {
                                 return new DeclaredResourceMetadata(
                                     resourceType,

--- a/src/Bicep.Core/Semantics/ResourceAncestorVisitor.cs
+++ b/src/Bicep.Core/Semantics/ResourceAncestorVisitor.cs
@@ -41,18 +41,13 @@ namespace Bicep.Core.Semantics
             }
             else if (resource.Symbol.TryGetBodyPropertyValue(LanguageConstants.ResourceParentPropertyName) is { } referenceParentSyntax)
             {
-                SyntaxBase? indexExpression = null;
-                if (referenceParentSyntax is ArrayAccessSyntax arrayAccess)
-                {
-                    referenceParentSyntax = arrayAccess.BaseExpression;
-                    indexExpression = arrayAccess.IndexExpression;
-                }
+                var (baseSyntax, indexExpression) = SyntaxHelper.UnwrapArrayAccessSyntax(referenceParentSyntax);
 
                 // parent property reference syntax
                 //
                 // This check is safe because we don't allow resources declared as parameters to be used with the
                 // parent property. Resources provided as parameters have an unknown scope.
-                if (semanticModel.ResourceMetadata.TryLookup(referenceParentSyntax) is DeclaredResourceMetadata parentResource)
+                if (semanticModel.ResourceMetadata.TryLookup(baseSyntax) is DeclaredResourceMetadata parentResource)
                 {
                     this.ancestry.Add(resource, new ResourceAncestor(ResourceAncestorType.ParentProperty, parentResource, indexExpression));
                 }


### PR DESCRIPTION
I've been experimenting with an IR on a branch for a while, thought I'd submit a PR to start a discussion on it and see if it's interesting. (@rynowak FYI) I'm not going to be offended if the answer is "no", this started off as a PoC 😄 

Some of the benefits I see with this approach:
* Moves away from being syntax-directed, making things like lowering, constant-folding, or other transformations simpler
* Simplifies the 'loop index manipulation' code
* Creates a more natural place to fit 'pre-emission' checks (e.g. so `EmitLimitationCalculator` could be replaced with a lazy alternative)

This feature is similar in design & usage to the [BoundTree](https://github.com/dotnet/roslyn/tree/main/src/Compilers/CSharp/Portable/BoundTree) APIs used in the Roslyn compiler (classes available [here](https://github.com/dotnet/roslyn/blob/39c57377c6075b2ee9ae343d293a5ce3b368e6bc/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs)).