### PR TITLE
Emit API versions for conditional resource references

### DIFF
--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6135893197178781329"
+      "templateHash": "12306829397421129331"
     }
   },
   "parameters": {
@@ -850,11 +850,11 @@
     },
     "lastNameServers": {
       "type": "array",
-      "value": "[reference(resourceId('Microsoft.Network/dnsZones', format('indexedZone-{0}-{1}', parameters('accounts')[sub(length(parameters('accounts')), 1)].name, sub(length(parameters('accounts')), 1)))).nameServers]"
+      "value": "[reference(resourceId('Microsoft.Network/dnsZones', format('indexedZone-{0}-{1}', parameters('accounts')[sub(length(parameters('accounts')), 1)].name, sub(length(parameters('accounts')), 1))), '2018-05-01').nameServers]"
     },
     "lastModuleOutput": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('stuff-{0}', sub(length(parameters('accounts')), 1)))).outputs.myOutput.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('stuff-{0}', sub(length(parameters('accounts')), 1))), '2020-10-01').outputs.myOutput.value]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17608560117045014269"
+      "templateHash": "3051020952527793145"
     }
   },
   "parameters": {
@@ -79,8 +79,8 @@
       "apiVersion": "2020-12-01",
       "name": "[format('{0}/{1}/{2}', 'conditionParent', 'conditionChild', 'conditionGrandchild')]",
       "properties": {
-        "size": "[reference(resourceId('My.Rp/parentType', 'conditionParent')).size]",
-        "style": "[reference(resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')).style]"
+        "size": "[reference(resourceId('My.Rp/parentType', 'conditionParent'), '2020-12-01').size]",
+        "style": "[reference(resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild'), '2020-12-01').style]"
       },
       "dependsOn": [
         "[resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')]",

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4897965198946026578"
+      "templateHash": "2564861032733655849"
     }
   },
   "parameters": {
@@ -309,7 +309,7 @@
       "name": "extensionDependencies",
       "properties": {
         "res1": "[resourceId('Microsoft.Compute/virtualMachines', 'vmName')]",
-        "res1runtime": "[reference(resourceId('Microsoft.Compute/virtualMachines', 'vmName')).something]",
+        "res1runtime": "[reference(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), '2020-06-01').something]",
         "res2": "[extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension')]",
         "res2runtime": "[reference(extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension')).something]",
         "res3": "[extensionResourceId(extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension'), 'My.Rp/extensionResource', 'extension')]",

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -639,7 +639,7 @@ namespace Bicep.Core.Emit
                     new JTokenExpression("outputs"));
             }
 
-            if (moduleSymbol.DeclaringModule.Value is IfConditionSyntax)
+            if (moduleSymbol.DeclaringModule.HasCondition())
             {
                 return AppendProperties(
                     CreateFunction(
@@ -699,10 +699,11 @@ namespace Bicep.Core.Emit
             }
 
             var shouldIncludeApiVersion =
-                resource.IsExistingResource ||
-                resource is DeclaredResourceMetadata { Symbol.DeclaringResource.Value: IfConditionSyntax };
+                !context.Settings.EnableSymbolicNames &&
+                (resource.IsExistingResource ||
+                (resource is DeclaredResourceMetadata { Symbol.DeclaringResource: var declaringResource } && declaringResource.HasCondition()));
 
-            if (!context.Settings.EnableSymbolicNames && shouldIncludeApiVersion)
+            if (shouldIncludeApiVersion)
             {
                 var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
 

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -698,7 +698,11 @@ namespace Bicep.Core.Emit
                     new JTokenExpression("full"));
             }
 
-            if (resource.IsExistingResource && !context.Settings.EnableSymbolicNames)
+            var shouldIncludeApiVersion =
+                resource.IsExistingResource ||
+                resource is DeclaredResourceMetadata { Symbol.DeclaringResource.Value: IfConditionSyntax };
+
+            if (!context.Settings.EnableSymbolicNames && shouldIncludeApiVersion)
             {
                 var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
 

--- a/src/Bicep.Core/Syntax/ModuleDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ModuleDeclarationSyntax.cs
@@ -67,5 +67,7 @@ namespace Bicep.Core.Syntax
 
         public ObjectSyntax GetBody() =>
             this.TryGetBody() ?? throw new InvalidOperationException($"A valid module body is not available on this module due to errors. Use {nameof(TryGetBody)}() instead.");
+
+        public bool HasCondition() => this.Value is IfConditionSyntax or ForSyntax { Body: IfConditionSyntax };
     }
 }

--- a/src/Bicep.Core/Syntax/ResourceDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ResourceDeclarationSyntax.cs
@@ -76,5 +76,7 @@ namespace Bicep.Core.Syntax
 
         public ObjectSyntax GetBody() =>
             this.TryGetBody() ?? throw new InvalidOperationException($"A valid resource body is not available on this module due to errors. Use {nameof(TryGetBody)}() instead.");
+
+        public bool HasCondition() => this.Value is IfConditionSyntax or ForSyntax { Body: IfConditionSyntax };
     }
 }


### PR DESCRIPTION
We should emit API versions for non-symbolic resource references if the referenced resources have conditions.

The PR partially addresses https://github.com/Azure/bicep/issues/1631. 