### PR TITLE
fixed codegen for nested resource loops with complex parent index expressions

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Issue6075Tests.cs
+++ b/src/Bicep.Core.IntegrationTests/Issue6075Tests.cs
@@ -1,0 +1,361 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bicep.Core.IntegrationTests
+{
+    /// <summary>
+    /// Fixing https://github.com/Azure/bicep/issues/6075 required major changes to how name expressions and classic dependencies
+    /// are emitted, so that complexity warrants adding a special test class for the entire issue.
+    /// </summary>
+    [TestClass]
+    public class Issue6075Tests
+    {
+        private const string OriginalReproBicep = @"
+var numberOfAccounts = 2
+var blobsPerAccount = 3
+var saprefix = uniqueString(resourceGroup().id)
+
+resource sa 'Microsoft.Storage/storageAccounts@2021-08-01' = [for i in range(0, numberOfAccounts): {
+  name: '${saprefix}${i}'
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}]
+
+resource blobSvc 'Microsoft.Storage/storageAccounts/blobServices@2021-08-01' = [for j in range(0, numberOfAccounts): {
+  parent: sa[j]
+  name: 'default'
+}]
+
+resource containers 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-08-01' = [for k in range(0, (numberOfAccounts * blobsPerAccount)): {
+  parent: blobSvc[k % numberOfAccounts]
+  name: 'container${k % blobsPerAccount}'
+}]
+";
+
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        [TestMethod]
+        public void OriginalReproTemplate_Classic_ShouldProduceExpectedExpressions()
+        {
+            var result = Compile(OriginalReproBicep, false);
+            result.Should().GenerateATemplate();
+
+            /*
+             The generated template was manually verified to be deployable.
+             */
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources[0].copy.name", "sa");
+                template.Should().HaveValueAtPath("$.resources[0].name", "[format('{0}{1}', variables('saprefix'), range(0, variables('numberOfAccounts'))[copyIndex()])]");
+                template.Should().NotHaveValueAtPath("$.resources[0].dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources[1].copy.name", "blobSvc");
+                template.Should().HaveValueAtPath("$.resources[1].name", "[format('{0}/{1}', format('{0}{1}', variables('saprefix'), range(0, variables('numberOfAccounts'))[range(0, variables('numberOfAccounts'))[copyIndex()]]), 'default')]");
+                template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray("[resourceId('Microsoft.Storage/storageAccounts', format('{0}{1}', variables('saprefix'), range(0, variables('numberOfAccounts'))[range(0, variables('numberOfAccounts'))[copyIndex()]]))]"));
+
+                template.Should().HaveValueAtPath("$.resources[2].copy.name", "containers");
+                template.Should().HaveValueAtPath("$.resources[2].name", "[format('{0}/{1}/{2}', format('{0}{1}', variables('saprefix'), range(0, variables('numberOfAccounts'))[range(0, variables('numberOfAccounts'))[mod(range(0, mul(variables('numberOfAccounts'), variables('blobsPerAccount')))[copyIndex()], variables('numberOfAccounts'))]]), 'default', format('container{0}', mod(range(0, mul(variables('numberOfAccounts'), variables('blobsPerAccount')))[copyIndex()], variables('blobsPerAccount'))))]");
+                template.Should().HaveValueAtPath("$.resources[2].dependsOn", new JArray("[resourceId('Microsoft.Storage/storageAccounts/blobServices', format('{0}{1}', variables('saprefix'), range(0, variables('numberOfAccounts'))[range(0, variables('numberOfAccounts'))[mod(range(0, mul(variables('numberOfAccounts'), variables('blobsPerAccount')))[copyIndex()], variables('numberOfAccounts'))]]), 'default')]"));
+            }
+        }
+
+        [TestMethod]
+        public void OriginalReproTemplate_Symbolic_ShouldProduceExpectedExpressions()
+        {
+            CompilationHelper.CompilationResult result = Compile(OriginalReproBicep, true);
+            result.Should().GenerateATemplate();
+
+            /*
+             The generated template was manually verified to be deployable.
+             */
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources.sa.copy.name", "sa");
+                template.Should().HaveValueAtPath("$.resources.sa.name", "[format('{0}{1}', variables('saprefix'), range(0, variables('numberOfAccounts'))[copyIndex()])]");
+                template.Should().NotHaveValueAtPath("$.resources.sa.dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources.blobSvc.copy.name", "blobSvc");
+                template.Should().HaveValueAtPath("$.resources.blobSvc.name", "[format('{0}/{1}', format('{0}{1}', variables('saprefix'), range(0, variables('numberOfAccounts'))[range(0, variables('numberOfAccounts'))[copyIndex()]]), 'default')]");
+                template.Should().HaveValueAtPath("$.resources.blobSvc.dependsOn", new JArray("[format('sa[{0}]', range(0, variables('numberOfAccounts'))[copyIndex()])]"));
+
+                template.Should().HaveValueAtPath("$.resources.containers.copy.name", "containers");
+                template.Should().HaveValueAtPath("$.resources.containers.name", "[format('{0}/{1}/{2}', format('{0}{1}', variables('saprefix'), range(0, variables('numberOfAccounts'))[range(0, variables('numberOfAccounts'))[mod(range(0, mul(variables('numberOfAccounts'), variables('blobsPerAccount')))[copyIndex()], variables('numberOfAccounts'))]]), 'default', format('container{0}', mod(range(0, mul(variables('numberOfAccounts'), variables('blobsPerAccount')))[copyIndex()], variables('blobsPerAccount'))))]");
+                template.Should().HaveValueAtPath("$.resources.containers.dependsOn", new JArray("[format('blobSvc[{0}]', mod(range(0, mul(variables('numberOfAccounts'), variables('blobsPerAccount')))[copyIndex()], variables('numberOfAccounts')))]"));
+            }
+        }
+
+        private const string AllIndexVariablesBicep = @"
+resource vnet 'Microsoft.Network/virtualNetworks@2021-05-01' = [for (ii, i) in range(0, 2): {
+  name: string(i)
+}]
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-05-01' = [for (jj, j) in range(0, 6): {
+  parent: vnet[j % 2]
+  name: string(j)
+}]
+
+resource thing 'Microsoft.Network/virtualNetworks/subnets/things@2021-05-01' = [for (kk, k) in range(0, 24): {
+  parent: subnet[k % 6]
+  name: string(k)
+}]
+";
+
+        [TestMethod]
+        public void ThreeNestedResources_Classic_AllIndexVariables_ShouldProduceExpectedExpressions()
+        {
+            var result = Compile(AllIndexVariablesBicep, false);
+            result.Should().GenerateATemplate();
+
+            /*
+             The generated template was manually verified to be deployable.
+             */
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources[0].copy.name", "vnet");
+                template.Should().HaveValueAtPath("$.resources[0].name", "[string(copyIndex())]");
+                template.Should().NotHaveValueAtPath("$.resources[0].dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources[1].copy.name", "subnet");
+                template.Should().HaveValueAtPath("$.resources[1].name", "[format('{0}/{1}', string(mod(copyIndex(), 2)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray("[resourceId('Microsoft.Network/virtualNetworks', string(mod(copyIndex(), 2)))]"));
+
+                template.Should().HaveValueAtPath("$.resources[2].copy.name", "thing");
+                template.Should().HaveValueAtPath("$.resources[2].name", "[format('{0}/{1}/{2}', string(mod(mod(copyIndex(), 6), 2)), string(mod(copyIndex(), 6)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources[2].dependsOn", new JArray("[resourceId('Microsoft.Network/virtualNetworks/subnets', string(mod(mod(copyIndex(), 6), 2)), string(mod(copyIndex(), 6)))]"));
+            }
+        }
+
+        [TestMethod]
+        public void ThreeNestedResources_Symbolic_AllIndexVariables_ShouldProduceExpectedExpressions()
+        {
+            var result = Compile(AllIndexVariablesBicep, true);
+            result.Should().GenerateATemplate();
+
+            /*
+             The generated template was manually verified to be deployable.
+             */
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources.vnet.copy.name", "vnet");
+                template.Should().HaveValueAtPath("$.resources.vnet.name", "[string(copyIndex())]");
+                template.Should().NotHaveValueAtPath("$.resources.vnet.dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources.subnet.copy.name", "subnet");
+                template.Should().HaveValueAtPath("$.resources.subnet.name", "[format('{0}/{1}', string(mod(copyIndex(), 2)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources.subnet.dependsOn", new JArray("[format('vnet[{0}]', mod(copyIndex(), 2))]"));
+
+                template.Should().HaveValueAtPath("$.resources.thing.copy.name", "thing");
+                template.Should().HaveValueAtPath("$.resources.thing.name", "[format('{0}/{1}/{2}', string(mod(mod(copyIndex(), 6), 2)), string(mod(copyIndex(), 6)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources.thing.dependsOn", new JArray("[format('subnet[{0}]', mod(copyIndex(), 6))]"));
+            }
+        }
+
+        private const string TopItemVariableBicep = @"
+resource vnet 'Microsoft.Network/virtualNetworks@2021-05-01' = [for (ii, i) in range(0, 2): {
+  name: string(ii)
+}]
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-05-01' = [for (jj, j) in range(0, 6): {
+  parent: vnet[j % 2]
+  name: string(j)
+}]
+
+resource thing 'Microsoft.Network/virtualNetworks/subnets/things@2021-05-01' = [for (kk, k) in range(0, 24): {
+  parent: subnet[k % 6]
+  name: string(k)
+}]
+";
+
+        [TestMethod]
+        public void ThreeNestedResources_TopItemVariable_Classic_ShouldProduceExpectedExpressions()
+        {
+            var result = Compile(TopItemVariableBicep, false);
+            result.Should().GenerateATemplate();
+
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources[0].copy.name", "vnet");
+                template.Should().HaveValueAtPath("$.resources[0].name", "[string(range(0, 2)[copyIndex()])]");
+                template.Should().NotHaveValueAtPath("$.resources[0].dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources[1].copy.name", "subnet");
+                template.Should().HaveValueAtPath("$.resources[1].name", "[format('{0}/{1}', string(range(0, 2)[mod(copyIndex(), 2)]), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray("[resourceId('Microsoft.Network/virtualNetworks', string(range(0, 2)[mod(copyIndex(), 2)]))]"));
+
+                template.Should().HaveValueAtPath("$.resources[2].copy.name", "thing");
+                template.Should().HaveValueAtPath("$.resources[2].name", "[format('{0}/{1}/{2}', string(range(0, 2)[mod(mod(copyIndex(), 6), 2)]), string(mod(copyIndex(), 6)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources[2].dependsOn", new JArray("[resourceId('Microsoft.Network/virtualNetworks/subnets', string(range(0, 2)[mod(mod(copyIndex(), 6), 2)]), string(mod(copyIndex(), 6)))]"));
+            }
+        }
+
+        [TestMethod]
+        public void ThreeNestedResources_TopItemVariable_Symbolic_ShouldProduceExpectedExpressions()
+        {
+            var result = Compile(TopItemVariableBicep, true);
+            result.Should().GenerateATemplate();
+
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources.vnet.copy.name", "vnet");
+                template.Should().HaveValueAtPath("$.resources.vnet.name", "[string(range(0, 2)[copyIndex()])]");
+                template.Should().NotHaveValueAtPath("$.resources.vnet.dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources.subnet.copy.name", "subnet");
+                template.Should().HaveValueAtPath("$.resources.subnet.name", "[format('{0}/{1}', string(range(0, 2)[mod(copyIndex(), 2)]), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources.subnet.dependsOn", new JArray("[format('vnet[{0}]', mod(copyIndex(), 2))]"));
+
+                template.Should().HaveValueAtPath("$.resources.thing.copy.name", "thing");
+                template.Should().HaveValueAtPath("$.resources.thing.name", "[format('{0}/{1}/{2}', string(range(0, 2)[mod(mod(copyIndex(), 6), 2)]), string(mod(copyIndex(), 6)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources.thing.dependsOn", new JArray("[format('subnet[{0}]', mod(copyIndex(), 6))]"));
+            }
+        }
+
+        private const string MiddleItemVariableBicep = @"
+resource vnet 'Microsoft.Network/virtualNetworks@2021-05-01' = [for (ii, i) in range(0, 2): {
+  name: string(i)
+}]
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-05-01' = [for (jj, j) in range(0, 6): {
+  parent: vnet[jj % 2]
+  name: string(j)
+}]
+
+resource thing 'Microsoft.Network/virtualNetworks/subnets/things@2021-05-01' = [for (kk, k) in range(0, 24): {
+  parent: subnet[k % 6]
+  name: string(k)
+}]
+";
+
+        [TestMethod]
+        public void ThreeNestedResources_MiddleItemVariable_Classic_ShouldProduceExpectedExpressions()
+        {
+            var result = Compile(MiddleItemVariableBicep, false);
+            result.Should().GenerateATemplate();
+
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources[0].copy.name", "vnet");
+                template.Should().HaveValueAtPath("$.resources[0].name", "[string(copyIndex())]");
+                template.Should().NotHaveValueAtPath("$.resources[0].dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources[1].copy.name", "subnet");
+                template.Should().HaveValueAtPath("$.resources[1].name", "[format('{0}/{1}', string(mod(range(0, 6)[copyIndex()], 2)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray("[resourceId('Microsoft.Network/virtualNetworks', string(mod(range(0, 6)[copyIndex()], 2)))]"));
+
+                template.Should().HaveValueAtPath("$.resources[2].copy.name", "thing");
+                template.Should().HaveValueAtPath("$.resources[2].name", "[format('{0}/{1}/{2}', string(mod(range(0, 6)[mod(copyIndex(), 6)], 2)), string(mod(copyIndex(), 6)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources[2].dependsOn", new JArray("[resourceId('Microsoft.Network/virtualNetworks/subnets', string(mod(range(0, 6)[mod(copyIndex(), 6)], 2)), string(mod(copyIndex(), 6)))]"));
+            }
+        }
+
+        [TestMethod]
+        public void ThreeNestedResources_MiddleItemVariable_Symbolic_ShouldProduceExpectedExpressions()
+        {
+            var result = Compile(MiddleItemVariableBicep, true);
+            result.Should().GenerateATemplate();
+
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources.vnet.copy.name", "vnet");
+                template.Should().HaveValueAtPath("$.resources.vnet.name", "[string(copyIndex())]");
+                template.Should().NotHaveValueAtPath("$.resources.vnet.dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources.subnet.copy.name", "subnet");
+                template.Should().HaveValueAtPath("$.resources.subnet.name", "[format('{0}/{1}', string(mod(range(0, 6)[copyIndex()], 2)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources.subnet.dependsOn", new JArray("[format('vnet[{0}]', mod(range(0, 6)[copyIndex()], 2))]"));
+
+                template.Should().HaveValueAtPath("$.resources.thing.copy.name", "thing");
+                template.Should().HaveValueAtPath("$.resources.thing.name", "[format('{0}/{1}/{2}', string(mod(range(0, 6)[mod(copyIndex(), 6)], 2)), string(mod(copyIndex(), 6)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources.thing.dependsOn", new JArray("[format('subnet[{0}]', mod(copyIndex(), 6))]"));
+            }
+        }
+
+        private const string BottomItemVariableBicep = @"
+resource vnet 'Microsoft.Network/virtualNetworks@2021-05-01' = [for (ii, i) in range(0, 2): {
+  name: string(i)
+}]
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-05-01' = [for (jj, j) in range(0, 6): {
+  parent: vnet[j % 2]
+  name: string(j)
+}]
+
+resource thing 'Microsoft.Network/virtualNetworks/subnets/things@2021-05-01' = [for (kk, k) in range(0, 24): {
+  parent: subnet[kk % 6]
+  name: string(k)
+}]
+";
+
+        [TestMethod]
+        public void ThreeNestedResources_BottomItemVariable_Classic_ShouldProduceExpectedExpressions()
+        {
+            var result = Compile(BottomItemVariableBicep, false);
+            result.Should().GenerateATemplate();
+
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources[0].copy.name", "vnet");
+                template.Should().HaveValueAtPath("$.resources[0].name", "[string(copyIndex())]");
+                template.Should().NotHaveValueAtPath("$.resources[0].dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources[1].copy.name", "subnet");
+                template.Should().HaveValueAtPath("$.resources[1].name", "[format('{0}/{1}', string(mod(copyIndex(), 2)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray("[resourceId('Microsoft.Network/virtualNetworks', string(mod(copyIndex(), 2)))]"));
+
+                template.Should().HaveValueAtPath("$.resources[2].copy.name", "thing");
+                template.Should().HaveValueAtPath("$.resources[2].name", "[format('{0}/{1}/{2}', string(mod(mod(range(0, 24)[copyIndex()], 6), 2)), string(mod(range(0, 24)[copyIndex()], 6)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources[2].dependsOn", new JArray("[resourceId('Microsoft.Network/virtualNetworks/subnets', string(mod(mod(range(0, 24)[copyIndex()], 6), 2)), string(mod(range(0, 24)[copyIndex()], 6)))]"));
+            }
+        }
+
+        [TestMethod]
+        public void ThreeNestedResources_BottomItemVariable_Symbolic_ShouldProduceExpectedExpressions()
+        {
+            var result = Compile(BottomItemVariableBicep, true);
+            result.Should().GenerateATemplate();
+
+            var template = result.Template;
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources.vnet.copy.name", "vnet");
+                template.Should().HaveValueAtPath("$.resources.vnet.name", "[string(copyIndex())]");
+                template.Should().NotHaveValueAtPath("$.resources.vnet.dependsOn");
+
+                template.Should().HaveValueAtPath("$.resources.subnet.copy.name", "subnet");
+                template.Should().HaveValueAtPath("$.resources.subnet.name", "[format('{0}/{1}', string(mod(copyIndex(), 2)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources.subnet.dependsOn", new JArray("[format('vnet[{0}]', mod(copyIndex(), 2))]"));
+
+                template.Should().HaveValueAtPath("$.resources.thing.copy.name", "thing");
+                template.Should().HaveValueAtPath("$.resources.thing.name", "[format('{0}/{1}/{2}', string(mod(mod(range(0, 24)[copyIndex()], 6), 2)), string(mod(range(0, 24)[copyIndex()], 6)), string(copyIndex()))]");
+                template.Should().HaveValueAtPath("$.resources.thing.dependsOn", new JArray("[format('subnet[{0}]', mod(range(0, 24)[copyIndex()], 6))]"));
+            }
+        }
+
+        private CompilationHelper.CompilationResult Compile(string bicep, bool symbolicNameCodegenEnabled)
+        {
+            var context = new CompilationHelper.CompilationHelperContext(Features: BicepTestConstants.CreateFeaturesProvider(this.TestContext, symbolicNameCodegenEnabled: symbolicNameCodegenEnabled));
+            return CompilationHelper.Compile(context, bicep);
+        }
+    }
+}

--- a/src/Bicep.Core/Emit/ExpressionEmitter.cs
+++ b/src/Bicep.Core/Emit/ExpressionEmitter.cs
@@ -130,7 +130,9 @@ namespace Bicep.Core.Emit
 
         public void EmitResourceIdReference(DeclaredResourceMetadata resource, SyntaxBase? indexExpression, SyntaxBase newContext)
         {
-            var converterForContext = this.converter.CreateConverterForIndexReplacement(resource.NameSyntax, indexExpression, newContext);
+            var nameComponents = SyntaxFactory.CreateArray(this.converter.GetResourceNameSyntaxSegments(resource));
+
+            var converterForContext = this.converter.CreateConverterForIndexReplacement(nameComponents, indexExpression, newContext);
 
             var resourceIdExpression = converterForContext.GetFullyQualifiedResourceId(resource);
             var serialized = ExpressionSerializer.SerializeExpression(resourceIdExpression);

--- a/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
@@ -237,7 +237,7 @@ namespace Bicep.Core.Emit
                 _ => throw new NotImplementedException($"Unexpected current declaration type '{this.currentDeclaration?.GetType().Name}'.")
             };
 
-            // using the resource/module body as the context to allow indexed depdnencies relying on the resource/module loop index to work as expected
+            // using the resource/module body as the context to allow indexed dependencies relying on the resource/module loop index to work as expected
             var inaccessibleLocals = dfa.GetInaccessibleLocalsAfterSyntaxMove(candidateIndexExpression, context);
             if (inaccessibleLocals.Any())
             {

--- a/src/Bicep.Core/Emit/SymbolReplacer.cs
+++ b/src/Bicep.Core/Emit/SymbolReplacer.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
+using System.Collections.Generic;
+
+namespace Bicep.Core.Emit
+{
+    public class SymbolReplacer : SyntaxRewriteVisitor
+    {
+        private readonly SemanticModel semanticModel;
+        private IReadOnlyDictionary<Symbol, SyntaxBase> replacements;
+
+        private SymbolReplacer(SemanticModel semanticModel, IReadOnlyDictionary<Symbol, SyntaxBase> replacements)
+        {
+            this.semanticModel = semanticModel;
+            this.replacements = replacements;
+        }
+
+        public static SyntaxBase Replace(SemanticModel semanticModel, IReadOnlyDictionary<Symbol, SyntaxBase> replacements, SyntaxBase syntax) =>
+            new SymbolReplacer(semanticModel, replacements).Rewrite(syntax);
+
+        protected override SyntaxBase ReplaceVariableAccessSyntax(VariableAccessSyntax syntax)
+        {
+            if (this.semanticModel.GetSymbolInfo(syntax) is not { } symbol || !this.replacements.TryGetValue(symbol, out var replacementSyntax))
+            {
+                // unbound variable access or not a symbol that we need to replace
+                // leave syntax as-is
+                return base.ReplaceVariableAccessSyntax(syntax);
+            }
+
+            // inject the replacement syntax
+            return replacementSyntax;
+        }
+    }
+
+    public class SyntaxReplacer: SyntaxRewriteVisitor
+    {
+        private IReadOnlyDictionary<VariableAccessSyntax, SyntaxBase> replacements;
+
+        private SyntaxReplacer(IReadOnlyDictionary<VariableAccessSyntax, SyntaxBase> replacements)
+        {
+            this.replacements = replacements;
+        }
+
+        public static SyntaxBase Replace(IReadOnlyDictionary<VariableAccessSyntax, SyntaxBase> replacements, SyntaxBase syntax) =>
+            new SyntaxReplacer(replacements).Rewrite(syntax);
+
+        protected override SyntaxBase ReplaceVariableAccessSyntax(VariableAccessSyntax syntax)
+        {
+            if(!this.replacements.TryGetValue(syntax, out var replacementSyntax))
+            {
+                // no match
+                // leave syntax as-is
+                return base.ReplaceVariableAccessSyntax(syntax);
+            }
+
+            // inject the replacment syntax
+            return replacementSyntax;
+        }
+    }
+}

--- a/src/Bicep.Core/Semantics/ResourceAncestorGraph.cs
+++ b/src/Bicep.Core/Semantics/ResourceAncestorGraph.cs
@@ -17,21 +17,7 @@ namespace Bicep.Core.Semantics
             ParentProperty,
         }
 
-        public class ResourceAncestor
-        {
-            public ResourceAncestor(ResourceAncestorType ancestorType, DeclaredResourceMetadata resource, SyntaxBase? indexExpression)
-            {
-                AncestorType = ancestorType;
-                Resource = resource;
-                IndexExpression = indexExpression;
-            }
-
-            public ResourceAncestorType AncestorType { get; }
-
-            public DeclaredResourceMetadata Resource { get; }
-
-            public SyntaxBase? IndexExpression { get; }
-        }
+        public record ResourceAncestor(ResourceAncestorType AncestorType, DeclaredResourceMetadata Resource, SyntaxBase? IndexExpression);
 
         private readonly ImmutableDictionary<DeclaredResourceMetadata, ImmutableArray<ResourceAncestor>> data;
 

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -130,6 +130,8 @@ namespace Bicep.Core.Syntax
                 RightSquareToken);
         }
 
+        public static ArrayAccessSyntax CreateArrayAccess(SyntaxBase baseExpression, SyntaxBase indexExpression) => new(baseExpression, LeftSquareToken, indexExpression, RightSquareToken);
+
         public static SyntaxBase CreateObjectPropertyKey(string text)
         {
             if (Regex.IsMatch(text, "^[a-zA-Z][a-zA-Z0-9_]*$"))

--- a/src/vscode-bicep/.vscode/launch.json
+++ b/src/vscode-bicep/.vscode/launch.json
@@ -18,7 +18,8 @@
       "env": {
         "BICEP_TRACING_ENABLED": "true",
         "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll",
-      
+        //"BICEP_SYMBOLIC_NAME_CODEGEN_EXPERIMENTAL": "true",
+
         // Defaulting to "verbose" when debugging so that new telemetry IDs during development aren't accidentally sent and created before they're finalized
         "DEBUGTELEMETRY": "v", // "" or "0" or "false": send telemetry as normal; "1": debug mode (no telemetry sent); "verbose": telemetry in console, don't send (from microsoft/vscode-azext-utils)
       }


### PR DESCRIPTION
Loops involving nested resources that index into parent symbols using non-trivial expressions are now generated correctly. This fixes #6075.