### PR TITLE
Disable live tests on PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,10 +155,11 @@ jobs:
     name: 'Test CLI (live) (${{ matrix.rid }})'
     runs-on: ${{ matrix.os }}
     needs: build-bicep
-    if: github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
+    if: env.CAN_ACCESS_SECRETS != null && github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
 
     env:
       CI: true
+      CAN_ACCESS_SECRETS: ${{ secrets.CAN_ACCESS_SECRETS }}
       BICEP_SPN_PASSWORD: ${{ secrets.BICEP_SPN_PASSWORD }}
       BICEP_SPN_PASSWORD_FF: ${{ secrets.BICEP_SPN_PASSWORD_FF }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
   check-secret-access:
     name: Check if the workflow run can access secrets
     runs-on: ${{ matrix.os }}
-    needs: build-step
+    needs: build-bicep
     outputs:
       can_access_secrets: ${{ steps.check-secret.outputs.can_access_secrets }}
     steps:
@@ -170,7 +170,7 @@ jobs:
     name: 'Test CLI (live) (${{ matrix.rid }})'
     runs-on: ${{ matrix.os }}
     needs:
-      - build-step
+      - build-bicep
       - check-secret-access
     if: needs.check-secret-access.outputs.can_access_secrets == 'true' && github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
 
   check-secret-access:
     name: Check if the workflow run can access secrets
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: build-bicep
     outputs:
       can_access_secrets: ${{ steps.check-secret.outputs.can_access_secrets }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build-bicep:
+    
     name: 'Build CLI (${{ matrix.rid }})'
     runs-on: ${{ matrix.os }}
 
@@ -151,15 +152,30 @@ jobs:
         with:
           flags: dotnet
 
+  check-secret-access:
+    name: Check if the workflow run can access secrets
+    runs-on: ${{ matrix.os }}
+    needs: build-step
+    outputs:
+      can_access_secrets: ${{ steps.check-secret.outputs.can_access_secrets }}
+    steps:
+      - name: Check secret
+        id: check-secret
+        env:
+          CAN_ACCESS_SECRETS: ${{ secrets.CAN_ACCESS_SECRETS }}
+        run: |
+          echo "::set-output name=can_access_secrets::${{ env.CAN_ACCESS_SECRETS != '' }}"
+    
   test-cli-live:
     name: 'Test CLI (live) (${{ matrix.rid }})'
     runs-on: ${{ matrix.os }}
-    needs: build-bicep
-    if: env.CAN_ACCESS_SECRETS != null && github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
+    needs:
+      - build-step
+      - check-secret-access
+    if: needs.check-secret-access.outputs.can_access_secrets == 'true' && github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
 
     env:
       CI: true
-      CAN_ACCESS_SECRETS: ${{ secrets.CAN_ACCESS_SECRETS }}
       BICEP_SPN_PASSWORD: ${{ secrets.BICEP_SPN_PASSWORD }}
       BICEP_SPN_PASSWORD_FF: ${{ secrets.BICEP_SPN_PASSWORD_FF }}
 


### PR DESCRIPTION
Added a new secret `CAN_ACCESS_SECRETS` which is used to check if secrets can be read by the workflow run. The PR was created from a fork to verify it.

Closes #6132 (again 😅).