### PR TITLE
#6516 Fix duplicate exampleUser1

### DIFF
--- a/docs/examples/201/api-management-create-all-resources/main.bicep
+++ b/docs/examples/201/api-management-create-all-resources/main.bicep
@@ -166,7 +166,7 @@ resource exampleUser2 'Microsoft.ApiManagement/service/users@2020-06-01-preview'
 }
 
 resource exampleUser3 'Microsoft.ApiManagement/service/users@2020-06-01-preview' = {
-  name: '${apiManagementService.name}/exampleUser1'
+  name: '${apiManagementService.name}/exampleUser3'
   properties: {
     firstName: 'ExampleFirstName3'
     lastName: 'ExampleLastName3'

--- a/docs/examples/201/api-management-create-all-resources/main.json
+++ b/docs/examples/201/api-management-create-all-resources/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17616543420192955257"
+      "templateHash": "4986791634164114531"
     }
   },
   "parameters": {

--- a/docs/examples/201/api-management-create-all-resources/main.json
+++ b/docs/examples/201/api-management-create-all-resources/main.json
@@ -255,7 +255,7 @@
     {
       "type": "Microsoft.ApiManagement/service/users",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleUser1', variables('apiManagementServiceName'))]",
+      "name": "[format('{0}/exampleUser3', variables('apiManagementServiceName'))]",
       "properties": {
         "firstName": "ExampleFirstName3",
         "lastName": "ExampleLastName3",

--- a/docs/examples/201/api-management-create-all-resources/main.json
+++ b/docs/examples/201/api-management-create-all-resources/main.json
@@ -304,12 +304,12 @@
       "properties": {
         "displayName": "examplesubscription2",
         "productId": "[resourceId('Microsoft.ApiManagement/service/products', split(format('{0}/exampleProduct', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleProduct', variables('apiManagementServiceName')), '/')[1])]",
-        "userId": "[resourceId('Microsoft.ApiManagement/service/users', split(format('{0}/exampleUser1', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleUser1', variables('apiManagementServiceName')), '/')[1])]"
+        "userId": "[resourceId('Microsoft.ApiManagement/service/users', split(format('{0}/exampleUser3', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleUser3', variables('apiManagementServiceName')), '/')[1])]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]",
         "[resourceId('Microsoft.ApiManagement/service/products', split(format('{0}/exampleProduct', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleProduct', variables('apiManagementServiceName')), '/')[1])]",
-        "[resourceId('Microsoft.ApiManagement/service/users', split(format('{0}/exampleUser1', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleUser1', variables('apiManagementServiceName')), '/')[1])]"
+        "[resourceId('Microsoft.ApiManagement/service/users', split(format('{0}/exampleUser3', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleUser3', variables('apiManagementServiceName')), '/')[1])]"
       ]
     },
     {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
@@ -306,12 +306,12 @@
       "properties": {
         "displayName": "examplesubscription2",
         "productId": "[resourceInfo('exampleProduct').id]",
-        "userId": "[resourceInfo('exampleUser1').id]"
+        "userId": "[resourceInfo('exampleUser3').id]"
       },
       "dependsOn": [
         "apiManagementService",
         "exampleProduct",
-        "exampleUser1"
+        "exampleUser3"
       ]
     },
     "certificate": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
@@ -257,7 +257,7 @@
     "exampleUser3": {
       "type": "Microsoft.ApiManagement/service/users",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleUser1', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleUser3', resourceInfo('apiManagementService').name)]",
       "properties": {
         "firstName": "ExampleFirstName3",
         "lastName": "ExampleLastName3",

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "554096486254860362"
+      "templateHash": "17701469026321761813"
     }
   },
   "parameters": {

--- a/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
+++ b/src/Bicep.Core.Samples/Files/experimental/symbolicnames/201/api-management-create-all-resources/main.json
@@ -306,12 +306,12 @@
       "properties": {
         "displayName": "examplesubscription2",
         "productId": "[resourceInfo('exampleProduct').id]",
-        "userId": "[resourceInfo('exampleUser3').id]"
+        "userId": "[resourceInfo('exampleUser1').id]"
       },
       "dependsOn": [
         "apiManagementService",
         "exampleProduct",
-        "exampleUser3"
+        "exampleUser1"
       ]
     },
     "certificate": {


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [x] This is a bug fix for an existing example
* [x] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [x] I have checked that all tests are passing by running `dotnet test`
* [x] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```

Fixes #6516 by renaming references for exampleUser3.
