### PR TITLE
Increase minimum node version to 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: '14'
 
       - name: Download Bicep CLI
         uses: actions/download-artifact@v3
@@ -301,7 +301,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 10.x
+          node-version: '14'
 
       - name: npm ci
         if: ${{ matrix.runTests == 'true' }}
@@ -383,7 +383,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: '14'
 
       - name: npm ci
         run: npm ci
@@ -466,7 +466,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: '14'
       
       - name: npm ci
         run: npm ci


### PR DESCRIPTION
We were using old node versions and it was blocking npm package upgrades on several PRs.