### PR TITLE
Work around GH Action output exclusion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-bicep:
-    
+
     name: 'Build CLI (${{ matrix.rid }})'
     runs-on: ${{ matrix.os }}
 
@@ -80,14 +80,14 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v2
-      
+
       - name: Build
         run: dotnet build --configuration ${{ matrix.configuration }}
 
       - name: Pack
         if: ${{ matrix.publishPackages == 'true' }}
         run: dotnet pack --configuration ${{ matrix.configuration }}
-      
+
       - name: Test
         if: ${{ matrix.runTests == 'true' }}
         run: dotnet test --configuration ${{ matrix.configuration }} --logger trx --blame --collect:"XPlat Code Coverage" --settings ./.github/workflows/codecov.runsettings --results-directory ./TestResults/
@@ -103,7 +103,7 @@ jobs:
       - name: Publish Language Server
         if: ${{ matrix.publishLanguageServer == 'true' }}
         run: dotnet publish --configuration ${{ matrix.configuration }} ./src/Bicep.LangServer/Bicep.LangServer.csproj
-      
+
       - name: Publish Bicep
         run: dotnet publish --configuration ${{ matrix.configuration }} --self-contained true -p:PublishTrimmed=true -p:PublishSingleFile=true -p:TrimmerDefaultAction=copyused -p:SuppressTrimAnalysisWarnings=true -r ${{ matrix.rid }} ./src/Bicep.Cli/Bicep.Cli.csproj
 
@@ -122,7 +122,7 @@ jobs:
           args: -c "apk add --update nodejs npm && npm ci --prefix ./src/Bicep.Cli.E2eTests && npm test --prefix ./src/Bicep.Cli.E2eTests"
         env:
           BICEP_CLI_EXECUTABLE: ../../../Bicep.Cli/bin/${{ matrix.configuration }}/net6.0/${{ matrix.rid }}/publish/bicep
-      
+
       - name: Upload Language Server
         uses: actions/upload-artifact@v3
         if: ${{ matrix.publishLanguageServer == 'true' }}
@@ -130,7 +130,7 @@ jobs:
           name: Bicep.LangServer
           path: ./src/Bicep.LangServer/bin/${{ matrix.configuration }}/net6.0/publish/*
           if-no-files-found: error
-      
+
       - name: Upload Bicep
         uses: actions/upload-artifact@v3
         with:
@@ -163,9 +163,10 @@ jobs:
         id: check-secret
         env:
           CAN_ACCESS_SECRETS: ${{ secrets.CAN_ACCESS_SECRETS }}
+        if: ${{ env.CAN_ACCESS_SECRETS != '' }}
         run: |
-          echo "::set-output name=can_access_secrets::${{ env.CAN_ACCESS_SECRETS != '' }}"
-    
+          echo "::set-output name=can_access_secrets::true"
+
   test-cli-live:
     name: 'Test CLI (live) (${{ matrix.rid }})'
     runs-on: ${{ matrix.os }}
@@ -197,7 +198,7 @@ jobs:
         - os: 'macos-latest'
           rid: 'osx-x64'
           configuration: 'release'
-    
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -255,16 +256,16 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v2
-      
+
       - name: Download Bicep CLI
         uses: actions/download-artifact@v3
         with:
           name: bicep-release-win-x64
           path: ./src/installer-win/bicep
-      
+
       - name: Build Windows Installer
         run: dotnet build --configuration release ./src/installer-win/installer.proj
-      
+
       - name: Upload Windows Installer
         uses: actions/upload-artifact@v3
         with:
@@ -283,7 +284,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      
+
       # should be the full list of RIDs that we support in the CLI
       matrix:
         include:
@@ -305,7 +306,7 @@ jobs:
         - os: 'ubuntu-latest'
           rid: 'osx-arm64'
           runTests: 'false'
-    
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -349,14 +350,14 @@ jobs:
 
       - name: Build CLI Package
         run: dotnet build --configuration release /p:RuntimeSuffix=${{ matrix.rid }} ./src/Bicep.Cli.Nuget/nuget.proj
-      
+
       - name: Upload CLI Package
         uses: actions/upload-artifact@v3
         with:
           name: bicep-nupkg-${{ matrix.rid }}
           path: ./src/Bicep.Cli.Nuget/*.nupkg
           if-no-files-found: error
-      
+
       - name: Download CLI Package
         if: ${{ matrix.runTests == 'true' }}
         uses: actions/download-artifact@v3
@@ -405,11 +406,11 @@ jobs:
       - name: npm ci
         run: npm ci
         working-directory: ./src/vscode-bicep
-        
+
       - name: Run lint
         run: npm run lint
         working-directory: ./src/vscode-bicep
-          
+
       - name: Run unit tests
         run: npm run test:unit
         working-directory: ./src/vscode-bicep
@@ -427,7 +428,7 @@ jobs:
       - name: Build prod
         run: npm run build:prod
         working-directory: ./src/vscode-bicep
-        
+
       - name: Build E2E tests
         run: npm run build:e2e
         working-directory: ./src/vscode-bicep
@@ -484,7 +485,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14'
-      
+
       - name: npm ci
         run: npm ci
         working-directory: ./src/playground
@@ -521,21 +522,21 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-      
+
       - name: TextMate Grammar
         run: |
           npm ci
           npm run lint
           npm test
         working-directory: ./src/textmate
-      
+
       - name: HighlightJs Grammar
         run: |
           npm ci
           npm run lint
           npm test
         working-directory: ./src/highlightjs
-      
+
       - name: Monarch Grammar
         run: |
           npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,27 +152,27 @@ jobs:
         with:
           flags: dotnet
 
-  check-secret-access:
+  can-run-live-tests:
     name: Check if the workflow run can access secrets
     runs-on: ubuntu-latest
     outputs:
-      access_verified: ${{ steps.check-secret.outputs.access_verified }}
+      access_verified: ${{ steps.check-access.outputs.verified }}
     steps:
-      - name: Check secret
-        id: check-secret
+      - name: Check access
+        id: check-access
         env:
-          CAN_ACCESS_SECRETS: ${{ secrets.CAN_ACCESS_SECRETS }}
-        if: ${{ env.CAN_ACCESS_SECRETS != '' }}
+          BICEP_SPN_PASSWORD: ${{ secrets.BICEP_SPN_PASSWORD }}
+        if: ${{ env.BICEP_SPN_PASSWORD != '' }}
         run: |
-          echo "::set-output name=access_verified::true"
+          echo "::set-output name=verified::true"
 
   test-cli-live:
     name: 'Test CLI (live) (${{ matrix.rid }})'
     runs-on: ${{ matrix.os }}
     needs:
       - build-bicep
-      - check-secret-access
-    if: needs.check-secret-access.outputs.access_verified == 'true' && github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
+      - can-run-live-tests
+    if: needs.can-run-live-tests.outputs.access_verified == 'true' && github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
 
     env:
       CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,9 +155,8 @@ jobs:
   check-secret-access:
     name: Check if the workflow run can access secrets
     runs-on: ubuntu-latest
-    needs: build-bicep
     outputs:
-      can_access_secrets: ${{ steps.check-secret.outputs.can_access_secrets }}
+      access_verified: ${{ steps.check-secret.outputs.access_verified }}
     steps:
       - name: Check secret
         id: check-secret

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
           CAN_ACCESS_SECRETS: ${{ secrets.CAN_ACCESS_SECRETS }}
         if: ${{ env.CAN_ACCESS_SECRETS != '' }}
         run: |
-          echo "::set-output name=can_access_secrets::true"
+          echo "::set-output name=access_verified::true"
 
   test-cli-live:
     name: 'Test CLI (live) (${{ matrix.rid }})'
@@ -173,7 +173,7 @@ jobs:
     needs:
       - build-bicep
       - check-secret-access
-    if: needs.check-secret-access.outputs.can_access_secrets == 'true' && github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
+    if: needs.check-secret-access.outputs.access_verified == 'true' && github.repository == 'Azure/bicep' && github.actor != 'dependabot[bot]'
 
     env:
       CI: true


### PR DESCRIPTION
The live tests are currently always excluded because GH actions will exclude any output that appears to contain a secret, e.g.:

![image](https://user-images.githubusercontent.com/705500/165122456-e8c2b47b-546a-4a54-bab2-8ca4aea9fd68.png)

I could not find anywhere that GitHub explicitly documents the criteria for excluding outputs, but a substring match of `/secret/i` seems to be one such criterion. Changing the workflow name from `can-access-secrets` to `can-run-live-tests` and the output name from `can_access_secrets` to `access_verified` seems to have reenabled the output and the live test workflows.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6648)