### PR TITLE
[Snippet] - Azure Firewall Standard SKU

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -1260,6 +1260,35 @@
     }
   },
   {
+    "label": "res-firewall-standard",
+    "kind": "snippet",
+    "detail": "Azure Firewall Standard SKU",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource firewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {\n  name: 'name'\n  location: location\n  properties: {\n    sku: {\n      name: 'AZFW_VNet'\n      tier: 'Standard'\n    }    \n    firewallPolicy: {\n      id: 'firewallPolicy.id'\n    }\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          subnet: {\n            id: 'subnet.id'\n          }\n          publicIPAddress: {\n            id: 'publicIPAddress.id'\n          }\n        }\n      }\n    ]\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-firewall-standard",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:firewall} 'Microsoft.Network/azureFirewalls@2021-05-01' = {\n  name: ${2:'name'}\n  location: ${3:location}\n  properties: {\n    sku: {\n      name: 'AZFW_VNet'\n      tier: 'Standard'\n    }    \n    firewallPolicy: {\n      id: ${4:'firewallPolicy.id'}\n    }\n    ipConfigurations: [\n      {\n        name: ${5:'name'}\n        properties: {\n          subnet: {\n            id: ${6:'subnet.id'}\n          }\n          publicIPAddress: {\n            id: ${7:'publicIPAddress.id'}\n          }\n        }\n      }\n    ]\n  }\n}\n"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "snippet/toplevel",
+          "Properties": {
+            "name": "res-firewall-standard"
+          }
+        }
+      ]
+    }
+  },
+  {
     "label": "res-function",
     "kind": "snippet",
     "detail": "Azure Functions (v2)",

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-firewall-standard/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-firewall-standard/main.bicep
@@ -1,0 +1,11 @@
+﻿// $1 = firewall
+// $2 = 'name'
+// $3 = location
+// $4 = 'firewallPolicy.id'
+// $5 = 'name'
+// $6 = 'subnet.id'
+// $7 = 'publicIPAddress.id'
+
+param location string
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-firewall-standard/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-firewall-standard/main.combined.bicep
@@ -1,0 +1,38 @@
+// $1 = firewall
+// $2 = 'name'
+// $3 = location
+// $4 = 'firewallPolicy.id'
+// $5 = 'name'
+// $6 = 'subnet.id'
+// $7 = 'publicIPAddress.id'
+
+param location string
+
+resource firewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {
+  name: 'name'
+  location: location
+  properties: {
+    sku: {
+      name: 'AZFW_VNet'
+      tier: 'Standard'
+    }    
+    firewallPolicy: {
+      id: 'firewallPolicy.id'
+    }
+    ipConfigurations: [
+      {
+        name: 'name'
+        properties: {
+          subnet: {
+            id: 'subnet.id'
+          }
+          publicIPAddress: {
+            id: 'publicIPAddress.id'
+          }
+        }
+      }
+    ]
+  }
+}
+// Insert snippet here
+

--- a/src/Bicep.LangServer/Snippets/Templates/res-firewall-standard.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-firewall-standard.bicep
@@ -1,0 +1,27 @@
+// Azure Firewall Standard SKU
+resource /*${1:firewall}*/firewall 'Microsoft.Network/azureFirewalls@2021-05-01' = {
+  name: /*${2:'name'}*/'name'
+  location: /*${3:location}*/'location'
+  properties: {
+    sku: {
+      name: 'AZFW_VNet'
+      tier: 'Standard'
+    }    
+    firewallPolicy: {
+      id: /*${4:'firewallPolicy.id'}*/'firewallPolicy.id'
+    }
+    ipConfigurations: [
+      {
+        name: /*${5:'name'}*/'name'
+        properties: {
+          subnet: {
+            id: /*${6:'subnet.id'}*/'subnet.id'
+          }
+          publicIPAddress: {
+            id: /*${7:'publicIPAddress.id'}*/'publicIPAddress.id'
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added a new Azure Firewall snippet that are using firewall policies instead of classic rules.

## Contributing a snippet

* [x] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"
* [x] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [x] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
