### PR TITLE
Make it easy to create a test VSIX from local repo (npm run packagelocal)

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -308,7 +308,7 @@
         },
         {
           "command": "bicep.showSource",
-          "when": "never"          
+          "when": "never"
         },
         {
           "command": "bicep.gettingStarted.createBicepFile",
@@ -424,7 +424,8 @@
     "test:update-snapshot": "jest --config jest.config.snapshot.js --updateSnapshot",
     "testlocal:e2e": "(export BICEP_LANGUAGE_SERVER_PATH=${INIT_CWD}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll || set BICEP_LANGUAGE_SERVER_PATH=%INIT_CWD%/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll) && npm run build && npm run build:e2e && npm run test:e2e",
     "clean": "rimraf ./out ./coverage",
-    "package": "npm run clean && nbgv-setversion && vsce package --githubBranch main --out ./vscode-bicep.vsix && nbgv-setversion --reset"
+    "package": "npm run clean && nbgv-setversion && vsce package --githubBranch main --out ./vscode-bicep.vsix && nbgv-setversion --reset",
+    "packagelocal": "rimraf ./bicepLanguageServer && cp -r ../Bicep.LangServer/bin/Debug/net6.0 ./bicepLanguageServer && npm run package"
   },
   "devDependencies": {
     "@types/copy-webpack-plugin": "^8.0.1",


### PR DESCRIPTION
Right now if you run "npm run package" you get a VSIX with no language server, essentially useless.  Now you can use:

npm run packagelocal