### PR TITLE
Added changes to allow non-DTC values for name in existing resources.

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -3115,15 +3115,16 @@ resource newStg 'Microsoft.Storage/storageAccounts@2021-04-01' = {
 }
 
 resource existingStg 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
-  name: existingStg2.name
+  name: newStg.name
 }
 
-resource existingStg2 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
-  name: newStg.properties.accessTier
-}
-
-resource existingStg3 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
+resource newStg2 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: existingStg.name
+  kind: 'StorageV2'
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
 }
 ");
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
@@ -3134,6 +3135,37 @@ resource existingStg3 'Microsoft.Storage/storageAccounts@2021-04-01' existing = 
         /// </summary>
         [TestMethod]
         public void Test_Issue_3169_4()
+        {
+            var result = CompilationHelper.Compile(@"
+resource newStg 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: 'test'
+  kind: 'StorageV2'
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+}
+
+resource existingStg1 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
+  name: existingStg2.name
+}
+
+resource existingStg2 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
+  name: newStg.properties.accessTier
+}
+
+resource existingStg3 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
+  name: existingStg1.name
+}
+");
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        }
+
+        /// <summary>
+        /// https://github.com/Azure/bicep/issues/3169
+        /// </summary>
+        [TestMethod]
+        public void Test_Issue_3169_5()
         {
             var result = CompilationHelper.Compile(@"
 resource newStg 'Microsoft.Storage/storageAccounts@2021-04-01' = {

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -3120,7 +3120,7 @@ resource existingStg 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
 
 resource newStg2 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: existingStg.name
-  kind: 'StorageV2'
+  kind: 'BlobStorage'
   location: resourceGroup().location
   sku: {
     name: 'Standard_LRS'
@@ -3128,6 +3128,7 @@ resource newStg2 'Microsoft.Storage/storageAccounts@2021-04-01' = {
 }
 ");
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+            result.Template.Should().HaveValueAtPath("$.resources[?(@.kind == 'BlobStorage')].name", "test");
         }
 
         /// <summary>

--- a/src/Bicep.Core/Diagnostics/SimpleDiagnosticWriter.cs
+++ b/src/Bicep.Core/Diagnostics/SimpleDiagnosticWriter.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Diagnostics
+{
+    public class SimpleDiagnosticWriter : IDiagnosticWriter
+    {
+        private bool hasDiagnostics;
+
+        public SimpleDiagnosticWriter()
+        {
+            this.hasDiagnostics = false;
+        }
+
+        public static SimpleDiagnosticWriter Create()
+            => new SimpleDiagnosticWriter();
+
+        public void Write(IDiagnostic diagnostic)
+            => hasDiagnostics = true;
+
+        public bool HasDiagnostics() => hasDiagnostics;
+    }
+}

--- a/src/Bicep.Core/Diagnostics/SimpleDiagnosticWriter.cs
+++ b/src/Bicep.Core/Diagnostics/SimpleDiagnosticWriter.cs
@@ -3,6 +3,8 @@
 
 namespace Bicep.Core.Diagnostics
 {
+    // SimpleDiagnosticWriter is a diagnostic writer that returns a boolean indicating whether or not diagnostics were written.
+    // By using a boolean we can avoid storing the diagnostics in a list like ToListDiagnosticWriter.
     public class SimpleDiagnosticWriter : IDiagnosticWriter
     {
         private bool hasDiagnostics;

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -26,7 +26,7 @@ namespace Bicep.Core.Emit
             DeployTimeConstantValidator.Validate(model, diagnosticWriter);
             ForSyntaxValidatorVisitor.Validate(model, diagnosticWriter);
             FunctionPlacementValidatorVisitor.Validate(model, diagnosticWriter);
-            IntegerValidatorVisitor.Validate(model.SourceFile.ProgramSyntax, diagnosticWriter);
+            IntegerValidatorVisitor.Validate(model, diagnosticWriter);
 
             DetectDuplicateNames(model, diagnosticWriter, resourceScopeData, moduleScopeData);
             DetectIncorrectlyFormattedNames(model, diagnosticWriter);

--- a/src/Bicep.Core/Emit/IntegerValidatorVisitor.cs
+++ b/src/Bicep.Core/Emit/IntegerValidatorVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Emit
@@ -9,17 +10,19 @@ namespace Bicep.Core.Emit
     public class IntegerValidatorVisitor : SyntaxVisitor
     {
         private readonly IDiagnosticWriter diagnosticWriter;
+        private readonly SemanticModel semanticModel;
 
-        private IntegerValidatorVisitor(IDiagnosticWriter diagnosticWriter)
+        private IntegerValidatorVisitor(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
             this.diagnosticWriter = diagnosticWriter;
+            this.semanticModel = semanticModel;
         }
 
-        public static void Validate(ProgramSyntax programSyntax, IDiagnosticWriter diagnosticWriter)
+        public static void Validate(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
-            var visitor = new IntegerValidatorVisitor(diagnosticWriter);
+            var visitor = new IntegerValidatorVisitor(semanticModel, diagnosticWriter);
             // visiting writes diagnostics in some cases
-            visitor.Visit(programSyntax);
+            visitor.Visit(semanticModel.SourceFile.ProgramSyntax);
         }
 
         public override void VisitIntegerLiteralSyntax(IntegerLiteralSyntax syntax)

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantContainerVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantContainerVisitor.cs
@@ -30,6 +30,14 @@ namespace Bicep.Core.TypeSystem
             return visitor.deployTimeConstantContainers;
         }
 
+        public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
+        {
+            if (!syntax.IsExistingResource())
+            {
+                base.VisitResourceDeclarationSyntax(syntax);
+            }
+        }
+
         public override void VisitObjectPropertySyntax(ObjectPropertySyntax syntax)
         {
             if (syntax.TryGetTypeProperty(this.semanticModel.Binder, this.semanticModel.TypeManager) is { } typeProperty &&

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantDirectViolationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantDirectViolationVisitor.cs
@@ -3,13 +3,14 @@
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
+using System.Collections.Generic;
 
 namespace Bicep.Core.TypeSystem
 {
     public class DeployTimeConstantDirectViolationVisitor : DeployTimeConstantViolationVisitor
     {
-        public DeployTimeConstantDirectViolationVisitor(SyntaxBase deployTimeConstantContainer, SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
-            : base(deployTimeConstantContainer, semanticModel, diagnosticWriter)
+        public DeployTimeConstantDirectViolationVisitor(SyntaxBase deployTimeConstantContainer, SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter, Dictionary<DeclaredSymbol, ObjectType> existingResourceBodyObjectTypeOverrides)
+            : base(deployTimeConstantContainer, semanticModel, diagnosticWriter, existingResourceBodyObjectTypeOverrides)
         {
         }
 

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantIndirectViolationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantIndirectViolationVisitor.cs
@@ -17,8 +17,8 @@ namespace Bicep.Core.TypeSystem
 
         private bool hasError = false;
 
-        public DeployTimeConstantIndirectViolationVisitor(SyntaxBase deployTimeConstantContainer, VariableAccessSyntax variableDependency, SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
-            : base(deployTimeConstantContainer, semanticModel, diagnosticWriter)
+        public DeployTimeConstantIndirectViolationVisitor(SyntaxBase deployTimeConstantContainer, VariableAccessSyntax variableDependency, SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter, Dictionary<DeclaredSymbol, ObjectType> existingResourceBodyObjectTypeOverrides)
+            : base(deployTimeConstantContainer, semanticModel, diagnosticWriter, existingResourceBodyObjectTypeOverrides)
         {
             this.variableDependency = variableDependency;
         }


### PR DESCRIPTION
Fixes #3169

When the "name" property for an existing resource has a value that cannot be calculated at deploy time, the current behavior in Bicep is that we block it. However, upon further investigation, it makes more sense to allow the existing resource use this non-DTC (non-DeployTimeConstant) value, and also allow other existing resources in the template to reference this non-DTC value. However, it is also necessary to make sure this non-DTC flow is managed; a non-existing resource cannot reference/use this non-DTC value because non-existing resources must require a DTC value.

Take this for example:
```
resource newStg 'Microsoft.Storage/storageAccounts@2021-04-01' = {
  name: 'test'
  kind: 'StorageV2'
  location: resourceGroup().location
  sku: {
    name: 'Standard_LRS'
  }
}

resource existingStg 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
  name: newStg.properties.accessTier
}

resource foo 'Microsoft.Storage/storageAccounts@2021-04-01' = {
  name: existingStg.name
  kind: 'StorageV2'
  location: resourceGroup().location
  sku: {
    name: 'Standard_LRS'
  }
}
```

A resource newStg is created and has a string "test" as its name value. String literals are DTC values so this is allowed. 
An existing resource is declared with the name referencing newStg.properties.accessTier. This value is not able to be calculated at deploy time, thus it is a non-DTC value. This is ok, as existing resources should be allowed to have a non-DTC value.

The problem lies with the resource foo that is declared with the existingStg.name. Because foo is not an existing resource, its "name" property **must** have a DTC value, like how newStg does. However, foo wants to use a non-DTC value, so we block it. 


**The fix**
The fix here is that for all existing resources whose "name" property have a non-DTC value, remove the ReadableAtDeployTime flag from the "name" property. This flag is used to determine if a value is a DTC value or not. After removing the ReadableAtDeployTime flag, any existing resources that reference the value will know that they themselves must be non-DTC as well and also remove the ReadableAtDeployTime flag from their "name" property.

We also need to remove the DeployTimeConstant flag from these "name" properties of existing resources so that they are marked as non-DTC values.

Finally, an override method is needed in the DeployTimeConstantContainerVisitor. After our new logic, the DeployTimeConstantContainerVisitor picks up all the syntaxes as containers, and these containers are checked for DTC errors. In order to ensure that existing resources are not checked for non-DTC values and throw errors when it should not, the override method ensures that existing resources are not picked up as containers.
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6778)