### PR TITLE
Use named pipes for LSP communication

### DIFF
--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -10,7 +10,12 @@ import {
   IActionContext,
   parseError,
 } from "vscode-azureextensionui";
-import { ErrorAction, Message, CloseAction } from "vscode-languageclient/node";
+import {
+  ErrorAction,
+  Message,
+  CloseAction,
+  TransportKind,
+} from "vscode-languageclient/node";
 
 const dotnetRuntimeVersion = "6.0";
 const packagedServerPath = "bicepLanguageServer/Bicep.LangServer.dll";
@@ -41,10 +46,11 @@ async function launchLanguageService(
   const languageServerPath = ensureLanguageServerExists(context);
   getLogger().debug(`Found language server at '${languageServerPath}'.`);
 
-  const serverExecutable: lsp.Executable = {
-    command: dotnetCommandPath,
+  const serverExecutable: lsp.NodeModule = {
+    runtime: dotnetCommandPath,
+    module: languageServerPath,
+    transport: TransportKind.pipe,
     args: [
-      languageServerPath,
       // uncomment the next line to pause server startup until a dotnet debugger has been attached
       // '--wait-for-debugger'
     ],


### PR DESCRIPTION
Closes #5551 

This PR is a follow-up from #5852 to add the ability to switch between stdin/stdout and named pipes for LSP communication, and to set the default to named pipes.