### PR TITLE
Stop emitting dependencies on non-direct ancestors

### DIFF
--- a/docs/examples/201/sql/main.json
+++ b/docs/examples/201/sql/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11609579889945901205"
+      "templateHash": "18429782161085201209"
     }
   },
   "parameters": {
@@ -71,8 +71,7 @@
         "state": "[parameters('transparentDataEncryption')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Sql/servers/databases', variables('sqlServerName'), variables('databaseName'))]",
-        "[resourceId('Microsoft.Sql/servers', variables('sqlServerName'))]"
+        "[resourceId('Microsoft.Sql/servers/databases', variables('sqlServerName'), variables('databaseName'))]"
       ]
     }
   ]

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3051020952527793145"
+      "templateHash": "7719469792547706737"
     }
   },
   "parameters": {
@@ -35,8 +35,7 @@
         "style": "[reference(resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')).style]"
       },
       "dependsOn": [
-        "[resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')]",
-        "[resourceId('My.Rp/parentType', 'basicParent')]"
+        "[resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')]"
       ]
     },
     {
@@ -83,8 +82,7 @@
         "style": "[reference(resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild'), '2020-12-01').style]"
       },
       "dependsOn": [
-        "[resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')]",
-        "[resourceId('My.Rp/parentType', 'conditionParent')]"
+        "[resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')]"
       ]
     },
     {

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15395751030098486023"
+      "templateHash": "6831743105336050792"
     }
   },
   "parameters": {
@@ -37,8 +37,7 @@
         "style": "[reference('basicChild').style]"
       },
       "dependsOn": [
-        "basicChild",
-        "basicParent"
+        "basicChild"
       ]
     },
     "basicChild": {
@@ -91,8 +90,7 @@
         "style": "[reference('conditionChild').style]"
       },
       "dependsOn": [
-        "conditionChild",
-        "conditionParent"
+        "conditionChild"
       ]
     },
     "conditionChild": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/sql/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/sql/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11202647491466524907"
+      "templateHash": "7810581404482823751"
     }
   },
   "parameters": {
@@ -73,8 +73,7 @@
         "state": "[parameters('transparentDataEncryption')]"
       },
       "dependsOn": [
-        "db",
-        "sqlServer"
+        "db"
       ]
     }
   }

--- a/src/Bicep.Core/Emit/ResourceDependency.cs
+++ b/src/Bicep.Core/Emit/ResourceDependency.cs
@@ -9,10 +9,11 @@ namespace Bicep.Core.Emit
 {
     public class ResourceDependency
     {
-        public ResourceDependency(DeclaredSymbol resource, SyntaxBase? indexExpression)
+        public ResourceDependency(DeclaredSymbol resource, SyntaxBase? indexExpression, ResourceDependencyKind kind)
         {
             this.Resource = resource;
             this.IndexExpression = indexExpression;
+            this.Kind = kind;
         }
 
         public DeclaredSymbol Resource { get; }
@@ -22,6 +23,8 @@ namespace Bicep.Core.Emit
         /// </summary>
         public SyntaxBase? IndexExpression { get; }
 
+        public ResourceDependencyKind Kind { get; }
+
         public override bool Equals(object? obj)
         {
             if (obj is not ResourceDependency other)
@@ -29,9 +32,9 @@ namespace Bicep.Core.Emit
                 return false;
             }
 
-            return ReferenceEquals(this.Resource, other.Resource) && ReferenceEquals(this.IndexExpression, other.IndexExpression);
+            return ReferenceEquals(this.Resource, other.Resource) && ReferenceEquals(this.IndexExpression, other.IndexExpression) && this.Kind == other.Kind;
         }
 
-        public override int GetHashCode() => HashCode.Combine(this.Resource, this.IndexExpression);
+        public override int GetHashCode() => HashCode.Combine(this.Resource, this.IndexExpression, this.Kind);
     }
 }

--- a/src/Bicep.Core/Emit/ResourceDependencyKind.cs
+++ b/src/Bicep.Core/Emit/ResourceDependencyKind.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Emit
+{
+    public enum ResourceDependencyKind
+    {
+        Primary,
+
+        Transitive
+    }
+}

--- a/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using Bicep.Core.DataFlow;
 using Bicep.Core.Extensions;
-using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
@@ -74,12 +73,13 @@ namespace Bicep.Core.Emit
 
             // Resource ancestors are always dependencies.
             var ancestors = this.model.ResourceAncestors.GetAncestors(resource);
+            var lastAncestorIndex = ancestors.Length - 1;
 
             // save previous declaration as we may call this recursively
             var prevDeclaration = this.currentDeclaration;
 
             this.currentDeclaration = resource.Symbol;
-            this.resourceDependencies[resource.Symbol] = new HashSet<ResourceDependency>(ancestors.Select(a => new ResourceDependency(a.Resource.Symbol, a.IndexExpression)));
+            this.resourceDependencies[resource.Symbol] = new HashSet<ResourceDependency>(ancestors.Select((a, i) => new ResourceDependency(a.Resource.Symbol, a.IndexExpression, i == lastAncestorIndex ? ResourceDependencyKind.Primary : ResourceDependencyKind.Transitive)));
             base.VisitResourceDeclarationSyntax(syntax);
 
             // restore previous declaration
@@ -168,11 +168,11 @@ namespace Bicep.Core.Emit
                         return;
                     }
 
-                    currentResourceDependencies.Add(new ResourceDependency(resourceSymbol, GetIndexExpression(syntax, resourceSymbol.IsCollection)));
+                    currentResourceDependencies.Add(new ResourceDependency(resourceSymbol, GetIndexExpression(syntax, resourceSymbol.IsCollection), ResourceDependencyKind.Primary));
                     return;
 
                 case ModuleSymbol moduleSymbol:
-                    currentResourceDependencies.Add(new ResourceDependency(moduleSymbol, GetIndexExpression(syntax, moduleSymbol.IsCollection)));
+                    currentResourceDependencies.Add(new ResourceDependency(moduleSymbol, GetIndexExpression(syntax, moduleSymbol.IsCollection), ResourceDependencyKind.Primary));
                     return;
             }
         }
@@ -201,11 +201,11 @@ namespace Bicep.Core.Emit
                         return;
                     }
 
-                    currentResourceDependencies.Add(new ResourceDependency(resourceSymbol, GetIndexExpression(syntax, resourceSymbol.IsCollection)));
+                    currentResourceDependencies.Add(new ResourceDependency(resourceSymbol, GetIndexExpression(syntax, resourceSymbol.IsCollection), ResourceDependencyKind.Primary));
                     return;
 
                 case ModuleSymbol moduleSymbol:
-                    currentResourceDependencies.Add(new ResourceDependency(moduleSymbol, GetIndexExpression(syntax, moduleSymbol.IsCollection)));
+                    currentResourceDependencies.Add(new ResourceDependency(moduleSymbol, GetIndexExpression(syntax, moduleSymbol.IsCollection), ResourceDependencyKind.Primary));
                     return;
             }
         }

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -682,12 +682,21 @@ namespace Bicep.Core.Emit
 
             jsonWriter.WriteEndObject();
         }
-        private static bool ShouldGenerateDependsOn(ResourceDependency dependency) => dependency.Resource switch
-        {   // We only want to add a 'dependsOn' for resources being deployed in this file.
-            ResourceSymbol resource => !resource.DeclaringResource.IsExistingResource(),
-            ModuleSymbol => true,
-            _ => throw new InvalidOperationException($"Found dependency '{dependency.Resource.Name}' of unexpected type {dependency.GetType()}"),
-        };
+        private static bool ShouldGenerateDependsOn(ResourceDependency dependency)
+        {
+            if(dependency.Kind == ResourceDependencyKind.Transitive)
+            {
+                // transitive dependencies do not have to be emitted
+                return false;
+            }
+
+            return dependency.Resource switch
+            {   // We only want to add a 'dependsOn' for resources being deployed in this file.
+                ResourceSymbol resource => !resource.DeclaringResource.IsExistingResource(),
+                ModuleSymbol => true,
+                _ => throw new InvalidOperationException($"Found dependency '{dependency.Resource.Name}' of unexpected type {dependency.GetType()}"),
+            };
+        }
 
         private void EmitSymbolicNameDependsOnEntry(JsonTextWriter jsonWriter, ExpressionEmitter emitter, SyntaxBase newContext, ResourceDependency dependency)
         {


### PR DESCRIPTION
If you have nested resources main<-child<-grandChild in your module, we used to emit the following dependencies:
1. main<-child (direct)
2. main<-grandChild (transitive)
3. child<-grandChild (direct)

This PR makes it so we no longer emit transitive dependencies obtained from ancestors. 

This is a prerequisite to for #6075, which requires that all dependencies have a corresponding syntax so index expressions can be reliably obtained and transformed.

I left the visualizer experience unaffected, so #2755 is not fixed by this PR.