### PR TITLE
Fix vscode e2e test failure

### DIFF
--- a/src/vscode-bicep/jest.config.e2e.js
+++ b/src/vscode-bicep/jest.config.e2e.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 module.exports = {
+  reporters: ["<rootDir>/out/test/e2e/testReporter.js"],
   roots: ["<rootDir>/out/test/e2e"],
   testMatch: ["<rootDir>/out/test/e2e/**/*.test.js"],
   runInBand: true,

--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -39,6 +39,7 @@
         "@types/webpack": "^5.28.0",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.31.0",
+        "@vscode/test-electron": "^2.1.2",
         "copy-webpack-plugin": "^9.0.1",
         "esbuild-loader": "^2.16.0",
         "eslint": "^7.32.0",
@@ -61,7 +62,6 @@
         "ts-node": "^10.2.1",
         "typescript": "^4.3.5",
         "vsce": "^1.99.0",
-        "vscode-test": "^1.6.1",
         "webpack": "^5.65.0",
         "webpack-cli": "^4.8.0"
       },
@@ -1755,6 +1755,21 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.2.tgz",
+      "integrity": "sha512-INjJ0YA9RgR1B/xBl8P4sxww4Dy2996f4Xn5oGTFfC0c2Mm45y/1Id8xmfuoba6tR5i8zZaUIHfEYWe7Rt4uZA==",
+      "dev": true,
+      "dependencies": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      },
+      "engines": {
+        "node": ">=8.9.3"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -8919,21 +8934,6 @@
         "vscode": "^1.19.1"
       }
     },
-    "node_modules/vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "dev": true,
-      "dependencies": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      },
-      "engines": {
-        "node": ">=8.9.3"
-      }
-    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -10805,6 +10805,18 @@
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
         }
+      }
+    },
+    "@vscode/test-electron": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.2.tgz",
+      "integrity": "sha512-INjJ0YA9RgR1B/xBl8P4sxww4Dy2996f4Xn5oGTFfC0c2Mm45y/1Id8xmfuoba6tR5i8zZaUIHfEYWe7Rt4uZA==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
       }
     },
     "@webassemblyjs/ast": {
@@ -16541,18 +16553,6 @@
       "integrity": "sha512-1sYH73nhiSRVQgfZkLQNJW7VzhKM9qNbCe8QyXgiKkLhH4GflDXRPAK4yy4P41jUgula+Fc9G7i5imj1dlKfaw==",
       "requires": {
         "tas-client": "0.1.21"
-      }
-    },
-    "vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
       }
     },
     "w3c-hr-time": {

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -280,6 +280,7 @@
     "@types/webpack": "^5.28.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.31.0",
+    "@vscode/test-electron": "^2.1.2",
     "copy-webpack-plugin": "^9.0.1",
     "esbuild-loader": "^2.16.0",
     "eslint": "^7.32.0",
@@ -302,7 +303,6 @@
     "ts-node": "^10.2.1",
     "typescript": "^4.3.5",
     "vsce": "^1.99.0",
-    "vscode-test": "^1.6.1",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.8.0"
   },

--- a/src/vscode-bicep/src/test/e2e/runTests.ts
+++ b/src/vscode-bicep/src/test/e2e/runTests.ts
@@ -8,8 +8,8 @@ import { minVersion } from "semver";
 import {
   runTests,
   downloadAndUnzipVSCode,
-  resolveCliPathFromVSCodeExecutablePath,
-} from "vscode-test";
+  resolveCliArgsFromVSCodeExecutablePath,
+} from "@vscode/test-electron";
 
 async function go() {
   try {
@@ -33,8 +33,8 @@ async function go() {
       console.log(`Running tests against VSCode-${vscodeVersion}`);
 
       const vscodeExecutablePath = await downloadAndUnzipVSCode(vscodeVersion);
-      const cliPath =
-        resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
+      const [cliPath, ...cliArguments] =
+        resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
 
       const isRoot = os.userInfo().username === "root";
 
@@ -44,6 +44,7 @@ async function go() {
       const userDataArguments = isRoot ? ["--user-data-dir", userDataDir] : [];
 
       const extensionInstallArguments = [
+        ...cliArguments,
         "--install-extension",
         "ms-dotnettools.vscode-dotnet-runtime",
         ...userDataArguments,
@@ -60,7 +61,11 @@ async function go() {
         extensionDevelopmentPath: path.resolve(__dirname, "../../.."),
         extensionTestsPath: path.resolve(__dirname, "index"),
         extensionTestsEnv: { TEST_MODE: "e2e" },
-        launchArgs: ["--enable-proposed-api", ...userDataArguments],
+        launchArgs: [
+          "--enable-proposed-api",
+          "ms-azuretools.vscode-bicep",
+          ...userDataArguments,
+        ],
       });
     }
 

--- a/src/vscode-bicep/src/test/e2e/runner.ts
+++ b/src/vscode-bicep/src/test/e2e/runner.ts
@@ -1,47 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import * as path from "path";
-
-// eslint-disable-next-line jest/no-jest-import
-import { runCLI } from "jest";
-import { WriteStream } from "tty";
+import { runCLI } from "jest"; // eslint-disable-line jest/no-jest-import
 
 // https://github.com/microsoft/vscode/blob/87dd7d6a9c2f5fcc2bf3abe555fee79fbbde34bb/src/vs/workbench/api/common/extHostExtensionService.ts#L44
 export type TestRunner = () => Promise<void>;
-
-async function captureWriteStreams<T>(
-  fn: () => Promise<T>,
-  writeStreams: WriteStream[] = [process.stdout, process.stderr]
-): Promise<[T, string]> {
-  const originalWrites = writeStreams.map((ws) => ws.write);
-  const outputs: string[] = [];
-
-  try {
-    const write = (chunk: Uint8Array | string) => {
-      if (typeof chunk === "string" && chunk.length > 0) {
-        outputs.push(chunk);
-      }
-      return true;
-    };
-    writeStreams.forEach((ws) => (ws.write = write));
-    return [await fn(), outputs.join("")];
-  } finally {
-    writeStreams.forEach((ws, i) => (ws.write = originalWrites[i]));
-  }
-}
 
 export function createTestRunner(configFile: string): TestRunner {
   return async () => {
     const workspaceRoot = path.resolve(__dirname, "../../..");
     const config = require(path.join(workspaceRoot, configFile)); // eslint-disable-line @typescript-eslint/no-var-requires
-    const [{ results }, outputs] = await captureWriteStreams(
-      async () => await runCLI({ _: [], $0: "", ...config }, [workspaceRoot])
-    );
 
-    console.log(outputs);
+    const { results } = await runCLI({ _: [], $0: "", ...config }, [
+      workspaceRoot,
+    ]);
 
     if (results.numFailedTestSuites > 0 || results.numFailedTests > 0) {
-      throw new Error(`Tests failed.`);
+      process.exit(1);
     }
   };
 }

--- a/src/vscode-bicep/src/test/e2e/testReporter.ts
+++ b/src/vscode-bicep/src/test/e2e/testReporter.ts
@@ -3,8 +3,6 @@
 import { Context, Reporter, Test } from "@jest/reporters";
 import { AggregatedResult, TestResult } from "@jest/test-result";
 
-// Our reporter implements only the onRunComplete lifecycle
-// function, run after all tests have completed
 export default class TestReporter
   implements Pick<Reporter, "onTestResult" | "onRunComplete">
 {

--- a/src/vscode-bicep/src/test/e2e/testReporter.ts
+++ b/src/vscode-bicep/src/test/e2e/testReporter.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { Context, Reporter, Test } from "@jest/reporters";
+import { AggregatedResult, TestResult } from "@jest/test-result";
+
+// Our reporter implements only the onRunComplete lifecycle
+// function, run after all tests have completed
+export default class TestReporter
+  implements Pick<Reporter, "onTestResult" | "onRunComplete">
+{
+  onTestResult(test: Test, { testResults }: TestResult): void {
+    for (const testResult of testResults) {
+      switch (testResult.status) {
+        case "passed":
+          console.log(`✓ ${testResult.fullName}`);
+          break;
+        case "skipped":
+        case "pending":
+        case "todo":
+        case "disabled":
+          console.log(`* ${testResult.fullName}`);
+          break;
+        case "failed":
+          console.log(`✘ ${testResult.fullName}`);
+          for (const failureMessage of testResult.failureMessages) {
+            console.log(failureMessage);
+          }
+          break;
+        default:
+          console.log(`(${testResult.status}) ${testResult.fullName}`);
+      }
+    }
+  }
+
+  onRunComplete(contexts: Set<Context>, results: AggregatedResult): void {
+    console.log("");
+    console.log(
+      `Test Suites: ${results.numPassedTestSuites} passed, ${results.numTotalTestSuites} total`
+    );
+    console.log(
+      `Tests:       ${results.numPassedTestSuites} passed, ${results.numTotalTestSuites} total`
+    );
+  }
+}


### PR DESCRIPTION
Capturing `process.stdout.write` in VSCode 1.64.0 causes `TypeError: Cannot assign to read only property 'write' of object '#<Socket>'`. The PR adds a custom test reporter to avoid overwriting `process.stdout.write`. It fixes the build failures on the main branch.