### PR TITLE
Fix parameter passing for resource->object params

### DIFF
--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -562,7 +562,10 @@ namespace Bicep.Core.Emit
                         jsonWriter.WriteEndArray();
                     });
                 }
-                else if (this.context.SemanticModel.ResourceMetadata.TryLookup(propertySyntax.Value) is {} resourceMetadata)
+                else if (
+                    this.context.SemanticModel.ResourceMetadata.TryLookup(propertySyntax.Value) is {} resourceMetadata &&
+                    moduleSymbol.TryGetModuleType() is ModuleType moduleType &&
+                    moduleType.TryGetParameterType(keyName) is ResourceParameterType parameterType)
                 {
                     // This is a resource being passed into a module, we actually want to pass in its id
                     // rather than the whole resource.

--- a/src/Bicep.Core/TypeSystem/ModuleType.cs
+++ b/src/Bicep.Core/TypeSystem/ModuleType.cs
@@ -31,5 +31,18 @@ namespace Bicep.Core.TypeSystem
                 ArrayType { Item: ModuleType moduleType } => moduleType,
                 _ => null
             };
+
+        public TypeSymbol? TryGetParameterType(string propertyName)
+        {
+            if (this.Body is ObjectType objectType &&
+                objectType.Properties.TryGetValue(LanguageConstants.ModuleParamsPropertyName, out var paramsProperty) &&
+                paramsProperty.TypeReference.Type is ObjectType paramsType &&
+                paramsType.Properties.TryGetValue(propertyName, out var property))
+            {
+                return property.TypeReference.Type;
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Fixes: #6038

This change fixes a regression introduced by adding resource-typed
parameter support. Resource-typed parameters require an implicit
conversion to pass the resource id as a string rather than the resource
body as an object.

The codegen for parameters was applying the conversion for all cases
where the RHS was a resource without checking for the LHS to be a
resource-typed parameter. The fix is to correct that check.

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
