### PR TITLE
Fix 6326

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepGetRecommendedConfigLocationHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepGetRecommendedConfigLocationHandlerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -58,6 +58,34 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
             var actual = BicepGetRecommendedConfigLocationHandler.GetRecommendedConfigFileLocation(workspaceFolders, null);
             var expected = workspaceFolders[0];
+
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void SingleWorkspaceFolder_CurrentFileUnsaved_ShouldReturnFirstWorkspaceFolder()
+        {
+            string[] workspaceFolders = new string[]
+            {
+                Environment.CurrentDirectory,
+                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+            };
+
+            var actual = BicepGetRecommendedConfigLocationHandler.GetRecommendedConfigFileLocation(workspaceFolders, "Untitled-1");
+            var expected = Environment.CurrentDirectory;
+
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void NoWorkspaceFolder_CurrentFileUnsaved_ShouldReturnProfileFolder()
+        {
+            string[] workspaceFolders = new string[]
+            {
+            };
+
+            var actual = BicepGetRecommendedConfigLocationHandler.GetRecommendedConfigFileLocation(workspaceFolders, "Untitled-1");
+            var expected = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
             actual.Should().Be(expected);
         }

--- a/src/Bicep.LangServer/Handlers/BicepGetRecommendedConfigLocationHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepGetRecommendedConfigLocationHandler.cs
@@ -87,13 +87,13 @@ namespace Bicep.LanguageServer.Handlers
 
         private static string? GetFolderContainingPath(string[]? workspaceFolderPaths, string bicepFolder)
         {
-            bool caseSensitive = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            bicepFolder = AddSeparator(bicepFolder);
-
             if (workspaceFolderPaths is null)
             {
                 return null;
             }
+
+            bool caseSensitive = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            bicepFolder = AddSeparator(bicepFolder);
 
             foreach (var folder in workspaceFolderPaths)
             {

--- a/src/Bicep.LangServer/Handlers/BicepGetRecommendedConfigLocationHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepGetRecommendedConfigLocationHandler.cs
@@ -57,52 +57,59 @@ namespace Bicep.LanguageServer.Handlers
 
         public static string GetRecommendedConfigFileLocation(string[]? workspaceFolderPaths, string? bicepFilePath)
         {
-            if (bicepFilePath is null && workspaceFolderPaths?.Length > 0)
+            var bicepFileFolder = Path.GetDirectoryName(bicepFilePath);
+            if (string.IsNullOrWhiteSpace(bicepFileFolder))
             {
-                // No bicep source file indicated - use first workspace folder root
-                return workspaceFolderPaths.First();
-            }
-
-            // If the bicep source file indicated is contained in a workspace folder, use its root
-            var applicableWorkspaceFolder = GetFolderContainingPath(workspaceFolderPaths, bicepFilePath);
-            if (applicableWorkspaceFolder is not null)
-            {
-                return applicableWorkspaceFolder;
-            }
-
-            // No workspace folder exists, use folder containing the bicep file source
-            if (bicepFilePath is not null)
-            {
-                var dir = Path.GetDirectoryName(bicepFilePath);
-                if (dir is not null)
+                // No bicep source file provided, or it wasn't an absolute path (e.g. an unsaved file)...
+          
+                // Use first workspace folder root if one exists
+                if (workspaceFolderPaths?.Length > 0)
                 {
-                    return dir;
+                    return workspaceFolderPaths.First();
                 }
-            }
 
-            // If all else fails
-            return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.Create);
+                // Just use user folder
+                return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.Create);
+            }
+            else
+            {
+                // If the bicep source file is contained in a workspace folder, use that workspace folder's root
+                var applicableWorkspaceFolder = GetFolderContainingPath(workspaceFolderPaths, bicepFileFolder);
+                if (applicableWorkspaceFolder is not null)
+                {
+                    return applicableWorkspaceFolder;
+                }
+
+                // No matching workspace folders, use folder containing the bicep file source
+                return bicepFileFolder;
+            }
         }
 
-        private static string? GetFolderContainingPath(string[]? workspaceFolderPaths, string? bicepFilePath)
+        private static string? GetFolderContainingPath(string[]? workspaceFolderPaths, string bicepFolder)
         {
             bool caseSensitive = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            bicepFolder = AddSeparator(bicepFolder);
 
-            if (workspaceFolderPaths is null || bicepFilePath is null)
+            if (workspaceFolderPaths is null)
             {
                 return null;
             }
 
             foreach (var folder in workspaceFolderPaths)
             {
-                string folderWithSeparator = folder[folder.Length - 1] == Path.DirectorySeparatorChar ? folder : folder + Path.DirectorySeparatorChar;
-                if (bicepFilePath.Contains(folderWithSeparator, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
+                string folderWithSeparator = AddSeparator(folder);
+                if (bicepFolder.Contains(folderWithSeparator, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
                 {
                     return folder;
                 }
             }
 
             return null;
+        }
+
+        private static string AddSeparator(string folder)
+        {
+            return folder[folder.Length - 1] == Path.DirectorySeparatorChar ? folder : folder + Path.DirectorySeparatorChar;
         }
     }
 }

--- a/src/vscode-bicep/src/test/e2e/hover.test.ts
+++ b/src/vscode-bicep/src/test/e2e/hover.test.ts
@@ -4,10 +4,7 @@ import * as vscode from "vscode";
 
 import { expectDefined, expectRange } from "../utils/assert";
 import { retryWhile, sleep } from "../utils/time";
-import {
-  executeCloseAllEditors,
-  executeHoverProvider,
-} from "./commands";
+import { executeCloseAllEditors, executeHoverProvider } from "./commands";
 import { readExampleFile } from "./examples";
 
 describe("hover", (): void => {

--- a/src/vscode-bicep/src/test/unit/logger.test.ts
+++ b/src/vscode-bicep/src/test/unit/logger.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 jest.mock("winston", () => ({
   createLogger: () => mockWinstonLogger,
   format: {
@@ -81,8 +82,7 @@ describe("getLogger()", () => {
   });
 });
 
-// eslint-disable-next-line jest/prefer-lowercase-title
-describe("WinstonLogger", () => {
+describe("winstonLogger", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });


### PR DESCRIPTION
Fixes #6326
Main problem was that Path.GetDirectoryName of a relative path returns empty string, not null.  But also improved the logic.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6617)