### PR TITLE
Avoid parsing snippets with placeholders

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -25,34 +25,25 @@ namespace Bicep.LangServer.UnitTests.Snippets
         private readonly NamespaceType azNamespaceType = BicepTestConstants.NamespaceProvider.TryGetNamespace("az", "az", ResourceScope.ResourceGroup)!;
 
         [TestMethod]
-        public void GetDescriptionAndText_WithEmptyInput_ReturnsEmptyDescriptionAndText()
+        public void GetDescriptionAndSnippetText_WithEmptyInput_ReturnsEmptyDescriptionAndText()
         {
-            (string description, string text) = snippetsProvider.GetDescriptionAndText(string.Empty, @"C:\foo.bicep");
+            (string description, string text) = snippetsProvider.GetDescriptionAndSnippetText(string.Empty, @"C:\foo.bicep");
 
-            Assert.IsTrue(description.Equals(string.Empty));
-            Assert.IsTrue(text.Equals(string.Empty));
+            description.Should().Be(string.Empty);
+            text.Should().Be(string.Empty);
         }
 
         [TestMethod]
-        public void GetDescriptionAndText_WithNullInput_ReturnsEmptyDescriptionAndText()
+        public void GetDescriptionAndSnippetText_WithOnlyWhitespaceInput_ReturnsEmptyDescriptionAndText()
         {
-            (string description, string text) = snippetsProvider.GetDescriptionAndText(null, @"C:\foo.bicep");
+            (string description, string text) = snippetsProvider.GetDescriptionAndSnippetText("   ", @"C:\foo.bicep");
 
-            Assert.IsTrue(description.Equals(string.Empty));
-            Assert.IsTrue(text.Equals(string.Empty));
+            description.Should().Be(string.Empty);
+            text.Should().Be(string.Empty);
         }
 
         [TestMethod]
-        public void GetDescriptionAndText_WithOnlyWhitespaceInput_ReturnsEmptyDescriptionAndText()
-        {
-            (string description, string text) = snippetsProvider.GetDescriptionAndText("   ", @"C:\foo.bicep");
-
-            Assert.IsTrue(description.Equals(string.Empty));
-            Assert.IsTrue(text.Equals(string.Empty));
-        }
-
-        [TestMethod]
-        public void GetDescriptionAndText_WithValidInput_ReturnsDescriptionAndText()
+        public void GetDescriptionAndSnippetText_WithValidInput_ReturnsDescriptionAndText()
         {
             string template = @"// DNS Zone
 resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
@@ -63,7 +54,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   }
 }";
 
-            (string description, string text) = snippetsProvider.GetDescriptionAndText(template, @"C:\foo.bicep");
+            (string description, string text) = snippetsProvider.GetDescriptionAndSnippetText(template, @"C:\foo.bicep");
 
             string expectedText = @"resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   name: '${1:dnsZone}'
@@ -73,12 +64,12 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   }
 }";
 
-            Assert.AreEqual("DNS Zone", description);
-            Assert.AreEqual(expectedText, text);
+            description.Should().Be("DNS Zone");
+            expectedText.Should().Be(text);
         }
 
         [TestMethod]
-        public void GetDescriptionAndText_WithMissingCommentInInput_ReturnsEmptyDescriptionAndValidText()
+        public void GetDescriptionAndSnippetText_WithMissingCommentInInput_ReturnsEmptyDescriptionAndValidText()
         {
             string template = @"resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   name: '${1:dnsZone}'
@@ -88,7 +79,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   }
 }";
 
-            (string description, string text) = snippetsProvider.GetDescriptionAndText(template, @"C:\foo.bicep");
+            (string description, string text) = snippetsProvider.GetDescriptionAndSnippetText(template, @"C:\foo.bicep");
 
             string expectedText = @"resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   name: '${1:dnsZone}'
@@ -98,19 +89,19 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   }
 }";
 
-            Assert.IsTrue(description.Equals(string.Empty));
-            Assert.AreEqual(expectedText, text);
+            description.Should().Be(string.Empty);
+            expectedText.Should().Be(text);
         }
 
         [TestMethod]
-        public void GetDescriptionAndText_WithCommentAndMissingDeclarations_ReturnsEmptyDescriptionAndText()
+        public void GetDescriptionAndSnippetText_WithCommentAndMissingDeclarations_ReturnsEmptyDescriptionAndText()
         {
             string template = @"// DNS Zone";
 
-            (string description, string text) = snippetsProvider.GetDescriptionAndText(template, @"C:\foo.bicep");
+            (string description, string text) = snippetsProvider.GetDescriptionAndSnippetText(template, @"C:\foo.bicep");
 
-            Assert.IsTrue(description.Equals(string.Empty));
-            Assert.IsTrue(text.Equals(string.Empty));
+            description.Should().Be(string.Empty);
+            text.Should().Be(string.Empty);
         }
 
         [TestMethod]
@@ -121,7 +112,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
 
             foreach (Snippet snippet in snippets)
             {
-                Assert.AreEqual(CompletionPriority.High, snippet.CompletionPriority);
+                snippet.CompletionPriority.Should().Be(CompletionPriority.High);
             }
         }
 
@@ -134,7 +125,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
 
             foreach (Snippet snippet in snippets)
             {
-                Assert.AreEqual(CompletionPriority.Medium, snippet.CompletionPriority);
+                snippet.CompletionPriority.Should().Be(CompletionPriority.Medium);
             }
         }
 
@@ -715,14 +706,13 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
         }
 
         [DataTestMethod]
-        [DataRow(null, null)]
         [DataRow("", "")]
         [DataRow("   ", "   ")]
         public void RemoveSnippetPlaceholderComments_WithInvalidInput_ReturnsInputTextAsIs(string input, string expected)
         {
             string actual = snippetsProvider.RemoveSnippetPlaceholderComments(input);
 
-            Assert.AreEqual(expected, actual);
+            actual.Should().Be(expected);
         }
 
         [TestMethod]

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -147,11 +147,11 @@ namespace Bicep.LanguageServer.Completions
         /// <summary>
         /// The current location is after # sign.
         /// </summary>
-        DisableNextLineDiagnosticsDirectiveStart = 1 << 25,
+        DisableNextLineDiagnosticsDirectiveStart = 1 << 26,
 
         /// <summary>
         /// The current location is after '#disable-next-line |'.
         /// </summary>
-        DisableNextLineDiagnosticsCodes = 1 << 26
+        DisableNextLineDiagnosticsCodes = 1 << 27
     }
 }


### PR DESCRIPTION
On my other branch, I was running into a huge number of `ExpectedTokenException` errors on startup, because the `SnippetProvider` processes the snippets *after* placeholder replacement - at which point in time, the file is not a syntactically valid Bicep file. This is unnecessary, and in my branch actually resulted in invalid snippets being generated due to syntax ambiguity.

Here I've modified `SnippetProvider` to do its analysis on the snippets with placeholders instead (which are validated for parse errors on checkin).

To give a concrete example, previously we were trying to parse the following (note that `${` and `}` are not recognized as valid Bicep syntax:
```bicep
resource ${1:aksCluster} 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
  name: ${2:'name'}
  location: ${3:location}
...
```

Now we're trying to parse the following:
```bicep
resource /*${1:aksCluster}*/aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
  name: /*${2:'name'}*/'name'
  location: /*${3:location}*/'location'
...
```