### PR TITLE
Add Insert Resource to context menus

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -238,7 +238,7 @@
         {
           "command": "bicep.insertResource",
           "when": "editorLangId == bicep",
-          "group": "navigation"
+          "group": "edit"
         }
       ],
       "explorer/context": [

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -234,6 +234,11 @@
           "command": "bicep.showSource",
           "when": "bicepVisualizerFocus",
           "group": "navigation"
+        },
+        {
+          "command": "bicep.insertResource",
+          "when": "editorLangId == bicep",
+          "group": "navigation"
         }
       ],
       "explorer/context": [
@@ -259,6 +264,11 @@
         },
         {
           "command": "bicep.forceModulesRestore",
+          "when": "resourceLangId == bicep",
+          "group": "0_bicep"
+        },
+        {
+          "command": "bicep.insertResource",
           "when": "resourceLangId == bicep",
           "group": "0_bicep"
         }
@@ -288,7 +298,12 @@
           "command": "bicep.forceModulesRestore",
           "when": "resourceLangId == bicep",
           "group": "0_bicep"
-        }        
+        },
+        {
+          "command": "bicep.insertResource",
+          "when": "resourceLangId == bicep",
+          "group": "0_bicep"
+        }
       ],
       "editor/context": [
         {

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -170,7 +170,7 @@
       },
       {
         "command": "bicep.insertResource",
-        "title": "Insert Resource",
+        "title": "Insert Resource...",
         "category": "Bicep",
         "icon": "$(cloud-download)"
       },
@@ -214,6 +214,12 @@
         "key": "ctrl+k v",
         "mac": "cmd+k v",
         "when": "resourceLangId == bicep"
+      },
+      {
+        "command": "bicep.insertResource",
+        "key": "ctrl+k i",
+        "mac": "cmd+k i",
+        "when": "resourceLangId == bicep"
       }
     ],
     "menus": {
@@ -255,7 +261,7 @@
           "command": "bicep.forceModulesRestore",
           "when": "resourceLangId == bicep",
           "group": "0_bicep"
-        }        
+        }
       ],
       "editor/title/context": [
         {
@@ -307,6 +313,11 @@
         },
         {
           "command": "bicep.showVisualizerToSide",
+          "when": "resourceLangId == bicep",
+          "group": "0_bicep"
+        },
+        {
+          "command": "bicep.insertResource",
           "when": "resourceLangId == bicep",
           "group": "0_bicep"
         }


### PR DESCRIPTION
Fixes #6690
1) Added to the editor/context menu
2) Added shortcut key CTRL+K, I (only available when active editor is bicep)
Didn't add it anywhere else

# Menus:
## editor/title: I don't think it belongs here
<img width="414" alt="image" src="https://user-images.githubusercontent.com/6913354/165408743-4dbb4b9a-7358-4eb8-8c2e-c8e276984a3a.png">

## explorer/context: I don't think it belongs here
<img width="366" alt="image" src="https://user-images.githubusercontent.com/6913354/165408709-f8388ae6-fe9e-442f-8fec-6458c6f83ae6.png">

## editor/title/context: I don't think it belongs here
<img width="188" alt="image" src="https://user-images.githubusercontent.com/6913354/165408839-e17e6be3-18bd-4367-91aa-a806b01f1ced.png">

## editor/context: **ADDED IT HERE**
<img width="503" alt="image" src="https://user-images.githubusercontent.com/6913354/165408886-4de7c4e1-e012-4c2b-9ef7-004a298ca872.png">

## commandPalette: ALREADY HERE, **ADDED NEW SHORTCUT KEY: CTRL+K, I**
<img width="720" alt="image" src="https://user-images.githubusercontent.com/6913354/165408921-18bfb300-efe9-4cfe-be34-ae9b0189fbfd.png">


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6695)