### PR TITLE
Force e2e test to use latest vscode-dotnet-runtime

### DIFF
--- a/src/vscode-bicep/src/test/e2e/runTests.ts
+++ b/src/vscode-bicep/src/test/e2e/runTests.ts
@@ -47,6 +47,7 @@ async function go() {
         ...cliArguments,
         "--install-extension",
         "ms-dotnettools.vscode-dotnet-runtime",
+        "--force", // Force use of latest version of vscode-dotnet-runtime
         ...userDataArguments,
       ];
 


### PR DESCRIPTION
Try enforcing latest version of vscode-dotnet-runtime (see https://github.com/Azure/bicep/issues/6258)