### PR TITLE
Add support for publishing ARM template files

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
@@ -132,6 +132,16 @@ namespace Bicep.Cli.IntegrationTests
             // we should still only have 1 module
             expectedCompiledStream.Position = 0;
             testClient.Should().OnlyHaveModule("v1", expectedCompiledStream);
+
+            // publish the compiled file
+            var (output3, error3, result3) = await Bicep(settings, "publish", compiledFilePath, "--target", $"br:{registryStr}/{repository}:v1");
+            result3.Should().Be(0);
+            output3.Should().BeEmpty();
+            AssertNoErrors(error2);
+
+            // we should still only have 1 module
+            expectedCompiledStream.Position = 0;
+            testClient.Should().OnlyHaveModule("v1", expectedCompiledStream);
         }
 
         [DataTestMethod]

--- a/src/Bicep.Cli/Commands/PublishCommand.cs
+++ b/src/Bicep.Cli/Commands/PublishCommand.cs
@@ -51,9 +51,7 @@ namespace Bicep.Cli.Commands
             var configuration = this.configurationManager.GetConfiguration(inputUri);
             var moduleReference = ValidateReference(args.TargetModuleReference, configuration);
 
-            if (PathHelper.HasExtension(inputUri, LanguageConstants.JsonFileExtension) ||
-                PathHelper.HasExtension(inputUri, LanguageConstants.JsoncFileExtension) ||
-                PathHelper.HasExtension(inputUri, LanguageConstants.ArmTemplateFileExtension))
+            if (PathHelper.HasArmTemplateLikeExtension(inputUri))
             {
                 // Publishing an ARM template file.
                 using var armTemplateStream = this.fileSystem.FileStream.Create(inputPath, FileMode.Open, FileAccess.Read);

--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -44,11 +44,12 @@ $@"
     Publishes the .bicep file to the module registry.
 
     Arguments:
-      <file>        The input file
+      <file>        The input file (can be a Bicep file or an ARM template file)
       <ref>         The module reference
 
     Examples:
       bicep publish file.bicep --target br:example.azurecr.io/hello/world:v1
+      bicep publish file.json --target br:example.azurecr.io/hello/world:v1
 
   {exeName} restore <file>
     Restores external modules from the specified Bicep file to the local module cache.

--- a/src/Bicep.Core/FileSystem/PathHelper.cs
+++ b/src/Bicep.Core/FileSystem/PathHelper.cs
@@ -150,6 +150,11 @@ namespace Bicep.Core.FileSystem
 
         public static bool HasBicepExtension(Uri uri) => HasExtension(uri, BicepExtension);
 
+        public static bool HasArmTemplateLikeExtension(Uri uri) =>
+                HasExtension(uri, LanguageConstants.JsonFileExtension) ||
+                HasExtension(uri, LanguageConstants.JsoncFileExtension) ||
+                HasExtension(uri, LanguageConstants.ArmTemplateFileExtension);
+
         private static string GetNormalizedPath(Uri uri) =>
             uri.Scheme != Uri.UriSchemeFile ? uri.AbsoluteUri.TrimEnd('/') : uri.AbsolutePath;
 

--- a/src/Bicep.Core/Workspaces/SourceFileFactory.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileFactory.cs
@@ -25,9 +25,7 @@ namespace Bicep.Core.Workspaces
 
         public static ISourceFile CreateSourceFile(Uri fileUri, string fileContents, ModuleReference? moduleReference = null)
         {
-            if (PathHelper.HasExtension(fileUri, LanguageConstants.JsonFileExtension) ||
-                PathHelper.HasExtension(fileUri, LanguageConstants.JsoncFileExtension) ||
-                PathHelper.HasExtension(fileUri, LanguageConstants.ArmTemplateFileExtension))
+            if (PathHelper.HasArmTemplateLikeExtension(fileUri))
             {
                 return moduleReference is TemplateSpecModuleReference
                     ? CreateTemplateSpecFile(fileUri, fileContents)


### PR DESCRIPTION
Currently `bicep publish` only supports publishing Bicep files. The PR makes it work with ARM template files. This is required for the registry module CI to publish modules.