### PR TITLE
added --allowoverwrite flag to decompile

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/DecompileCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/DecompileCommandTests.cs
@@ -299,7 +299,7 @@ namespace Bicep.Cli.IntegrationTests
             {
                 // keep the output stream open while we attempt to write to it
                 // this should force an access denied error
-                var (output, error, result) = await Bicep("decompile", "--allowoverwrite", jsonPath);
+                var (output, error, result) = await Bicep("decompile", "--force", jsonPath);
 
                 output.Should().BeEmpty();
                 error.AsLines().Should().Contain(DecompilationDisclaimer);

--- a/src/Bicep.Cli.IntegrationTests/DecompileCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/DecompileCommandTests.cs
@@ -299,7 +299,7 @@ namespace Bicep.Cli.IntegrationTests
             {
                 // keep the output stream open while we attempt to write to it
                 // this should force an access denied error
-                var (output, error, result) = await Bicep("decompile", jsonPath);
+                var (output, error, result) = await Bicep("decompile", "--allowoverwrite", jsonPath);
 
                 output.Should().BeEmpty();
                 error.AsLines().Should().Contain(DecompilationDisclaimer);

--- a/src/Bicep.Cli/Arguments/DecompileArguments.cs
+++ b/src/Bicep.Cli/Arguments/DecompileArguments.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.FileSystem;
+using LanguageConstants = Bicep.Core.LanguageConstants;
+
+
 using System.IO;
 
 namespace Bicep.Cli.Arguments
@@ -17,7 +20,7 @@ namespace Bicep.Cli.Arguments
                     case "--stdout":
                         OutputToStdOut = true;
                         break;
-                    case "--allowoverwrite":
+                    case "--force":
                         AllowOverwrite = true;
                         break;
                     case "--outdir":
@@ -87,13 +90,14 @@ namespace Bicep.Cli.Arguments
                 }
             }
 
-            var inputPath = PathHelper.ResolvePath(InputFile);
-            static string DefaultOutputPath(string path) => PathHelper.GetDefaultDecompileOutputPath(path);
-            var outputPath = PathHelper.ResolveDefaultOutputPath(inputPath, OutputDir, OutputFile, DefaultOutputPath);
-
-            if (!OutputToStdOut && !AllowOverwrite && File.Exists(outputPath))
+            if (!OutputToStdOut && !AllowOverwrite)
             {
-                throw new CommandLineException($"The output path \"{outputPath}\" already exists. Use --allowoverwrite to overwrite the existing file.");
+                string outputFilePath = Path.ChangeExtension(PathHelper.ResolvePath(InputFile), LanguageConstants.LanguageFileExtension);
+                if (File.Exists(outputFilePath))
+                {
+                    throw new CommandLineException($"The output path \"{outputFilePath}\" already exists. Use --force to overwrite the existing file.");
+                }
+
             }
         }
 

--- a/src/Bicep.Cli/Arguments/DecompileArguments.cs
+++ b/src/Bicep.Cli/Arguments/DecompileArguments.cs
@@ -18,7 +18,7 @@ namespace Bicep.Cli.Arguments
                         OutputToStdOut = true;
                         break;
                     case "--allowoverwrite":
-                        allowOverwrite = true;
+                        AllowOverwrite = true;
                         break;
                     case "--outdir":
                         if (args.Length == i + 1)
@@ -91,7 +91,7 @@ namespace Bicep.Cli.Arguments
             static string DefaultOutputPath(string path) => PathHelper.GetDefaultDecompileOutputPath(path);
             var outputPath = PathHelper.ResolveDefaultOutputPath(inputPath, OutputDir, OutputFile, DefaultOutputPath);
 
-            if (!OutputToStdOut && !allowOverwrite && File.Exists(outputPath))
+            if (!OutputToStdOut && !AllowOverwrite && File.Exists(outputPath))
             {
                 throw new CommandLineException($"The --allowoverwrite should be used to override file");
             }
@@ -105,6 +105,6 @@ namespace Bicep.Cli.Arguments
 
         public string? OutputFile { get; }
 
-        public bool allowOverwrite { get; }
+        public bool AllowOverwrite { get; }
     }
 }

--- a/src/Bicep.Cli/Arguments/DecompileArguments.cs
+++ b/src/Bicep.Cli/Arguments/DecompileArguments.cs
@@ -93,7 +93,7 @@ namespace Bicep.Cli.Arguments
 
             if (!OutputToStdOut && !AllowOverwrite && File.Exists(outputPath))
             {
-                throw new CommandLineException($"The --allowoverwrite should be used to override file");
+                throw new CommandLineException($"The output path \"{outputPath}\" already exists. Use --allowoverwrite to overwrite the existing file.");
             }
         }
 

--- a/src/Bicep.Cli/Arguments/DecompileArguments.cs
+++ b/src/Bicep.Cli/Arguments/DecompileArguments.cs
@@ -17,6 +17,9 @@ namespace Bicep.Cli.Arguments
                     case "--stdout":
                         OutputToStdOut = true;
                         break;
+                    case "--allowoverwrite":
+                        allowOverwrite = true;
+                        break;
                     case "--outdir":
                         if (args.Length == i + 1)
                         {
@@ -64,7 +67,6 @@ namespace Bicep.Cli.Arguments
             {
                 throw new CommandLineException($"The --outdir and --stdout parameters cannot both be used");
             }
-
             if (OutputToStdOut && OutputFile is not null)
             {
                 throw new CommandLineException($"The --outfile and --stdout parameters cannot both be used");
@@ -84,6 +86,15 @@ namespace Bicep.Cli.Arguments
                     throw new CommandLineException(string.Format(CliResources.DirectoryDoesNotExistFormat, outputDir));
                 }
             }
+
+            var inputPath = PathHelper.ResolvePath(InputFile);
+            static string DefaultOutputPath(string path) => PathHelper.GetDefaultDecompileOutputPath(path);
+            var outputPath = PathHelper.ResolveDefaultOutputPath(inputPath, OutputDir, OutputFile, DefaultOutputPath);
+
+            if (!OutputToStdOut && !allowOverwrite && File.Exists(outputPath))
+            {
+                throw new CommandLineException($"The --allowoverwrite should be used to override file");
+            }
         }
 
         public bool OutputToStdOut { get; }
@@ -93,5 +104,7 @@ namespace Bicep.Cli.Arguments
         public string? OutputDir { get; }
 
         public string? OutputFile { get; }
+
+        public bool allowOverwrite { get; }
     }
 }

--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -96,7 +96,7 @@ Usage:
       --outdir <dir>    Saves the output at the specified directory.
       --outfile <file>  Saves the output as the specified file path.
       --stdout          Prints the output to stdout.
-      --allowoverwrite  Allows confirmation for overwriting existing bicep file.
+      --allowoverwrite  Allows overwriting the output file if it exists (applies only to 'bicep decompile').
 
     Examples:
       bicep decompile file.json

--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -96,11 +96,13 @@ Usage:
       --outdir <dir>    Saves the output at the specified directory.
       --outfile <file>  Saves the output as the specified file path.
       --stdout          Prints the output to stdout.
+      --allowoverwrite  Allows confirmation for overwriting existing bicep file.
 
     Examples:
       bicep decompile file.json
       bicep decompile file.json --stdout
       bicep decompile file.json --outdir dir1
+      bicep decompile file.json --allowoverwrite
       bicep decompile file.json --outfile file.bicep
 {registryPlaceholder}  {exeName} [options]
     Options:

--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -96,13 +96,13 @@ Usage:
       --outdir <dir>    Saves the output at the specified directory.
       --outfile <file>  Saves the output as the specified file path.
       --stdout          Prints the output to stdout.
-      --allowoverwrite  Allows overwriting the output file if it exists (applies only to 'bicep decompile').
+      --force           Allows overwriting the output file if it exists (applies only to 'bicep decompile').
 
     Examples:
       bicep decompile file.json
       bicep decompile file.json --stdout
       bicep decompile file.json --outdir dir1
-      bicep decompile file.json --allowoverwrite
+      bicep decompile file.json --force
       bicep decompile file.json --outfile file.bicep
 {registryPlaceholder}  {exeName} [options]
     Options:


### PR DESCRIPTION
Fixes: https://github.com/Azure/bicep/issues/5659

Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

* [x] I have checked that all tests are passing by running `dotnet test` for bicep CLI unit tests
* [x]  I have Locally tested bicep decompile command with newly added flag.
