### PR TITLE
Bicep deploy - better handle scenario when user doesn't have access to any management group

### DIFF
--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -166,8 +166,6 @@ export class DeployCommand implements Command {
         this.outputChannelManager.appendToOutputChannel(
           "Deployment was canceled."
         );
-      } else {
-        this.client.error("Deploy failed", parseError(exception).message, true);
       }
 
       throw exception;
@@ -181,12 +179,21 @@ export class DeployCommand implements Command {
     deploymentScope: string,
     template: string
   ) {
-    const managementGroupTreeItem =
-      await this.treeManager.azManagementGroupTreeItem.showTreeItemPicker<LocationTreeItem>(
-        "",
-        context
+    let managementGroupTreeItem: LocationTreeItem | undefined;
+    try {
+      managementGroupTreeItem =
+        await this.treeManager.azManagementGroupTreeItem.showTreeItemPicker<LocationTreeItem>(
+          "",
+          context
+        );
+    } catch (exception) {
+      this.outputChannelManager.appendToOutputChannel(
+        "Deployment failed. " + parseError(exception).message
       );
-    const managementGroupId = managementGroupTreeItem.id;
+
+      throw exception;
+    }
+    const managementGroupId = managementGroupTreeItem?.id;
 
     if (managementGroupId) {
       const location = await vscode.window.showInputBox({

--- a/src/vscode-bicep/src/tree/AzManagementGroupTreeItem.ts
+++ b/src/vscode-bicep/src/tree/AzManagementGroupTreeItem.ts
@@ -32,6 +32,13 @@ export class AzManagementGroupTreeItem extends AzExtParentTreeItem {
     );
 
     const managementGroupInfos = managementGroupsAPI.managementGroups.list();
+
+    if (managementGroupInfos.byPage.length == 0) {
+      throw new Error(
+        "You do not have access to any management group. Please create one in azure portal and try deploy again"
+      );
+    }
+
     const managementGroupInfoList: ManagementGroupInfo[] =
       await uiUtils.listAllIterator(managementGroupInfos);
 


### PR DESCRIPTION
Currently when user doesn't have access to any management group, we don't not show any information in output channel and show request failed notification.
![image](https://user-images.githubusercontent.com/30270536/159086523-25a0fd92-377b-4b46-9160-606e063e11e0.png)

With changes in this PR, we will now show the issue in output channel:
![image](https://user-images.githubusercontent.com/30270536/159086626-6b271f4c-c466-4b85-8bdf-bb0f00ad29d4.png)
