### PR TITLE
Add support for public ACRs

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -176,7 +176,7 @@ namespace Bicep.Cli.IntegrationTests
             var client = new MockRegistryBlobClient();
 
             var clientFactory = StrictMock.Of<IContainerRegistryClientFactory>();
-            clientFactory.Setup(m => m.CreateBlobClient(It.IsAny<RootConfiguration>(), registryUri, repository)).Returns(client);
+            clientFactory.Setup(m => m.CreateAuthenticatedBlobClient(It.IsAny<RootConfiguration>(), registryUri, repository)).Returns(client);
 
             var templateSpecRepositoryFactory = BicepTestConstants.TemplateSpecRepositoryFactory;
 

--- a/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
@@ -109,7 +109,7 @@ namespace Bicep.Cli.IntegrationTests
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);
 
             // mock client factory caches the clients
-            var testClient = (MockRegistryBlobClient)clientFactory.CreateBlobClient(BicepTestConstants.BuiltInConfiguration, registryUri, repository);
+            var testClient = (MockRegistryBlobClient)clientFactory.CreateAuthenticatedBlobClient(BicepTestConstants.BuiltInConfiguration, registryUri, repository);
 
             var settings = new InvocationSettings(BicepTestConstants.CreateFeaturesProvider(TestContext, registryEnabled: true), clientFactory, templateSpecRepositoryFactory);
 
@@ -150,7 +150,7 @@ namespace Bicep.Cli.IntegrationTests
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);
 
             // mock client factory caches the clients
-            var testClient = (MockRegistryBlobClient)clientFactory.CreateBlobClient(BicepTestConstants.BuiltInConfiguration, registryUri, repository);
+            var testClient = (MockRegistryBlobClient)clientFactory.CreateAuthenticatedBlobClient(BicepTestConstants.BuiltInConfiguration, registryUri, repository);
 
             var settings = new InvocationSettings(BicepTestConstants.CreateFeaturesProvider(TestContext, registryEnabled: true), clientFactory, templateSpecRepositoryFactory);
 

--- a/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
@@ -83,7 +83,7 @@ namespace Bicep.Cli.IntegrationTests
             var client = new MockRegistryBlobClient();
 
             var clientFactory = StrictMock.Of<IContainerRegistryClientFactory>();
-            clientFactory.Setup(m => m.CreateBlobClient(It.IsAny<RootConfiguration>(), registryUri, repository)).Returns(client);
+            clientFactory.Setup(m => m.CreateAuthenticatedBlobClient(It.IsAny<RootConfiguration>(), registryUri, repository)).Returns(client);
 
             var templateSpecRepositoryFactory = BicepTestConstants.TemplateSpecRepositoryFactory;
 

--- a/src/Bicep.Core.Samples/DataSetsExtensions.cs
+++ b/src/Bicep.Core.Samples/DataSetsExtensions.cs
@@ -86,7 +86,7 @@ namespace Bicep.Core.Samples
 
             var clientFactory = new Mock<IContainerRegistryClientFactory>(MockBehavior.Strict);
             clientFactory
-                .Setup(m => m.CreateBlobClient(It.IsAny<RootConfiguration>(), It.IsAny<Uri>(), It.IsAny<string>()))
+                .Setup(m => m.CreateAuthenticatedBlobClient(It.IsAny<RootConfiguration>(), It.IsAny<Uri>(), It.IsAny<string>()))
                 .Returns<RootConfiguration, Uri, string>((_, registryUri, repository) =>
                 {
                     if (repoToClient.TryGetValue((registryUri, repository), out var client))

--- a/src/Bicep.Core/Registry/ContainerRegistryClientFactory.cs
+++ b/src/Bicep.Core/Registry/ContainerRegistryClientFactory.cs
@@ -19,7 +19,7 @@ namespace Bicep.Core.Registry
             this.credentialFactory = credentialFactory;
         }
 
-        public ContainerRegistryBlobClient CreateBlobClient(RootConfiguration configuration, Uri registryUri, string repository)
+        public ContainerRegistryBlobClient CreateAuthenticatedBlobClient(RootConfiguration configuration, Uri registryUri, string repository)
         {
             var options = new ContainerRegistryClientOptions();
             options.Diagnostics.ApplySharedContainerRegistrySettings();
@@ -28,6 +28,15 @@ namespace Bicep.Core.Registry
             var credential = this.credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.ActiveDirectoryAuthorityUri);
 
             return new(registryUri, credential, repository, options);
+        }
+
+        public ContainerRegistryBlobClient CreateAnonymouosBlobClient(RootConfiguration configuration, Uri registryUri, string repository)
+        {
+            var options = new ContainerRegistryClientOptions();
+            options.Diagnostics.ApplySharedContainerRegistrySettings();
+            options.Audience = new ContainerRegistryAudience(configuration.Cloud.ResourceManagerAudience);
+
+            return new(registryUri, repository, options);
         }
     }
 }

--- a/src/Bicep.Core/Registry/IContainerRegistryClientFactory.cs
+++ b/src/Bicep.Core/Registry/IContainerRegistryClientFactory.cs
@@ -13,6 +13,8 @@ namespace Bicep.Core.Registry
     /// <remarks>This exists because we need to inject mock clients in integration tests and because the real client constructor requires parameters.</remarks>
     public interface IContainerRegistryClientFactory
     {
-        ContainerRegistryBlobClient CreateBlobClient(RootConfiguration configuration, Uri registryUri, string repository);
+        ContainerRegistryBlobClient CreateAuthenticatedBlobClient(RootConfiguration configuration, Uri registryUri, string repository);
+
+        ContainerRegistryBlobClient CreateAnonymouosBlobClient(RootConfiguration configuration, Uri registryUri, string repository);
     }
 }

--- a/src/Bicep.Core/Registry/OciModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/OciModuleRegistry.cs
@@ -26,7 +26,7 @@ namespace Bicep.Core.Registry
             : base(FileResolver)
         {
             this.cachePath = Path.Combine(features.CacheRootDirectory, ModuleReferenceSchemes.Oci);
-            this.client = new AzureContainerRegistryManager(new DefaultAzureCredential(), clientFactory);
+            this.client = new AzureContainerRegistryManager(clientFactory);
         }
 
         public override string Scheme => ModuleReferenceSchemes.Oci;


### PR DESCRIPTION
Closes #5031.

Verified this manually. I don't know if there's a way to test this other than writing e2e tests, but that requires us to set up a new ACR with anonymous access enabled, which I'll do later.