### PR TITLE
Emit API version for conditional module output references

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Scenarios/InliningResourcesAndModulesTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/InliningResourcesAndModulesTests.cs
@@ -349,7 +349,7 @@ output test bool = true
                     },
                     "Module should be added to depends on section");
                 result.Template.Should().HaveValueAtPath("$.resources[?(@.name == 'test2')].properties.allowBlobPublicAccess",
-                    "[if(equals(parameters('mode'), 1), reference(resourceId('Microsoft.Resources/deployments', 'testmod1')).outputs, reference(resourceId('Microsoft.Resources/deployments', 'testmod2')).outputs).test.value]",
+                    "[if(equals(parameters('mode'), 1), reference(resourceId('Microsoft.Resources/deployments', 'testmod1'), '2020-10-01').outputs, reference(resourceId('Microsoft.Resources/deployments', 'testmod2'), '2020-10-01').outputs).test.value]",
                     "Module access should be in-lined correctly");
             }
         }
@@ -401,7 +401,7 @@ output test bool = true
                     },
                     "Module should be added to depends on section");
                 result.Template.Should().HaveValueAtPath("$.resources[?(@.name == 'test2')].properties.allowBlobPublicAccess",
-                    "[if(equals(parameters('mode'), 1), reference(resourceId('Microsoft.Resources/deployments', 'testmod1')).outputs, reference(resourceId('Microsoft.Resources/deployments', 'testmod2')).outputs).test.value]",
+                    "[if(equals(parameters('mode'), 1), reference(resourceId('Microsoft.Resources/deployments', 'testmod1'), '2020-10-01').outputs, reference(resourceId('Microsoft.Resources/deployments', 'testmod2'), '2020-10-01').outputs).test.value]",
                     "Module access should be in-lined correctly");
             }
         }

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -639,6 +639,16 @@ namespace Bicep.Core.Emit
                     new JTokenExpression("outputs"));
             }
 
+            if (moduleSymbol.DeclaringModule.Value is IfConditionSyntax)
+            {
+                return AppendProperties(
+                    CreateFunction(
+                        "reference",
+                        GetFullyQualifiedResourceId(moduleSymbol),
+                        new JTokenExpression(TemplateWriter.NestedDeploymentResourceApiVersion)),
+                    new JTokenExpression("outputs"));
+            }
+
             return AppendProperties(
                 CreateFunction(
                     "reference",


### PR DESCRIPTION
An API version is required for a module output reference if the module has a condition equaling `false`. Since we cannot evaluate the condition in compile-time we should always emit API versions for output references of conditional modules.