### PR TITLE
Bicep deploy - avoid duplicate error message in case of cancellation

### DIFF
--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -178,20 +178,11 @@ export class DeployCommand implements Command {
     deploymentScope: string,
     template: string
   ) {
-    let managementGroupTreeItem: AzManagementGroupTreeItem | undefined;
-    try {
-      managementGroupTreeItem =
-        await this.treeManager.azManagementGroupTreeItem.showTreeItemPicker<AzManagementGroupTreeItem>(
-          "",
-          context
-        );
-    } catch (exception) {
-      this.outputChannelManager.appendToOutputChannel(
-        "Deployment failed. " + parseError(exception).message
+    const managementGroupTreeItem =
+      await this.treeManager.azManagementGroupTreeItem.showTreeItemPicker<AzManagementGroupTreeItem>(
+        "",
+        context
       );
-
-      throw exception;
-    }
     const managementGroupId = managementGroupTreeItem?.id;
 
     if (managementGroupId) {


### PR DESCRIPTION
In case of mg level deployment, looks like there is a duplicate cancellation error message:
![image](https://user-images.githubusercontent.com/30270536/161875885-21fed4fa-291e-4f90-9b5e-b60a0dc7192f.png)

With changes in this PR:
![image](https://user-images.githubusercontent.com/30270536/161875972-785dcd92-06b1-4bc6-b752-ab2e9d7cd73a.png)
