### PR TITLE
Update Bicep registry module tool to generate and validate examples section in README

### DIFF
--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -257,6 +257,11 @@
           "System.Text.Json": "4.7.2"
         }
       },
+      "Markdig": {
+        "type": "Transitive",
+        "resolved": "0.27.0",
+        "contentHash": "0nX9KT/sxKpuYc6tjnCP8FQhrFCUe438c4CcXPgwJkri1SEi9iHfvMkYmI44l1Djp+ThhC2KNfmRBpXN72Z/Mw=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -1793,6 +1798,7 @@
           "FluentAssertions": "6.5.1",
           "JsonPath.Net": "0.1.14",
           "JsonSchema.Net": "1.12.0",
+          "Markdig": "0.27.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
           "Serilog.Extensions.Hosting": "4.2.0",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Invalid/README.md
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Invalid/README.md
@@ -25,4 +25,4 @@ Sample description for test
 									| :--------------- | :----: | :--------------------- |
 	| controlPlaneFQDN | string | The control plane FQDN |
 
-
+## Examples

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Invalid/metadata.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Invalid/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/bicep-registry-module-metadata-schema#",
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema#",
   "name": "Test module",
   "description": "",
   "owner": "42"

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Modified/README.md
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Modified/README.md
@@ -1,16 +1,29 @@
 # 
 
-
-
 ## Parameters
 
 | Name | Type | Required | Description |
 | :--- | :--: | :------: | :---------- |
-
 
 ## Outputs
 
 | Name | Type | Description |
 | :--- | :--: | :---------- |
 
+## Examples
 
+### Example 1
+
+```bicep
+module mod 'br/public:test/testmodule:1.1.1' = {
+  name: 'mod'
+  params: {
+    dnsPrefix: ''
+    linuxAdminUsername: ''
+    sshRSAPublicKey: ''
+    servicePrincipalClientId: ''
+    servicePrincipalClientSecret: ''
+    osDiskSizeGB: 1
+  }
+}
+```

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Modified/metadata.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Modified/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/bicep-registry-module-metadata-schema#",
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema#",
   "name": "Sample module",
   "description": "Sample description",
   "owner": "test"

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/NewlyGenerated/README.md
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/NewlyGenerated/README.md
@@ -1,16 +1,23 @@
 # 
 
-
-
 ## Parameters
 
 | Name | Type | Required | Description |
 | :--- | :--: | :------: | :---------- |
-
 
 ## Outputs
 
 | Name | Type | Description |
 | :--- | :--: | :---------- |
 
+## Examples
 
+### Example 1
+
+```bicep
+```
+
+### Example 2
+
+```bicep
+```

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/NewlyGenerated/metadata.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/NewlyGenerated/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/bicep-registry-module-metadata-schema#",
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema#",
   "name": "",
   "description": "",
   "owner": ""

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/README.md
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/README.md
@@ -17,11 +17,26 @@ Sample description
 | `agentCount`                   | `int`          | No       | The agent count                     |
 | `agentVMSize`                  | `string`       | No       | The agent VM size                   |
 
-
 ## Outputs
 
 | Name             | Type   | Description            |
 | :--------------- | :----: | :--------------------- |
 | controlPlaneFQDN | string | The control plane FQDN |
 
+## Examples
 
+### Example 1
+
+```bicep
+module mod 'br/public:test/testmodule:1.1.1' = {
+  name: 'mod'
+  params: {
+    dnsPrefix: ''
+    linuxAdminUsername: ''
+    sshRSAPublicKey: ''
+    servicePrincipalClientId: ''
+    servicePrincipalClientSecret: ''
+    osDiskSizeGB: 1
+  }
+}
+```

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/metadata.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://aka.ms/bicep-registry-module-metadata-schema#",
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema#",
   "name": "Sample module",
   "description": "Sample description",
   "owner": "test"

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -239,6 +239,11 @@
           "System.Text.Json": "4.7.2"
         }
       },
+      "Markdig": {
+        "type": "Transitive",
+        "resolved": "0.27.0",
+        "contentHash": "0nX9KT/sxKpuYc6tjnCP8FQhrFCUe438c4CcXPgwJkri1SEi9iHfvMkYmI44l1Djp+ThhC2KNfmRBpXN72Z/Mw=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -1715,6 +1720,7 @@
           "FluentAssertions": "6.5.1",
           "JsonPath.Net": "0.1.14",
           "JsonSchema.Net": "1.12.0",
+          "Markdig": "0.27.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
           "Serilog.Extensions.Hosting": "4.2.0",

--- a/src/Bicep.RegistryModuleTool.UnitTests/ModuleFileValidators/DiffValidatorTests.cs
+++ b/src/Bicep.RegistryModuleTool.UnitTests/ModuleFileValidators/DiffValidatorTests.cs
@@ -8,7 +8,9 @@ using Bicep.RegistryModuleTool.TestFixtures.MockFactories;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.IO.Abstractions.TestingHelpers;
+using System.Text.RegularExpressions;
 using static FluentAssertions.FluentActions;
 
 namespace Bicep.RegistryModuleTool.UnitTests.ModuleFileValidators
@@ -69,6 +71,19 @@ namespace Bicep.RegistryModuleTool.UnitTests.ModuleFileValidators
                 .WithMessage($@"The file ""{fileToValidate.Path}"" is modified or outdated. Please regenerate the file to fix it.{Environment.NewLine}");
         }
 
+        [DataTestMethod]
+        [DynamicData(nameof(GetEmptyExamplesSectionData), DynamicDataSourceType.Method)]
+        public void Validate_EmptyExamplesSectionInReadmeFile_ThrowsException(string readmeFileContents)
+        {
+            this.fileSystem.AddFile(this.fileSystem.Path.GetFullPath(ReadmeFile.FileName), readmeFileContents);
+
+            var fileToValidate = ReadmeFile.ReadFromFileSystem(this.fileSystem);
+
+            Invoking(() => this.sut.Validate(fileToValidate)).Should()
+                .Throw<InvalidModuleException>()
+                .WithMessage($@"The file ""{fileToValidate.Path}"" is modified or outdated. Please regenerate the file to fix it.{Environment.NewLine}");
+        }
+
         [TestMethod]
         public void Validate_ValidVersionFile_Succeeds()
         {
@@ -93,6 +108,29 @@ namespace Bicep.RegistryModuleTool.UnitTests.ModuleFileValidators
             Invoking(() => this.sut.Validate(fileToValidate)).Should()
                 .Throw<InvalidModuleException>()
                 .WithMessage($@"The file ""{fileToValidate.Path}"" is modified or outdated. Please regenerate the file to fix it.{Environment.NewLine}");
+        }
+
+        private static IEnumerable<object[]> GetEmptyExamplesSectionData()
+        {
+            var fileSystem = MockFileSystemFactory.CreateFileSystemWithValidFiles();
+            var validReadmeFile = ReadmeFile.ReadFromFileSystem(fileSystem);
+
+            var emptyExamplesSections = new string[]
+            {
+                "## Examples",
+                "## Examples\r\n\r\n",
+                "## Examples\r\n\t   ",
+                "## Examples\n  \n",
+            };
+
+
+            foreach (var section in emptyExamplesSections)
+            {
+                yield return new object[]
+                {
+                    Regex.Replace(validReadmeFile.Content, "## Examples.+", section, RegexOptions.Singleline)
+                };
+            }
         }
     }
 }

--- a/src/Bicep.RegistryModuleTool.UnitTests/ModuleFileValidators/DiffValidatorTests.cs
+++ b/src/Bicep.RegistryModuleTool.UnitTests/ModuleFileValidators/DiffValidatorTests.cs
@@ -128,7 +128,7 @@ namespace Bicep.RegistryModuleTool.UnitTests.ModuleFileValidators
             {
                 yield return new object[]
                 {
-                    Regex.Replace(validReadmeFile.Content, "## Examples.+", section, RegexOptions.Singleline)
+                    Regex.Replace(validReadmeFile.Contents, "## Examples.+", section, RegexOptions.Singleline)
                 };
             }
         }

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -257,6 +257,11 @@
           "System.Text.Json": "4.7.2"
         }
       },
+      "Markdig": {
+        "type": "Transitive",
+        "resolved": "0.27.0",
+        "contentHash": "0nX9KT/sxKpuYc6tjnCP8FQhrFCUe438c4CcXPgwJkri1SEi9iHfvMkYmI44l1Djp+ThhC2KNfmRBpXN72Z/Mw=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -1793,6 +1798,7 @@
           "FluentAssertions": "6.5.1",
           "JsonPath.Net": "0.1.14",
           "JsonSchema.Net": "1.12.0",
+          "Markdig": "0.27.0",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
           "Serilog.Extensions.Hosting": "4.2.0",

--- a/src/Bicep.RegistryModuleTool/Bicep.RegistryModuleTool.csproj
+++ b/src/Bicep.RegistryModuleTool/Bicep.RegistryModuleTool.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="JsonPath.Net" Version="0.1.14" />
     <PackageReference Include="JsonSchema.Net" Version="1.12.0" />
+    <PackageReference Include="Markdig" Version="0.27.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />

--- a/src/Bicep.RegistryModuleTool/JsonSchemas/schema.metadata.json
+++ b/src/Bicep.RegistryModuleTool/JsonSchemas/schema.metadata.json
@@ -3,7 +3,7 @@
     "$schema": {
       "type": "string",
       "enum": [
-        "https://aka.ms/bicep-registry-module-metadata-schema#"
+        "https://aka.ms/bicep-registry-module-metadata-file-schema#"
       ],
       "description": "Bicep registry module metadata file JSON schema reference."
     },

--- a/src/Bicep.RegistryModuleTool/ModuleFileValidators/DiffValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFileValidators/DiffValidator.cs
@@ -31,14 +31,14 @@ namespace Bicep.RegistryModuleTool.ModuleFileValidators
             var latestMetadataFile = MetadataFile.ReadFromFileSystem(this.fileSystem);
             var latestReadmeFile = ReadmeFile.Generate(this.fileSystem, latestMetadataFile, latestMainArmTemplateFile);
 
-            this.Validate(file.Path, file.Content, latestReadmeFile.Content);
+            this.Validate(file.Path, file.Contents, latestReadmeFile.Contents);
         }
 
         public void Validate(VersionFile file)
         {
             var latestVersionFile = VersionFile.Generate(this.fileSystem);
 
-            this.Validate(file.Path, file.Content, latestVersionFile.Content);
+            this.Validate(file.Path, file.Contents, latestVersionFile.Contents);
         }
 
         private void Validate(string filePath, string newContent, string oldContent)

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MetadataFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MetadataFile.cs
@@ -18,7 +18,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         private static readonly JsonElement EmptyFileElement = JsonElementFactory.CreateElement(new Dictionary<string, string>
         {
-            ["$schema"] = "https://aka.ms/bicep-registry-module-metadata-schema#",
+            ["$schema"] = "https://aka.ms/bicep-registry-module-metadata-file-schema#",
             ["name"] = "",
             ["description"] = "",
             ["owner"] = "",

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
@@ -19,13 +19,13 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
     {
         public const string FileName = "README.md";
 
-        public ReadmeFile(string path, string content)
+        public ReadmeFile(string path, string contents)
             : base(path)
         {
-            this.Content = content;
+            this.Contents = contents;
         }
 
-        public string Content { get; }
+        public string Contents { get; }
 
         public static ReadmeFile Generate(IFileSystem fileSystem, MetadataFile metadataFile, MainArmTemplateFile mainArmTemplateFile)
         {
@@ -40,7 +40,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             try
             {
                 var existingFile = ReadFromFileSystem(fileSystem);
-                var existingExamplesSection = TryReadSection(existingFile.Content, 2, "Examples");
+                var existingExamplesSection = TryReadSection(existingFile.Contents, 2, "Examples");
 
                 if (existingExamplesSection is not null && !existingExamplesSection.Equals("## Examples", StringComparison.Ordinal))
                 {
@@ -82,7 +82,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         public ReadmeFile WriteToFileSystem(IFileSystem fileSystem)
         {
-            fileSystem.File.WriteAllText(FileName, this.Content);
+            fileSystem.File.WriteAllText(FileName, this.Contents);
 
             return this;
         }

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
@@ -3,7 +3,12 @@
 
 using Bicep.RegistryModuleTool.Extensions;
 using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
@@ -24,6 +29,30 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         public static ReadmeFile Generate(IFileSystem fileSystem, MetadataFile metadataFile, MainArmTemplateFile mainArmTemplateFile)
         {
+            var examplesSection = @"## Examples
+### Example 1
+```bicep
+```
+### Example 2
+```bicep
+```".ReplaceLineEndings();
+
+            try
+            {
+                var existingFile = ReadFromFileSystem(fileSystem);
+                var existingExamplesSection = TryReadSection(existingFile.Content, 2, "Examples");
+
+                if (existingExamplesSection is not null && !existingExamplesSection.Equals("## Examples", StringComparison.Ordinal))
+                {
+                    // The existing examples section is not empty.
+                    examplesSection = existingExamplesSection;
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                // Do thing.
+            }
+
             var builder = new StringBuilder();
 
             builder.AppendLine($"# {metadataFile.Name}");
@@ -35,7 +64,12 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             BuildParametersTable(builder, mainArmTemplateFile.Parameters);
             BuildOutputsTable(builder, mainArmTemplateFile.Outputs);
 
-            return new(fileSystem.Path.GetFullPath(FileName), builder.ToString());
+            builder.AppendLine(examplesSection);
+
+            var contents = builder.ToString();
+            var normalizedContents = Markdown.Normalize(contents);
+
+            return new(fileSystem.Path.GetFullPath(FileName), normalizedContents);
         }
 
         public static ReadmeFile ReadFromFileSystem(IFileSystem fileSystem)
@@ -85,6 +119,29 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
                     ? MarkdownTableColumnAlignment.Center
                     : MarkdownTableColumnAlignment.Left));
             builder.AppendLine();
+        }
+
+        private static string? TryReadSection(string markdownText, int level, string title)
+        {
+            var document = Markdown.Parse(markdownText);
+            var headingBlock = document.Descendants<HeadingBlock>().FirstOrDefault(x =>
+                x.Level == level &&
+                x.Inline?.Descendants<LiteralInline>().SingleOrDefault()?.ToString().Equals(title, StringComparison.Ordinal) == true);
+
+            if (headingBlock is null)
+            {
+                return null;
+            }
+
+            var nextHeadingBlock = document.Descendants<HeadingBlock>()
+                .FirstOrDefault(x => x.Level <= level && x.Line > headingBlock.Line);
+
+            var section = nextHeadingBlock is not null
+                ? markdownText[headingBlock.Span.Start..nextHeadingBlock.Span.Start]
+                : markdownText[headingBlock.Span.Start..];
+
+            // Normlize the section to remove trivia characters.
+            return Markdown.Normalize(section);
         }
     }
 }

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/VersionFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/VersionFile.cs
@@ -29,14 +29,14 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         private static readonly JsonElement NoVersionFileElement = EmptyFileElement.Patch(JsonPatchOperations.Remove("/version"));
 
-        public VersionFile(string path, string content, JsonElement rootElement)
+        public VersionFile(string path, string contents, JsonElement rootElement)
             : base(path)
         {
-            this.Content = content;
+            this.Contents = contents;
             this.RootElement = rootElement;
         }
 
-        public string Content { get; }
+        public string Contents { get; }
 
         public JsonElement RootElement { get; }
 
@@ -89,7 +89,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         public VersionFile WriteToFileSystem(IFileSystem fileSystem)
         {
-            fileSystem.File.WriteAllText(this.Path, this.Content);
+            fileSystem.File.WriteAllText(this.Path, this.Contents);
 
             return this;
         }

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -38,6 +38,12 @@
           "System.Text.Json": "4.7.2"
         }
       },
+      "Markdig": {
+        "type": "Direct",
+        "requested": "[0.27.0, )",
+        "resolved": "0.27.0",
+        "contentHash": "0nX9KT/sxKpuYc6tjnCP8FQhrFCUe438c4CcXPgwJkri1SEi9iHfvMkYmI44l1Djp+ThhC2KNfmRBpXN72Z/Mw=="
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.3.3, )",


### PR DESCRIPTION
- `brm generate` now generates an empty `Examples` section the module README file
- `brm validate` now validates that the `Examples` section in the module README file is not empty