### PR TITLE
Bicep deploy - fix content modified error

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
@@ -40,17 +40,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
             deploymentCollectionProvider
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), scope))
                 .Throws(new Exception(string.Format(LangServerResources.UnsupportedTargetScopeMessage, scope)));
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 armClient,
+                documentPath,
                 string.Empty,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41",
                 scope,
                 string.Empty);
 
-            var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage,
+            var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath,
                 string.Format(LangServerResources.UnsupportedTargetScopeMessage, scope));
 
             result.Should().Be(expectedDeploymentOutputMessage);
@@ -63,16 +65,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
         public async Task CreateDeployment_WithSubscriptionScopeAndInvalidLocation_ReturnsDeploymentFailedMessage(string location)
         {
             var armClient = CreateMockArmClient();
+            var documentPath = "some_path";
+
             var result = await DeploymentHelper.CreateDeployment(
                 CreateDeploymentCollectionProvider(),
                 armClient,
+                documentPath,
                 string.Empty,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41",
                 LanguageConstants.TargetScopeTypeSubscription,
                 location);
 
-            result.Should().Be(LangServerResources.MissingLocationDeploymentFailedMessage);
+            result.Should().Be(string.Format(LangServerResources.MissingLocationDeploymentFailedMessage, documentPath));
         }
 
         [DataRow(null)]
@@ -82,16 +87,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
         public async Task CreateDeployment_WithManagementGroupScopeAndInvalidLocation_ReturnsDeploymentFailedMessage(string location)
         {
             var armClient = CreateMockArmClient();
+            var documentPath = "some_path";
+
             var result = await DeploymentHelper.CreateDeployment(
                 CreateDeploymentCollectionProvider(),
                 armClient,
+                documentPath,
                 string.Empty,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41",
                 LanguageConstants.TargetScopeTypeManagementGroup,
                 location);
 
-            result.Should().Be(LangServerResources.MissingLocationDeploymentFailedMessage);
+            result.Should().Be(string.Format(LangServerResources.MissingLocationDeploymentFailedMessage, documentPath));
         }
 
         [TestMethod]
@@ -102,17 +110,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
             deploymentCollectionProvider
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeTenant))
                 .Throws(new Exception(string.Format(LangServerResources.UnsupportedTargetScopeMessage, LanguageConstants.TargetScopeTypeTenant)));
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 armClient,
+                documentPath,
                 string.Empty,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41",
                 LanguageConstants.TargetScopeTypeTenant,
                 string.Empty);
 
-            var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage,
+            var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath,
                 string.Format(LangServerResources.UnsupportedTargetScopeMessage, LanguageConstants.TargetScopeTypeTenant));
 
             result.Should().Be(expectedDeploymentOutputMessage);
@@ -141,17 +151,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
             deploymentCollectionProvider
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), scope))
                 .Returns(deploymentCollection);
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 CreateMockArmClient(),
+                documentPath,
                 template,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 scope,
                 location);
 
-            result.Should().Be(LangServerResources.DeploymentSucceededMessage);
+            result.Should().Be(string.Format(LangServerResources.DeploymentSucceededMessage, documentPath));
         }
 
         [TestMethod]
@@ -174,17 +186,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
             deploymentCollectionProvider
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeSubscription))
                 .Returns(deploymentCollection);
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 CreateMockArmClient(),
+                documentPath,
                 template,
                 @"c:\parameter.json",
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeSubscription,
                 "eastus");
 
-            result.Should().Contain(string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, @"Could not find file"));
+            result.Should().Contain(string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, @"Could not find file"));
         }
 
         [TestMethod]
@@ -208,17 +222,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeSubscription))
                 .Returns(deploymentCollection);
             string parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", "invalid_parameters_file");
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 CreateMockArmClient(),
+                documentPath,
                 template,
                 parametersFilePath,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeSubscription,
                 "eastus");
 
-            result.Should().Be(string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, @"'i' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0."));
+            result.Should().Be(string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, @"'i' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0."));
         }
 
         [TestMethod]
@@ -240,17 +256,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
             deploymentCollectionProvider
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeResourceGroup))
                 .Returns<DeploymentCollection>(null);
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 CreateMockArmClient(),
+                documentPath,
                 template,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "");
 
-            result.Should().Be(LangServerResources.DeploymentFailedMessage);
+            result.Should().Be(string.Format(LangServerResources.DeploymentFailedMessage, documentPath));
         }
 
         [TestMethod]
@@ -273,17 +291,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
             deploymentCollectionProvider
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeResourceGroup))
                 .Throws(new Exception(errorMessage));
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 CreateMockArmClient(),
+                documentPath,
                 template,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "");
 
-            result.Should().Be(string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, errorMessage));
+            result.Should().Be(string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, errorMessage));
         }
 
         [TestMethod]
@@ -315,17 +335,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
             deploymentCollectionProvider
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeResourceGroup))
                 .Returns(deploymentCollection.Object);
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 CreateMockArmClient(),
+                documentPath,
                 template,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "");
 
-            result.Should().Be(LangServerResources.DeploymentFailedMessage);
+            result.Should().Be(string.Format(LangServerResources.DeploymentFailedMessage, documentPath));
         }
 
         [TestMethod]
@@ -364,17 +386,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
             deploymentCollectionProvider
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeResourceGroup))
                 .Returns(deploymentCollection.Object);
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 CreateMockArmClient(),
+                documentPath,
                 template,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "");
 
-            result.Should().Be(string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, responseMessage));
+            result.Should().Be(string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, responseMessage));
         }
 
         [TestMethod]
@@ -405,17 +429,19 @@ namespace Bicep.LangServer.UnitTests.Deploy
             deploymentCollectionProvider
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeResourceGroup))
                 .Returns(deploymentCollection.Object);
+            var documentPath = "some_path";
 
             var result = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider.Object,
                 CreateMockArmClient(),
+                documentPath,
                 template,
                 string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "");
 
-            result.Should().Be(string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, errorMessage));
+            result.Should().Be(string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, errorMessage));
         }
 
         private static ArmClient CreateMockArmClient()

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentScopeRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentScopeRequestHandlerTests.cs
@@ -13,11 +13,13 @@ using Bicep.Core.Registry;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.LanguageServer;
 using Bicep.LanguageServer.Handlers;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using IOFileSystem = System.IO.Abstractions.FileSystem;
@@ -33,6 +35,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         private static readonly FileResolver FileResolver = new();
         private static readonly IConfigurationManager configurationManager = new ConfigurationManager(new IOFileSystem());
         private readonly ModuleDispatcher ModuleDispatcher = new ModuleDispatcher(BicepTestConstants.RegistryProvider);
+        private readonly ISerializer Serializer = StrictMock.Of<ISerializer>().Object;
 
         [TestMethod]
         public async Task Handle_WithInvalidInputFile_ReturnsBicepDeploymentScopeResponseWithErrorMessage()
@@ -52,7 +55,8 @@ namespace Bicep.LangServer.UnitTests.Handlers
                 BicepTestConstants.Features,
                 FileResolver,
                 ModuleDispatcher,
-                BicepTestConstants.NamespaceProvider);
+                BicepTestConstants.NamespaceProvider,
+                Serializer);
 
             var textDocumentIdentifier = new TextDocumentIdentifier(documentUri);
             BicepDeploymentScopeParams bicepDeploymentScopeParams = new BicepDeploymentScopeParams(textDocumentIdentifier);
@@ -84,7 +88,8 @@ namespace Bicep.LangServer.UnitTests.Handlers
                 BicepTestConstants.Features,
                 FileResolver,
                 ModuleDispatcher,
-                BicepTestConstants.NamespaceProvider);
+                BicepTestConstants.NamespaceProvider,
+                Serializer);
 
             var textDocumentIdentifier = new TextDocumentIdentifier(documentUri);
             BicepDeploymentScopeParams bicepDeploymentScopeParams = new BicepDeploymentScopeParams(textDocumentIdentifier);
@@ -114,7 +119,8 @@ namespace Bicep.LangServer.UnitTests.Handlers
                 BicepTestConstants.Features,
                 FileResolver,
                 ModuleDispatcher,
-                BicepTestConstants.NamespaceProvider);
+                BicepTestConstants.NamespaceProvider,
+                Serializer);
 
             var textDocumentIdentifier = new TextDocumentIdentifier(documentUri);
             BicepDeploymentScopeParams bicepDeploymentScopeParams = new BicepDeploymentScopeParams(textDocumentIdentifier);
@@ -168,7 +174,8 @@ namespace Bicep.LangServer.UnitTests.Handlers
                 BicepTestConstants.Features,
                 FileResolver,
                 ModuleDispatcher,
-                BicepTestConstants.NamespaceProvider);
+                BicepTestConstants.NamespaceProvider,
+                Serializer);
 
             var textDocumentIdentifier = new TextDocumentIdentifier(documentUri);
             BicepDeploymentScopeParams bicepDeploymentScopeParams = new BicepDeploymentScopeParams(textDocumentIdentifier);

--- a/src/Bicep.LangServer/Deploy/DeploymentHelper.cs
+++ b/src/Bicep.LangServer/Deploy/DeploymentHelper.cs
@@ -21,6 +21,7 @@ namespace Bicep.LanguageServer.Deploy
         /// </summary>
         /// <param name="deploymentCollectionProvider">deployment collection provider</param>
         /// <param name="armClient">arm client</param>
+        /// <param name="documentPath">path to bicep file used in deployment</param>
         /// <param name="template">template used in deployment</param>
         /// <param name="parameterFilePath">path to parameter file used in deployment</param>
         /// <param name="id">id string to create the ResourceIdentifier from</param>
@@ -30,6 +31,7 @@ namespace Bicep.LanguageServer.Deploy
         public static async Task<string> CreateDeployment(
             IDeploymentCollectionProvider deploymentCollectionProvider,
             ArmClient armClient,
+            string documentPath,
             string template,
             string parameterFilePath,
             string id,
@@ -40,7 +42,7 @@ namespace Bicep.LanguageServer.Deploy
                 scope == LanguageConstants.TargetScopeTypeManagementGroup) &&
                 string.IsNullOrWhiteSpace(location))
             {
-                return LangServerResources.MissingLocationDeploymentFailedMessage;
+                return string.Format(LangServerResources.MissingLocationDeploymentFailedMessage, documentPath);
             }
 
             DeploymentCollection? deploymentCollection;
@@ -52,7 +54,7 @@ namespace Bicep.LanguageServer.Deploy
             }
             catch (Exception e)
             {
-                return string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, e.Message);
+                return string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, e.Message);
             }
 
             if (deploymentCollection is not null)
@@ -61,7 +63,7 @@ namespace Bicep.LanguageServer.Deploy
 
                 try
                 {
-                    parameters = GetParameters(parameterFilePath);
+                    parameters = GetParameters(documentPath, parameterFilePath);
                 }
                 catch (Exception e)
                 {
@@ -84,22 +86,22 @@ namespace Bicep.LanguageServer.Deploy
                 {
                     var deploymentCreateOrUpdateOperation = await deploymentCollection.CreateOrUpdateAsync(waitForCompletion:true, deployment, input);
 
-                    return GetDeploymentResultMessage(deploymentCreateOrUpdateOperation);
+                    return GetDeploymentResultMessage(deploymentCreateOrUpdateOperation, documentPath);
                 }
                 catch (Exception e)
                 {
-                    return string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, e.Message);
+                    return string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, e.Message);
                 }
             }
 
-            return LangServerResources.DeploymentFailedMessage;
+            return string.Format(LangServerResources.DeploymentFailedMessage, documentPath);
         }
 
-        private static string GetDeploymentResultMessage(DeploymentCreateOrUpdateOperation deploymentCreateOrUpdateOperation)
+        private static string GetDeploymentResultMessage(DeploymentCreateOrUpdateOperation deploymentCreateOrUpdateOperation, string documentPath)
         {
             if (!deploymentCreateOrUpdateOperation.HasValue)
             {
-                return LangServerResources.DeploymentFailedMessage;
+                return string.Format(LangServerResources.DeploymentFailedMessage, documentPath);
             }
 
             var response = deploymentCreateOrUpdateOperation.GetRawResponse();
@@ -107,15 +109,15 @@ namespace Bicep.LanguageServer.Deploy
 
             if (status == 200 || status == 201)
             {
-                return LangServerResources.DeploymentSucceededMessage;
+                return string.Format(LangServerResources.DeploymentSucceededMessage, documentPath);
             }
             else
             {
-                return string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, response.ToString());
+                return string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, response.ToString());
             }
         }
 
-        private static JsonElement GetParameters(string parameterFilePath)
+        private static JsonElement GetParameters(string documentPath, string parameterFilePath)
         {
             if (string.IsNullOrWhiteSpace(parameterFilePath))
             {
@@ -130,7 +132,7 @@ namespace Bicep.LanguageServer.Deploy
                 }
                 catch (Exception e)
                 {
-                    throw new Exception(string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, e.Message));
+                    throw new Exception(string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, e.Message));
                 }
             }
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeployCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeployCommandHandler.cs
@@ -7,25 +7,23 @@ using Azure.ResourceManager;
 using Bicep.LanguageServer.Deploy;
 using MediatR;
 using OmniSharp.Extensions.JsonRpc;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    [Method(BicepDeployCommandHandler.MethodName, Direction.ClientToServer)]
-    public record BicepDeployParams(TextDocumentIdentifier textDocument, string parameterFilePath, string id, string deploymentScope, string location, string template, string token, string expiresOnTimestamp) : IRequest<string>;
+    public record BicepDeployParams(string documentPath, string parameterFilePath, string id, string deploymentScope, string location, string template, string token, string expiresOnTimestamp) : IRequest<string>;
 
-    public class BicepDeployCommandHandler : IJsonRpcRequestHandler<BicepDeployParams, string>
+    public class BicepDeployCommandHandler : ExecuteTypedResponseCommandHandlerBase<BicepDeployParams, string>
     {
-        public const string MethodName = "bicep/deploy";
-
         private readonly IDeploymentCollectionProvider deploymentCollectionProvider;
 
-        public BicepDeployCommandHandler(IDeploymentCollectionProvider deploymentCollectionProvider)
+        public BicepDeployCommandHandler(IDeploymentCollectionProvider deploymentCollectionProvider, ISerializer serializer)
+            : base(LangServerConstants.DeployCommand, serializer)
         {
             this.deploymentCollectionProvider = deploymentCollectionProvider;
         }
 
-        public async Task<string> Handle(BicepDeployParams request, CancellationToken cancellationToken)
+        public override async Task<string> Handle(BicepDeployParams request, CancellationToken cancellationToken)
         {
             var credential = new CredentialFromTokenAndTimeStamp(request.token, request.expiresOnTimestamp);
             var armClient = new ArmClient(credential);
@@ -33,6 +31,7 @@ namespace Bicep.LanguageServer.Handlers
             string deploymentOutput = await DeploymentHelper.CreateDeployment(
                 deploymentCollectionProvider,
                 armClient,
+                request.documentPath,
                 request.template,
                 request.parameterFilePath,
                 request.id,

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
@@ -26,23 +26,21 @@ using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    [Method(BicepDeploymentScopeRequestHandler.MethodName, Direction.ClientToServer)]
     public record BicepDeploymentScopeParams(TextDocumentIdentifier TextDocument) : ITextDocumentIdentifierParams, IRequest<BicepDeploymentScopeResponse>;
 
     public record BicepDeploymentScopeResponse(string scope, string? template, string? errorMessage);
 
     /// <summary>
-    /// Handles bicep/getDeploymentScope LSP request.
+    /// Handles getDeploymentScope LSP request.
     /// The BicepDeploymentScopeRequestHandler returns targetScope, template and error message.
     /// Error message would be null if provided bicep file was error free.
     /// </summary>
-    public class BicepDeploymentScopeRequestHandler : IJsonRpcRequestHandler<BicepDeploymentScopeParams, BicepDeploymentScopeResponse>
+    public class BicepDeploymentScopeRequestHandler : ExecuteTypedResponseCommandHandlerBase<BicepDeploymentScopeParams, BicepDeploymentScopeResponse>
     {
-        public const string MethodName = "bicep/getDeploymentScope";
-
         private readonly EmitterSettings emitterSettings;
         private readonly ICompilationManager compilationManager;
         private readonly IConfigurationManager configurationManager;
@@ -58,7 +56,9 @@ namespace Bicep.LanguageServer.Handlers
             IFeatureProvider features,
             IFileResolver fileResolver,
             IModuleDispatcher moduleDispatcher,
-            INamespaceProvider namespaceProvider)
+            INamespaceProvider namespaceProvider,
+            ISerializer serializer)
+            : base(LangServerConstants.GetDeploymentScopeCommand, serializer)
         {
             this.compilationManager = compilationManager;
             this.configurationManager = configurationManager;
@@ -69,7 +69,7 @@ namespace Bicep.LanguageServer.Handlers
             this.namespaceProvider = namespaceProvider;
         }
 
-        public Task<BicepDeploymentScopeResponse> Handle(BicepDeploymentScopeParams request, CancellationToken cancellationToken)
+        public override Task<BicepDeploymentScopeResponse> Handle(BicepDeploymentScopeParams request, CancellationToken cancellationToken)
         {
             var documentUri = request.TextDocument.Uri;
 

--- a/src/Bicep.LangServer/LangServerConstants.cs
+++ b/src/Bicep.LangServer/LangServerConstants.cs
@@ -7,5 +7,6 @@ namespace Bicep.LanguageServer
     {
         public const string BuildCommand = "build";
         public const string DeployCommand = "deploy";
+        public const string GetDeploymentScopeCommand = "getDeploymentScope";
     }
 }

--- a/src/Bicep.LangServer/LangServerResources.Designer.cs
+++ b/src/Bicep.LangServer/LangServerResources.Designer.cs
@@ -61,7 +61,7 @@ namespace Bicep.LanguageServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deployment failed..
+        ///   Looks up a localized string similar to Deployment failed for {0}..
         /// </summary>
         public static string DeploymentFailedMessage {
             get {
@@ -70,7 +70,7 @@ namespace Bicep.LanguageServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deployment failed. {0}.
+        ///   Looks up a localized string similar to Deployment failed for {0}. {1}.
         /// </summary>
         public static string DeploymentFailedWithExceptionMessage {
             get {
@@ -79,7 +79,7 @@ namespace Bicep.LanguageServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deployment succeeded..
+        ///   Looks up a localized string similar to Deployment succeeded for {0}..
         /// </summary>
         public static string DeploymentSucceededMessage {
             get {
@@ -115,7 +115,7 @@ namespace Bicep.LanguageServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deployment failed. Please provide a valid location..
+        ///   Looks up a localized string similar to Deployment failed for {0}. Please provide a valid location..
         /// </summary>
         public static string MissingLocationDeploymentFailedMessage {
             get {

--- a/src/Bicep.LangServer/LangServerResources.resx
+++ b/src/Bicep.LangServer/LangServerResources.resx
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DeploymentFailedMessage" xml:space="preserve">
-    <value>Deployment failed.</value>
+    <value>Deployment failed for {0}.</value>
   </data>
   <data name="DeploymentFailedWithExceptionMessage" xml:space="preserve">
-    <value>Deployment failed. {0}</value>
+    <value>Deployment failed for {0}. {1}</value>
   </data>
   <data name="DeploymentSucceededMessage" xml:space="preserve">
-    <value>Deployment succeeded.</value>
+    <value>Deployment succeeded for {0}.</value>
   </data>
   <data name="DisableDiagnosticForThisLine" xml:space="preserve">
     <value>Disable {0} for this line</value>
@@ -134,10 +134,10 @@
     <comment>{0} = programmatic name of a linter rule</comment>
   </data>
   <data name="InvalidParameterFileDeploymentFailedMessage" xml:space="preserve">
-    <value>Deployment failed. Please fix the following issues in the parameter file: {0}</value>
+    <value>Deployment failed for {0}. Please fix the following issues in the parameter file: {1}</value>
   </data>
   <data name="MissingLocationDeploymentFailedMessage" xml:space="preserve">
-    <value>Deployment failed. Please provide a valid location.</value>
+    <value>Deployment failed for {0}. Please provide a valid location.</value>
   </data>
   <data name="UnsupportedTargetScopeMessage" xml:space="preserve">
     <value>Unsupported target scope: {0}.</value>

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import * as path from "path";
-import vscode, { Uri } from "vscode";
+import vscode, { commands, Uri } from "vscode";
 import { AccessToken } from "@azure/identity";
 import { AzLoginTreeItem } from "../tree/AzLoginTreeItem";
 import { AzManagementGroupTreeItem } from "../tree/AzManagementGroupTreeItem";
@@ -27,9 +27,9 @@ import {
 } from "@microsoft/vscode-azext-utils";
 
 import {
+  BicepDeploymentScopeParams,
+  BicepDeploymentScopeResponse,
   BicepDeployParams,
-  bicepDeployRequestType,
-  deploymentScopeRequestType,
 } from "../language";
 
 export class DeployCommand implements Command {
@@ -83,10 +83,14 @@ export class DeployCommand implements Command {
     context.errorHandling.suppressDisplay = true;
 
     try {
-      const deploymentScopeResponse = await this.client.sendRequest(
-        deploymentScopeRequestType,
-        { textDocument: textDocument }
-      );
+      const bicepDeploymentScopeParams: BicepDeploymentScopeParams = {
+        textDocument,
+      };
+      const deploymentScopeResponse: BicepDeploymentScopeResponse =
+        await this.client.sendRequest("workspace/executeCommand", {
+          command: "getDeploymentScope",
+          arguments: [bicepDeploymentScopeParams],
+        });
       const deploymentScope = deploymentScopeResponse?.scope;
       const template = deploymentScopeResponse?.template;
 
@@ -120,7 +124,6 @@ export class DeployCommand implements Command {
         case "resourceGroup":
           await this.handleResourceGroupDeployment(
             context,
-            textDocument,
             documentUri,
             deploymentScope,
             template
@@ -129,7 +132,6 @@ export class DeployCommand implements Command {
         case "subscription":
           await this.handleSubscriptionDeployment(
             context,
-            textDocument,
             documentUri,
             deploymentScope,
             template
@@ -138,7 +140,6 @@ export class DeployCommand implements Command {
         case "managementGroup":
           await this.handleManagementGroupDeployment(
             context,
-            textDocument,
             documentUri,
             deploymentScope,
             template
@@ -157,18 +158,36 @@ export class DeployCommand implements Command {
         }
       }
     } catch (err) {
-      this.outputChannelManager.appendToOutputChannel(
-        err instanceof UserCancelledError
-          ? `Deployment canceled for ${documentPath}.`
-          : `Deployment failed for ${documentPath}. ${parseError(err).message}`
-      );
+      let errorMessage: string;
+
+      if (err instanceof UserCancelledError) {
+        errorMessage = `Deployment canceled for ${documentPath}.`;
+      }
+      // Long-standing issue that is pretty common for all Azure calls, but can be fixed with a simple reload of VS Code.
+      // https://github.com/microsoft/vscode-azure-account/issues/53
+      else if (parseError(err).message === "Entry not found in cache.") {
+        errorMessage = `Deployment canceled for ${documentPath}. Your VS Code window must be reloaded to perform this action.`;
+        context.errorHandling.suppressReportIssue = true;
+        context.errorHandling.buttons = [
+          {
+            title: localize("reloadWindow", "Reload Window"),
+            callback: async (): Promise<void> => {
+              await commands.executeCommand("workbench.action.reloadWindow");
+            },
+          },
+        ];
+      } else {
+        errorMessage = `Deployment failed for ${documentPath}. ${
+          parseError(err).message
+        }`;
+      }
+      this.outputChannelManager.appendToOutputChannel(errorMessage);
       throw err;
     }
   }
 
   private async handleManagementGroupDeployment(
     context: IActionContext,
-    textDocument: TextDocumentIdentifier,
     documentUri: vscode.Uri,
     deploymentScope: string,
     template: string
@@ -201,8 +220,7 @@ export class DeployCommand implements Command {
         );
 
         await this.sendDeployCommand(
-          context,
-          textDocument,
+          documentUri.fsPath,
           parameterFilePath,
           managementGroupId,
           deploymentScope,
@@ -216,7 +234,6 @@ export class DeployCommand implements Command {
 
   private async handleResourceGroupDeployment(
     context: IActionContext,
-    textDocument: TextDocumentIdentifier,
     documentUri: vscode.Uri,
     deploymentScope: string,
     template: string
@@ -235,8 +252,7 @@ export class DeployCommand implements Command {
       );
 
       await this.sendDeployCommand(
-        context,
-        textDocument,
+        documentUri.fsPath,
         parameterFilePath,
         resourceGroupId,
         deploymentScope,
@@ -249,7 +265,6 @@ export class DeployCommand implements Command {
 
   private async handleSubscriptionDeployment(
     context: IActionContext,
-    textDocument: TextDocumentIdentifier,
     documentUri: vscode.Uri,
     deploymentScope: string,
     template: string
@@ -269,8 +284,7 @@ export class DeployCommand implements Command {
     );
 
     await this.sendDeployCommand(
-      context,
-      textDocument,
+      documentUri.fsPath,
       parameterFilePath,
       subscriptionId,
       deploymentScope,
@@ -281,8 +295,7 @@ export class DeployCommand implements Command {
   }
 
   private async sendDeployCommand(
-    context: IActionContext,
-    textDocument: TextDocumentIdentifier,
+    documentPath: string,
     parameterFilePath: string | undefined,
     id: string,
     deploymentScope: string,
@@ -291,13 +304,10 @@ export class DeployCommand implements Command {
     subscription: ISubscriptionContext
   ) {
     if (!parameterFilePath) {
-      context.telemetry.properties.parameterFileProvided = "false";
       this.outputChannelManager.appendToOutputChannel(
         `No parameter file was provided`
       );
       parameterFilePath = "";
-    } else {
-      context.telemetry.properties.parameterFileProvided = "true";
     }
 
     const accessToken: AccessToken = await subscription.credentials.getToken(
@@ -309,7 +319,7 @@ export class DeployCommand implements Command {
       const expiresOnTimestamp = String(accessToken.expiresOnTimestamp);
 
       const bicepDeployParams: BicepDeployParams = {
-        textDocument,
+        documentPath,
         parameterFilePath,
         id,
         deploymentScope,
@@ -319,8 +329,11 @@ export class DeployCommand implements Command {
         expiresOnTimestamp,
       };
       const deploymentResponse: string = await this.client.sendRequest(
-        bicepDeployRequestType,
-        bicepDeployParams
+        "workspace/executeCommand",
+        {
+          command: "deploy",
+          arguments: [bicepDeployParams],
+        }
       );
       this.outputChannelManager.appendToOutputChannel(deploymentResponse);
     }

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -165,7 +165,7 @@ export class DeployCommand implements Command {
       // Long-standing issue that is pretty common for all Azure calls, but can be fixed with a simple reload of VS Code.
       // https://github.com/microsoft/vscode-azure-account/issues/53
       else if (parseError(err).message === "Entry not found in cache.") {
-        errorMessage = `Deployment canceled for ${documentPath}. Your VS Code window must be reloaded to perform this action.`;
+        errorMessage = `Deployment failed for ${documentPath}. Token cache is out of date. Please reload VS Code and try again. If this problem persists, consider changing the VS Code setting "Azure: Authentication Library" to "MSAL".`;
         context.errorHandling.suppressReportIssue = true;
         context.errorHandling.buttons = [
           {

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -220,6 +220,7 @@ export class DeployCommand implements Command {
         );
 
         await this.sendDeployCommand(
+          context,
           documentUri.fsPath,
           parameterFilePath,
           managementGroupId,
@@ -252,6 +253,7 @@ export class DeployCommand implements Command {
       );
 
       await this.sendDeployCommand(
+        context,
         documentUri.fsPath,
         parameterFilePath,
         resourceGroupId,
@@ -284,6 +286,7 @@ export class DeployCommand implements Command {
     );
 
     await this.sendDeployCommand(
+      context,
       documentUri.fsPath,
       parameterFilePath,
       subscriptionId,
@@ -295,6 +298,7 @@ export class DeployCommand implements Command {
   }
 
   private async sendDeployCommand(
+    context: IActionContext,
     documentPath: string,
     parameterFilePath: string | undefined,
     id: string,
@@ -304,10 +308,13 @@ export class DeployCommand implements Command {
     subscription: ISubscriptionContext
   ) {
     if (!parameterFilePath) {
+      context.telemetry.properties.parameterFileProvided = "false";
       this.outputChannelManager.appendToOutputChannel(
         `No parameter file was provided`
       );
       parameterFilePath = "";
+    } else {
+      context.telemetry.properties.parameterFileProvided = "true";
     }
 
     const accessToken: AccessToken = await subscription.credentials.getToken(

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -23,7 +23,6 @@ import {
   IAzureQuickPickItem,
   ISubscriptionContext,
   parseError,
-  UserCancelledError,
 } from "@microsoft/vscode-azext-utils";
 
 import {
@@ -160,7 +159,7 @@ export class DeployCommand implements Command {
     } catch (err) {
       let errorMessage: string;
 
-      if (err instanceof UserCancelledError) {
+      if (parseError(err).isUserCancelledError) {
         errorMessage = `Deployment canceled for ${documentPath}.`;
       }
       // Long-standing issue that is pretty common for all Azure calls, but can be fixed with a simple reload of VS Code.

--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -56,16 +56,8 @@ export interface BicepDeploymentScopeResponse {
   errorMessage?: string;
 }
 
-export const deploymentScopeRequestType = new ProtocolRequestType<
-  BicepDeploymentScopeParams,
-  BicepDeploymentScopeResponse | undefined,
-  never,
-  void,
-  void
->("bicep/getDeploymentScope");
-
 export interface BicepDeployParams {
-  textDocument: TextDocumentIdentifier;
+  documentPath: string;
   parameterFilePath: string;
   id: string;
   deploymentScope: string;
@@ -74,14 +66,6 @@ export interface BicepDeployParams {
   token: string;
   expiresOnTimestamp: string;
 }
-
-export const bicepDeployRequestType = new ProtocolRequestType<
-  BicepDeployParams,
-  string,
-  never,
-  void,
-  void
->("bicep/deploy");
 
 export interface BicepCacheResponse {
   content: string;


### PR DESCRIPTION
Changes in this PR includes:
- Updated BicepDeployCommandHandler and BicepDeploymentScopeRequestHandler to use ExecuteTypedResponseCommandHandlerBase instead of IJsonRpcRequestHandler. With IJsonRpcRequestHandler, text changes are detected(open/close/edit) and server sends ContentModified exception. For long running operations like deploy, content changes are expected. ExecuteTypedResponseCommandHandlerBase works off of the workspace and this should work for us. Note: ExecuteTypedResponseCommandHandlerBase is the base class used in build command handler
- I hit the issue described in https://github.com/microsoft/vscode-azure-account/issues/53 once. It's not reproducible. Added error handling that I found here: https://github.com/microsoft/vscode-azuretools/blob/d38498f0085deb912675e4d2cb376f973c12f31e/utils/src/extensionVariables.ts#L59
- Updated log messages to include file name since we don't support multiple output channels