### PR TITLE
Update command names and grouping

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -152,13 +152,13 @@
       },
       {
         "command": "bicep.build",
-        "title": "Build Bicep file",
+        "title": "Build Bicep File",
         "category": "Bicep",
         "icon": "$(output)"
       },
       {
         "command": "bicep.deploy",
-        "title": "Deploy Bicep file...",
+        "title": "Deploy Bicep File...",
         "category": "Bicep",
         "icon": "$(cloud-upload)"
       },

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -134,13 +134,13 @@
     "commands": [
       {
         "command": "bicep.showVisualizer",
-        "title": "Open Visualizer",
+        "title": "Open Bicep Visualizer",
         "category": "Bicep",
         "icon": "$(type-hierarchy-sub)"
       },
       {
         "command": "bicep.showVisualizerToSide",
-        "title": "Open Visualizer to the Side",
+        "title": "Open Bicep Visualizer to the Side",
         "category": "Bicep",
         "icon": "$(type-hierarchy-sub)"
       },
@@ -152,13 +152,13 @@
       },
       {
         "command": "bicep.build",
-        "title": "Build",
+        "title": "Build Bicep file",
         "category": "Bicep",
         "icon": "$(output)"
       },
       {
         "command": "bicep.deploy",
-        "title": "Deploy...",
+        "title": "Deploy Bicep file...",
         "category": "Bicep",
         "icon": "$(cloud-upload)"
       },
@@ -210,101 +210,101 @@
           "command": "bicep.showVisualizerToSide",
           "when": "editorLangId == bicep",
           "alt": "bicep.showVisualizer",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.showSource",
           "when": "bicepVisualizerFocus",
-          "group": "navigation"
+          "group": "0_bicep"
         }
       ],
       "explorer/context": [
         {
           "command": "bicep.showVisualizer",
           "when": "resourceLangId == bicep",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.showVisualizerToSide",
           "when": "resourceLangId == bicep",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.build",
           "when": "resourceLangId == bicep",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.deploy",
           "when": "resourceLangId == bicep && config.bicep.enableDeploy",
-          "group": "navigation"
+          "group": "0_bicep"
         }
       ],
       "editor/title/context": [
         {
           "command": "bicep.showVisualizer",
           "when": "resourceLangId == bicep",
-          "group": "1_open"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.showVisualizerToSide",
           "when": "resourceLangId == bicep",
-          "group": "1_open"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.build",
           "when": "resourceLangId == bicep",
-          "group": "1_build"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.deploy",
           "when": "resourceLangId == bicep && config.bicep.enableDeploy",
-          "group": "1_build"
+          "group": "0_bicep"
         }
       ],
       "editor/context": [
         {
           "command": "bicep.build",
           "when": "resourceLangId == bicep",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.deploy",
           "when": "resourceLangId == bicep && config.bicep.enableDeploy",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.showVisualizer",
           "when": "resourceLangId == bicep",
-          "group": "1_open"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.showVisualizerToSide",
           "when": "resourceLangId == bicep",
-          "group": "1_open"
+          "group": "0_bicep"
         }
       ],
       "commandPalette": [
         {
           "command": "bicep.build",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.deploy",
           "when": "config.bicep.enableDeploy",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.insertResource",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.showVisualizer",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.showVisualizerToSide",
-          "group": "navigation"
+          "group": "0_bicep"
         },
         {
           "command": "bicep.showSource",
@@ -347,7 +347,7 @@
             "title": "Open a Bicep File",
             "description": "To get started with Bicep extension features, open or create a Bicep file (any file with '.bicep' extension).\n[Open Bicep file](command:bicep.gettingStarted.openBicepFile)\n[Create Bicep file](command:bicep.gettingStarted.createBicepFile)\nTip: [Close the side bar for more space](command:workbench.action.closeSidebar)",
             "media": {
-              "image": "media/walkthroughs/gettingStarted/1_BicepLogoImage.png",
+              "image": "media/walkthroughs/gettingStarted/0_bicepLogoImage.png",
               "altText": "Bicep logo"
             },
             "completionEvents": [
@@ -402,7 +402,7 @@
             "title": "Learn More",
             "description": "Great Job! You've completed Getting Started with Bicep. But don't stop now!\nCheck out our [Bicep Documentation](https://aka.ms/Bicep) to learn more about importing Bicep files as [modules](https://aka.ms/bicep/docs/modules) and [other extension features](https://aka.ms/bicep/docs/vscode).\nWanna take a deep dive into the Bicep language? Take a look at [Microsoft Learn - Bicep](https://aka.ms/microsoftlearnbicep).",
             "media": {
-              "image": "media/walkthroughs/gettingStarted/1_BicepLogoImage.png",
+              "image": "media/walkthroughs/gettingStarted/0_bicepLogoImage.png",
               "altText": "Bicep logo"
             }
           }

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -347,7 +347,7 @@
             "title": "Open a Bicep File",
             "description": "To get started with Bicep extension features, open or create a Bicep file (any file with '.bicep' extension).\n[Open Bicep file](command:bicep.gettingStarted.openBicepFile)\n[Create Bicep file](command:bicep.gettingStarted.createBicepFile)\nTip: [Close the side bar for more space](command:workbench.action.closeSidebar)",
             "media": {
-              "image": "media/walkthroughs/gettingStarted/0_bicepLogoImage.png",
+              "image": "media/walkthroughs/gettingStarted/1_BicepLogoImage.png",
               "altText": "Bicep logo"
             },
             "completionEvents": [
@@ -402,7 +402,7 @@
             "title": "Learn More",
             "description": "Great Job! You've completed Getting Started with Bicep. But don't stop now!\nCheck out our [Bicep Documentation](https://aka.ms/Bicep) to learn more about importing Bicep files as [modules](https://aka.ms/bicep/docs/modules) and [other extension features](https://aka.ms/bicep/docs/vscode).\nWanna take a deep dive into the Bicep language? Take a look at [Microsoft Learn - Bicep](https://aka.ms/microsoftlearnbicep).",
             "media": {
-              "image": "media/walkthroughs/gettingStarted/0_bicepLogoImage.png",
+              "image": "media/walkthroughs/gettingStarted/1_BicepLogoImage.png",
               "altText": "Bicep logo"
             }
           }


### PR DESCRIPTION
Changes include:
1. Updating below command names:
    Build -> Build Bicep File
    Deploy... -> Deploy Bicep file...
    Open Visualizer -> Open Bicep Visualizer
    Open Visualizer to the Side -> Open Bicep Visualizer to the Side
2. All our commands are now group together

Note: For explorer and editor context, navigation group would always show up first. That's by design. Please see https://code.visualstudio.com/api/references/contribution-points#contributes.menus for more info. For editor title, our commands would show up first

![ExplorerContext](https://user-images.githubusercontent.com/30270536/161352103-2f98f622-cafc-46ae-b75b-ab7632dfbeb5.png)
![EditorContext](https://user-images.githubusercontent.com/30270536/161352109-0b5d3c0a-0433-4f3d-85e4-532e390941a9.png)
![EditorTitle](https://user-images.githubusercontent.com/30270536/161352118-18274754-8fa0-48ed-b475-53fb309f22f2.png)

@ucheNkadiCode, could you please take a look at the screenshots and +1 if it looks good
