### PR TITLE
Fix 6437 Edit config with rule but no 'level'

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepEditLinterRuleCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepEditLinterRuleCommandHandlerTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Bicep.Core.Text;
+using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
@@ -166,6 +167,40 @@ namespace Bicep.LangServer.UnitTests.Handlers
                     { "error", string.Empty },
                     { "result", Result.Succeeded },
                 });
+        }
+
+        [TestMethod]
+        public async Task IfConfigExists_AndContainsRuleButNotLevel_ThenJustAddLevelAndSelect()
+        {
+            string bicepConfig = @"{
+              ""analyzers"": {
+                ""core"": {
+                  ""verbose"": false,
+                  ""enabled"": true,
+                  ""rules"": {
+                    ""no-unused-params"": {
+                    }
+                  }
+                }
+              }
+            }";
+
+            var (bicepPath, configPath) = CreateFiles(bicepConfig);
+
+            string? selectedText = null;
+            var server = CreateMockLanguageServer(
+                (ShowDocumentParams @params, CancellationToken token) =>
+                {
+                    @params.Uri.GetFileSystemPath().ToLowerInvariant().Should().Be(configPath.ToLowerInvariant());
+                    selectedText = GetSelectedTextFromFile(@params.Uri, @params.Selection);
+                },
+                new ShowDocumentResult() { Success = true });
+
+            var telemetryProvider = BicepTestConstants.CreateMockTelemetryProvider();
+            BicepEditLinterRuleCommandHandler bicepEditLinterRuleHandler = new(StrictMock.Of<ISerializer>().Object, server.Object, telemetryProvider.Object);
+            await bicepEditLinterRuleHandler.Handle(new Uri(bicepPath), "no-unused-params", configPath, CancellationToken.None);
+
+            selectedText.Should().Be("warning", "rule's current level value should be selected when the config file is opened");
         }
 
         [TestMethod]

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepEditLinterRuleCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepEditLinterRuleCommandHandlerTests.cs
@@ -164,6 +164,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             ev.Properties.Should().Contain(new Dictionary<string, string> {
                     { "code", "no-unused-params" },
                     { "newConfigFile", "false" },
+                    { "newRuleAdded", "false" },
                     { "error", string.Empty },
                     { "result", Result.Succeeded },
                 });
@@ -265,6 +266,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             ev.Properties.Should().Contain(new Dictionary<string, string> {
                     { "code", "whatever" },
                     { "newConfigFile", "false" },
+                    { "newRuleAdded", "true" },
                     { "error", string.Empty },
                     { "result", Result.Succeeded },
                 });
@@ -304,6 +306,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             ev.Properties.Should().Contain(new Dictionary<string, string> {
                     { "code", "whatever" },
                     { "newConfigFile", "false" },
+                    { "newRuleAdded", "false" },
                     { "error", "JsonReaderException" },
                     { "result", Result.Failed },
                 });
@@ -363,6 +366,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             ev.Properties.Should().Contain(new Dictionary<string, string> {
                     { "code", "whatever" },
                     { "newConfigFile", "true" },
+                    { "newRuleAdded", "true" },
                     { "error", string.Empty },
                     { "result", Result.Succeeded },
                 });

--- a/src/Bicep.LangServer/Handlers/BicepEditLinterRuleCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepEditLinterRuleCommandHandler.cs
@@ -95,8 +95,8 @@ namespace Bicep.LanguageServer.Handlers
 
             string json = File.ReadAllText(bicepConfigFilePath);
             (int line, int column, string text)? insertion = new JsonEditor(json).InsertIfNotExist(
-                new string[] { "analyzers", "core", "rules", ruleCode },
-                new { level = "warning" });
+                new string[] { "analyzers", "core", "rules", ruleCode, "level" },
+                "warning");
 
             if (insertion.HasValue)
             {
@@ -109,9 +109,9 @@ namespace Bicep.LanguageServer.Handlers
                 {
                     server.Window.ShowError($"Unable to write to configuration file \"{bicepConfigFilePath}\": {ex.Message}");
                 }
-
-                await SelectRuleLevelIfExists(ruleCode, bicepConfigFilePath);
             }
+
+            await SelectRuleLevelIfExists(ruleCode, bicepConfigFilePath);
         }
 
         /// <summary>

--- a/src/Bicep.LangServer/Handlers/BicepEditLinterRuleCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepEditLinterRuleCommandHandler.cs
@@ -42,6 +42,7 @@ namespace Bicep.LanguageServer.Handlers
         {
             string? error = "unknown";
             bool newConfigFile = false;
+            bool newRuleAdded = false;
             try
             {
                 // bicepConfigFilePath will be empty string if no current configuration file was found
@@ -68,7 +69,7 @@ namespace Bicep.LanguageServer.Handlers
                 }
 
 
-                await AddAndSelectRuleLevel(bicepConfigFilePath, ruleCode);
+                newRuleAdded = await AddAndSelectRuleLevel(bicepConfigFilePath, ruleCode);
 
                 error = null;
                 return Unit.Value;
@@ -81,16 +82,17 @@ namespace Bicep.LanguageServer.Handlers
             }
             finally
             {
-                telemetryProvider.PostEvent(BicepTelemetryEvent.EditLinterRule(ruleCode, newConfigFile, error));
+                telemetryProvider.PostEvent(BicepTelemetryEvent.EditLinterRule(ruleCode, newConfigFile, newRuleAdded, error));
             }
         }
 
-        public async Task AddAndSelectRuleLevel(string bicepConfigFilePath, string ruleCode)
+        // Returns true if the rule was added to the config file
+        public async Task<bool> AddAndSelectRuleLevel(string bicepConfigFilePath, string ruleCode)
         {
             if (await SelectRuleLevelIfExists(ruleCode, bicepConfigFilePath))
             {
                 // The rule already exists and has been shown/selected
-                return;
+                return false;
             }
 
             string json = File.ReadAllText(bicepConfigFilePath);
@@ -98,12 +100,14 @@ namespace Bicep.LanguageServer.Handlers
                 new string[] { "analyzers", "core", "rules", ruleCode, "level" },
                 "warning");
 
+            bool added = false;
             if (insertion.HasValue)
             {
                 var (line, column, insertText) = insertion.Value;
                 try
                 {
                     File.WriteAllText(bicepConfigFilePath, JsonEditor.ApplyInsertion(json, (line, column, insertText)));
+                    added = true;
                 }
                 catch (Exception ex)
                 {
@@ -112,6 +116,7 @@ namespace Bicep.LanguageServer.Handlers
             }
 
             await SelectRuleLevelIfExists(ruleCode, bicepConfigFilePath);
+            return added;
         }
 
         /// <summary>

--- a/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
+++ b/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
@@ -19,7 +19,7 @@ namespace Bicep.LanguageServer.Telemetry
 
         public Dictionary<string, string> Properties { get; private set; }
 
-        private static string ToString(bool f)
+        private static string ToTrueFalse(bool f)
         {
             return f ? "true" : "false";
         }
@@ -111,14 +111,15 @@ namespace Bicep.LanguageServer.Telemetry
                 }
             );
 
-        public static BicepTelemetryEvent EditLinterRule(string code, bool newConfigFile, string? error)
+        public static BicepTelemetryEvent EditLinterRule(string code, bool newConfigFile, bool newRuleAdded, string? error)
             => new BicepTelemetryEvent
             (
                 eventName:  TelemetryConstants.EventNames.EditLinterRule,
                 properties: new()
                 {
                     ["code"] = code,
-                    ["newConfigFile"] = ToString(newConfigFile),
+                    ["newConfigFile"] = ToTrueFalse(newConfigFile),
+                    ["newRuleAdded"] = ToTrueFalse(newRuleAdded),
                     ["error"] = error ?? string.Empty,
                     ["result"] = error == null ? Result.Succeeded : Result.Failed,
                 }


### PR DESCRIPTION
Fixes #6437  

2 fixes:
1) Make sure to search all the way down to the "level" property when calling InsertIfNotExist
2) If for some reason we can't insert (not sure how to repro), still at least show the bicepconfig.json file

Plus added related telemetry