### PR TITLE
Add visualizer icon to editor command bar

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -210,12 +210,12 @@
           "command": "bicep.showVisualizerToSide",
           "when": "editorLangId == bicep",
           "alt": "bicep.showVisualizer",
-          "group": "0_bicep"
+          "group": "navigation"
         },
         {
           "command": "bicep.showSource",
           "when": "bicepVisualizerFocus",
-          "group": "0_bicep"
+          "group": "navigation"
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
Adds visualizer icon to editor command bar. Regression was caused by below commit:
https://github.com/Azure/bicep/commit/50be98ac63ea9eab949e282ce304e7600e24da43

![image](https://user-images.githubusercontent.com/30270536/162492117-dbc8d3ff-37c5-4c91-8578-123811af5cd4.png)
