### PR TITLE
Updated snippet descriptions to fix declarations.json "typos"

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -1929,7 +1929,7 @@
   {
     "label": "res-policy-exemption",
     "kind": "snippet",
-    "detail": "olicy Exemption",
+    "detail": "Policy Exemption",
     "documentation": {
       "kind": "markdown",
       "value": "```bicep\nresource policyExemption 'Microsoft.Authorization/policyExemptions@2020-07-01-preview' = {\n  name: 'name'\n  properties: {\n    policyAssignmentId: 'policyAssignmentId'\n    policyDefinitionReferenceIds: [\n      'policyDefinitionReferenceIds'\n    ]\n    exemptionCategory: 'Mitigated'\n    expiresOn: 'expiresOn'\n    displayName: 'displayName'\n    description: 'description'\n    metadata: {\n      version: '0.1.0'\n      source: 'source'\n    }\n  }\n}\n\n```"
@@ -2045,7 +2045,7 @@
   {
     "label": "res-policy-remediation",
     "kind": "snippet",
-    "detail": "olicy Remediation",
+    "detail": "Policy Remediation",
     "documentation": {
       "kind": "markdown",
       "value": "```bicep\nresource policyRemediation 'Microsoft.PolicyInsights/remediations@2019-07-01' = {\n  name: 'name'\n  properties: {\n    policyAssignmentId: 'policyAssignmentId'\n    policyDefinitionReferenceId: 'policyDefinitionReferenceId'\n    resourceDiscoveryMode: 'ExistingNonCompliant'\n    filters: {\n      locations: [\n        location\n      ]\n    }\n  }\n}\n\n```"

--- a/src/Bicep.LangServer/Snippets/Templates/res-policy-exemption.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-policy-exemption.bicep
@@ -1,4 +1,4 @@
-//Policy Exemption
+// Policy Exemption
 resource /*${1:policyExemption}*/policyExemption 'Microsoft.Authorization/policyExemptions@2020-07-01-preview' = {
   name: /*${2:'name'}*/'name'
   properties: {

--- a/src/Bicep.LangServer/Snippets/Templates/res-policy-remediation.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-policy-remediation.bicep
@@ -1,4 +1,4 @@
-//Policy Remediation
+// Policy Remediation
 resource /*${1:policyRemediation}*/policyRemediation 'Microsoft.PolicyInsights/remediations@2019-07-01' = {
   name: /*${2:'name'}*/'name'
   properties: {


### PR DESCRIPTION
Fixes #6211 

- Added missing space in description comments
- Updated `declarations.json`

## Contributing a snippet

* [x] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"
