### PR TITLE
Add telemetry when command is from walkthrough

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -397,7 +397,14 @@
       "  onContext:contextKeyExpression: Check off step when a context key expression evaluates true.",
       "  extensionInstalled:myExt.id: Check off step if the given extension is installed.",
       "  onView:myView.id: Check off step once a given view becomes visible.",
-      "  onLink:https://...: Check off step once a given link has been opened via a Walkthrough."
+      "  onLink:https://...: Check off step once a given link has been opened via a Walkthrough.",
+      "",
+      "Passing arguments to commands: See https://github.com/Microsoft/vscode/issues/69757,",
+      "  Example: [Copy code to clipboard](command:bicep.gettingStarted.copyToClipboard?%7B%22step%22%3A%22resources%22%7D)",
+      "",
+      "Walkthrough commands (bicep.gettingStarted.xxx) are automatically marked in telemetry as being from the walkthrough.  Regular commands",
+      "  which are called from the walkthrough markdown should be marked with a query string ?walkthrough=true to have it marked in telemetry.",
+      "  Example: [Open Visualizer](command:bicep.showVisualizerToSide?%7B%22walkthrough%22%3A%22true%22%7D)"
     ],
     "walkthroughs": [
       {
@@ -438,7 +445,7 @@
           {
             "id": "visualizeYourResources",
             "title": "Visualize your resources",
-            "description": "The Visualizer gives you a representation of the resources in your Bicep file.\n[Open Visualizer](command:bicep.showVisualizerToSide)",
+            "description": "The Visualizer gives you a representation of the resources in your Bicep file.\n[Open Visualizer](command:bicep.showVisualizerToSide?%7B%22walkthrough%22%3A%22true%22%7D)",
             "media": {
               "markdown": "media/walkthroughs/gettingStarted/4_Show_Visualizer.md"
             },
@@ -450,7 +457,7 @@
           {
             "id": "deployToAzure",
             "title": "Deploy to Azure",
-            "description": "It's time to get these resources into Azure. If you don't have the [Azure Account Extension](command:extension.open?%5B%22ms-vscode.azure-account%22%5D) installed, you will need it to complete this step.\n[Deploy](command:bicep.deploy)",
+            "description": "It's time to get these resources into Azure. If you don't have the [Azure Account Extension](command:extension.open?%5B%22ms-vscode.azure-account%22%5D) installed, you will need it to complete this step.\n[Deploy](command:bicep.deploy?%7B%22walkthrough%22%3A%22true%22%7D)",
             "media": {
               "image": "media/walkthroughs/gettingStarted/5_Deploy.gif",
               "altText": "Example of deploying Bicep file to Azure"

--- a/src/vscode-bicep/src/commands/commandManager.ts
+++ b/src/vscode-bicep/src/commands/commandManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ExtensionContext } from "vscode";
+import { ExtensionContext, Uri } from "vscode";
 import * as fse from "fs-extra";
 import { Disposable } from "../utils/disposable";
 import { Command } from "./types";
@@ -32,7 +32,38 @@ export class CommandManager extends Disposable {
     azureextensionui.registerCommand(
       command.id,
       async (context: azureextensionui.IActionContext, ...args: unknown[]) => {
-        return await command.execute(context, ...args);
+        let documentUri: Uri | undefined = undefined;
+        let isFromWalkthrough = false;
+
+        if (args[0] instanceof Uri) {
+          // First argument is a Uri (this is how VsCode communicates the target URI for a comment invoked through a menu, context menu, etc.)
+          documentUri = args[0];
+          args = args.slice(1);
+        }
+
+        // If the command is coming from a [command:xxx] inside a markdown file (e.g. from
+        //   a walkthrough), and the command contains a query string, the query string values
+        //   will be in an object in the next argument.
+        if (
+          !!args[0] &&
+          args[0] instanceof Object &&
+          "walkthrough" in args[0] &&
+          args[0]["walkthrough"] === "true"
+        ) {
+          // Marked as a walkthrough via query string in markdow
+          isFromWalkthrough = true;
+        }
+
+        // Commands starting with bicep.gettingStarted are obviously from the walkthrough
+        if (command.id.startsWith("bicep.gettingStarted")) {
+          isFromWalkthrough = true;
+        }
+
+        if (isFromWalkthrough) {
+          context.telemetry.properties.contextValue = "walkthrough";
+        }
+
+        return await command.execute(context, documentUri, ...args);
       },
       undefined,
       telemetryId

--- a/src/vscode-bicep/src/commands/gettingStarted/WalkthroughCopyToClipboardCommand.ts
+++ b/src/vscode-bicep/src/commands/gettingStarted/WalkthroughCopyToClipboardCommand.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import vscode from "vscode";
+import vscode, { Uri } from "vscode";
 import { Command } from "../types";
 
 const paramsCode =
@@ -35,6 +35,7 @@ export class WalkthroughCopyToClipboardCommand implements Command {
 
   public async execute(
     context: IActionContext,
+    _documentUri: Uri,
     args: { step: "params" | "resources" }
   ): Promise<void> {
     const step = args.step;

--- a/src/vscode-bicep/src/commands/types.ts
+++ b/src/vscode-bicep/src/commands/types.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { Uri } from "vscode";
 
 export interface Command {
   readonly id: string;
@@ -11,5 +12,9 @@ export interface Command {
    * @param context Optionally used to control telemetry and error-handling behavior
    * @param args Optional arguments that are being passed to the command
    */
-  execute(context: IActionContext, ...args: unknown[]): unknown;
+  execute(
+    context: IActionContext,
+    documentUri: Uri | undefined,
+    ...args: unknown[]
+  ): unknown | Promise<unknown>;
 }

--- a/src/vscode-bicep/src/test/unit/packageJson.test.ts
+++ b/src/vscode-bicep/src/test/unit/packageJson.test.ts
@@ -22,23 +22,25 @@ function getPackageJson(): IPackage {
   return fse.readJsonSync(packagePath);
 }
 
-describe("macShortcutKeys", () => {
-  it("shortcut keys using CTRL should have a Mac equivalent using CMD", () => {
-    const packageJson = getPackageJson();
+describe("package.json tests", () => {
+  describe("macShortcutKeys", () => {
+    it("shortcut keys using CTRL should have a Mac equivalent using CMD", () => {
+      const packageJson = getPackageJson();
 
-    // If there are no keybindings found we're doing something wrong in the test
-    const bindings: IPackageKeyBinding[] =
-      packageJson.contributes?.keybindings ?? [];
-    expect(bindings).not.toHaveLength(0);
+      // If there are no keybindings found we're doing something wrong in the test
+      const bindings: IPackageKeyBinding[] =
+        packageJson.contributes?.keybindings ?? [];
+      expect(bindings).not.toHaveLength(0);
 
-    for (const binding of bindings) {
-      if (binding.key.match(/ctrl/i)) {
-        // See https://code.visualstudio.com/api/references/contribution-points#keybinding-example
-        // Note that "ALT" in a "mac" binding is interpreted as "OPT"
+      for (const binding of bindings) {
+        if (binding.key.match(/ctrl/i)) {
+          // See https://code.visualstudio.com/api/references/contribution-points#keybinding-example
+          // Note that "ALT" in a "mac" binding is interpreted as "OPT"
 
-        // eslint-disable-next-line jest/no-conditional-expect
-        expect(binding.mac).toMatch(/cmd/i);
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(binding.mac).toMatch(/cmd/i);
+        }
       }
-    }
+    });
   });
 });


### PR DESCRIPTION
Fixes #6526

All command telemetry events have an (existing) property called contextValue.  I've added a new value to this, "walkthrough", so the possible values are now:

  "Uri": command comes a VS Code menu (context menu, file explorer context menu, editor menu, etc)
  "walkthrough": command comes from a button in the walkthrough
  null: probably from the command palette
  (other values) - shouldn't occur in this extension right now

Changed logic in commands so that they consistently get a documentUri (if provided) first, followed by any remaining arbitrary arguments (natively in vscode those would be in the same spot in the list - one or the other).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6801)