### PR TITLE
Fix issue while inserting resource

### DIFF
--- a/src/Bicep.Core/Configuration/CloudConfiguration.cs
+++ b/src/Bicep.Core/Configuration/CloudConfiguration.cs
@@ -43,7 +43,7 @@ namespace Bicep.Core.Configuration
         public Uri ActiveDirectoryAuthorityUri { get; }
 
         // this is needed for all track 1 SDKs and track 2 management plane SDKs
-        public string AuthenticationScope => ResourceManagerEndpointUri.AbsoluteUri + ".default";
+        public string AuthenticationScope => ResourceManagerEndpointUri.AbsoluteUri;
 
         // this is needed for track 2 data plane SDKs
         // this does not work with regional ARM endpoints


### PR DESCRIPTION
Fixes #6762

Fix regression caused by https://github.com/Azure/bicep/commit/14fd377360d01fd7ad0b010770606930927f9cb1.

[azure-sdk-for-net](https://github.com/Azure/azure-sdk-for-net) appends .default to DefaultScope [here](https://github.com/Azure/azure-sdk-for-net/blob/715937db8399434e43c63f9ff53f2f07e37bc4f2/sdk/resourcemanager/Azure.ResourceManager/src/ArmEnvironment.cs#L56) and we don't need to append the same at our end anymore

**Scenarios tested:**

1. Insert resource

1. Bicep build with a file referencing a registry module with only "AzurePowerShell" credential in bicepconfig.json

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6808)