### PR TITLE
add mg snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -1695,6 +1695,35 @@
     }
   },
   {
+    "label": "res-mg",
+    "kind": "snippet",
+    "detail": "Management Group(for tenant scope)",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource 'managementGroup' 'Microsoft.Management/managementGroups@2021-04-01' = {\n  name: 'name'\n  properties: {\n    displayName: 'displayName'\n    details: {\n      parent: {\n        id: 'id'\n      }\n    }\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-mg",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:'managementGroup'} 'Microsoft.Management/managementGroups@2021-04-01' = {\n  name: ${2:'name'}\n  properties: {\n    displayName: ${3:'displayName'}\n    details: {\n      parent: {\n        id: ${4:'id'}\n      }\n    }\n  }\n}\n"
+    },
+    "command": {
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "snippet/toplevel",
+          "Properties": {
+            "name": "res-mg"
+          }
+        }
+      ]
+    }
+  },
+  {
     "label": "res-mysql",
     "kind": "snippet",
     "detail": "MySQL Database",

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-mg/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-mg/main.bicep
@@ -1,0 +1,6 @@
+﻿// $1 = managementGroup
+// $2 = 'name'
+// $3 = 'displayName'
+// $4 = 'id'
+targetScope = 'tenant'
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-mg/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-mg/main.combined.bicep
@@ -1,0 +1,18 @@
+// $1 = managementGroup
+// $2 = 'name'
+// $3 = 'displayName'
+// $4 = 'id'
+targetScope = 'tenant'
+resource managementGroup 'Microsoft.Management/managementGroups@2021-04-01' = {
+  name: 'name'
+  properties: {
+    displayName: 'displayName'
+    details: {
+      parent: {
+        id: 'id'
+      }
+    }
+  }
+}
+// Insert snippet here
+

--- a/src/Bicep.LangServer/Snippets/Templates/res-mg.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-mg.bicep
@@ -1,0 +1,12 @@
+// Management Group(for tenant scope)
+resource /*${1:'managementGroup'}*/managementGroup 'Microsoft.Management/managementGroups@2021-04-01' = {
+  name: /*${2:'name'}*/'name'
+  properties: {
+    displayName: /*${3:'displayName'}*/'displayName'
+    details: {
+      parent: {
+        id: /*${4:'id'}*/'id'
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Contributing a snippet

* [x] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"
* [x] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [x] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
