### PR TITLE
Change assembly name from Bicep.RegistryModuleTool to Azure.Bicep.RegistryModuleTool

### DIFF
--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -1797,7 +1797,7 @@
           "System.IO.Abstractions": "13.2.47"
         }
       },
-      "bicep.registrymoduletool": {
+      "Azure.Bicep.RegistryModuleTool": {
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
@@ -1819,7 +1819,7 @@
       "bicep.registrymoduletool.testfixtures": {
         "type": "Project",
         "dependencies": {
-          "Bicep.RegistryModuleTool": "1.0.0",
+          "Azure.Bicep.RegistryModuleTool": "1.0.0",
           "FluentAssertions": "6.4.0",
           "JsonPatch.Net": "1.1.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -1719,7 +1719,7 @@
           "System.IO.Abstractions": "13.2.47"
         }
       },
-      "bicep.registrymoduletool": {
+      "Azure.Bicep.RegistryModuleTool": {
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -1797,7 +1797,7 @@
           "System.IO.Abstractions": "13.2.47"
         }
       },
-      "bicep.registrymoduletool": {
+      "Azure.Bicep.RegistryModuleTool": {
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
@@ -1819,7 +1819,7 @@
       "bicep.registrymoduletool.testfixtures": {
         "type": "Project",
         "dependencies": {
-          "Bicep.RegistryModuleTool": "1.0.0",
+          "Azure.Bicep.RegistryModuleTool": "1.0.0",
           "FluentAssertions": "6.4.0",
           "JsonPatch.Net": "1.1.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",

--- a/src/Bicep.RegistryModuleTool/Bicep.RegistryModuleTool.csproj
+++ b/src/Bicep.RegistryModuleTool/Bicep.RegistryModuleTool.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AssemblyName>Azure.Bicep.RegistryModuleTool</AssemblyName>
+    <RootNamespace>Bicep.RegistryModuleTool</RootNamespace>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>brm</ToolCommandName>


### PR DESCRIPTION
This keeps the assembly names consistent.