### PR TITLE
Bicep deploy - add telemetry for deployment scope and parameter file usage

### DIFF
--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -50,7 +50,7 @@ export class DeployCommand implements Command {
     private readonly client: LanguageClient,
     private readonly outputChannelManager: OutputChannelManager,
     private readonly treeManager: TreeManager
-  ) { }
+  ) {}
 
   public async execute(
     context: IActionContext,
@@ -92,12 +92,12 @@ export class DeployCommand implements Command {
       if (!template) {
         this.outputChannelManager.appendToOutputChannel(
           "Unable to deploy. Please fix below errors:\n " +
-          deploymentScopeResponse?.errorMessage
+            deploymentScopeResponse?.errorMessage
         );
         return;
       }
 
-      context.telemetry.properties.deploymentScope = deploymentScope;
+      context.telemetry.properties.targetScope = deploymentScope;
       this.outputChannelManager.appendToOutputChannel(
         `Scope specified in ${path.basename(
           documentPath
@@ -298,8 +298,7 @@ export class DeployCommand implements Command {
         `No parameter file was provided`
       );
       parameterFilePath = "";
-    }
-    else {
+    } else {
       context.telemetry.properties.parameterFileProvided = "true";
     }
     const bicepDeployParams: BicepDeployParams = {

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -50,7 +50,7 @@ export class DeployCommand implements Command {
     private readonly client: LanguageClient,
     private readonly outputChannelManager: OutputChannelManager,
     private readonly treeManager: TreeManager
-  ) {}
+  ) { }
 
   public async execute(
     context: IActionContext,
@@ -92,11 +92,12 @@ export class DeployCommand implements Command {
       if (!template) {
         this.outputChannelManager.appendToOutputChannel(
           "Unable to deploy. Please fix below errors:\n " +
-            deploymentScopeResponse?.errorMessage
+          deploymentScopeResponse?.errorMessage
         );
         return;
       }
 
+      context.telemetry.properties.deploymentScope = deploymentScope;
       this.outputChannelManager.appendToOutputChannel(
         `Scope specified in ${path.basename(
           documentPath
@@ -208,6 +209,7 @@ export class DeployCommand implements Command {
         );
 
         await this.sendDeployCommand(
+          context,
           textDocument,
           parameterFilePath,
           managementGroupId,
@@ -240,6 +242,7 @@ export class DeployCommand implements Command {
       );
 
       await this.sendDeployCommand(
+        context,
         textDocument,
         parameterFilePath,
         resourceGroupId,
@@ -270,6 +273,7 @@ export class DeployCommand implements Command {
     );
 
     await this.sendDeployCommand(
+      context,
       textDocument,
       parameterFilePath,
       subscriptionId,
@@ -280,6 +284,7 @@ export class DeployCommand implements Command {
   }
 
   private async sendDeployCommand(
+    context: IActionContext,
     textDocument: TextDocumentIdentifier,
     parameterFilePath: string | undefined,
     id: string,
@@ -288,10 +293,14 @@ export class DeployCommand implements Command {
     template: string
   ) {
     if (!parameterFilePath) {
+      context.telemetry.properties.parameterFileProvided = "false";
       this.outputChannelManager.appendToOutputChannel(
         `No parameter file was provided`
       );
       parameterFilePath = "";
+    }
+    else {
+      context.telemetry.properties.parameterFileProvided = "true";
     }
     const bicepDeployParams: BicepDeployParams = {
       textDocument,


### PR DESCRIPTION
Add telemetry for deployment scope and parameter file usage.

Sample output from vscode debug console:

** TELEMETRY("vscode-bicep/command/bicep.deploy", 0.0.0-placeholder) properties={"isActivationEvent":"false","lastStep":"quickPick|Selectaparameterfile","result":"Succeeded","stack":"","error":"","errorMessage":"","contextValue":"Uri",**"deploymentScope":"subscription"**,"treeItemSource":"treeItemPicker","accountStatus":"LoggedIn","x-ms-correlation-request-id":"12096574-a438-4845-9149-931c1ae6ecfe",**"parameterFileProvided":"false"**}, measures={"duration":18.285}

** TELEMETRY("vscode-bicep/command/bicep.deploy", 0.0.0-placeholder) properties={"isActivationEvent":"false","lastStep":"quickPick|Selectaparameterfile","result":"Succeeded","stack":"","error":"","errorMessage":"","contextValue":"Uri",**"deploymentScope":"resourceGroup"**,"treeItemSource":"treeItemPicker","accountStatus":"LoggedIn"**,"parameterFileProvided":"true"**}, measures={"duration":38.117}