### PR TITLE
Another fix for the `con` issue on Windows

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -3022,9 +3022,14 @@ resource managementGroup 'Microsoft.Management/managementGroups@2021-04-01'
         {
             var inputFile = FileHelper.SaveResultFile(TestContext, "main.bicep", @"
 var text = loadTextContent('./con')
+var text2 = loadTextContent('./con.txt')
 var base64 = loadFileAsBase64('./con')
+var base64_2 = loadFileAsBase64('./con.txt')
 
 module test './con'
+
+module test './con.txt'
+
 ");
             var fileResolver = new FileResolver();
             var configuration = BicepTestConstants.BuiltInConfiguration;

--- a/src/Bicep.Core/FileSystem/FileResolver.cs
+++ b/src/Bicep.Core/FileSystem/FileResolver.cs
@@ -246,7 +246,7 @@ namespace Bicep.Core.FileSystem
         {
             /*
              * Win10 (and possibly older versions) will block without returning when
-             * reading a file whose name is CON which breaks the language server
+             * reading a file whose name is CON or CON.<any extension> which breaks the language server
              * 
              * as a workaround, we will simulate Win11+ behavior that throws a
              * FileNotFoundException
@@ -260,10 +260,10 @@ namespace Bicep.Core.FileSystem
                 return;
             }
 
-            string fileName = Path.GetFileName(localPath);
+            string fileName = Path.GetFileNameWithoutExtension(localPath);
             if(!string.Equals(fileName, "CON", StringComparison.InvariantCultureIgnoreCase))
             {
-                // file is not named CON, so we can proceed normally
+                // file is not named CON or CON.<any extension>, so we can proceed normally
                 return;
             }
 


### PR DESCRIPTION
It turns out that windows treats files named `con` and `con.<any extension>` in a special way. Modified the fix from #6636 to ignore the file extension.

This fixes #6224.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6638)