### PR TITLE
Suppress 'Report an issue' on .NET acquisition failure

### DIFF
--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -49,8 +49,9 @@ export async function activate(
   extension.register(createLogger(context, outputChannel));
   registerUIExtensionVariables({ context, outputChannel });
 
-  await activateWithTelemetryAndErrorHandling(async () => {
+  await activateWithTelemetryAndErrorHandling(async (actionContext) => {
     const languageClient = await launchLanguageServiceWithProgressReport(
+      actionContext,
       context,
       outputChannel
     );

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -17,6 +17,7 @@ const packagedServerPath = "bicepLanguageServer/Bicep.LangServer.dll";
 const extensionId = "ms-azuretools.vscode-bicep";
 
 export async function launchLanguageServiceWithProgressReport(
+  actionContext: IActionContext,
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel
 ): Promise<lsp.LanguageClient> {
@@ -25,17 +26,19 @@ export async function launchLanguageServiceWithProgressReport(
       title: "Launching Bicep language service...",
       location: vscode.ProgressLocation.Notification,
     },
-    async () => await launchLanguageService(context, outputChannel)
+    async () =>
+      await launchLanguageService(actionContext, context, outputChannel)
   );
 }
 
 async function launchLanguageService(
+  actionContext: IActionContext,
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel
 ): Promise<lsp.LanguageClient> {
   getLogger().info("Launching Bicep language service...");
 
-  const dotnetCommandPath = await ensureDotnetRuntimeInstalled();
+  const dotnetCommandPath = await ensureDotnetRuntimeInstalled(actionContext);
   getLogger().debug(`Found dotnet command at '${dotnetCommandPath}'.`);
 
   const languageServerPath = ensureLanguageServerExists(context);
@@ -111,7 +114,9 @@ async function launchLanguageService(
   return client;
 }
 
-async function ensureDotnetRuntimeInstalled(): Promise<string> {
+async function ensureDotnetRuntimeInstalled(
+  actionContext: IActionContext
+): Promise<string> {
   getLogger().info("Acquiring dotnet runtime...");
 
   const result = await vscode.commands.executeCommand<{ dotnetPath: string }>(
@@ -123,7 +128,10 @@ async function ensureDotnetRuntimeInstalled(): Promise<string> {
   );
 
   if (!result) {
-    const errorMessage = `Failed to install .NET runtime v${dotnetRuntimeVersion}.`;
+    // Suppress the 'Report Issue' button - we want people to use the dialog displayed by the .NET installer extension.
+    // It captures much more detail about the problem, and directs people to the correct repo (https://github.com/dotnet/vscode-dotnet-runtime).
+    actionContext.errorHandling.suppressReportIssue = true;
+    const errorMessage = `Failed to install .NET runtime v${dotnetRuntimeVersion}. Please see the .NET install tool error dialog for more detailed information, or to report an issue.`;
 
     getLogger().error(errorMessage);
     throw new Error(errorMessage);

--- a/src/vscode-bicep/src/utils/telemetry.ts
+++ b/src/vscode-bicep/src/utils/telemetry.ts
@@ -8,22 +8,22 @@ import {
 import { getLogger } from "./logger";
 
 export async function activateWithTelemetryAndErrorHandling(
-  activateCallback: () => Promise<void>
+  activateCallback: (actionContext: IActionContext) => Promise<void>
 ): Promise<void> {
   await callWithTelemetryAndErrorHandling(
     "bicep.activate",
-    async (activateContext: IActionContext) => {
+    async (actionContext: IActionContext) => {
       const startTime = Date.now();
-      activateContext.telemetry.properties.isActivationEvent = "true";
+      actionContext.telemetry.properties.isActivationEvent = "true";
 
       try {
-        await activateCallback();
+        await activateCallback(actionContext);
       } catch (e) {
         getLogger().error(e.message ?? e);
         throw e;
       }
 
-      activateContext.telemetry.measurements.extensionLoad =
+      actionContext.telemetry.measurements.extensionLoad =
         (Date.now() - startTime) / 1000;
     }
   );


### PR DESCRIPTION
New experience (tested by setting dotnet version to "100.0"):
![image](https://user-images.githubusercontent.com/38542602/152534942-a284039f-0b45-408d-a114-f65c4a4b9d99.png)

This removes the "Report an issue" button and instead points users to use the error dialog reported by the .NET acquisition tool (which is able to capture context & logs, and triggers a report to the dotnet runtime repo rather than this one). Our current "Report an Issue" button has no available context about the failure, which leads to unactionable issue reports like:
![image](https://user-images.githubusercontent.com/38542602/152535383-b3a669d0-b8bd-43c2-9768-2a7a0f998034.png)

Closes #2428