### PR TITLE
Return a transformed string literal from ARM transformation functions invoked with arguments that are all string literals

### DIFF
--- a/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
@@ -92,6 +92,50 @@ namespace Bicep.Core.UnitTests.TypeSystem
             }
         }
 
+        [DataTestMethod]
+        [DynamicData(nameof(GetStringLiteralTransformations), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetDisplayName))]
+        public void StringLiteralTransformationsYieldStringLiteralReturnType(string displayName, string functionName, string[] argumentTypeLiterals, string returnTypeLiteral)
+        {
+            var arguments = argumentTypeLiterals.Select(atl => new FunctionArgumentSyntax(TestSyntaxFactory.CreateString(atl), default)).ToList();
+            var argumentTypes = argumentTypeLiterals.Select(atl => new StringLiteralType(atl) as TypeSymbol).ToList();
+
+            var matches = GetMatches(functionName, argumentTypes, out _, out _);
+            matches.Should().HaveCount(1);
+
+            var returnType = matches.Single().ReturnTypeBuilder(
+                Repository.Create<IBinder>().Object,
+                Repository.Create<IFileResolver>().Object,
+                Repository.Create<IDiagnosticWriter>().Object,
+                arguments.ToImmutableArray(),
+                argumentTypes.ToImmutableArray()
+            );
+            returnType.Should().BeAssignableTo<StringLiteralType>().Subject.RawStringValue.Should().Be(returnTypeLiteral);
+        }
+
+        private static IEnumerable<object[]> GetStringLiteralTransformations()
+        {
+            object[] CreateRow(string returnedLiteral, string functionName, params string[] argumentLiterals)
+            {
+                string displayName = $@"{functionName}({string.Join(", ", argumentLiterals.Select(l => $@"""{l}"""))}): ""{returnedLiteral}""";
+                return new object[] { displayName, functionName, argumentLiterals, returnedLiteral };
+            }
+
+            yield return CreateRow("IEZpenog", "base64", " Fizz ");
+            yield return CreateRow(" Fizz ", "base64ToString", "IEZpenog");
+            yield return CreateRow("data:text/plain;charset=utf8;base64,IEZpenog", "dataUri", " Fizz ");
+            yield return CreateRow(" Fizz ", "dataUriToString", "data:text/plain;charset=utf-8;base64,IEZpenog");
+            yield return CreateRow("F", "first", "Fizz");
+            yield return CreateRow("z", "last", "Fizz");
+            yield return CreateRow(" fizz ", "toLower", " Fizz ");
+            yield return CreateRow(" FIZZ ", "toUpper", " Fizz ");
+            yield return CreateRow("Fizz", "trim", " Fizz ");
+            yield return CreateRow("%20Fizz%20", "uriComponent", " Fizz ");
+            yield return CreateRow(" Fizz ", "uriComponentToString", "%20Fizz%20");
+            yield return CreateRow("byghxckddilkc", "uniqueString", "snap", "crackle", "pop");
+            yield return CreateRow("2ed86837-7c7c-5eaa-9864-dd077fd19b0d", "guid", "foo", "bar", "baz");
+            yield return CreateRow("food", "replace", "foot", "t", "d");
+        }
+
         public static string GetDisplayName(MethodInfo method, object[] row)
         {
             row.Length.Should().BeGreaterThan(0);
@@ -254,4 +298,3 @@ namespace Bicep.Core.UnitTests.TypeSystem
         }
     }
 }
-

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1376,12 +1376,18 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP232",
                 $"Unable to delete the module with reference \"{moduleRef}\" from cache.");
-                
+
             public ErrorDiagnostic ModuleDeleteFailedWithMessage(string moduleRef, string message) => new(
                 TextSpan,
                 "BCP233",
                 $"Unable to delete the module with reference \"{moduleRef}\" from cache: {message}");
-    
+
+            public Diagnostic ArmFunctionLiteralTypeConversionFailedWithMessage(string literalValue, string armFunctionName, string message) => new(
+                TextSpan,
+                DiagnosticLevel.Warning,
+                "BCP234",
+                $"The ARM function \"{armFunctionName}\" failed when invoked on the value [{literalValue}]: {message}");
+
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -73,7 +73,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("base64")
-                .WithDynamicReturnType(Base64TypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("base64"), LanguageConstants.String)
                 .WithGenericDescription("Returns the base64 representation of the input string.")
                 .WithRequiredParameter("inputString", LanguageConstants.String, "The value to return as a base64 representation.")
                 .Build(),
@@ -87,7 +87,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("replace")
-                .WithDynamicReturnType(ReplaceTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("replace"), LanguageConstants.String)
                 .WithGenericDescription("Returns a new string with all instances of one string replaced by another string.")
                 .WithRequiredParameter("originalString", LanguageConstants.String, "The original string.")
                 .WithRequiredParameter("oldString", LanguageConstants.String, "The string to be removed from the original string.")
@@ -95,13 +95,13 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("toLower")
-                .WithDynamicReturnType(ToLowerTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("toLower"), LanguageConstants.String)
                 .WithGenericDescription("Converts the specified string to lower case.")
                 .WithRequiredParameter("stringToChange", LanguageConstants.String, "The value to convert to lower case.")
                 .Build(),
 
             new FunctionOverloadBuilder("toUpper")
-                .WithDynamicReturnType(ToUpperTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("toUpper"), LanguageConstants.String)
                 .WithGenericDescription("Converts the specified string to upper case.")
                 .WithRequiredParameter("stringToChange", LanguageConstants.String, "The value to convert to upper case.")
                 .Build(),
@@ -132,19 +132,19 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("uniqueString")
-                .WithDynamicReturnType(UniqueStringTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("uniqueString"), LanguageConstants.String)
                 .WithGenericDescription("Creates a deterministic hash string based on the values provided as parameters.")
                 .WithVariableParameter("arg", LanguageConstants.String, minimumCount: 1, "The value used in the hash function to create a unique string.")
                 .Build(),
 
             new FunctionOverloadBuilder("guid")
-                .WithDynamicReturnType(GuidTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("guid"), LanguageConstants.String)
                 .WithGenericDescription("Creates a value in the format of a globally unique identifier based on the values provided as parameters.")
                 .WithVariableParameter("arg", LanguageConstants.String, minimumCount: 1, "The value used in the hash function to create the GUID.")
                 .Build(),
 
             new FunctionOverloadBuilder("trim")
-                .WithDynamicReturnType(TrimTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("trim"), LanguageConstants.String)
                 .WithGenericDescription("Removes all leading and trailing white-space characters from the specified string.")
                 .WithRequiredParameter("stringToTrim", LanguageConstants.String, "The value to trim.")
                 .Build(),
@@ -263,7 +263,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("first")
-                .WithDynamicReturnType(FirstStringTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("first"), LanguageConstants.String)
                 .WithGenericDescription(firstDescription)
                 .WithDescription("Returns the first character of the string.")
                 .WithRequiredParameter("string", LanguageConstants.String, "The value to retrieve the first character.")
@@ -277,7 +277,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("last")
-                .WithDynamicReturnType(LastStringTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("last"), LanguageConstants.String)
                 .WithGenericDescription(lastDescription)
                 .WithDescription("Returns the last character of the string.")
                 .WithRequiredParameter("string", LanguageConstants.String, "The value to retrieve the last character.")
@@ -367,7 +367,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("base64ToString")
-                .WithDynamicReturnType(Base64ToStringTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("base64ToString"), LanguageConstants.String)
                 .WithGenericDescription("Converts a base64 representation to a string.")
                 .WithRequiredParameter("base64Value", LanguageConstants.String, "The base64 representation to convert to a string.")
                 .Build(),
@@ -379,26 +379,26 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("uriComponentToString")
-                .WithDynamicReturnType(UriComponentToStringTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("uriComponentToString"), LanguageConstants.String)
                 .WithGenericDescription("Returns a string of a URI encoded value.")
                 .WithRequiredParameter("uriEncodedString", LanguageConstants.String, "The URI encoded value to convert to a string.")
                 .Build(),
 
             new FunctionOverloadBuilder("uriComponent")
-                .WithDynamicReturnType(UriComponentTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("uriComponent"), LanguageConstants.String)
                 .WithGenericDescription("Encodes a URI.")
                 .WithRequiredParameter("stringToEncode", LanguageConstants.String, "The value to encode.")
                 .Build(),
 
             new FunctionOverloadBuilder("dataUriToString")
                 .WithGenericDescription("Converts a data URI formatted value to a string.")
-                .WithDynamicReturnType(DataUriToStringTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("dataUriToString"), LanguageConstants.String)
                 .WithRequiredParameter("dataUriToConvert", LanguageConstants.String, "The data URI value to convert.")
                 .Build(),
 
             // TODO: Docs have wrong param type and param name (any is actually supported)
             new FunctionOverloadBuilder("dataUri")
-                .WithDynamicReturnType(DataUriTypeBuilder, LanguageConstants.String)
+                .WithDynamicReturnType(PerformArmConversionOfStringLiterals("dataUri"), LanguageConstants.String)
                 .WithGenericDescription("Converts a value to a data URI.")
                 .WithRequiredParameter("valueToConvert", LanguageConstants.Any, "The value to convert to a data URI.")
                 .Build(),
@@ -515,72 +515,31 @@ namespace Bicep.Core.Semantics.Namespaces
             return fileUri;
         }
 
-        private static TypeSymbol Base64ToStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("base64ToString", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol Base64TypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("base64", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol DataUriToStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("dataUriToString", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol DataUriTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("dataUri", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol FirstStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("first", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol GuidTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("guid", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol LastStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("last", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol ReplaceTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("replace", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol ToLowerTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("toLower", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol ToUpperTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("toUpper", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol TrimTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("trim", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol UniqueStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("uniqueString", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol UriComponentToStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("uriComponentToString", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol UriComponentTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-            => PerformArmConversionOfStringLiterals("uriComponent", diagnostics, arguments, argumentTypes);
-
-        private static TypeSymbol PerformArmConversionOfStringLiterals(string armFunctionName, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
-        {
-            if (arguments.Length > 0 && argumentTypes.All(s => s is StringLiteralType)) {
-                var parameters = argumentTypes.OfType<StringLiteralType>().Select(slt => JValue.CreateString(slt.RawStringValue)).ToArray();
-                try {
-                    if (ExpressionBuiltInFunctions.Functions.EvaluateFunction(armFunctionName, parameters) is JValue jValue && jValue.Value is string stringValue)
-                    {
-                        return new StringLiteralType(stringValue);
+        private static FunctionOverload.ReturnTypeBuilderDelegate PerformArmConversionOfStringLiterals(string armFunctionName) =>
+            (IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes) =>
+            {
+                if (arguments.Length > 0 && argumentTypes.All(s => s is StringLiteralType)) {
+                    var parameters = argumentTypes.OfType<StringLiteralType>().Select(slt => JValue.CreateString(slt.RawStringValue)).ToArray();
+                    try {
+                        if (ExpressionBuiltInFunctions.Functions.EvaluateFunction(armFunctionName, parameters) is JValue jValue && jValue.Value is string stringValue)
+                        {
+                            return new StringLiteralType(stringValue);
+                        }
+                    } catch (Exception e) {
+                        // The ARM function invoked will almost certainly fail at runtime, but there's a chance a fix has been
+                        // deployed to ARM since this version of Bicep was released. Given that context, this failure will only
+                        // be reported as a warning, and the fallback type will be used.
+                        diagnostics.Write(
+                            DiagnosticBuilder.ForPosition(TextSpan.Between(arguments.First().Span, arguments.Last().Span))
+                                .ArmFunctionLiteralTypeConversionFailedWithMessage(
+                                    string.Join(", ", parameters.Select(t => t.ToString())),
+                                    armFunctionName,
+                                    e.Message));
                     }
-                } catch (Exception e) {
-                    // The ARM function invoked will almost certainly fail at runtime, but there's a chance a fix has been
-                    // deployed to ARM since this version of Bicep was released. Given that context, this failure will only
-                    // be reported as a warning, and the fallback type will be used.
-                    diagnostics.Write(
-                        DiagnosticBuilder.ForPosition(TextSpan.Between(arguments.First().Span, arguments.Last().Span))
-                            .ArmFunctionLiteralTypeConversionFailedWithMessage(
-                                string.Join(", ", parameters.Select(t => t.ToString())),
-                                armFunctionName,
-                                e.Message));
                 }
-            }
 
-            return LanguageConstants.String;
-        }
+                return LanguageConstants.String;
+            };
 
         private static TypeSymbol LoadTextContentTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
         {

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -6,10 +6,12 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using Azure.Deployments.Expression.Expressions;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Modules;
+using Bicep.Core.Parsing;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
@@ -71,7 +73,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("base64")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(Base64TypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Returns the base64 representation of the input string.")
                 .WithRequiredParameter("inputString", LanguageConstants.String, "The value to return as a base64 representation.")
                 .Build(),
@@ -85,7 +87,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("replace")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(ReplaceTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Returns a new string with all instances of one string replaced by another string.")
                 .WithRequiredParameter("originalString", LanguageConstants.String, "The original string.")
                 .WithRequiredParameter("oldString", LanguageConstants.String, "The string to be removed from the original string.")
@@ -93,13 +95,13 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("toLower")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(ToLowerTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Converts the specified string to lower case.")
                 .WithRequiredParameter("stringToChange", LanguageConstants.String, "The value to convert to lower case.")
                 .Build(),
 
             new FunctionOverloadBuilder("toUpper")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(ToUpperTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Converts the specified string to upper case.")
                 .WithRequiredParameter("stringToChange", LanguageConstants.String, "The value to convert to upper case.")
                 .Build(),
@@ -130,19 +132,19 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("uniqueString")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(UniqueStringTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Creates a deterministic hash string based on the values provided as parameters.")
                 .WithVariableParameter("arg", LanguageConstants.String, minimumCount: 1, "The value used in the hash function to create a unique string.")
                 .Build(),
 
             new FunctionOverloadBuilder("guid")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(GuidTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Creates a value in the format of a globally unique identifier based on the values provided as parameters.")
                 .WithVariableParameter("arg", LanguageConstants.String, minimumCount: 1, "The value used in the hash function to create the GUID.")
                 .Build(),
 
             new FunctionOverloadBuilder("trim")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(TrimTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Removes all leading and trailing white-space characters from the specified string.")
                 .WithRequiredParameter("stringToTrim", LanguageConstants.String, "The value to trim.")
                 .Build(),
@@ -261,7 +263,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("first")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(FirstStringTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription(firstDescription)
                 .WithDescription("Returns the first character of the string.")
                 .WithRequiredParameter("string", LanguageConstants.String, "The value to retrieve the first character.")
@@ -275,7 +277,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("last")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(LastStringTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription(lastDescription)
                 .WithDescription("Returns the last character of the string.")
                 .WithRequiredParameter("string", LanguageConstants.String, "The value to retrieve the last character.")
@@ -365,7 +367,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("base64ToString")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(Base64ToStringTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Converts a base64 representation to a string.")
                 .WithRequiredParameter("base64Value", LanguageConstants.String, "The base64 representation to convert to a string.")
                 .Build(),
@@ -377,26 +379,26 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build(),
 
             new FunctionOverloadBuilder("uriComponentToString")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(UriComponentToStringTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Returns a string of a URI encoded value.")
                 .WithRequiredParameter("uriEncodedString", LanguageConstants.String, "The URI encoded value to convert to a string.")
                 .Build(),
 
             new FunctionOverloadBuilder("uriComponent")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(UriComponentTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Encodes a URI.")
                 .WithRequiredParameter("stringToEncode", LanguageConstants.String, "The value to encode.")
                 .Build(),
 
             new FunctionOverloadBuilder("dataUriToString")
                 .WithGenericDescription("Converts a data URI formatted value to a string.")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(DataUriToStringTypeBuilder, LanguageConstants.String)
                 .WithRequiredParameter("dataUriToConvert", LanguageConstants.String, "The data URI value to convert.")
                 .Build(),
 
             // TODO: Docs have wrong param type and param name (any is actually supported)
             new FunctionOverloadBuilder("dataUri")
-                .WithReturnType(LanguageConstants.String)
+                .WithDynamicReturnType(DataUriTypeBuilder, LanguageConstants.String)
                 .WithGenericDescription("Converts a value to a data URI.")
                 .WithRequiredParameter("valueToConvert", LanguageConstants.Any, "The value to convert to a data URI.")
                 .Build(),
@@ -511,6 +513,73 @@ namespace Bicep.Core.Semantics.Namespaces
                 return null;
             }
             return fileUri;
+        }
+
+        private static TypeSymbol Base64ToStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("base64ToString", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol Base64TypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("base64", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol DataUriToStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("dataUriToString", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol DataUriTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("dataUri", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol FirstStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("first", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol GuidTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("guid", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol LastStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("last", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol ReplaceTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("replace", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol ToLowerTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("toLower", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol ToUpperTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("toUpper", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol TrimTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("trim", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol UniqueStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("uniqueString", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol UriComponentToStringTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("uriComponentToString", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol UriComponentTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+            => PerformArmConversionOfStringLiterals("uriComponent", diagnostics, arguments, argumentTypes);
+
+        private static TypeSymbol PerformArmConversionOfStringLiterals(string armFunctionName, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)
+        {
+            if (arguments.Length > 0 && argumentTypes.All(s => s is StringLiteralType)) {
+                var parameters = argumentTypes.OfType<StringLiteralType>().Select(slt => JValue.CreateString(slt.RawStringValue)).ToArray();
+                try {
+                    if (ExpressionBuiltInFunctions.Functions.EvaluateFunction(armFunctionName, parameters) is JValue jValue && jValue.Value is string stringValue)
+                    {
+                        return new StringLiteralType(stringValue);
+                    }
+                } catch (Exception e) {
+                    // The ARM function invoked will almost certainly fail at runtime, but there's a chance a fix has been
+                    // deployed to ARM since this version of Bicep was released. Given that context, this failure will only
+                    // be reported as a warning, and the fallback type will be used.
+                    diagnostics.Write(
+                        DiagnosticBuilder.ForPosition(TextSpan.Between(arguments.First().Span, arguments.Last().Span))
+                            .ArmFunctionLiteralTypeConversionFailedWithMessage(
+                                string.Join(", ", parameters.Select(t => t.ToString())),
+                                armFunctionName,
+                                e.Message));
+                }
+            }
+
+            return LanguageConstants.String;
         }
 
         private static TypeSymbol LoadTextContentTypeBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, ImmutableArray<FunctionArgumentSyntax> arguments, ImmutableArray<TypeSymbol> argumentTypes)


### PR DESCRIPTION
Resolves #4134

This PR uses the ARM Expressions library to derive literal return types for ARM functions when invoked with arguments that are themselves all literal types. At present, this is only possible for ARM functions that take one or more string arguments and return a single string, but the pattern could be applied to other deterministic ARM function signatures if Bicep adds literal specializations for other primitive types.

## Contributing a feature

* [X] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [X] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [X] I have appropriate test coverage of my new feature

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6765)