### PR TITLE
Convert createArray and createObject function calls to array and object literals, respectively.

### DIFF
--- a/src/Bicep.Decompiler.IntegrationTests/Working/issue5621/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/issue5621/main.bicep
@@ -1,0 +1,32 @@
+var emptyObject = {}
+var simpleObject = {
+  'foo': 'bar'
+}
+var emptyArray = []
+var singletonList = [
+  'boo!'
+]
+var krispies = [
+  'snap'
+  'crackle'
+  'pop'
+]
+var nestedArrays = [
+  [
+    1
+    2
+  ]
+  {
+    'key1': [
+      3
+      4
+    ]
+    'key2': {
+      'nestedKey1': [
+        5
+        6
+      ]
+      'nestedKey2': {}
+    }
+  }
+]

--- a/src/Bicep.Decompiler.IntegrationTests/Working/issue5621/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/issue5621/main.bicep
@@ -1,6 +1,6 @@
 var emptyObject = {}
 var simpleObject = {
-  'foo': 'bar'
+  foo: 'bar'
 }
 var emptyArray = []
 var singletonList = [
@@ -17,16 +17,16 @@ var nestedArrays = [
     2
   ]
   {
-    'key1': [
+    key1: [
       3
       4
     ]
-    'key2': {
-      'nestedKey1': [
+    key2: {
+      nestedKey1: [
         5
         6
       ]
-      'nestedKey2': {}
+      nestedKey2: {}
     }
   }
 ]

--- a/src/Bicep.Decompiler.IntegrationTests/Working/issue5621/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/issue5621/main.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "variables": {
+    "emptyObject": "[createObject()]",
+    "simpleObject": "[createObject('foo', 'bar')]",
+    "emptyArray": "[createArray()]",
+    "singletonList": "[createArray('boo!')]",
+    "krispies": "[createArray('snap', 'crackle', 'pop')]",
+    "nestedArrays": "[createArray(createArray(1, 2), createObject('key1', createArray(3, 4), 'key2', createObject('nestedKey1', createArray(5, 6), 'nestedKey2', createObject())))]"
+  },
+  "resources": []
+}

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -340,6 +340,22 @@ namespace Bicep.Decompiler
                 return true;
             }
 
+            if (StringComparer.OrdinalIgnoreCase.Equals(expression.Function, "createArray"))
+            {
+                syntax = SyntaxFactory.CreateArray(expression.Parameters.Select(ParseLanguageExpression));
+                return true;
+            }
+
+            if (StringComparer.OrdinalIgnoreCase.Equals(expression.Function, "createObject"))
+            {
+                syntax = SyntaxFactory.CreateObject(expression.Parameters.Chunk(2)
+                    .Select(pair => new ObjectPropertySyntax(
+                        ParseLanguageExpression(pair[0]),
+                        SyntaxFactory.ColonToken,
+                        ParseLanguageExpression(pair[1]))));
+                return true;
+            }
+
             syntax = null;
             return false;
         }
@@ -676,7 +692,7 @@ namespace Bicep.Decompiler
             {
                 var expressionValue = valueLookupFunc(functionName);
                 if (TryParseJToken(expressionValue) is SyntaxBase expression &&
-                    transformFunc((functionName, expression)) is {} transformOutput)
+                    transformFunc((functionName, expression)) is { } transformOutput)
                 {
                     var (newFunctionName, newExpression) = transformOutput;
 
@@ -690,11 +706,12 @@ namespace Bicep.Decompiler
             => ProcessDecoratorsWithTransform(
                 new[] { "metadata" },
                 valueLookupFunc,
-                input => {
+                input =>
+                {
                     var (name, expression) = input;
 
                     if (expression is ObjectSyntax metadataObject &&
-                        metadataObject.TryGetPropertyByName("description") is {} descriptionProperty)
+                        metadataObject.TryGetPropertyByName("description") is { } descriptionProperty)
                     {
                         // Replace metadata decorator with description decorator if the metadata object only contains description.
                         return ("description", descriptionProperty.Value);
@@ -707,7 +724,8 @@ namespace Bicep.Decompiler
             => ProcessDecoratorsWithTransform(
                 new[] { "metadata" },
                 valueLookupFunc,
-                input => {
+                input =>
+                {
                     var (name, expression) = input;
 
                     if (expression is ObjectSyntax metadataObject &&
@@ -735,7 +753,8 @@ namespace Bicep.Decompiler
                 ProcessDecoratorsWithTransform(
                 new[] { "minValue", "maxValue", "minLength", "maxLength", "allowedValues" },
                 name => value.Value?[name],
-                input => {
+                input =>
+                {
                     var (name, expression) = input;
 
                     if (name == "allowedValues")

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -348,11 +348,19 @@ namespace Bicep.Decompiler
 
             if (StringComparer.OrdinalIgnoreCase.Equals(expression.Function, "createObject"))
             {
-                syntax = SyntaxFactory.CreateObject(expression.Parameters.Chunk(2)
-                    .Select(pair => new ObjectPropertySyntax(
-                        ParseLanguageExpression(pair[0]),
-                        SyntaxFactory.ColonToken,
-                        ParseLanguageExpression(pair[1]))));
+                syntax = SyntaxFactory.CreateObject(expression.Parameters.Select(ParseLanguageExpression).Chunk(2).Select(pair =>
+                {
+                    if (pair[0] is StringSyntax keyString)
+                    {
+                        var keyLiteral = keyString.TryGetLiteralValue();
+                        if (keyLiteral is not null)
+                        {
+                            return SyntaxFactory.CreateObjectProperty(keyLiteral, pair[1]);
+                        }
+                    }
+
+                    return new ObjectPropertySyntax(pair[0], SyntaxFactory.ColonToken, pair[1]);
+                }));
                 return true;
             }
 


### PR DESCRIPTION
This PR adds support for dynamically created arrays and objects to the decompiler. Previously, `createArray` and `createObject` function calls would be preserved as function expressions in decompiler-generated bicep, which resulted in an invalid template.

Fixes #5621

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6645)