### PR TITLE
Add dev option for e2e ext test launch config

### DIFF
--- a/src/vscode-bicep/.vscode/launch.json
+++ b/src/vscode-bicep/.vscode/launch.json
@@ -58,7 +58,7 @@
       }
     },
     {
-      "name": "Launch Tests: E2E",
+      "name": "Launch Tests: E2E (prod)",
       "type": "extensionHost",
       "request": "launch",
       "args": [
@@ -68,6 +68,22 @@
       ],
       "outFiles": ["${workspaceRoot}/out/test/e2e/**/*.js"],
       "preLaunchTask": "build:e2e",
+      "env": {
+        "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll",
+        "TEST_MODE": "e2e"
+      }
+    },
+    {
+      "name": "Launch Tests: E2E (development)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--enable-proposed-api",
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/e2e/index"
+      ],
+      "outFiles": ["${workspaceRoot}/out/test/e2e/**/*.js"],
+      "preLaunchTask": "build:e2e:dev",
       "env": {
         "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll",
         "TEST_MODE": "e2e"

--- a/src/vscode-bicep/.vscode/tasks.json
+++ b/src/vscode-bicep/.vscode/tasks.json
@@ -102,6 +102,18 @@
       "dependsOrder": "sequence"
     },
     {
+      "label": "build:e2e:dev",
+      "type": "typescript",
+      "tsconfig": "tsconfig.e2e.dev.json",
+      "problemMatcher": "$tsc",
+      "group": "build",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "dependsOn": ["build"],
+      "dependsOrder": "sequence"
+    },
+    {
       "label": "watch",
       "type": "npm",
       "script": "watch",

--- a/src/vscode-bicep/tsconfig.e2e.dev.json
+++ b/src/vscode-bicep/tsconfig.e2e.dev.json
@@ -1,0 +1,18 @@
+// We need to compile the e2e tests until https://github.com/microsoft/vscode-test/issues/92 is closed.
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["es2016"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "outDir": "out/test",
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/test/e2e"]
+}


### PR DESCRIPTION
Mostly for quicker startup than running webpack prod, at least for now.