### PR TITLE
Remove unused CLI help for --no-summary option

### DIFF
--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -74,14 +74,12 @@ Usage:
     Options:
       --outdir <dir>    Saves the output at the specified directory.
       --outfile <file>  Saves the output as the specified file path.
-      --no-summary      Omits the summary at the end of the build.
       --stdout          Prints the output to stdout.
       --no-restore      Builds the bicep file without restoring external modules.
 
     Examples:
       bicep build file.bicep
       bicep build file.bicep --stdout
-      bicep build file.bicep --no-summary
       bicep build file.bicep --outdir dir1
       bicep build file.bicep --outfile file.json
       bicep build file.bicep --no-restore


### PR DESCRIPTION
The `--no-summary` flag was removed in #3686 and it is still present in the help text for the CLI.

Fixes #5828

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature
