### PR TITLE
Apply SimplifyInterpolationRule to all expressions

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
@@ -705,6 +705,7 @@ module secureModule1 'moduleb.bicep' = {
     stringParamA: kv.getSecret('mySecret')
 //@[18:42) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
     stringParamB: '${kv.getSecret('mySecret')}'
+//@[18:47) [simplify-interpolation (Warning)] Remove unnecessary string interpolation. (CodeDescription: bicep core(https://aka.ms/bicep/linter/simplify-interpolation)) |'${kv.getSecret('mySecret')}'|
 //@[21:45) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
     objParam: kv.getSecret('mySecret')
 //@[14:38) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
@@ -713,11 +714,13 @@ module secureModule1 'moduleb.bicep' = {
 //@[16:40) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
 //@[16:40) [BCP036 (Error)] The property "arrayParam" expected a value of type "array" but the provided value is of type "string". (CodeDescription: none) |kv.getSecret('mySecret')|
     secureStringParam: '${kv.getSecret('mySecret')}'
+//@[23:52) [simplify-interpolation (Warning)] Remove unnecessary string interpolation. (CodeDescription: bicep core(https://aka.ms/bicep/linter/simplify-interpolation)) |'${kv.getSecret('mySecret')}'|
 //@[26:50) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
     secureObjectParam: kv.getSecret('mySecret')
 //@[23:47) [BCP036 (Error)] The property "secureObjectParam" expected a value of type "object" but the provided value is of type "string". (CodeDescription: none) |kv.getSecret('mySecret')|
     secureStringParam2: '${kv.getSecret('mySecret')}'
 //@[4:22) [BCP037 (Error)] The property "secureStringParam2" is not allowed on objects of type "params". No other properties are allowed. (CodeDescription: none) |secureStringParam2|
+//@[24:53) [simplify-interpolation (Warning)] Remove unnecessary string interpolation. (CodeDescription: bicep core(https://aka.ms/bicep/linter/simplify-interpolation)) |'${kv.getSecret('mySecret')}'|
 //@[27:51) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
     secureObjectParam2: kv.getSecret('mySecret')
 //@[4:22) [BCP037 (Error)] The property "secureObjectParam2" is not allowed on objects of type "params". No other properties are allowed. (CodeDescription: none) |secureObjectParam2|

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.diagnostics.bicep
@@ -231,6 +231,7 @@ resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
 output keyVaultSecretOutput string = kv.getSecret('mySecret')
 //@[37:61) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
 output keyVaultSecretInterpolatedOutput string = '${kv.getSecret('mySecret')}'
+//@[49:78) [simplify-interpolation (Warning)] Remove unnecessary string interpolation. (CodeDescription: bicep core(https://aka.ms/bicep/linter/simplify-interpolation)) |'${kv.getSecret('mySecret')}'|
 //@[52:76) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
 output keyVaultSecretObjectOutput object = {
   secret: kv.getSecret('mySecret')

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -442,6 +442,7 @@ resource runtimeInvalidRes9 'Microsoft.Advisor/recommendations/suppressions@2020
 
 resource runtimeInvalidRes10 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
   name: '${runtimeValidRes3.location}'
+//@[8:38) [simplify-interpolation (Warning)] Remove unnecessary string interpolation. (CodeDescription: bicep core(https://aka.ms/bicep/linter/simplify-interpolation)) |'${runtimeValidRes3.location}'|
 //@[11:36) [BCP120 (Error)] This expression is being used in an assignment to the "name" property of the "Microsoft.Advisor/recommendations/suppressions" type, which requires a value that can be calculated at the start of the deployment. Properties of runtimeValidRes3 which can be calculated at the start include "apiVersion", "id", "name", "type". (CodeDescription: none) |runtimeValidRes3.location|
 //@[28:36) [BCP187 (Warning)] The property "location" does not exist in the resource definition, although it might still be valid. If this is an inaccuracy in the documentation, please report it to the Bicep Team. (CodeDescription: bicep(https://aka.ms/bicep-type-issues)) |location|
 }

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -395,6 +395,7 @@ var keyVaultSecretVar = kv.getSecret('mySecret')
 //@[24:48) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
 var keyVaultSecretInterpolatedVar = '${kv.getSecret('mySecret')}'
 //@[4:33) [no-unused-vars (Warning)] Variable "keyVaultSecretInterpolatedVar" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |keyVaultSecretInterpolatedVar|
+//@[36:65) [simplify-interpolation (Warning)] Remove unnecessary string interpolation. (CodeDescription: bicep core(https://aka.ms/bicep/linter/simplify-interpolation)) |'${kv.getSecret('mySecret')}'|
 //@[39:63) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
 var keyVaultSecretObjectVar = {
 //@[4:27) [no-unused-vars (Warning)] Variable "keyVaultSecretObjectVar" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |keyVaultSecretObjectVar|

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SimplifyInterpolationRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SimplifyInterpolationRuleTests.cs
@@ -246,6 +246,23 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             ]
             var stringVal = '${arrayOfStrings}'
         ")]
+        [DataRow(@"
+            var arrayOne = [
+                'a'
+                'b'
+            ]
+            var arrayTwo = [
+                'c'
+            ]
+
+            var stringVal = '${concat(arrayOne, arrayTwo)}'
+        ")]
+        [DataRow(@"
+            var stringVal = '${max(1, 2)}'
+        ")]
+        [DataRow(@"
+            var stringVal = '${resourceGroup().tags}'
+        ")]
         [DataTestMethod]
         public void TypeIsNotString_Passes(string text)
         {

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SimplifyInterpolationRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SimplifyInterpolationRuleTests.cs
@@ -119,6 +119,29 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             ExpectDiagnosticWithFix(text, expectedFix);
         }
 
+        [DataRow(
+            @"
+            var s = '${concat('a', 'b')}'
+            ",
+            "concat('a', 'b')"
+        )]
+        [DataRow(
+            @"
+                resource AutomationAccount 'Microsoft.Automation/automationAccounts@2020-01-13-preview' = {
+                    name: 'name'
+                    location: '${resourceGroup().location}'
+                    properties: {
+                        encryption: 'a'
+                    }
+                }",
+            "resourceGroup().location"
+        )]
+        [DataTestMethod]
+        public void StringExpression(string text, string expectedFix)
+        {
+            ExpectDiagnosticWithFix(text, expectedFix);
+        }
+
         [DataRow(@"
                     param AutomationAccountName string
                     resource AutomationAccount 'Microsoft.Automation/automationAccounts@2020-01-13-preview' = {
@@ -146,11 +169,6 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         name: '${AutomationAccountName}${AutomationAccountName}'
                         location: resourceGroup().location
                     }"
-        )]
-        [DataRow(
-            @"
-            var s = '${concat('a','b')}'
-            "
         )]
         [DataTestMethod]
         public void InterpolationMoreThanJustParamOrVar_Passes(string text)
@@ -258,4 +276,3 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
     }
 }
-

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
@@ -3,6 +3,7 @@
 
 using Bicep.Core.CodeAction;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
@@ -82,14 +83,14 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 if (valueSyntax is StringSyntax strSyntax
                     && strSyntax.Expressions.Length == 1
                     && strSyntax.SegmentValues.All(s => string.IsNullOrEmpty(s))
-                    && strSyntax.Expressions.First() is VariableAccessSyntax variableAccessSyntax) // VariableAccessSyntax applies to params and vars and modules
+                    && strSyntax.Expressions.First() is ExpressionSyntax expression)
                 {
                     // We only want to trigger if the var or param is of type string (because interpolation
                     // using non-string types can be a perfectly valid way to convert to string, e.g. '${intVar}')
-                    var type = model.GetTypeInfo(variableAccessSyntax);
+                    var type = model.GetTypeInfo(expression);
                     if (IsStrictlyAssignableToString(type))
                     {
-                        AddCodeFix(valueSyntax.Span, variableAccessSyntax.Name.IdentifierName);
+                        AddCodeFix(valueSyntax.Span, expression.ToText());
                     }
                 }
                 return null;

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
@@ -85,7 +85,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     && strSyntax.SegmentValues.All(s => string.IsNullOrEmpty(s))
                     && strSyntax.Expressions.First() is ExpressionSyntax expression)
                 {
-                    // We only want to trigger if the var or param is of type string (because interpolation
+                    // We only want to trigger if the expression is of type string (because interpolation
                     // using non-string types can be a perfectly valid way to convert to string, e.g. '${intVar}')
                     var type = model.GetTypeInfo(expression);
                     if (IsStrictlyAssignableToString(type))


### PR DESCRIPTION
Fixes #5963

Update the SimplifyInterpolationRule linter rule to apply to all expressions that resolve to strings, not just identifiers of string variables and parameters.

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [X] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [X] I have appropriate test coverage of my new feature
