### PR TITLE
Emit scope properties on `existing` resources with symbolic names enabled

### DIFF
--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17982262982198579672"
+      "templateHash": "10105950490850461524"
     }
   },
   "parameters": {
@@ -95,6 +95,7 @@
       "existing": true,
       "type": "Microsoft.KeyVault/vaults",
       "apiVersion": "2019-09-01",
+      "resourceGroup": "otherGroup",
       "name": "testkeyvault"
     },
     "loopedKv": {
@@ -105,6 +106,8 @@
       "existing": true,
       "type": "Microsoft.KeyVault/vaults",
       "apiVersion": "2019-09-01",
+      "subscriptionId": "[variables('vaults')[copyIndex()].vaultSub]",
+      "resourceGroup": "[variables('vaults')[copyIndex()].vaultRG]",
       "name": "[variables('vaults')[copyIndex()].vaultName]"
     },
     "modATest": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/databricks-all-in-one-template-for-vnet-injection/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/databricks-all-in-one-template-for-vnet-injection/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18417593559327655298"
+      "templateHash": "7621613489475986772"
     }
   },
   "parameters": {
@@ -101,6 +101,7 @@
       "existing": true,
       "type": "Microsoft.Resources/resourceGroups",
       "apiVersion": "2021-04-01",
+      "subscriptionId": "[subscription().subscriptionId]",
       "name": "[variables('managedResourceGroupName')]"
     },
     "nsg": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/template-spec-deploy/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/template-spec-deploy/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3214106287326946885"
+      "templateHash": "2129236952501743137"
     }
   },
   "parameters": {
@@ -31,12 +31,16 @@
       "existing": true,
       "type": "Microsoft.Resources/templateSpecs/versions",
       "apiVersion": "2019-06-01-preview",
+      "subscriptionId": "[parameters('templateSpecSub')]",
+      "resourceGroup": "[parameters('templateSpecRg')]",
       "name": "[format('{0}/{1}', parameters('templateSpecName'), parameters('templateSpecVersion'))]"
     },
     "ts": {
       "existing": true,
       "type": "Microsoft.Resources/templateSpecs",
       "apiVersion": "2019-06-01-preview",
+      "subscriptionId": "[parameters('templateSpecSub')]",
+      "resourceGroup": "[parameters('templateSpecRg')]",
       "name": "[parameters('templateSpecName')]"
     },
     "deployTs": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/website-with-container/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/101/website-with-container/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "97755062618535923"
+      "templateHash": "8882781331082655516"
     }
   },
   "parameters": {
@@ -49,6 +49,8 @@
       "existing": true,
       "type": "Microsoft.ContainerRegistry/registries",
       "apiVersion": "2019-05-01",
+      "subscriptionId": "[parameters('acrSubscription')]",
+      "resourceGroup": "[parameters('acrResourceGroup')]",
       "name": "[parameters('acrName')]"
     },
     "site": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4698237609729778047"
+      "templateHash": "799864613260087717"
     }
   },
   "parameters": {
@@ -61,7 +61,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7891355063625276557"
+              "templateHash": "5674317740980132409"
             }
           },
           "parameters": {
@@ -133,6 +133,8 @@
               "existing": true,
               "type": "Microsoft.KeyVault/vaults",
               "apiVersion": "2021-04-01-preview",
+              "subscriptionId": "[union(variables('defaultSqlLogicalServerProperties'), parameters('sqlLogicalServers')[copyIndex()]).passwordFromKeyVault.subscriptionId]",
+              "resourceGroup": "[parameters('sqlLogicalServers')[copyIndex()].passwordFromKeyVault.resourceGroupName]",
               "name": "[parameters('sqlLogicalServers')[copyIndex()].passwordFromKeyVault.name]"
             },
             "sqlLogicalServer": {
@@ -173,7 +175,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "11627375028675542139"
+                      "templateHash": "17481587090364955512"
                     }
                   },
                   "parameters": {
@@ -300,6 +302,7 @@
                       "existing": true,
                       "type": "Microsoft.Storage/storageAccounts",
                       "apiVersion": "2021-04-01",
+                      "resourceGroup": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName]",
                       "name": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name]"
                     },
                     "vulnerabilityAssessments": {
@@ -377,6 +380,8 @@
                       "existing": true,
                       "type": "Microsoft.OperationalInsights/workspaces",
                       "apiVersion": "2020-10-01",
+                      "subscriptionId": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId]",
+                      "resourceGroup": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName]",
                       "name": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name]"
                     },
                     "auditDiagnosticSettings": {
@@ -535,7 +540,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "174370743240355342"
+                              "templateHash": "13476748154905990322"
                             }
                           },
                           "parameters": {
@@ -610,6 +615,7 @@
                               "existing": true,
                               "type": "Microsoft.Storage/storageAccounts",
                               "apiVersion": "2021-04-01",
+                              "resourceGroup": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName]",
                               "name": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name]"
                             },
                             "vulnerabilityAssessments": {
@@ -637,6 +643,8 @@
                               "existing": true,
                               "type": "Microsoft.OperationalInsights/workspaces",
                               "apiVersion": "2020-10-01",
+                              "subscriptionId": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId]",
+                              "resourceGroup": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName]",
                               "name": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.name]"
                             },
                             "auditDiagnosticSettings": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-database.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-database.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "174370743240355342"
+      "templateHash": "13476748154905990322"
     }
   },
   "parameters": {
@@ -82,6 +82,7 @@
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2021-04-01",
+      "resourceGroup": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName]",
       "name": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name]"
     },
     "vulnerabilityAssessments": {
@@ -109,6 +110,8 @@
       "existing": true,
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2020-10-01",
+      "subscriptionId": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId]",
+      "resourceGroup": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName]",
       "name": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.name]"
     },
     "auditDiagnosticSettings": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-logical-server.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-logical-server.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11627375028675542139"
+      "templateHash": "17481587090364955512"
     }
   },
   "parameters": {
@@ -134,6 +134,7 @@
       "existing": true,
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2021-04-01",
+      "resourceGroup": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName]",
       "name": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name]"
     },
     "vulnerabilityAssessments": {
@@ -211,6 +212,8 @@
       "existing": true,
       "type": "Microsoft.OperationalInsights/workspaces",
       "apiVersion": "2020-10-01",
+      "subscriptionId": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId]",
+      "resourceGroup": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName]",
       "name": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name]"
     },
     "auditDiagnosticSettings": {
@@ -369,7 +372,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "174370743240355342"
+              "templateHash": "13476748154905990322"
             }
           },
           "parameters": {
@@ -444,6 +447,7 @@
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
               "apiVersion": "2021-04-01",
+              "resourceGroup": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName]",
               "name": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name]"
             },
             "vulnerabilityAssessments": {
@@ -471,6 +475,8 @@
               "existing": true,
               "type": "Microsoft.OperationalInsights/workspaces",
               "apiVersion": "2020-10-01",
+              "subscriptionId": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId]",
+              "resourceGroup": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName]",
               "name": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.name]"
             },
             "auditDiagnosticSettings": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-logical-servers.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/301/sql-database-with-management/modules/sql-logical-servers.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7891355063625276557"
+      "templateHash": "5674317740980132409"
     }
   },
   "parameters": {
@@ -79,6 +79,8 @@
       "existing": true,
       "type": "Microsoft.KeyVault/vaults",
       "apiVersion": "2021-04-01-preview",
+      "subscriptionId": "[union(variables('defaultSqlLogicalServerProperties'), parameters('sqlLogicalServers')[copyIndex()]).passwordFromKeyVault.subscriptionId]",
+      "resourceGroup": "[parameters('sqlLogicalServers')[copyIndex()].passwordFromKeyVault.resourceGroupName]",
       "name": "[parameters('sqlLogicalServers')[copyIndex()].passwordFromKeyVault.name]"
     },
     "sqlLogicalServer": {
@@ -119,7 +121,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11627375028675542139"
+              "templateHash": "17481587090364955512"
             }
           },
           "parameters": {
@@ -246,6 +248,7 @@
               "existing": true,
               "type": "Microsoft.Storage/storageAccounts",
               "apiVersion": "2021-04-01",
+              "resourceGroup": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName]",
               "name": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name]"
             },
             "vulnerabilityAssessments": {
@@ -323,6 +326,8 @@
               "existing": true,
               "type": "Microsoft.OperationalInsights/workspaces",
               "apiVersion": "2020-10-01",
+              "subscriptionId": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId]",
+              "resourceGroup": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName]",
               "name": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name]"
             },
             "auditDiagnosticSettings": {
@@ -481,7 +486,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "174370743240355342"
+                      "templateHash": "13476748154905990322"
                     }
                   },
                   "parameters": {
@@ -556,6 +561,7 @@
                       "existing": true,
                       "type": "Microsoft.Storage/storageAccounts",
                       "apiVersion": "2021-04-01",
+                      "resourceGroup": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName]",
                       "name": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name]"
                     },
                     "vulnerabilityAssessments": {
@@ -583,6 +589,8 @@
                       "existing": true,
                       "type": "Microsoft.OperationalInsights/workspaces",
                       "apiVersion": "2020-10-01",
+                      "subscriptionId": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId]",
+                      "resourceGroup": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName]",
                       "name": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.name]"
                     },
                     "auditDiagnosticSettings": {

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -6,11 +6,9 @@ using System.Linq;
 using Bicep.Core.DataFlow;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
-using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
-using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Utils;
 using Bicep.Core.Extensions;
 

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -619,7 +619,7 @@ namespace Bicep.Core.Emit
             emitter.EmitObjectProperties((ObjectSyntax)body, ModulePropertiesToOmit);
 
             var scopeData = context.ModuleScopeData[moduleSymbol];
-            ScopeHelper.EmitModuleScopeProperties(context.SemanticModel.TargetScope, scopeData, emitter, body);
+            ScopeHelper.EmitModuleScopeProperties(context.SemanticModel, scopeData, emitter, body);
 
             if (scopeData.RequestedScope != ResourceScope.ResourceGroup)
             {


### PR DESCRIPTION
We now emit scope properties (such as `resourceGroup`, `subscriptionId` or `scope`) on `existing` resources when symbolic names codegen is enabled.

Fixes #6139. 