### PR TITLE
Disable CLI live tests for dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
     name: 'Test CLI (live) (${{ matrix.rid }})'
     runs-on: ${{ matrix.os }}
     needs: build-bicep
-    if: github.repository == 'Azure/bicep'
+    if: github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
 
     env:
       CI: true


### PR DESCRIPTION
dependabot PRs are not sent from forks so need to disable live tests for it explicitly.