### PR TITLE
Use default built-in codespace image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,34 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal
+FROM mcr.microsoft.com/vscode/devcontainers/universal:linux
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Configure apt and install packages
-RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils dialog libssl1.1 2>&1 \
-    #
-    # Verify wget, jq, unzip, git and process tools installed
-    && apt-get -y install git iproute2 procps wget unzip jq \
-    #
-    # Upgrade existing packages
-    && apt-get -y upgrade \
-    #
-    # Install Docker CE CLI
-    && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \
-    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
-    && apt-get update \
-    && apt-get install -y docker-ce-cli \
-    #
-    # [Optional] Add sudo support for the non-root user
-    && apt-get install -y sudo \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
-
-# Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=
-
-CMD ["bash"]
+# Install dotnet 6.0
+RUN curl -sfL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 6.0

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,0 @@
-FROM mcr.microsoft.com/vscode/devcontainers/universal:linux
-
-# Install dotnet 6.0
-RUN curl -sfL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 6.0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,12 @@
 {
   "name": "Bicep Development Environment",
-  "dockerFile": "Dockerfile",
-  "remoteUser": "codespace",
   "extensions": [
     "msazurermtools.azurerm-vscode-tools",
     "ms-azuretools.vscode-bicep",
     "ms-dotnettools.csharp",
     "ms-azuretools.vscode-docker",
-    "ms-vsliveshare.vsliveshare",
     "editorconfig.editorconfig",
-    "github.vscode-pull-request-github",
-    "davidanson.vscode-markdownlint"
-  ],
-  "overrideCommand": false,
-  "mounts": [
-    "source=codespaces-linux-var-lib-docker,target=/var/lib/docker,type=volume"
-  ],
-  "runArgs": [
-    "--cap-add=SYS_PTRACE",
-    "--security-opt",
-    "seccomp=unconfined",
-    "--privileged",
-    "--init"
+    "github.vscode-pull-request-github"
   ],
   "features": {
     "github-cli": "latest",
@@ -29,6 +14,9 @@
     "node": {
       "version": "lts",
       "nodeGypDependencies": true
+    },
+    "dotnet": {
+      "version": "6.0"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,7 @@
 {
   "name": "Bicep Development Environment",
   "dockerFile": "Dockerfile",
-  "runArgs": [
-    "-v",
-    "/var/run/docker.sock:/var/run/docker.sock"
-  ],
-  "settings": {
-    "terminal.integrated.profiles.linux": {
-      "bash": {
-        "path": "/bin/bash"
-      }
-    }
-  },
+  "remoteUser": "codespace",
   "extensions": [
     "msazurermtools.azurerm-vscode-tools",
     "ms-azuretools.vscode-bicep",
@@ -19,9 +9,19 @@
     "ms-azuretools.vscode-docker",
     "ms-vsliveshare.vsliveshare",
     "editorconfig.editorconfig",
-    "github.copilot",
     "github.vscode-pull-request-github",
     "davidanson.vscode-markdownlint"
+  ],
+  "overrideCommand": false,
+  "mounts": [
+    "source=codespaces-linux-var-lib-docker,target=/var/lib/docker,type=volume"
+  ],
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--privileged",
+    "--init"
   ],
   "features": {
     "github-cli": "latest",


### PR DESCRIPTION
The default Codespaces image comes with a bunch of nice CLI utils pre-installed. This PR switches us back to using this image, and uses devcontainer "features" to install necessary pre-requisites.