### PR TITLE
Add title to commands

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/resourceTypes.json
+++ b/src/Bicep.Core.Samples/Files/Completions/resourceTypes.json
@@ -16,6 +16,7 @@
       "newText": "'Microsoft.AAD/domainServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "'Microsoft.AVS/privateClouds@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -56,6 +58,7 @@
       "newText": "'Microsoft.AVS/privateClouds/addons@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -76,6 +79,7 @@
       "newText": "'Microsoft.AVS/privateClouds/authorizations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -96,6 +100,7 @@
       "newText": "'Microsoft.AVS/privateClouds/cloudLinks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -116,6 +121,7 @@
       "newText": "'Microsoft.AVS/privateClouds/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -136,6 +142,7 @@
       "newText": "'Microsoft.AVS/privateClouds/clusters/datastores@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -156,6 +163,7 @@
       "newText": "'Microsoft.AVS/privateClouds/clusters/placementPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -176,6 +184,7 @@
       "newText": "'Microsoft.AVS/privateClouds/globalReachConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -196,6 +205,7 @@
       "newText": "'Microsoft.AVS/privateClouds/hcxEnterpriseSites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -216,6 +226,7 @@
       "newText": "'Microsoft.AVS/privateClouds/scriptExecutions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -236,6 +247,7 @@
       "newText": "'Microsoft.AVS/privateClouds/workloadNetworks/dhcpConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -256,6 +268,7 @@
       "newText": "'Microsoft.AVS/privateClouds/workloadNetworks/dnsServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -276,6 +289,7 @@
       "newText": "'Microsoft.AVS/privateClouds/workloadNetworks/dnsZones@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -296,6 +310,7 @@
       "newText": "'Microsoft.AVS/privateClouds/workloadNetworks/portMirroringProfiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -316,6 +331,7 @@
       "newText": "'Microsoft.AVS/privateClouds/workloadNetworks/publicIPs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -336,6 +352,7 @@
       "newText": "'Microsoft.AVS/privateClouds/workloadNetworks/segments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -356,6 +373,7 @@
       "newText": "'Microsoft.AVS/privateClouds/workloadNetworks/vmGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -376,6 +394,7 @@
       "newText": "'Microsoft.Aad/domainServices/ouContainer@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -396,6 +415,7 @@
       "newText": "'Microsoft.Addons/supportProviders/supportPlanTypes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -416,6 +436,7 @@
       "newText": "'Microsoft.Advisor/configurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -436,6 +457,7 @@
       "newText": "'Microsoft.Advisor/recommendations/suppressions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -456,6 +478,7 @@
       "newText": "'Microsoft.AgFoodPlatform/farmBeats@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -476,6 +499,7 @@
       "newText": "'Microsoft.AgFoodPlatform/farmBeats/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -496,6 +520,7 @@
       "newText": "'Microsoft.AlertsManagement/actionRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -516,6 +541,7 @@
       "newText": "'Microsoft.AnalysisServices/servers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -536,6 +562,7 @@
       "newText": "'Microsoft.ApiManagement/service@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -556,6 +583,7 @@
       "newText": "'Microsoft.ApiManagement/service/api-version-sets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -576,6 +604,7 @@
       "newText": "'Microsoft.ApiManagement/service/apiVersionSets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -596,6 +625,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -616,6 +646,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/diagnostics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -636,6 +667,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/diagnostics/loggers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -656,6 +688,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/issues@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -676,6 +709,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/issues/attachments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -696,6 +730,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/issues/comments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -716,6 +751,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/operations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -736,6 +772,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/operations/policies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -756,6 +793,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/operations/tags@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -776,6 +814,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/policies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -796,6 +835,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/releases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -816,6 +856,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/schemas@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -836,6 +877,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/tagDescriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -856,6 +898,7 @@
       "newText": "'Microsoft.ApiManagement/service/apis/tags@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -876,6 +919,7 @@
       "newText": "'Microsoft.ApiManagement/service/authorizationServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -896,6 +940,7 @@
       "newText": "'Microsoft.ApiManagement/service/backends@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -916,6 +961,7 @@
       "newText": "'Microsoft.ApiManagement/service/caches@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -936,6 +982,7 @@
       "newText": "'Microsoft.ApiManagement/service/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -956,6 +1003,7 @@
       "newText": "'Microsoft.ApiManagement/service/contentTypes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -976,6 +1024,7 @@
       "newText": "'Microsoft.ApiManagement/service/contentTypes/contentItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -996,6 +1045,7 @@
       "newText": "'Microsoft.ApiManagement/service/diagnostics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1016,6 +1066,7 @@
       "newText": "'Microsoft.ApiManagement/service/diagnostics/loggers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1036,6 +1087,7 @@
       "newText": "'Microsoft.ApiManagement/service/gateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1056,6 +1108,7 @@
       "newText": "'Microsoft.ApiManagement/service/gateways/apis@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1076,6 +1129,7 @@
       "newText": "'Microsoft.ApiManagement/service/gateways/certificateAuthorities@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1096,6 +1150,7 @@
       "newText": "'Microsoft.ApiManagement/service/gateways/hostnameConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1116,6 +1171,7 @@
       "newText": "'Microsoft.ApiManagement/service/groups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1136,6 +1192,7 @@
       "newText": "'Microsoft.ApiManagement/service/groups/users@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1156,6 +1213,7 @@
       "newText": "'Microsoft.ApiManagement/service/identityProviders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1176,6 +1234,7 @@
       "newText": "'Microsoft.ApiManagement/service/loggers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1196,6 +1255,7 @@
       "newText": "'Microsoft.ApiManagement/service/namedValues@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1216,6 +1276,7 @@
       "newText": "'Microsoft.ApiManagement/service/notifications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1236,6 +1297,7 @@
       "newText": "'Microsoft.ApiManagement/service/notifications/recipientEmails@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1256,6 +1318,7 @@
       "newText": "'Microsoft.ApiManagement/service/notifications/recipientUsers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1276,6 +1339,7 @@
       "newText": "'Microsoft.ApiManagement/service/openidConnectProviders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1296,6 +1360,7 @@
       "newText": "'Microsoft.ApiManagement/service/policies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1316,6 +1381,7 @@
       "newText": "'Microsoft.ApiManagement/service/policyFragments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1336,6 +1402,7 @@
       "newText": "'Microsoft.ApiManagement/service/portalRevisions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1356,6 +1423,7 @@
       "newText": "'Microsoft.ApiManagement/service/portalconfigs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1376,6 +1444,7 @@
       "newText": "'Microsoft.ApiManagement/service/portalsettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1396,6 +1465,7 @@
       "newText": "'Microsoft.ApiManagement/service/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1416,6 +1486,7 @@
       "newText": "'Microsoft.ApiManagement/service/products@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1436,6 +1507,7 @@
       "newText": "'Microsoft.ApiManagement/service/products/apis@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1456,6 +1528,7 @@
       "newText": "'Microsoft.ApiManagement/service/products/groups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1476,6 +1549,7 @@
       "newText": "'Microsoft.ApiManagement/service/products/policies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1496,6 +1570,7 @@
       "newText": "'Microsoft.ApiManagement/service/products/tags@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1516,6 +1591,7 @@
       "newText": "'Microsoft.ApiManagement/service/properties@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1536,6 +1612,7 @@
       "newText": "'Microsoft.ApiManagement/service/schemas@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1556,6 +1633,7 @@
       "newText": "'Microsoft.ApiManagement/service/subscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1576,6 +1654,7 @@
       "newText": "'Microsoft.ApiManagement/service/tags@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1596,6 +1675,7 @@
       "newText": "'Microsoft.ApiManagement/service/templates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1616,6 +1696,7 @@
       "newText": "'Microsoft.ApiManagement/service/tenant@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1636,6 +1717,7 @@
       "newText": "'Microsoft.ApiManagement/service/users@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1656,6 +1738,7 @@
       "newText": "'Microsoft.App/containerApps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1676,6 +1759,7 @@
       "newText": "'Microsoft.App/containerApps/authConfigs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1696,6 +1780,7 @@
       "newText": "'Microsoft.App/containerApps/sourcecontrols@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1716,6 +1801,7 @@
       "newText": "'Microsoft.App/managedEnvironments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1736,6 +1822,7 @@
       "newText": "'Microsoft.App/managedEnvironments/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1756,6 +1843,7 @@
       "newText": "'Microsoft.App/managedEnvironments/daprComponents@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1776,6 +1864,7 @@
       "newText": "'Microsoft.App/managedEnvironments/storages@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1796,6 +1885,7 @@
       "newText": "'Microsoft.AppConfiguration/configurationStores@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1816,6 +1906,7 @@
       "newText": "'Microsoft.AppConfiguration/configurationStores/keyValues@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1836,6 +1927,7 @@
       "newText": "'Microsoft.AppConfiguration/configurationStores/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1856,6 +1948,7 @@
       "newText": "'Microsoft.AppPlatform/Spring@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1876,6 +1969,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/apiPortals@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1896,6 +1990,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/apiPortals/domains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1916,6 +2011,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/apps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1936,6 +2032,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/apps/bindings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1956,6 +2053,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/apps/deployments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1976,6 +2074,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/apps/domains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1996,6 +2095,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/buildServices/agentPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2016,6 +2116,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/buildServices/builders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2036,6 +2137,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/buildServices/builders/buildpackBindings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2056,6 +2158,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/buildServices/builds@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2076,6 +2179,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2096,6 +2200,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/configServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2116,6 +2221,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/configurationServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2136,6 +2242,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/gateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2156,6 +2263,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/gateways/domains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2176,6 +2284,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/gateways/routeConfigs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2196,6 +2305,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/monitoringSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2216,6 +2326,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/serviceRegistries@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2236,6 +2347,7 @@
       "newText": "'Microsoft.AppPlatform/Spring/storages@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2256,6 +2368,7 @@
       "newText": "'Microsoft.Attestation/attestationProviders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2276,6 +2389,7 @@
       "newText": "'Microsoft.Attestation/attestationProviders/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2296,6 +2410,7 @@
       "newText": "'Microsoft.Authorization/accessReviewHistoryDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2316,6 +2431,7 @@
       "newText": "'Microsoft.Authorization/accessReviewScheduleDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2336,6 +2452,7 @@
       "newText": "'Microsoft.Authorization/accessReviewScheduleDefinitions/instances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2356,6 +2473,7 @@
       "newText": "'Microsoft.Authorization/accessReviewScheduleSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2376,6 +2494,7 @@
       "newText": "'Microsoft.Authorization/locks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2396,6 +2515,7 @@
       "newText": "'Microsoft.Authorization/policyAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2416,6 +2536,7 @@
       "newText": "'Microsoft.Authorization/policyDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2436,6 +2557,7 @@
       "newText": "'Microsoft.Authorization/policyExemptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2456,6 +2578,7 @@
       "newText": "'Microsoft.Authorization/policySetDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2476,6 +2599,7 @@
       "newText": "'Microsoft.Authorization/policyassignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2496,6 +2620,7 @@
       "newText": "'Microsoft.Authorization/policydefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2516,6 +2641,7 @@
       "newText": "'Microsoft.Authorization/privateLinkAssociations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2536,6 +2662,7 @@
       "newText": "'Microsoft.Authorization/resourceManagementPrivateLinks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2556,6 +2683,7 @@
       "newText": "'Microsoft.Authorization/roleAssignmentApprovals/stages@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2576,6 +2704,7 @@
       "newText": "'Microsoft.Authorization/roleAssignmentScheduleRequests@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2596,6 +2725,7 @@
       "newText": "'Microsoft.Authorization/roleAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2616,6 +2746,7 @@
       "newText": "'Microsoft.Authorization/roleDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2636,6 +2767,7 @@
       "newText": "'Microsoft.Authorization/roleEligibilityScheduleRequests@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2656,6 +2788,7 @@
       "newText": "'Microsoft.Authorization/roleManagementPolicyAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2676,6 +2809,7 @@
       "newText": "'Microsoft.Automanage/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2696,6 +2830,7 @@
       "newText": "'Microsoft.Automanage/configurationProfileAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2716,6 +2851,7 @@
       "newText": "'Microsoft.Automanage/configurationProfilePreferences@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2736,6 +2872,7 @@
       "newText": "'Microsoft.Automanage/configurationProfiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2756,6 +2893,7 @@
       "newText": "'Microsoft.Automanage/configurationProfiles/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2776,6 +2914,7 @@
       "newText": "'Microsoft.Automation/automationAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2796,6 +2935,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2816,6 +2956,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/compilationjobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2836,6 +2977,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/configurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2856,6 +2998,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/connectionTypes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2876,6 +3019,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/connections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2896,6 +3040,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/credentials@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2916,6 +3061,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2936,6 +3082,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/hybridRunbookWorkerGroups/hybridRunbookWorkers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2956,6 +3103,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/jobSchedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2976,6 +3124,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/jobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2996,6 +3145,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/modules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3016,6 +3166,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/nodeConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3036,6 +3187,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3056,6 +3208,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/python2Packages@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3076,6 +3229,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/runbooks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3096,6 +3250,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/runbooks/draft@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3116,6 +3271,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/schedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3136,6 +3292,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/softwareUpdateConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3156,6 +3313,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/sourceControls@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3176,6 +3334,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/sourceControls/sourceControlSyncJobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3196,6 +3355,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/variables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3216,6 +3376,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/watchers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3236,6 +3397,7 @@
       "newText": "'Microsoft.Automation/automationAccounts/webhooks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3256,6 +3418,7 @@
       "newText": "'Microsoft.AutonomousDevelopmentPlatform/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3276,6 +3439,7 @@
       "newText": "'Microsoft.AutonomousDevelopmentPlatform/accounts/dataPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3296,6 +3460,7 @@
       "newText": "'Microsoft.AzureActiveDirectory/b2cDirectories@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3316,6 +3481,7 @@
       "newText": "'Microsoft.AzureActiveDirectory/guestUsages@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3336,6 +3502,7 @@
       "newText": "'Microsoft.AzureArcData/dataControllers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3356,6 +3523,7 @@
       "newText": "'Microsoft.AzureArcData/dataControllers/activeDirectoryConnectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3376,6 +3544,7 @@
       "newText": "'Microsoft.AzureArcData/postgresInstances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3396,6 +3565,7 @@
       "newText": "'Microsoft.AzureArcData/sqlManagedInstances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3416,6 +3586,7 @@
       "newText": "'Microsoft.AzureArcData/sqlServerInstances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3436,6 +3607,7 @@
       "newText": "'Microsoft.AzureData/sqlServerRegistrations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3456,6 +3628,7 @@
       "newText": "'Microsoft.AzureData/sqlServerRegistrations/sqlServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3476,6 +3649,7 @@
       "newText": "'Microsoft.AzureStack/linkedSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3496,6 +3670,7 @@
       "newText": "'Microsoft.AzureStack/registrations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3516,6 +3691,7 @@
       "newText": "'Microsoft.AzureStack/registrations/customerSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3536,6 +3712,7 @@
       "newText": "'Microsoft.AzureStackHCI/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3556,6 +3733,7 @@
       "newText": "'Microsoft.AzureStackHCI/clusters/arcSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3576,6 +3754,7 @@
       "newText": "'Microsoft.AzureStackHCI/clusters/arcSettings/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3596,6 +3775,7 @@
       "newText": "'Microsoft.Batch/batchAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3616,6 +3796,7 @@
       "newText": "'Microsoft.Batch/batchAccounts/applications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3636,6 +3817,7 @@
       "newText": "'Microsoft.Batch/batchAccounts/applications/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3656,6 +3838,7 @@
       "newText": "'Microsoft.Batch/batchAccounts/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3676,6 +3859,7 @@
       "newText": "'Microsoft.Batch/batchAccounts/pools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3696,6 +3880,7 @@
       "newText": "'Microsoft.BatchAI/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3716,6 +3901,7 @@
       "newText": "'Microsoft.BatchAI/fileServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3736,6 +3922,7 @@
       "newText": "'Microsoft.BatchAI/jobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3756,6 +3943,7 @@
       "newText": "'Microsoft.BatchAI/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3776,6 +3964,7 @@
       "newText": "'Microsoft.BatchAI/workspaces/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3796,6 +3985,7 @@
       "newText": "'Microsoft.BatchAI/workspaces/experiments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3816,6 +4006,7 @@
       "newText": "'Microsoft.BatchAI/workspaces/experiments/jobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3836,6 +4027,7 @@
       "newText": "'Microsoft.BatchAI/workspaces/fileServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3856,6 +4048,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/billingProfiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3876,6 +4069,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/billingProfiles/instructions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3896,6 +4090,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/billingProfiles/invoiceSections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3916,6 +4111,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/billingProfiles/policies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3936,6 +4132,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/billingRoleAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3956,6 +4153,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/billingSubscriptionAliases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3976,6 +4174,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/customers/policies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -3996,6 +4195,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/departments/billingRoleAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4016,6 +4216,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/enrollmentAccounts/billingRoleAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4036,6 +4237,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/invoiceSections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4056,6 +4258,7 @@
       "newText": "'Microsoft.Billing/billingAccounts/lineOfCredit@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4076,6 +4279,7 @@
       "newText": "'Microsoft.Billing/promotions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4096,6 +4300,7 @@
       "newText": "'Microsoft.Blockchain/blockchainMembers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4116,6 +4321,7 @@
       "newText": "'Microsoft.Blockchain/blockchainMembers/transactionNodes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4136,6 +4342,7 @@
       "newText": "'Microsoft.Blueprint/blueprintAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4156,6 +4363,7 @@
       "newText": "'Microsoft.Blueprint/blueprints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4176,6 +4384,7 @@
       "newText": "'Microsoft.Blueprint/blueprints/artifacts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4196,6 +4405,7 @@
       "newText": "'Microsoft.Blueprint/blueprints/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4216,6 +4426,7 @@
       "newText": "'Microsoft.BotService/botServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4236,6 +4447,7 @@
       "newText": "'Microsoft.BotService/botServices/Connections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4256,6 +4468,7 @@
       "newText": "'Microsoft.BotService/botServices/channels@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4276,6 +4489,7 @@
       "newText": "'Microsoft.BotService/botServices/connections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4296,6 +4510,7 @@
       "newText": "'Microsoft.BotService/botServices/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4316,6 +4531,7 @@
       "newText": "'Microsoft.BotService/enterpriseChannels@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4336,6 +4552,7 @@
       "newText": "'Microsoft.Cache/Redis@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4356,6 +4573,7 @@
       "newText": "'Microsoft.Cache/Redis/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4376,6 +4594,7 @@
       "newText": "'Microsoft.Cache/Redis/linkedServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4396,6 +4615,7 @@
       "newText": "'Microsoft.Cache/Redis/patchSchedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4416,6 +4636,7 @@
       "newText": "'Microsoft.Cache/redis@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4436,6 +4657,7 @@
       "newText": "'Microsoft.Cache/redis/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4456,6 +4678,7 @@
       "newText": "'Microsoft.Cache/redis/linkedServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4476,6 +4699,7 @@
       "newText": "'Microsoft.Cache/redis/patchSchedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4496,6 +4720,7 @@
       "newText": "'Microsoft.Cache/redis/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4516,6 +4741,7 @@
       "newText": "'Microsoft.Cache/redisEnterprise@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4536,6 +4762,7 @@
       "newText": "'Microsoft.Cache/redisEnterprise/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4556,6 +4783,7 @@
       "newText": "'Microsoft.Cache/redisEnterprise/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4576,6 +4804,7 @@
       "newText": "'Microsoft.Capacity/reservationOrders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4596,6 +4825,7 @@
       "newText": "'Microsoft.Capacity/resourceProviders/locations/serviceLimits@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4616,6 +4846,7 @@
       "newText": "'Microsoft.Cdn/CdnWebApplicationFirewallPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4636,6 +4867,7 @@
       "newText": "'Microsoft.Cdn/cdnWebApplicationFirewallPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4656,6 +4888,7 @@
       "newText": "'Microsoft.Cdn/profiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4676,6 +4909,7 @@
       "newText": "'Microsoft.Cdn/profiles/afdEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4696,6 +4930,7 @@
       "newText": "'Microsoft.Cdn/profiles/afdEndpoints/routes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4716,6 +4951,7 @@
       "newText": "'Microsoft.Cdn/profiles/customDomains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4736,6 +4972,7 @@
       "newText": "'Microsoft.Cdn/profiles/endpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4756,6 +4993,7 @@
       "newText": "'Microsoft.Cdn/profiles/endpoints/customDomains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4776,6 +5014,7 @@
       "newText": "'Microsoft.Cdn/profiles/endpoints/originGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4796,6 +5035,7 @@
       "newText": "'Microsoft.Cdn/profiles/endpoints/origins@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4816,6 +5056,7 @@
       "newText": "'Microsoft.Cdn/profiles/originGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4836,6 +5077,7 @@
       "newText": "'Microsoft.Cdn/profiles/originGroups/origins@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4856,6 +5098,7 @@
       "newText": "'Microsoft.Cdn/profiles/ruleSets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4876,6 +5119,7 @@
       "newText": "'Microsoft.Cdn/profiles/ruleSets/rules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4896,6 +5140,7 @@
       "newText": "'Microsoft.Cdn/profiles/secrets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4916,6 +5161,7 @@
       "newText": "'Microsoft.Cdn/profiles/securityPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4936,6 +5182,7 @@
       "newText": "'Microsoft.CertificateRegistration/certificateOrders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4956,6 +5203,7 @@
       "newText": "'Microsoft.CertificateRegistration/certificateOrders/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4976,6 +5224,7 @@
       "newText": "'Microsoft.ChangeAnalysis/profile@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -4996,6 +5245,7 @@
       "newText": "'Microsoft.Chaos/experiments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5016,6 +5266,7 @@
       "newText": "'Microsoft.Chaos/targets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5036,6 +5287,7 @@
       "newText": "'Microsoft.Chaos/targets/capabilities@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5056,6 +5308,7 @@
       "newText": "'Microsoft.CognitiveServices/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5076,6 +5329,7 @@
       "newText": "'Microsoft.CognitiveServices/accounts/commitmentPlans@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5096,6 +5350,7 @@
       "newText": "'Microsoft.CognitiveServices/accounts/deployments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5116,6 +5371,7 @@
       "newText": "'Microsoft.CognitiveServices/accounts/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5136,6 +5392,7 @@
       "newText": "'Microsoft.Communication/communicationServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5156,6 +5413,7 @@
       "newText": "'Microsoft.Compute/availabilitySets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5176,6 +5434,7 @@
       "newText": "'Microsoft.Compute/capacityReservationGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5196,6 +5455,7 @@
       "newText": "'Microsoft.Compute/capacityReservationGroups/capacityReservations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5216,6 +5476,7 @@
       "newText": "'Microsoft.Compute/cloudServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5236,6 +5497,7 @@
       "newText": "'Microsoft.Compute/cloudServices/updateDomains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5256,6 +5518,7 @@
       "newText": "'Microsoft.Compute/diskAccesses@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5276,6 +5539,7 @@
       "newText": "'Microsoft.Compute/diskAccesses/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5296,6 +5560,7 @@
       "newText": "'Microsoft.Compute/diskEncryptionSets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5316,6 +5581,7 @@
       "newText": "'Microsoft.Compute/disks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5336,6 +5602,7 @@
       "newText": "'Microsoft.Compute/galleries@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5356,6 +5623,7 @@
       "newText": "'Microsoft.Compute/galleries/applications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5376,6 +5644,7 @@
       "newText": "'Microsoft.Compute/galleries/applications/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5396,6 +5665,7 @@
       "newText": "'Microsoft.Compute/galleries/images@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5416,6 +5686,7 @@
       "newText": "'Microsoft.Compute/galleries/images/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5436,6 +5707,7 @@
       "newText": "'Microsoft.Compute/hostGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5456,6 +5728,7 @@
       "newText": "'Microsoft.Compute/hostGroups/hosts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5476,6 +5749,7 @@
       "newText": "'Microsoft.Compute/images@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5496,6 +5770,7 @@
       "newText": "'Microsoft.Compute/proximityPlacementGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5516,6 +5791,7 @@
       "newText": "'Microsoft.Compute/restorePointCollections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5536,6 +5812,7 @@
       "newText": "'Microsoft.Compute/restorePointCollections/restorePoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5556,6 +5833,7 @@
       "newText": "'Microsoft.Compute/snapshots@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5576,6 +5854,7 @@
       "newText": "'Microsoft.Compute/sshPublicKeys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5596,6 +5875,7 @@
       "newText": "'Microsoft.Compute/virtualMachineScaleSets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5616,6 +5896,7 @@
       "newText": "'Microsoft.Compute/virtualMachineScaleSets/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5636,6 +5917,7 @@
       "newText": "'Microsoft.Compute/virtualMachineScaleSets/virtualMachines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5656,6 +5938,7 @@
       "newText": "'Microsoft.Compute/virtualMachineScaleSets/virtualMachines/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5676,6 +5959,7 @@
       "newText": "'Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5696,6 +5980,7 @@
       "newText": "'Microsoft.Compute/virtualMachineScaleSets/virtualmachines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5716,6 +6001,7 @@
       "newText": "'Microsoft.Compute/virtualMachines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5736,6 +6022,7 @@
       "newText": "'Microsoft.Compute/virtualMachines/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5756,6 +6043,7 @@
       "newText": "'Microsoft.Compute/virtualMachines/runCommands@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5776,6 +6064,7 @@
       "newText": "'Microsoft.ConfidentialLedger/ledgers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5796,6 +6085,7 @@
       "newText": "'Microsoft.Confluent/agreements@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5816,6 +6106,7 @@
       "newText": "'Microsoft.Confluent/organizations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5836,6 +6127,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5856,6 +6148,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/datastores@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5876,6 +6169,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/hosts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5896,6 +6190,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/resourcePools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5916,6 +6211,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/vcenters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5936,6 +6232,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/vcenters/inventoryItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5956,6 +6253,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/virtualMachineTemplates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5976,6 +6274,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/virtualMachines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5996,6 +6295,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/virtualMachines/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6016,6 +6316,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/virtualMachines/guestAgents@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6036,6 +6337,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/virtualMachines/hybridIdentityMetadata@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6056,6 +6358,7 @@
       "newText": "'Microsoft.ConnectedVMwarevSphere/virtualNetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6076,6 +6379,7 @@
       "newText": "'Microsoft.Consumption/budgets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6096,6 +6400,7 @@
       "newText": "'Microsoft.ContainerInstance/containerGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6116,6 +6421,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6136,6 +6442,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/agentPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6156,6 +6463,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/buildTasks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6176,6 +6484,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/buildTasks/steps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6196,6 +6505,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/connectedRegistries@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6216,6 +6526,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/exportPipelines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6236,6 +6547,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/importPipelines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6256,6 +6568,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/pipelineRuns@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6276,6 +6589,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6296,6 +6610,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/replications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6316,6 +6631,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/scopeMaps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6336,6 +6652,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/taskRuns@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6356,6 +6673,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/tasks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6376,6 +6694,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/tokens@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6396,6 +6715,7 @@
       "newText": "'Microsoft.ContainerRegistry/registries/webhooks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6416,6 +6736,7 @@
       "newText": "'Microsoft.ContainerService/containerServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6436,6 +6757,7 @@
       "newText": "'Microsoft.ContainerService/managedClusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6456,6 +6778,7 @@
       "newText": "'Microsoft.ContainerService/managedClusters/agentPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6476,6 +6799,7 @@
       "newText": "'Microsoft.ContainerService/managedClusters/maintenanceConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6496,6 +6820,7 @@
       "newText": "'Microsoft.ContainerService/managedClusters/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6516,6 +6841,7 @@
       "newText": "'Microsoft.ContainerService/managedclustersnapshots@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6536,6 +6862,7 @@
       "newText": "'Microsoft.ContainerService/openShiftManagedClusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6556,6 +6883,7 @@
       "newText": "'Microsoft.ContainerService/snapshots@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6576,6 +6904,7 @@
       "newText": "'Microsoft.CostManagement/budgets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6596,6 +6925,7 @@
       "newText": "'Microsoft.CostManagement/cloudConnectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6616,6 +6946,7 @@
       "newText": "'Microsoft.CostManagement/connectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6636,6 +6967,7 @@
       "newText": "'Microsoft.CostManagement/costAllocationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6656,6 +6988,7 @@
       "newText": "'Microsoft.CostManagement/exports@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6676,6 +7009,7 @@
       "newText": "'Microsoft.CostManagement/externalSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6696,6 +7030,7 @@
       "newText": "'Microsoft.CostManagement/reportconfigs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6716,6 +7051,7 @@
       "newText": "'Microsoft.CostManagement/reports@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6736,6 +7072,7 @@
       "newText": "'Microsoft.CostManagement/scheduledActions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6756,6 +7093,7 @@
       "newText": "'Microsoft.CostManagement/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6776,6 +7114,7 @@
       "newText": "'Microsoft.CostManagement/showbackRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6796,6 +7135,7 @@
       "newText": "'Microsoft.CostManagement/views@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6816,6 +7156,7 @@
       "newText": "'Microsoft.CustomProviders/associations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6836,6 +7177,7 @@
       "newText": "'Microsoft.CustomProviders/resourceProviders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6856,6 +7198,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6876,6 +7219,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/authorizationPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6896,6 +7240,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/connectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6916,6 +7261,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/connectors/mappings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6936,6 +7282,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/interactions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6956,6 +7303,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/kpi@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6976,6 +7324,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/links@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -6996,6 +7345,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/predictions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7016,6 +7366,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/profiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7036,6 +7387,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/relationshipLinks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7056,6 +7408,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/relationships@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7076,6 +7429,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/roleAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7096,6 +7450,7 @@
       "newText": "'Microsoft.CustomerInsights/hubs/views@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7116,6 +7471,7 @@
       "newText": "'Microsoft.DBForMySql/flexibleServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7136,6 +7492,7 @@
       "newText": "'Microsoft.DBForMySql/flexibleServers/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7156,6 +7513,7 @@
       "newText": "'Microsoft.DBForMySql/flexibleServers/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7176,6 +7534,7 @@
       "newText": "'Microsoft.DBForMySql/flexibleServers/keys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7196,6 +7555,7 @@
       "newText": "'Microsoft.DBForPostgreSql/flexibleServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7216,6 +7576,7 @@
       "newText": "'Microsoft.DBForPostgreSql/flexibleServers/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7236,6 +7597,7 @@
       "newText": "'Microsoft.DBForPostgreSql/flexibleServers/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7256,6 +7618,7 @@
       "newText": "'Microsoft.DBforMariaDB/servers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7276,6 +7639,7 @@
       "newText": "'Microsoft.DBforMariaDB/servers/configurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7296,6 +7660,7 @@
       "newText": "'Microsoft.DBforMariaDB/servers/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7316,6 +7681,7 @@
       "newText": "'Microsoft.DBforMariaDB/servers/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7336,6 +7702,7 @@
       "newText": "'Microsoft.DBforMariaDB/servers/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7356,6 +7723,7 @@
       "newText": "'Microsoft.DBforMariaDB/servers/securityAlertPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7376,6 +7744,7 @@
       "newText": "'Microsoft.DBforMariaDB/servers/virtualNetworkRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7396,6 +7765,7 @@
       "newText": "'Microsoft.DBforMySQL/flexibleServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7416,6 +7786,7 @@
       "newText": "'Microsoft.DBforMySQL/flexibleServers/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7436,6 +7807,7 @@
       "newText": "'Microsoft.DBforMySQL/flexibleServers/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7456,6 +7828,7 @@
       "newText": "'Microsoft.DBforMySQL/servers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7476,6 +7849,7 @@
       "newText": "'Microsoft.DBforMySQL/servers/administrators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7496,6 +7870,7 @@
       "newText": "'Microsoft.DBforMySQL/servers/configurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7516,6 +7891,7 @@
       "newText": "'Microsoft.DBforMySQL/servers/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7536,6 +7912,7 @@
       "newText": "'Microsoft.DBforMySQL/servers/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7556,6 +7933,7 @@
       "newText": "'Microsoft.DBforMySQL/servers/keys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7576,6 +7954,7 @@
       "newText": "'Microsoft.DBforMySQL/servers/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7596,6 +7975,7 @@
       "newText": "'Microsoft.DBforMySQL/servers/securityAlertPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7616,6 +7996,7 @@
       "newText": "'Microsoft.DBforMySQL/servers/virtualNetworkRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7636,6 +8017,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/flexibleServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7656,6 +8038,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/flexibleServers/configurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7676,6 +8059,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/flexibleServers/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7696,6 +8080,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7716,6 +8101,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/servers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7736,6 +8122,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/servers/administrators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7756,6 +8143,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/servers/configurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7776,6 +8164,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/servers/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7796,6 +8185,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/servers/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7816,6 +8206,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/servers/keys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7836,6 +8227,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/servers/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7856,6 +8248,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/servers/securityAlertPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7876,6 +8269,7 @@
       "newText": "'Microsoft.DBforPostgreSQL/servers/virtualNetworkRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7896,6 +8290,7 @@
       "newText": "'Microsoft.Dashboard/grafana@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7916,6 +8311,7 @@
       "newText": "'Microsoft.DataBox/jobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7936,6 +8332,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7956,6 +8353,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/bandwidthSchedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7976,6 +8374,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/diagnosticProactiveLogCollectionSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -7996,6 +8395,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/diagnosticRemoteSupportSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8016,6 +8416,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/orders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8036,6 +8437,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/roles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8056,6 +8458,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/roles/addons@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8076,6 +8479,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/roles/monitoringConfig@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8096,6 +8500,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/shares@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8116,6 +8521,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/storageAccountCredentials@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8136,6 +8542,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/storageAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8156,6 +8563,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/storageAccounts/containers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8176,6 +8584,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/triggers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8196,6 +8605,7 @@
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/users@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8216,6 +8626,7 @@
       "newText": "'Microsoft.DataCatalog/catalogs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8236,6 +8647,7 @@
       "newText": "'Microsoft.DataFactory/factories@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8256,6 +8668,7 @@
       "newText": "'Microsoft.DataFactory/factories/dataflows@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8276,6 +8689,7 @@
       "newText": "'Microsoft.DataFactory/factories/datasets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8296,6 +8710,7 @@
       "newText": "'Microsoft.DataFactory/factories/integrationRuntimes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8316,6 +8731,7 @@
       "newText": "'Microsoft.DataFactory/factories/linkedservices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8336,6 +8752,7 @@
       "newText": "'Microsoft.DataFactory/factories/managedVirtualNetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8356,6 +8773,7 @@
       "newText": "'Microsoft.DataFactory/factories/managedVirtualNetworks/managedPrivateEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8376,6 +8794,7 @@
       "newText": "'Microsoft.DataFactory/factories/pipelines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8396,6 +8815,7 @@
       "newText": "'Microsoft.DataFactory/factories/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8416,6 +8836,7 @@
       "newText": "'Microsoft.DataFactory/factories/triggers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8436,6 +8857,7 @@
       "newText": "'Microsoft.DataLakeAnalytics/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8456,6 +8878,7 @@
       "newText": "'Microsoft.DataLakeAnalytics/accounts/DataLakeStoreAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8476,6 +8899,7 @@
       "newText": "'Microsoft.DataLakeAnalytics/accounts/StorageAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8496,6 +8920,7 @@
       "newText": "'Microsoft.DataLakeAnalytics/accounts/computePolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8516,6 +8941,7 @@
       "newText": "'Microsoft.DataLakeAnalytics/accounts/dataLakeStoreAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8536,6 +8962,7 @@
       "newText": "'Microsoft.DataLakeAnalytics/accounts/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8556,6 +8983,7 @@
       "newText": "'Microsoft.DataLakeAnalytics/accounts/storageAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8576,6 +9004,7 @@
       "newText": "'Microsoft.DataLakeStore/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8596,6 +9025,7 @@
       "newText": "'Microsoft.DataLakeStore/accounts/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8616,6 +9046,7 @@
       "newText": "'Microsoft.DataLakeStore/accounts/trustedIdProviders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8636,6 +9067,7 @@
       "newText": "'Microsoft.DataLakeStore/accounts/virtualNetworkRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8656,6 +9088,7 @@
       "newText": "'Microsoft.DataMigration/databaseMigrations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8676,6 +9109,7 @@
       "newText": "'Microsoft.DataMigration/services@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8696,6 +9130,7 @@
       "newText": "'Microsoft.DataMigration/services/projects@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8716,6 +9151,7 @@
       "newText": "'Microsoft.DataMigration/services/projects/files@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8736,6 +9172,7 @@
       "newText": "'Microsoft.DataMigration/services/projects/tasks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8756,6 +9193,7 @@
       "newText": "'Microsoft.DataMigration/services/serviceTasks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8776,6 +9214,7 @@
       "newText": "'Microsoft.DataMigration/sqlMigrationServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8796,6 +9235,7 @@
       "newText": "'Microsoft.DataProtection/backupVaults@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8816,6 +9256,7 @@
       "newText": "'Microsoft.DataProtection/backupVaults/backupInstances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8836,6 +9277,7 @@
       "newText": "'Microsoft.DataProtection/backupVaults/backupPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8856,6 +9298,7 @@
       "newText": "'Microsoft.DataProtection/resourceGuards@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8876,6 +9319,7 @@
       "newText": "'Microsoft.DataShare/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8896,6 +9340,7 @@
       "newText": "'Microsoft.DataShare/accounts/shareSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8916,6 +9361,7 @@
       "newText": "'Microsoft.DataShare/accounts/shareSubscriptions/dataSetMappings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8936,6 +9382,7 @@
       "newText": "'Microsoft.DataShare/accounts/shareSubscriptions/triggers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8956,6 +9403,7 @@
       "newText": "'Microsoft.DataShare/accounts/shares@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8976,6 +9424,7 @@
       "newText": "'Microsoft.DataShare/accounts/shares/dataSets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -8996,6 +9445,7 @@
       "newText": "'Microsoft.DataShare/accounts/shares/invitations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9016,6 +9466,7 @@
       "newText": "'Microsoft.DataShare/accounts/shares/synchronizationSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9036,6 +9487,7 @@
       "newText": "'Microsoft.Databricks/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9056,6 +9508,7 @@
       "newText": "'Microsoft.Databricks/workspaces/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9076,6 +9529,7 @@
       "newText": "'Microsoft.Databricks/workspaces/virtualNetworkPeerings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9096,6 +9550,7 @@
       "newText": "'Microsoft.Datadog/agreements@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9116,6 +9571,7 @@
       "newText": "'Microsoft.Datadog/monitors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9136,6 +9592,7 @@
       "newText": "'Microsoft.Datadog/monitors/singleSignOnConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9156,6 +9613,7 @@
       "newText": "'Microsoft.Datadog/monitors/tagRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9176,6 +9634,7 @@
       "newText": "'Microsoft.DelegatedNetwork/controller@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9196,6 +9655,7 @@
       "newText": "'Microsoft.DelegatedNetwork/delegatedSubnets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9216,6 +9676,7 @@
       "newText": "'Microsoft.DelegatedNetwork/orchestrators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9236,6 +9697,7 @@
       "newText": "'Microsoft.DeploymentManager/artifactSources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9256,6 +9718,7 @@
       "newText": "'Microsoft.DeploymentManager/rollouts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9276,6 +9739,7 @@
       "newText": "'Microsoft.DeploymentManager/serviceTopologies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9296,6 +9760,7 @@
       "newText": "'Microsoft.DeploymentManager/serviceTopologies/services@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9316,6 +9781,7 @@
       "newText": "'Microsoft.DeploymentManager/serviceTopologies/services/serviceUnits@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9336,6 +9802,7 @@
       "newText": "'Microsoft.DeploymentManager/steps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9356,6 +9823,7 @@
       "newText": "'Microsoft.DesktopVirtualization/applicationGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9376,6 +9844,7 @@
       "newText": "'Microsoft.DesktopVirtualization/applicationGroups/applications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9396,6 +9865,7 @@
       "newText": "'Microsoft.DesktopVirtualization/hostPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9416,6 +9886,7 @@
       "newText": "'Microsoft.DesktopVirtualization/hostPools/msixPackages@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9436,6 +9907,7 @@
       "newText": "'Microsoft.DesktopVirtualization/hostPools/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9456,6 +9928,7 @@
       "newText": "'Microsoft.DesktopVirtualization/scalingPlans@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9476,6 +9949,7 @@
       "newText": "'Microsoft.DesktopVirtualization/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9496,6 +9970,7 @@
       "newText": "'Microsoft.DesktopVirtualization/workspaces/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9516,6 +9991,7 @@
       "newText": "'Microsoft.DevOps/pipelines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9536,6 +10012,7 @@
       "newText": "'Microsoft.DevSpaces/controllers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9556,6 +10033,7 @@
       "newText": "'Microsoft.DevTestLab/labs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9576,6 +10054,7 @@
       "newText": "'Microsoft.DevTestLab/labs/artifactsources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9596,6 +10075,7 @@
       "newText": "'Microsoft.DevTestLab/labs/costs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9616,6 +10096,7 @@
       "newText": "'Microsoft.DevTestLab/labs/customimages@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9636,6 +10117,7 @@
       "newText": "'Microsoft.DevTestLab/labs/formulas@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9656,6 +10138,7 @@
       "newText": "'Microsoft.DevTestLab/labs/notificationchannels@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9676,6 +10159,7 @@
       "newText": "'Microsoft.DevTestLab/labs/policysets/policies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9696,6 +10180,7 @@
       "newText": "'Microsoft.DevTestLab/labs/schedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9716,6 +10201,7 @@
       "newText": "'Microsoft.DevTestLab/labs/servicerunners@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9736,6 +10222,7 @@
       "newText": "'Microsoft.DevTestLab/labs/users@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9756,6 +10243,7 @@
       "newText": "'Microsoft.DevTestLab/labs/users/disks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9776,6 +10264,7 @@
       "newText": "'Microsoft.DevTestLab/labs/users/environments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9796,6 +10285,7 @@
       "newText": "'Microsoft.DevTestLab/labs/users/secrets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9816,6 +10306,7 @@
       "newText": "'Microsoft.DevTestLab/labs/users/servicefabrics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9836,6 +10327,7 @@
       "newText": "'Microsoft.DevTestLab/labs/users/servicefabrics/schedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9856,6 +10348,7 @@
       "newText": "'Microsoft.DevTestLab/labs/virtualmachines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9876,6 +10369,7 @@
       "newText": "'Microsoft.DevTestLab/labs/virtualmachines/schedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9896,6 +10390,7 @@
       "newText": "'Microsoft.DevTestLab/labs/virtualnetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9916,6 +10411,7 @@
       "newText": "'Microsoft.DevTestLab/schedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9936,6 +10432,7 @@
       "newText": "'Microsoft.DeviceUpdate/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9956,6 +10453,7 @@
       "newText": "'Microsoft.DeviceUpdate/accounts/instances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9976,6 +10474,7 @@
       "newText": "'Microsoft.DeviceUpdate/accounts/privateEndpointConnectionProxies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -9996,6 +10495,7 @@
       "newText": "'Microsoft.DeviceUpdate/accounts/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10016,6 +10516,7 @@
       "newText": "'Microsoft.Devices/IotHubs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10036,6 +10537,7 @@
       "newText": "'Microsoft.Devices/IotHubs/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10056,6 +10558,7 @@
       "newText": "'Microsoft.Devices/IotHubs/eventHubEndpoints/ConsumerGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10076,6 +10579,7 @@
       "newText": "'Microsoft.Devices/iotHubs/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10096,6 +10600,7 @@
       "newText": "'Microsoft.Devices/provisioningServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10116,6 +10621,7 @@
       "newText": "'Microsoft.Devices/provisioningServices/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10136,6 +10642,7 @@
       "newText": "'Microsoft.Devices/provisioningServices/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10156,6 +10663,7 @@
       "newText": "'Microsoft.DigitalTwins/digitalTwinsInstances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10176,6 +10684,7 @@
       "newText": "'Microsoft.DigitalTwins/digitalTwinsInstances/endpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10196,6 +10705,7 @@
       "newText": "'Microsoft.DigitalTwins/digitalTwinsInstances/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10216,6 +10726,7 @@
       "newText": "'Microsoft.DigitalTwins/digitalTwinsInstances/timeSeriesDatabaseConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10236,6 +10747,7 @@
       "newText": "'Microsoft.DocumentDB/cassandraClusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10256,6 +10768,7 @@
       "newText": "'Microsoft.DocumentDB/cassandraClusters/dataCenters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10276,6 +10789,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10296,6 +10810,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10316,6 +10831,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/collections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10336,6 +10852,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/collections/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10356,6 +10873,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/containers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10376,6 +10894,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/containers/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10396,6 +10915,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10416,6 +10936,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10436,6 +10957,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10456,6 +10978,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10476,6 +10999,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10496,6 +11020,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10516,6 +11041,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10536,6 +11062,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/tables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10556,6 +11083,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/apis/tables/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10576,6 +11104,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10596,6 +11125,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10616,6 +11146,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10636,6 +11167,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10656,6 +11188,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10676,6 +11209,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10696,6 +11230,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/dataTransferJobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10716,6 +11251,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/graphs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10736,6 +11272,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10756,6 +11293,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10776,6 +11314,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10796,6 +11335,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10816,6 +11356,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10836,6 +11377,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10856,6 +11398,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10876,6 +11419,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10896,6 +11440,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10916,6 +11461,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10936,6 +11482,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/notebookWorkspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10956,6 +11503,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10976,6 +11524,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/services@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -10996,6 +11545,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11016,6 +11566,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/clientEncryptionKeys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11036,6 +11587,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11056,6 +11608,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11076,6 +11629,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11096,6 +11650,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11116,6 +11671,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11136,6 +11692,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11156,6 +11713,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11176,6 +11734,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11196,6 +11755,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/tables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11216,6 +11776,7 @@
       "newText": "'Microsoft.DocumentDB/databaseAccounts/tables/throughputSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11236,6 +11797,7 @@
       "newText": "'Microsoft.DomainRegistration/domains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11256,6 +11818,7 @@
       "newText": "'Microsoft.DomainRegistration/domains/domainOwnershipIdentifiers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11276,6 +11839,7 @@
       "newText": "'Microsoft.Dynamics365FraudProtection/instances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11296,6 +11860,7 @@
       "newText": "'Microsoft.EdgeOrder/addresses@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11316,6 +11881,7 @@
       "newText": "'Microsoft.EdgeOrder/orderItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11336,6 +11902,7 @@
       "newText": "'Microsoft.Education/labs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11356,6 +11923,7 @@
       "newText": "'Microsoft.Education/labs/students@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11376,6 +11944,7 @@
       "newText": "'Microsoft.Elastic/monitors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11396,6 +11965,7 @@
       "newText": "'Microsoft.Elastic/monitors/tagRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11416,6 +11986,7 @@
       "newText": "'Microsoft.ElasticSan/elasticSans@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11436,6 +12007,7 @@
       "newText": "'Microsoft.ElasticSan/elasticSans/volumegroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11456,6 +12028,7 @@
       "newText": "'Microsoft.ElasticSan/elasticSans/volumegroups/volumes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11476,6 +12049,7 @@
       "newText": "'Microsoft.EngagementFabric/Accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11496,6 +12070,7 @@
       "newText": "'Microsoft.EngagementFabric/Accounts/Channels@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11516,6 +12091,7 @@
       "newText": "'Microsoft.EnterpriseKnowledgeGraph/services@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11536,6 +12112,7 @@
       "newText": "'Microsoft.EventGrid/domains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11556,6 +12133,7 @@
       "newText": "'Microsoft.EventGrid/domains/eventSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11576,6 +12154,7 @@
       "newText": "'Microsoft.EventGrid/domains/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11596,6 +12175,7 @@
       "newText": "'Microsoft.EventGrid/domains/topics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11616,6 +12196,7 @@
       "newText": "'Microsoft.EventGrid/domains/topics/eventSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11636,6 +12217,7 @@
       "newText": "'Microsoft.EventGrid/eventSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11656,6 +12238,7 @@
       "newText": "'Microsoft.EventGrid/partnerConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11676,6 +12259,7 @@
       "newText": "'Microsoft.EventGrid/partnerDestinations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11696,6 +12280,7 @@
       "newText": "'Microsoft.EventGrid/partnerNamespaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11716,6 +12301,7 @@
       "newText": "'Microsoft.EventGrid/partnerNamespaces/channels@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11736,6 +12322,7 @@
       "newText": "'Microsoft.EventGrid/partnerNamespaces/eventChannels@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11756,6 +12343,7 @@
       "newText": "'Microsoft.EventGrid/partnerNamespaces/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11776,6 +12364,7 @@
       "newText": "'Microsoft.EventGrid/partnerRegistrations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11796,6 +12385,7 @@
       "newText": "'Microsoft.EventGrid/partnerTopics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11816,6 +12406,7 @@
       "newText": "'Microsoft.EventGrid/partnerTopics/eventSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11836,6 +12427,7 @@
       "newText": "'Microsoft.EventGrid/systemTopics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11856,6 +12448,7 @@
       "newText": "'Microsoft.EventGrid/systemTopics/eventSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11876,6 +12469,7 @@
       "newText": "'Microsoft.EventGrid/topics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11896,6 +12490,7 @@
       "newText": "'Microsoft.EventGrid/topics/eventSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11916,6 +12511,7 @@
       "newText": "'Microsoft.EventGrid/topics/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11936,6 +12532,7 @@
       "newText": "'Microsoft.EventHub/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11956,6 +12553,7 @@
       "newText": "'Microsoft.EventHub/namespaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11976,6 +12574,7 @@
       "newText": "'Microsoft.EventHub/namespaces/AuthorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -11996,6 +12595,7 @@
       "newText": "'Microsoft.EventHub/namespaces/authorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12016,6 +12616,7 @@
       "newText": "'Microsoft.EventHub/namespaces/disasterRecoveryConfigs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12036,6 +12637,7 @@
       "newText": "'Microsoft.EventHub/namespaces/eventhubs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12056,6 +12658,7 @@
       "newText": "'Microsoft.EventHub/namespaces/eventhubs/authorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12076,6 +12679,7 @@
       "newText": "'Microsoft.EventHub/namespaces/eventhubs/consumergroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12096,6 +12700,7 @@
       "newText": "'Microsoft.EventHub/namespaces/ipfilterrules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12116,6 +12721,7 @@
       "newText": "'Microsoft.EventHub/namespaces/networkRuleSets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12136,6 +12742,7 @@
       "newText": "'Microsoft.EventHub/namespaces/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12156,6 +12763,7 @@
       "newText": "'Microsoft.EventHub/namespaces/schemagroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12176,6 +12784,7 @@
       "newText": "'Microsoft.EventHub/namespaces/virtualnetworkrules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12196,6 +12805,7 @@
       "newText": "'Microsoft.ExtendedLocation/customLocations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12216,6 +12826,7 @@
       "newText": "'Microsoft.ExtendedLocation/customLocations/resourceSyncRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12236,6 +12847,7 @@
       "newText": "'Microsoft.Features/featureProviders/subscriptionFeatureRegistrations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12256,6 +12868,7 @@
       "newText": "'Microsoft.FluidRelay/fluidRelayServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12276,6 +12889,7 @@
       "newText": "'Microsoft.GuestConfiguration/guestConfigurationAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12296,6 +12910,7 @@
       "newText": "'Microsoft.HDInsight/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12316,6 +12931,7 @@
       "newText": "'Microsoft.HDInsight/clusters/applications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12336,6 +12952,7 @@
       "newText": "'Microsoft.HDInsight/clusters/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12356,6 +12973,7 @@
       "newText": "'Microsoft.HanaOnAzure/hanaInstances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12376,6 +12994,7 @@
       "newText": "'Microsoft.HanaOnAzure/sapMonitors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12396,6 +13015,7 @@
       "newText": "'Microsoft.HanaOnAzure/sapMonitors/providerInstances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12416,6 +13036,7 @@
       "newText": "'Microsoft.HardwareSecurityModules/dedicatedHSMs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12436,6 +13057,7 @@
       "newText": "'Microsoft.HealthBot/healthBots@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12456,6 +13078,7 @@
       "newText": "'Microsoft.HealthcareApis/services@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12476,6 +13099,7 @@
       "newText": "'Microsoft.HealthcareApis/services/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12496,6 +13120,7 @@
       "newText": "'Microsoft.HealthcareApis/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12516,6 +13141,7 @@
       "newText": "'Microsoft.HealthcareApis/workspaces/dicomservices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12536,6 +13162,7 @@
       "newText": "'Microsoft.HealthcareApis/workspaces/fhirservices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12556,6 +13183,7 @@
       "newText": "'Microsoft.HealthcareApis/workspaces/iotconnectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12576,6 +13204,7 @@
       "newText": "'Microsoft.HealthcareApis/workspaces/iotconnectors/fhirdestinations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12596,6 +13225,7 @@
       "newText": "'Microsoft.HealthcareApis/workspaces/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12616,6 +13246,7 @@
       "newText": "'Microsoft.HybridCompute/machines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12636,6 +13267,7 @@
       "newText": "'Microsoft.HybridCompute/machines/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12656,6 +13288,7 @@
       "newText": "'Microsoft.HybridCompute/privateLinkScopes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12676,6 +13309,7 @@
       "newText": "'Microsoft.HybridCompute/privateLinkScopes/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12696,6 +13330,7 @@
       "newText": "'Microsoft.HybridCompute/privateLinkScopes/scopedResources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12716,6 +13351,7 @@
       "newText": "'Microsoft.HybridConnectivity/endpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12736,6 +13372,7 @@
       "newText": "'Microsoft.HybridData/dataManagers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12756,6 +13393,7 @@
       "newText": "'Microsoft.HybridData/dataManagers/dataServices/jobDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12776,6 +13414,7 @@
       "newText": "'Microsoft.HybridData/dataManagers/dataStores@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12796,6 +13435,7 @@
       "newText": "'Microsoft.HybridNetwork/devices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12816,6 +13456,7 @@
       "newText": "'Microsoft.HybridNetwork/locations/vendors/networkFunctions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12836,6 +13477,7 @@
       "newText": "'Microsoft.HybridNetwork/networkFunctions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12856,6 +13498,7 @@
       "newText": "'Microsoft.HybridNetwork/vendors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12876,6 +13519,7 @@
       "newText": "'Microsoft.HybridNetwork/vendors/vendorSkus@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12896,6 +13540,7 @@
       "newText": "'Microsoft.HybridNetwork/vendors/vendorSkus/previewSubscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12916,6 +13561,7 @@
       "newText": "'Microsoft.ImportExport/jobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12936,6 +13582,7 @@
       "newText": "'Microsoft.Insights/actionGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12956,6 +13603,7 @@
       "newText": "'Microsoft.Insights/activityLogAlerts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12976,6 +13624,7 @@
       "newText": "'Microsoft.Insights/alertrules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -12996,6 +13645,7 @@
       "newText": "'Microsoft.Insights/autoscalesettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13016,6 +13666,7 @@
       "newText": "'Microsoft.Insights/components@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13036,6 +13687,7 @@
       "newText": "'Microsoft.Insights/components/ProactiveDetectionConfigs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13056,6 +13708,7 @@
       "newText": "'Microsoft.Insights/components/exportconfiguration@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13076,6 +13729,7 @@
       "newText": "'Microsoft.Insights/components/favorites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13096,6 +13750,7 @@
       "newText": "'Microsoft.Insights/dataCollectionEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13116,6 +13771,7 @@
       "newText": "'Microsoft.Insights/dataCollectionRuleAssociations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13136,6 +13792,7 @@
       "newText": "'Microsoft.Insights/dataCollectionRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13156,6 +13813,7 @@
       "newText": "'Microsoft.Insights/diagnosticSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13176,6 +13834,7 @@
       "newText": "'Microsoft.Insights/logprofiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13196,6 +13855,7 @@
       "newText": "'Microsoft.Insights/metricAlerts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13216,6 +13876,7 @@
       "newText": "'Microsoft.Insights/myWorkbooks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13236,6 +13897,7 @@
       "newText": "'Microsoft.Insights/privateLinkScopes/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13256,6 +13918,7 @@
       "newText": "'Microsoft.Insights/privateLinkScopes/scopedResources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13276,6 +13939,7 @@
       "newText": "'Microsoft.Insights/scheduledQueryRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13296,6 +13960,7 @@
       "newText": "'Microsoft.Insights/webtests@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13316,6 +13981,7 @@
       "newText": "'Microsoft.Insights/workbooks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13336,6 +14002,7 @@
       "newText": "'Microsoft.Insights/workbooktemplates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13356,6 +14023,7 @@
       "newText": "'Microsoft.Intune/locations/androidPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13376,6 +14044,7 @@
       "newText": "'Microsoft.Intune/locations/androidPolicies/apps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13396,6 +14065,7 @@
       "newText": "'Microsoft.Intune/locations/androidPolicies/groups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13416,6 +14086,7 @@
       "newText": "'Microsoft.Intune/locations/iosPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13436,6 +14107,7 @@
       "newText": "'Microsoft.Intune/locations/iosPolicies/apps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13456,6 +14128,7 @@
       "newText": "'Microsoft.Intune/locations/iosPolicies/groups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13476,6 +14149,7 @@
       "newText": "'Microsoft.IoTCentral/iotApps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13496,6 +14170,7 @@
       "newText": "'Microsoft.IoTCentral/iotApps/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13516,6 +14191,7 @@
       "newText": "'Microsoft.IoTSecurity/defenderSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13536,6 +14212,7 @@
       "newText": "'Microsoft.IoTSecurity/locations/deviceGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13556,6 +14233,7 @@
       "newText": "'Microsoft.IoTSecurity/onPremiseSensors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13576,6 +14254,7 @@
       "newText": "'Microsoft.IoTSecurity/sensors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13596,6 +14275,7 @@
       "newText": "'Microsoft.IoTSecurity/sites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13616,6 +14296,7 @@
       "newText": "'Microsoft.KeyVault/managedHSMs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13636,6 +14317,7 @@
       "newText": "'Microsoft.KeyVault/managedHSMs/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13656,6 +14338,7 @@
       "newText": "'Microsoft.KeyVault/vaults@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13676,6 +14359,7 @@
       "newText": "'Microsoft.KeyVault/vaults/accessPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13696,6 +14380,7 @@
       "newText": "'Microsoft.KeyVault/vaults/keys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13716,6 +14401,7 @@
       "newText": "'Microsoft.KeyVault/vaults/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13736,6 +14422,7 @@
       "newText": "'Microsoft.KeyVault/vaults/secrets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13756,6 +14443,7 @@
       "newText": "'Microsoft.Kubernetes/connectedClusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13776,6 +14464,7 @@
       "newText": "'Microsoft.KubernetesConfiguration/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13796,6 +14485,7 @@
       "newText": "'Microsoft.KubernetesConfiguration/fluxConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13816,6 +14506,7 @@
       "newText": "'Microsoft.KubernetesConfiguration/privateLinkScopes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13836,6 +14527,7 @@
       "newText": "'Microsoft.KubernetesConfiguration/privateLinkScopes/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13856,6 +14548,7 @@
       "newText": "'Microsoft.KubernetesConfiguration/sourceControlConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13876,6 +14569,7 @@
       "newText": "'Microsoft.Kusto/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13896,6 +14590,7 @@
       "newText": "'Microsoft.Kusto/clusters/attachedDatabaseConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13916,6 +14611,7 @@
       "newText": "'Microsoft.Kusto/clusters/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13936,6 +14632,7 @@
       "newText": "'Microsoft.Kusto/clusters/databases/dataConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13956,6 +14653,7 @@
       "newText": "'Microsoft.Kusto/clusters/databases/eventhubconnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13976,6 +14674,7 @@
       "newText": "'Microsoft.Kusto/clusters/databases/principalAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -13996,6 +14695,7 @@
       "newText": "'Microsoft.Kusto/clusters/databases/scripts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14016,6 +14716,7 @@
       "newText": "'Microsoft.Kusto/clusters/managedPrivateEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14036,6 +14737,7 @@
       "newText": "'Microsoft.Kusto/clusters/principalAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14056,6 +14758,7 @@
       "newText": "'Microsoft.Kusto/clusters/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14076,6 +14779,7 @@
       "newText": "'Microsoft.LabServices/labPlans@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14096,6 +14800,7 @@
       "newText": "'Microsoft.LabServices/labPlans/images@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14116,6 +14821,7 @@
       "newText": "'Microsoft.LabServices/labaccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14136,6 +14842,7 @@
       "newText": "'Microsoft.LabServices/labaccounts/galleryimages@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14156,6 +14863,7 @@
       "newText": "'Microsoft.LabServices/labaccounts/labs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14176,6 +14884,7 @@
       "newText": "'Microsoft.LabServices/labaccounts/labs/environmentsettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14196,6 +14905,7 @@
       "newText": "'Microsoft.LabServices/labaccounts/labs/environmentsettings/environments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14216,6 +14926,7 @@
       "newText": "'Microsoft.LabServices/labaccounts/labs/users@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14236,6 +14947,7 @@
       "newText": "'Microsoft.LabServices/labs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14256,6 +14968,7 @@
       "newText": "'Microsoft.LabServices/labs/schedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14276,6 +14989,7 @@
       "newText": "'Microsoft.LabServices/labs/users@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14296,6 +15010,7 @@
       "newText": "'Microsoft.LoadTestService/loadTests@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14316,6 +15031,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14336,6 +15052,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts/agreements@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14356,6 +15073,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts/assemblies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14376,6 +15094,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts/batchConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14396,6 +15115,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14416,6 +15136,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts/maps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14436,6 +15157,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts/partners@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14456,6 +15178,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts/rosettanetprocessconfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14476,6 +15199,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts/schemas@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14496,6 +15220,7 @@
       "newText": "'Microsoft.Logic/integrationAccounts/sessions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14516,6 +15241,7 @@
       "newText": "'Microsoft.Logic/integrationServiceEnvironments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14536,6 +15262,7 @@
       "newText": "'Microsoft.Logic/integrationServiceEnvironments/managedApis@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14556,6 +15283,7 @@
       "newText": "'Microsoft.Logic/workflows@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14576,6 +15304,7 @@
       "newText": "'Microsoft.Logic/workflows/accessKeys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14596,6 +15325,7 @@
       "newText": "'Microsoft.Logz/monitors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14616,6 +15346,7 @@
       "newText": "'Microsoft.Logz/monitors/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14636,6 +15367,7 @@
       "newText": "'Microsoft.Logz/monitors/accounts/tagRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14656,6 +15388,7 @@
       "newText": "'Microsoft.Logz/monitors/metricsSource@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14676,6 +15409,7 @@
       "newText": "'Microsoft.Logz/monitors/metricsSource/tagRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14696,6 +15430,7 @@
       "newText": "'Microsoft.Logz/monitors/singleSignOnConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14716,6 +15451,7 @@
       "newText": "'Microsoft.Logz/monitors/tagRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14736,6 +15472,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForEDMUpload@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14756,6 +15493,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForEDMUpload/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14776,6 +15514,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14796,6 +15535,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14816,6 +15556,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365SecurityCenter@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14836,6 +15577,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14856,6 +15598,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForMIPPolicySync@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14876,6 +15619,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14896,6 +15640,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14916,6 +15661,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14936,6 +15682,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForSCCPowershell@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14956,6 +15703,7 @@
       "newText": "'Microsoft.M365SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14976,6 +15724,7 @@
       "newText": "'Microsoft.MachineLearning/commitmentPlans@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -14996,6 +15745,7 @@
       "newText": "'Microsoft.MachineLearning/webServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15016,6 +15766,7 @@
       "newText": "'Microsoft.MachineLearning/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15036,6 +15787,7 @@
       "newText": "'Microsoft.MachineLearningCompute/operationalizationClusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15056,6 +15808,7 @@
       "newText": "'Microsoft.MachineLearningExperimentation/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15076,6 +15829,7 @@
       "newText": "'Microsoft.MachineLearningExperimentation/accounts/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15096,6 +15850,7 @@
       "newText": "'Microsoft.MachineLearningExperimentation/accounts/workspaces/projects@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15116,6 +15871,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15136,6 +15892,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/batchEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15156,6 +15913,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/batchEndpoints/deployments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15176,6 +15934,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/codes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15196,6 +15955,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/codes/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15216,6 +15976,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/computes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15236,6 +15997,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/connections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15256,6 +16018,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/data@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15276,6 +16039,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/data/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15296,6 +16060,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/datasets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15316,6 +16081,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/datastores@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15336,6 +16102,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/environments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15356,6 +16123,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/environments/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15376,6 +16144,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/jobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15396,6 +16165,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/labelingJobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15416,6 +16186,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/linkedServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15436,6 +16207,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/linkedWorkspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15456,6 +16228,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/models@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15476,6 +16249,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/models/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15496,6 +16270,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/onlineEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15516,6 +16291,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/onlineEndpoints/deployments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15536,6 +16312,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15556,6 +16333,7 @@
       "newText": "'Microsoft.MachineLearningServices/workspaces/services@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15576,6 +16354,7 @@
       "newText": "'Microsoft.Maintenance/applyUpdates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15596,6 +16375,7 @@
       "newText": "'Microsoft.Maintenance/configurationAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15616,6 +16396,7 @@
       "newText": "'Microsoft.Maintenance/maintenanceConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15636,6 +16417,7 @@
       "newText": "'Microsoft.ManagedIdentity/userAssignedIdentities@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15656,6 +16438,7 @@
       "newText": "'Microsoft.ManagedNetwork/managedNetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15676,6 +16459,7 @@
       "newText": "'Microsoft.ManagedNetwork/managedNetworks/managedNetworkGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15696,6 +16480,7 @@
       "newText": "'Microsoft.ManagedNetwork/managedNetworks/managedNetworkPeeringPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15716,6 +16501,7 @@
       "newText": "'Microsoft.ManagedNetwork/scopeAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15736,6 +16522,7 @@
       "newText": "'Microsoft.ManagedServices/registrationAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15756,6 +16543,7 @@
       "newText": "'Microsoft.ManagedServices/registrationDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15776,6 +16564,7 @@
       "newText": "'Microsoft.Management/managementGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15796,6 +16585,7 @@
       "newText": "'Microsoft.Management/managementGroups/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15816,6 +16606,7 @@
       "newText": "'Microsoft.Management/managementGroups/subscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15836,6 +16627,7 @@
       "newText": "'Microsoft.ManagementPartner/partners@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15856,6 +16648,7 @@
       "newText": "'Microsoft.Maps/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15876,6 +16669,7 @@
       "newText": "'Microsoft.Maps/accounts/creators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15896,6 +16690,7 @@
       "newText": "'Microsoft.Maps/accounts/privateAtlases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15916,6 +16711,7 @@
       "newText": "'Microsoft.Marketplace/privateStores@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15936,6 +16732,7 @@
       "newText": "'Microsoft.Marketplace/privateStores/adminRequestApprovals@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15956,6 +16753,7 @@
       "newText": "'Microsoft.Marketplace/privateStores/collections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15976,6 +16774,7 @@
       "newText": "'Microsoft.Marketplace/privateStores/collections/offers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -15996,6 +16795,7 @@
       "newText": "'Microsoft.Marketplace/privateStores/offers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16016,6 +16816,7 @@
       "newText": "'Microsoft.Marketplace/privateStores/requestApprovals@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16036,6 +16837,7 @@
       "newText": "'Microsoft.MarketplaceOrdering/offerTypes/publishers/offers/plans/agreements@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16056,6 +16858,7 @@
       "newText": "'Microsoft.Media/mediaServices/accountFilters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16076,6 +16879,7 @@
       "newText": "'Microsoft.Media/mediaServices/assets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16096,6 +16900,7 @@
       "newText": "'Microsoft.Media/mediaServices/assets/assetFilters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16116,6 +16921,7 @@
       "newText": "'Microsoft.Media/mediaServices/assets/tracks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16136,6 +16942,7 @@
       "newText": "'Microsoft.Media/mediaServices/contentKeyPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16156,6 +16963,7 @@
       "newText": "'Microsoft.Media/mediaServices/mediaGraphs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16176,6 +16984,7 @@
       "newText": "'Microsoft.Media/mediaServices/streamingLocators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16196,6 +17005,7 @@
       "newText": "'Microsoft.Media/mediaServices/streamingPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16216,6 +17026,7 @@
       "newText": "'Microsoft.Media/mediaServices/transforms@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16236,6 +17047,7 @@
       "newText": "'Microsoft.Media/mediaServices/transforms/jobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16256,6 +17068,7 @@
       "newText": "'Microsoft.Media/mediaservices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16276,6 +17089,7 @@
       "newText": "'Microsoft.Media/mediaservices/liveEvents@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16296,6 +17110,7 @@
       "newText": "'Microsoft.Media/mediaservices/liveEvents/liveOutputs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16316,6 +17131,7 @@
       "newText": "'Microsoft.Media/mediaservices/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16336,6 +17152,7 @@
       "newText": "'Microsoft.Media/mediaservices/streamingEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16356,6 +17173,7 @@
       "newText": "'Microsoft.Media/videoAnalyzers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16376,6 +17194,7 @@
       "newText": "'Microsoft.Media/videoAnalyzers/accessPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16396,6 +17215,7 @@
       "newText": "'Microsoft.Media/videoAnalyzers/edgeModules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16416,6 +17236,7 @@
       "newText": "'Microsoft.Media/videoAnalyzers/livePipelines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16436,6 +17257,7 @@
       "newText": "'Microsoft.Media/videoAnalyzers/pipelineJobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16456,6 +17278,7 @@
       "newText": "'Microsoft.Media/videoAnalyzers/pipelineTopologies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16476,6 +17299,7 @@
       "newText": "'Microsoft.Media/videoAnalyzers/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16496,6 +17320,7 @@
       "newText": "'Microsoft.Media/videoAnalyzers/videos@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16516,6 +17341,7 @@
       "newText": "'Microsoft.Migrate/assessmentProjects@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16536,6 +17362,7 @@
       "newText": "'Microsoft.Migrate/assessmentProjects/groups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16556,6 +17383,7 @@
       "newText": "'Microsoft.Migrate/assessmentProjects/groups/assessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16576,6 +17404,7 @@
       "newText": "'Microsoft.Migrate/assessmentProjects/hypervcollectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16596,6 +17425,7 @@
       "newText": "'Microsoft.Migrate/assessmentProjects/importcollectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16616,6 +17446,7 @@
       "newText": "'Microsoft.Migrate/assessmentProjects/servercollectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16636,6 +17467,7 @@
       "newText": "'Microsoft.Migrate/assessmentProjects/vmwarecollectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16656,6 +17488,7 @@
       "newText": "'Microsoft.Migrate/assessmentprojects/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16676,6 +17509,7 @@
       "newText": "'Microsoft.Migrate/migrateProjects@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16696,6 +17530,7 @@
       "newText": "'Microsoft.Migrate/migrateProjects/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16716,6 +17551,7 @@
       "newText": "'Microsoft.Migrate/migrateProjects/solutions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16736,6 +17572,7 @@
       "newText": "'Microsoft.Migrate/moveCollections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16756,6 +17593,7 @@
       "newText": "'Microsoft.Migrate/moveCollections/moveResources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16776,6 +17614,7 @@
       "newText": "'Microsoft.Migrate/projects@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16796,6 +17635,7 @@
       "newText": "'Microsoft.Migrate/projects/groups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16816,6 +17656,7 @@
       "newText": "'Microsoft.Migrate/projects/groups/assessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16836,6 +17677,7 @@
       "newText": "'Microsoft.MixedReality/objectAnchorsAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16856,6 +17698,7 @@
       "newText": "'Microsoft.MixedReality/remoteRenderingAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16876,6 +17719,7 @@
       "newText": "'Microsoft.MixedReality/spatialAnchorsAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16896,6 +17740,7 @@
       "newText": "'Microsoft.MobileNetwork/mobileNetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16916,6 +17761,7 @@
       "newText": "'Microsoft.MobileNetwork/mobileNetworks/dataNetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16936,6 +17782,7 @@
       "newText": "'Microsoft.MobileNetwork/mobileNetworks/services@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16956,6 +17803,7 @@
       "newText": "'Microsoft.MobileNetwork/mobileNetworks/simPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16976,6 +17824,7 @@
       "newText": "'Microsoft.MobileNetwork/mobileNetworks/sites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -16996,6 +17845,7 @@
       "newText": "'Microsoft.MobileNetwork/mobileNetworks/slices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17016,6 +17866,7 @@
       "newText": "'Microsoft.MobileNetwork/packetCoreControlPlanes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17036,6 +17887,7 @@
       "newText": "'Microsoft.MobileNetwork/packetCoreControlPlanes/packetCoreDataPlanes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17056,6 +17908,7 @@
       "newText": "'Microsoft.MobileNetwork/packetCoreControlPlanes/packetCoreDataPlanes/attachedDataNetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17076,6 +17929,7 @@
       "newText": "'Microsoft.MobileNetwork/sims@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17096,6 +17950,7 @@
       "newText": "'Microsoft.NetApp/netAppAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17116,6 +17971,7 @@
       "newText": "'Microsoft.NetApp/netAppAccounts/backupPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17136,6 +17992,7 @@
       "newText": "'Microsoft.NetApp/netAppAccounts/capacityPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17156,6 +18013,7 @@
       "newText": "'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17176,6 +18034,7 @@
       "newText": "'Microsoft.NetApp/netAppAccounts/capacityPools/volumes/backups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17196,6 +18055,7 @@
       "newText": "'Microsoft.NetApp/netAppAccounts/capacityPools/volumes/snapshots@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17216,6 +18076,7 @@
       "newText": "'Microsoft.NetApp/netAppAccounts/capacityPools/volumes/subvolumes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17236,6 +18097,7 @@
       "newText": "'Microsoft.NetApp/netAppAccounts/snapshotPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17256,6 +18118,7 @@
       "newText": "'Microsoft.NetApp/netAppAccounts/volumeGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17276,6 +18139,7 @@
       "newText": "'Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17296,6 +18160,7 @@
       "newText": "'Microsoft.Network/ExpressRoutePorts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17316,6 +18181,7 @@
       "newText": "'Microsoft.Network/FrontDoorWebApplicationFirewallPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17336,6 +18202,7 @@
       "newText": "'Microsoft.Network/IpAllocations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17356,6 +18223,7 @@
       "newText": "'Microsoft.Network/NetworkExperimentProfiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17376,6 +18244,7 @@
       "newText": "'Microsoft.Network/NetworkExperimentProfiles/Experiments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17396,6 +18265,7 @@
       "newText": "'Microsoft.Network/applicationGateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17416,6 +18286,7 @@
       "newText": "'Microsoft.Network/applicationGateways/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17436,6 +18307,7 @@
       "newText": "'Microsoft.Network/applicationSecurityGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17456,6 +18328,7 @@
       "newText": "'Microsoft.Network/azureFirewalls@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17476,6 +18349,7 @@
       "newText": "'Microsoft.Network/bastionHosts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17496,6 +18370,7 @@
       "newText": "'Microsoft.Network/connections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17516,6 +18391,7 @@
       "newText": "'Microsoft.Network/customIpPrefixes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17536,6 +18412,7 @@
       "newText": "'Microsoft.Network/ddosCustomPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17556,6 +18433,7 @@
       "newText": "'Microsoft.Network/ddosProtectionPlans@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17576,6 +18454,7 @@
       "newText": "'Microsoft.Network/dnsForwardingRulesets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17596,6 +18475,7 @@
       "newText": "'Microsoft.Network/dnsForwardingRulesets/forwardingRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17616,6 +18496,7 @@
       "newText": "'Microsoft.Network/dnsForwardingRulesets/virtualNetworkLinks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17636,6 +18517,7 @@
       "newText": "'Microsoft.Network/dnsResolvers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17656,6 +18538,7 @@
       "newText": "'Microsoft.Network/dnsResolvers/inboundEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17676,6 +18559,7 @@
       "newText": "'Microsoft.Network/dnsResolvers/outboundEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17696,6 +18580,7 @@
       "newText": "'Microsoft.Network/dnsZones@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17716,6 +18601,7 @@
       "newText": "'Microsoft.Network/dnsZones/A@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17736,6 +18622,7 @@
       "newText": "'Microsoft.Network/dnsZones/AAAA@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17756,6 +18643,7 @@
       "newText": "'Microsoft.Network/dnsZones/CAA@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17776,6 +18664,7 @@
       "newText": "'Microsoft.Network/dnsZones/CNAME@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17796,6 +18685,7 @@
       "newText": "'Microsoft.Network/dnsZones/MX@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17816,6 +18706,7 @@
       "newText": "'Microsoft.Network/dnsZones/NS@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17836,6 +18727,7 @@
       "newText": "'Microsoft.Network/dnsZones/PTR@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17856,6 +18748,7 @@
       "newText": "'Microsoft.Network/dnsZones/SOA@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17876,6 +18769,7 @@
       "newText": "'Microsoft.Network/dnsZones/SRV@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17896,6 +18790,7 @@
       "newText": "'Microsoft.Network/dnsZones/TXT@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17916,6 +18811,7 @@
       "newText": "'Microsoft.Network/dnszones@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17936,6 +18832,7 @@
       "newText": "'Microsoft.Network/dnszones/A@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17956,6 +18853,7 @@
       "newText": "'Microsoft.Network/dnszones/AAAA@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17976,6 +18874,7 @@
       "newText": "'Microsoft.Network/dnszones/CNAME@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -17996,6 +18895,7 @@
       "newText": "'Microsoft.Network/dnszones/MX@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18016,6 +18916,7 @@
       "newText": "'Microsoft.Network/dnszones/NS@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18036,6 +18937,7 @@
       "newText": "'Microsoft.Network/dnszones/PTR@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18056,6 +18958,7 @@
       "newText": "'Microsoft.Network/dnszones/SOA@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18076,6 +18979,7 @@
       "newText": "'Microsoft.Network/dnszones/SRV@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18096,6 +19000,7 @@
       "newText": "'Microsoft.Network/dnszones/TXT@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18116,6 +19021,7 @@
       "newText": "'Microsoft.Network/dscpConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18136,6 +19042,7 @@
       "newText": "'Microsoft.Network/expressRouteCircuits@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18156,6 +19063,7 @@
       "newText": "'Microsoft.Network/expressRouteCircuits/authorizations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18176,6 +19084,7 @@
       "newText": "'Microsoft.Network/expressRouteCircuits/peerings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18196,6 +19105,7 @@
       "newText": "'Microsoft.Network/expressRouteCircuits/peerings/connections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18216,6 +19126,7 @@
       "newText": "'Microsoft.Network/expressRouteCrossConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18236,6 +19147,7 @@
       "newText": "'Microsoft.Network/expressRouteCrossConnections/peerings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18256,6 +19168,7 @@
       "newText": "'Microsoft.Network/expressRouteGateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18276,6 +19189,7 @@
       "newText": "'Microsoft.Network/expressRouteGateways/expressRouteConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18296,6 +19210,7 @@
       "newText": "'Microsoft.Network/expressRoutePorts/authorizations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18316,6 +19231,7 @@
       "newText": "'Microsoft.Network/firewallPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18336,6 +19252,7 @@
       "newText": "'Microsoft.Network/firewallPolicies/ruleCollectionGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18356,6 +19273,7 @@
       "newText": "'Microsoft.Network/firewallPolicies/ruleGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18376,6 +19294,7 @@
       "newText": "'Microsoft.Network/firewallPolicies/signatureOverrides@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18396,6 +19315,7 @@
       "newText": "'Microsoft.Network/frontDoors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18416,6 +19336,7 @@
       "newText": "'Microsoft.Network/frontDoors/rulesEngines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18436,6 +19357,7 @@
       "newText": "'Microsoft.Network/interfaceEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18456,6 +19378,7 @@
       "newText": "'Microsoft.Network/ipGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18476,6 +19399,7 @@
       "newText": "'Microsoft.Network/loadBalancers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18496,6 +19420,7 @@
       "newText": "'Microsoft.Network/loadBalancers/backendAddressPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18516,6 +19441,7 @@
       "newText": "'Microsoft.Network/loadBalancers/inboundNatRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18536,6 +19462,7 @@
       "newText": "'Microsoft.Network/localNetworkGateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18556,6 +19483,7 @@
       "newText": "'Microsoft.Network/managementGroups/networkManagerConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18576,6 +19504,7 @@
       "newText": "'Microsoft.Network/natGateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18596,6 +19525,7 @@
       "newText": "'Microsoft.Network/networkInterfaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18616,6 +19546,7 @@
       "newText": "'Microsoft.Network/networkInterfaces/tapConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18636,6 +19567,7 @@
       "newText": "'Microsoft.Network/networkManagerConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18656,6 +19588,7 @@
       "newText": "'Microsoft.Network/networkManagers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18676,6 +19609,7 @@
       "newText": "'Microsoft.Network/networkManagers/connectivityConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18696,6 +19630,7 @@
       "newText": "'Microsoft.Network/networkManagers/networkGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18716,6 +19651,7 @@
       "newText": "'Microsoft.Network/networkManagers/networkGroups/staticMembers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18736,6 +19672,7 @@
       "newText": "'Microsoft.Network/networkManagers/scopeConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18756,6 +19693,7 @@
       "newText": "'Microsoft.Network/networkManagers/securityAdminConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18776,6 +19714,7 @@
       "newText": "'Microsoft.Network/networkManagers/securityAdminConfigurations/ruleCollections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18796,6 +19735,7 @@
       "newText": "'Microsoft.Network/networkManagers/securityAdminConfigurations/ruleCollections/rules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18816,6 +19756,7 @@
       "newText": "'Microsoft.Network/networkManagers/securityUserConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18836,6 +19777,7 @@
       "newText": "'Microsoft.Network/networkManagers/securityUserConfigurations/ruleCollections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18856,6 +19798,7 @@
       "newText": "'Microsoft.Network/networkManagers/securityUserConfigurations/ruleCollections/rules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18876,6 +19819,7 @@
       "newText": "'Microsoft.Network/networkProfiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18896,6 +19840,7 @@
       "newText": "'Microsoft.Network/networkSecurityGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18916,6 +19861,7 @@
       "newText": "'Microsoft.Network/networkSecurityGroups/securityRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18936,6 +19882,7 @@
       "newText": "'Microsoft.Network/networkSecurityPerimeters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18956,6 +19903,7 @@
       "newText": "'Microsoft.Network/networkSecurityPerimeters/profiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18976,6 +19924,7 @@
       "newText": "'Microsoft.Network/networkSecurityPerimeters/profiles/accessRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -18996,6 +19945,7 @@
       "newText": "'Microsoft.Network/networkSecurityPerimeters/resourceAssociations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19016,6 +19966,7 @@
       "newText": "'Microsoft.Network/networkVirtualAppliances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19036,6 +19987,7 @@
       "newText": "'Microsoft.Network/networkVirtualAppliances/inboundSecurityRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19056,6 +20008,7 @@
       "newText": "'Microsoft.Network/networkVirtualAppliances/virtualApplianceSites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19076,6 +20029,7 @@
       "newText": "'Microsoft.Network/networkWatchers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19096,6 +20050,7 @@
       "newText": "'Microsoft.Network/networkWatchers/connectionMonitors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19116,6 +20071,7 @@
       "newText": "'Microsoft.Network/networkWatchers/flowLogs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19136,6 +20092,7 @@
       "newText": "'Microsoft.Network/networkWatchers/packetCaptures@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19156,6 +20113,7 @@
       "newText": "'Microsoft.Network/p2svpnGateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19176,6 +20134,7 @@
       "newText": "'Microsoft.Network/privateDnsZones@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19196,6 +20155,7 @@
       "newText": "'Microsoft.Network/privateDnsZones/A@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19216,6 +20176,7 @@
       "newText": "'Microsoft.Network/privateDnsZones/AAAA@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19236,6 +20197,7 @@
       "newText": "'Microsoft.Network/privateDnsZones/CNAME@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19256,6 +20218,7 @@
       "newText": "'Microsoft.Network/privateDnsZones/MX@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19276,6 +20239,7 @@
       "newText": "'Microsoft.Network/privateDnsZones/PTR@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19296,6 +20260,7 @@
       "newText": "'Microsoft.Network/privateDnsZones/SOA@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19316,6 +20281,7 @@
       "newText": "'Microsoft.Network/privateDnsZones/SRV@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19336,6 +20302,7 @@
       "newText": "'Microsoft.Network/privateDnsZones/TXT@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19356,6 +20323,7 @@
       "newText": "'Microsoft.Network/privateDnsZones/virtualNetworkLinks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19376,6 +20344,7 @@
       "newText": "'Microsoft.Network/privateEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19396,6 +20365,7 @@
       "newText": "'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19416,6 +20386,7 @@
       "newText": "'Microsoft.Network/privateLinkServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19436,6 +20407,7 @@
       "newText": "'Microsoft.Network/privateLinkServices/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19456,6 +20428,7 @@
       "newText": "'Microsoft.Network/publicIPAddresses@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19476,6 +20449,7 @@
       "newText": "'Microsoft.Network/publicIPPrefixes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19496,6 +20470,7 @@
       "newText": "'Microsoft.Network/routeFilters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19516,6 +20491,7 @@
       "newText": "'Microsoft.Network/routeFilters/routeFilterRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19536,6 +20512,7 @@
       "newText": "'Microsoft.Network/routeTables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19556,6 +20533,7 @@
       "newText": "'Microsoft.Network/routeTables/routes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19576,6 +20554,7 @@
       "newText": "'Microsoft.Network/securityPartnerProviders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19596,6 +20575,7 @@
       "newText": "'Microsoft.Network/serviceEndpointPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19616,6 +20596,7 @@
       "newText": "'Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19636,6 +20617,7 @@
       "newText": "'Microsoft.Network/trafficManagerUserMetricsKeys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19656,6 +20638,7 @@
       "newText": "'Microsoft.Network/trafficmanagerprofiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19676,6 +20659,7 @@
       "newText": "'Microsoft.Network/trafficmanagerprofiles/AzureEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19696,6 +20680,7 @@
       "newText": "'Microsoft.Network/trafficmanagerprofiles/ExternalEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19716,6 +20701,7 @@
       "newText": "'Microsoft.Network/trafficmanagerprofiles/NestedEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19736,6 +20722,7 @@
       "newText": "'Microsoft.Network/virtualHubs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19756,6 +20743,7 @@
       "newText": "'Microsoft.Network/virtualHubs/bgpConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19776,6 +20764,7 @@
       "newText": "'Microsoft.Network/virtualHubs/hubRouteTables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19796,6 +20785,7 @@
       "newText": "'Microsoft.Network/virtualHubs/hubVirtualNetworkConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19816,6 +20806,7 @@
       "newText": "'Microsoft.Network/virtualHubs/ipConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19836,6 +20827,7 @@
       "newText": "'Microsoft.Network/virtualHubs/routeTables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19856,6 +20848,7 @@
       "newText": "'Microsoft.Network/virtualHubs/routingIntent@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19876,6 +20869,7 @@
       "newText": "'Microsoft.Network/virtualNetworkGateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19896,6 +20890,7 @@
       "newText": "'Microsoft.Network/virtualNetworkGateways/natRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19916,6 +20911,7 @@
       "newText": "'Microsoft.Network/virtualNetworkTaps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19936,6 +20932,7 @@
       "newText": "'Microsoft.Network/virtualNetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19956,6 +20953,7 @@
       "newText": "'Microsoft.Network/virtualNetworks/subnets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19976,6 +20974,7 @@
       "newText": "'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -19996,6 +20995,7 @@
       "newText": "'Microsoft.Network/virtualRouters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20016,6 +21016,7 @@
       "newText": "'Microsoft.Network/virtualRouters/peerings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20036,6 +21037,7 @@
       "newText": "'Microsoft.Network/virtualWans@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20056,6 +21058,7 @@
       "newText": "'Microsoft.Network/virtualWans/p2sVpnServerConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20076,6 +21079,7 @@
       "newText": "'Microsoft.Network/virtualnetworkgateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20096,6 +21100,7 @@
       "newText": "'Microsoft.Network/virtualnetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20116,6 +21121,7 @@
       "newText": "'Microsoft.Network/virtualnetworks/subnets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20136,6 +21142,7 @@
       "newText": "'Microsoft.Network/vpnGateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20156,6 +21163,7 @@
       "newText": "'Microsoft.Network/vpnGateways/natRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20176,6 +21184,7 @@
       "newText": "'Microsoft.Network/vpnGateways/vpnConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20196,6 +21205,7 @@
       "newText": "'Microsoft.Network/vpnServerConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20216,6 +21226,7 @@
       "newText": "'Microsoft.Network/vpnServerConfigurations/configurationPolicyGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20236,6 +21247,7 @@
       "newText": "'Microsoft.Network/vpnSites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20256,6 +21268,7 @@
       "newText": "'Microsoft.NotificationHubs/namespaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20276,6 +21289,7 @@
       "newText": "'Microsoft.NotificationHubs/namespaces/AuthorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20296,6 +21310,7 @@
       "newText": "'Microsoft.NotificationHubs/namespaces/notificationHubs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20316,6 +21331,7 @@
       "newText": "'Microsoft.NotificationHubs/namespaces/notificationHubs/AuthorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20336,6 +21352,7 @@
       "newText": "'Microsoft.OffAzure/HyperVSites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20356,6 +21373,7 @@
       "newText": "'Microsoft.OffAzure/HyperVSites/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20376,6 +21394,7 @@
       "newText": "'Microsoft.OffAzure/HyperVSites/hosts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20396,6 +21415,7 @@
       "newText": "'Microsoft.OffAzure/MasterSites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20416,6 +21436,7 @@
       "newText": "'Microsoft.OffAzure/VMwareSites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20436,6 +21457,7 @@
       "newText": "'Microsoft.OffAzure/VMwareSites/vCenters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20456,6 +21478,7 @@
       "newText": "'Microsoft.OffAzure/masterSites/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20476,6 +21499,7 @@
       "newText": "'Microsoft.OpenEnergyPlatform/energyServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20496,6 +21520,7 @@
       "newText": "'Microsoft.OperationalInsights/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20516,6 +21541,7 @@
       "newText": "'Microsoft.OperationalInsights/queryPacks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20536,6 +21562,7 @@
       "newText": "'Microsoft.OperationalInsights/queryPacks/queries@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20556,6 +21583,7 @@
       "newText": "'Microsoft.OperationalInsights/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20576,6 +21604,7 @@
       "newText": "'Microsoft.OperationalInsights/workspaces/dataExports@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20596,6 +21625,7 @@
       "newText": "'Microsoft.OperationalInsights/workspaces/dataSources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20616,6 +21646,7 @@
       "newText": "'Microsoft.OperationalInsights/workspaces/linkedServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20636,6 +21667,7 @@
       "newText": "'Microsoft.OperationalInsights/workspaces/linkedStorageAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20656,6 +21688,7 @@
       "newText": "'Microsoft.OperationalInsights/workspaces/savedSearches@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20676,6 +21709,7 @@
       "newText": "'Microsoft.OperationalInsights/workspaces/storageInsightConfigs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20696,6 +21730,7 @@
       "newText": "'Microsoft.OperationalInsights/workspaces/tables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20716,6 +21751,7 @@
       "newText": "'Microsoft.OperationsManagement/ManagementAssociations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20736,6 +21772,7 @@
       "newText": "'Microsoft.OperationsManagement/ManagementConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20756,6 +21793,7 @@
       "newText": "'Microsoft.OperationsManagement/solutions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20776,6 +21814,7 @@
       "newText": "'Microsoft.Orbital/contactProfiles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20796,6 +21835,7 @@
       "newText": "'Microsoft.Orbital/spacecrafts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20816,6 +21856,7 @@
       "newText": "'Microsoft.Orbital/spacecrafts/contacts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20836,6 +21877,7 @@
       "newText": "'Microsoft.Peering/peerAsns@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20856,6 +21898,7 @@
       "newText": "'Microsoft.Peering/peeringServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20876,6 +21919,7 @@
       "newText": "'Microsoft.Peering/peeringServices/connectionMonitorTests@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20896,6 +21940,7 @@
       "newText": "'Microsoft.Peering/peeringServices/prefixes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20916,6 +21961,7 @@
       "newText": "'Microsoft.Peering/peerings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20936,6 +21982,7 @@
       "newText": "'Microsoft.Peering/peerings/registeredAsns@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20956,6 +22003,7 @@
       "newText": "'Microsoft.Peering/peerings/registeredPrefixes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20976,6 +22024,7 @@
       "newText": "'Microsoft.PolicyInsights/attestations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -20996,6 +22045,7 @@
       "newText": "'Microsoft.PolicyInsights/remediations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21016,6 +22066,7 @@
       "newText": "'Microsoft.Portal/consoles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21036,6 +22087,7 @@
       "newText": "'Microsoft.Portal/dashboards@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21056,6 +22108,7 @@
       "newText": "'Microsoft.Portal/locations/consoles@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21076,6 +22129,7 @@
       "newText": "'Microsoft.Portal/locations/userSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21096,6 +22150,7 @@
       "newText": "'Microsoft.Portal/tenantConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21116,6 +22171,7 @@
       "newText": "'Microsoft.Portal/userSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21136,6 +22192,7 @@
       "newText": "'Microsoft.PowerBI/privateLinkServicesForPowerBI@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21156,6 +22213,7 @@
       "newText": "'Microsoft.PowerBI/privateLinkServicesForPowerBI/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21176,6 +22234,7 @@
       "newText": "'Microsoft.PowerBI/workspaceCollections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21196,6 +22255,7 @@
       "newText": "'Microsoft.PowerBIDedicated/autoScaleVCores@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21216,6 +22276,7 @@
       "newText": "'Microsoft.PowerBIDedicated/capacities@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21236,6 +22297,7 @@
       "newText": "'Microsoft.PowerPlatform/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21256,6 +22318,7 @@
       "newText": "'Microsoft.PowerPlatform/enterprisePolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21276,6 +22339,7 @@
       "newText": "'Microsoft.PowerPlatform/enterprisePolicies/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21296,6 +22360,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21316,6 +22381,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations/customRollouts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21336,6 +22402,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations/defaultRollouts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21356,6 +22423,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations/notificationRegistrations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21376,6 +22444,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations/operations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21396,6 +22465,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21416,6 +22486,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/skus@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21436,6 +22507,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/skus@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21456,6 +22528,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/resourcetypeRegistrations/skus@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21476,6 +22549,7 @@
       "newText": "'Microsoft.ProviderHub/providerRegistrations/resourcetypeRegistrations/skus@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21496,6 +22570,7 @@
       "newText": "'Microsoft.Purview/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21516,6 +22591,7 @@
       "newText": "'Microsoft.Purview/accounts/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21536,6 +22612,7 @@
       "newText": "'Microsoft.Quantum/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21556,6 +22633,7 @@
       "newText": "'Microsoft.Quota/quotaLimits@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21576,6 +22654,7 @@
       "newText": "'Microsoft.Quota/quotas@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21596,6 +22675,7 @@
       "newText": "'Microsoft.RecommendationsService/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21616,6 +22696,7 @@
       "newText": "'Microsoft.RecommendationsService/accounts/modeling@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21636,6 +22717,7 @@
       "newText": "'Microsoft.RecommendationsService/accounts/serviceEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21656,6 +22738,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21676,6 +22759,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/backupEncryptionConfigs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21696,6 +22780,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/backupFabrics/backupProtectionIntent@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21716,6 +22801,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21736,6 +22822,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21756,6 +22843,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/backupPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21776,6 +22864,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/backupResourceGuardProxies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21796,6 +22885,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/backupconfig@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21816,6 +22906,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/backupstorageconfig@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21836,6 +22927,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21856,6 +22948,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/extendedInformation@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21876,6 +22969,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21896,6 +22990,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationAlertSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21916,6 +23011,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationFabrics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21936,6 +23032,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationNetworks/replicationNetworkMappings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21956,6 +23053,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21976,6 +23074,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationMigrationItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -21996,6 +23095,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22016,6 +23116,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionContainerMappings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22036,6 +23137,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationRecoveryServicesProviders@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22056,6 +23158,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationStorageClassifications/replicationStorageClassificationMappings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22076,6 +23179,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationFabrics/replicationvCenters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22096,6 +23200,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22116,6 +23221,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationProtectionIntents@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22136,6 +23242,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationRecoveryPlans@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22156,6 +23263,7 @@
       "newText": "'Microsoft.RecoveryServices/vaults/replicationVaultSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22176,6 +23284,7 @@
       "newText": "'Microsoft.RedHatOpenShift/openShiftClusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22196,6 +23305,7 @@
       "newText": "'Microsoft.Relay/namespaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22216,6 +23326,7 @@
       "newText": "'Microsoft.Relay/namespaces/AuthorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22236,6 +23347,7 @@
       "newText": "'Microsoft.Relay/namespaces/HybridConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22256,6 +23368,7 @@
       "newText": "'Microsoft.Relay/namespaces/HybridConnections/authorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22276,6 +23389,7 @@
       "newText": "'Microsoft.Relay/namespaces/WcfRelays@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22296,6 +23410,7 @@
       "newText": "'Microsoft.Relay/namespaces/WcfRelays/authorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22316,6 +23431,7 @@
       "newText": "'Microsoft.Relay/namespaces/authorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22336,6 +23452,7 @@
       "newText": "'Microsoft.Relay/namespaces/hybridConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22356,6 +23473,7 @@
       "newText": "'Microsoft.Relay/namespaces/hybridConnections/authorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22376,6 +23494,7 @@
       "newText": "'Microsoft.Relay/namespaces/networkRuleSets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22396,6 +23515,7 @@
       "newText": "'Microsoft.Relay/namespaces/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22416,6 +23536,7 @@
       "newText": "'Microsoft.Relay/namespaces/wcfRelays@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22436,6 +23557,7 @@
       "newText": "'Microsoft.Relay/namespaces/wcfRelays/authorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22456,6 +23578,7 @@
       "newText": "'Microsoft.ResourceConnector/appliances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22476,6 +23599,7 @@
       "newText": "'Microsoft.ResourceGraph/queries@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22496,6 +23620,7 @@
       "newText": "'Microsoft.Resources/deploymentScripts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22516,6 +23641,7 @@
       "newText": "'Microsoft.Resources/deployments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22536,6 +23662,7 @@
       "newText": "'Microsoft.Resources/resourceGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22556,6 +23683,7 @@
       "newText": "'Microsoft.Resources/tags@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22576,6 +23704,7 @@
       "newText": "'Microsoft.Resources/templateSpecs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22596,6 +23725,7 @@
       "newText": "'Microsoft.Resources/templateSpecs/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22616,6 +23746,7 @@
       "newText": "'Microsoft.ScVmm/availabilitySets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22636,6 +23767,7 @@
       "newText": "'Microsoft.ScVmm/clouds@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22656,6 +23788,7 @@
       "newText": "'Microsoft.ScVmm/virtualMachineTemplates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22676,6 +23809,7 @@
       "newText": "'Microsoft.ScVmm/virtualMachines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22696,6 +23830,7 @@
       "newText": "'Microsoft.ScVmm/virtualNetworks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22716,6 +23851,7 @@
       "newText": "'Microsoft.ScVmm/vmmServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22736,6 +23872,7 @@
       "newText": "'Microsoft.ScVmm/vmmServers/inventoryItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22756,6 +23893,7 @@
       "newText": "'Microsoft.Scheduler/jobCollections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22776,6 +23914,7 @@
       "newText": "'Microsoft.Scheduler/jobCollections/jobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22796,6 +23935,7 @@
       "newText": "'Microsoft.Search/searchServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22816,6 +23956,7 @@
       "newText": "'Microsoft.Search/searchServices/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22836,6 +23977,7 @@
       "newText": "'Microsoft.Search/searchServices/sharedPrivateLinkResources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22856,6 +23998,7 @@
       "newText": "'Microsoft.Security/advancedThreatProtectionSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22876,6 +24019,7 @@
       "newText": "'Microsoft.Security/alertsSuppressionRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22896,6 +24040,7 @@
       "newText": "'Microsoft.Security/assessmentMetadata@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22916,6 +24061,7 @@
       "newText": "'Microsoft.Security/assessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22936,6 +24082,7 @@
       "newText": "'Microsoft.Security/assignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22956,6 +24103,7 @@
       "newText": "'Microsoft.Security/autoProvisioningSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22976,6 +24124,7 @@
       "newText": "'Microsoft.Security/automations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -22996,6 +24145,7 @@
       "newText": "'Microsoft.Security/connectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23016,6 +24166,7 @@
       "newText": "'Microsoft.Security/customAssessmentAutomations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23036,6 +24187,7 @@
       "newText": "'Microsoft.Security/customEntityStoreAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23056,6 +24208,7 @@
       "newText": "'Microsoft.Security/deviceSecurityGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23076,6 +24229,7 @@
       "newText": "'Microsoft.Security/informationProtectionPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23096,6 +24250,7 @@
       "newText": "'Microsoft.Security/ingestionSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23116,6 +24271,7 @@
       "newText": "'Microsoft.Security/iotSecuritySolutions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23136,6 +24292,7 @@
       "newText": "'Microsoft.Security/locations/applicationWhitelistings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23156,6 +24313,7 @@
       "newText": "'Microsoft.Security/locations/jitNetworkAccessPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23176,6 +24334,7 @@
       "newText": "'Microsoft.Security/pricings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23196,6 +24355,7 @@
       "newText": "'Microsoft.Security/securityConnectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23216,6 +24376,7 @@
       "newText": "'Microsoft.Security/securityContacts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23236,6 +24397,7 @@
       "newText": "'Microsoft.Security/serverVulnerabilityAssessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23256,6 +24418,7 @@
       "newText": "'Microsoft.Security/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23276,6 +24439,7 @@
       "newText": "'Microsoft.Security/sqlVulnerabilityAssessments/baselineRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23296,6 +24460,7 @@
       "newText": "'Microsoft.Security/standards@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23316,6 +24481,7 @@
       "newText": "'Microsoft.Security/workspaceSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23336,6 +24502,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23356,6 +24523,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForEDMUpload/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23376,6 +24544,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23396,6 +24565,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForM365ComplianceCenter/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23416,6 +24586,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23436,6 +24607,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForM365SecurityCenter/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23456,6 +24628,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23476,6 +24649,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForMIPPolicySync/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23496,6 +24670,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23516,6 +24691,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForO365ManagementActivityAPI/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23536,6 +24712,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23556,6 +24733,7 @@
       "newText": "'Microsoft.SecurityAndCompliance/privateLinkServicesForSCCPowershell/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23576,6 +24754,7 @@
       "newText": "'Microsoft.SecurityInsights/alertRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23596,6 +24775,7 @@
       "newText": "'Microsoft.SecurityInsights/alertRules/actions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23616,6 +24796,7 @@
       "newText": "'Microsoft.SecurityInsights/automationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23636,6 +24817,7 @@
       "newText": "'Microsoft.SecurityInsights/bookmarks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23656,6 +24838,7 @@
       "newText": "'Microsoft.SecurityInsights/bookmarks/relations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23676,6 +24859,7 @@
       "newText": "'Microsoft.SecurityInsights/cases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23696,6 +24880,7 @@
       "newText": "'Microsoft.SecurityInsights/cases/comments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23716,6 +24901,7 @@
       "newText": "'Microsoft.SecurityInsights/cases/relations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23736,6 +24922,7 @@
       "newText": "'Microsoft.SecurityInsights/dataConnectors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23756,6 +24943,7 @@
       "newText": "'Microsoft.SecurityInsights/entityQueries@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23776,6 +24964,7 @@
       "newText": "'Microsoft.SecurityInsights/incidents@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23796,6 +24985,7 @@
       "newText": "'Microsoft.SecurityInsights/incidents/comments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23816,6 +25006,7 @@
       "newText": "'Microsoft.SecurityInsights/incidents/relations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23836,6 +25027,7 @@
       "newText": "'Microsoft.SecurityInsights/metadata@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23856,6 +25048,7 @@
       "newText": "'Microsoft.SecurityInsights/onboardingStates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23876,6 +25069,7 @@
       "newText": "'Microsoft.SecurityInsights/settings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23896,6 +25090,7 @@
       "newText": "'Microsoft.SecurityInsights/sourcecontrols@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23916,6 +25111,7 @@
       "newText": "'Microsoft.SecurityInsights/threatIntelligence/indicators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23936,6 +25132,7 @@
       "newText": "'Microsoft.SecurityInsights/watchlists@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23956,6 +25153,7 @@
       "newText": "'Microsoft.SecurityInsights/watchlists/watchlistItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23976,6 +25174,7 @@
       "newText": "'Microsoft.SerialConsole/serialPorts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -23996,6 +25195,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24016,6 +25216,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/AuthorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24036,6 +25237,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24056,6 +25258,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/ipfilterrules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24076,6 +25279,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/migrationConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24096,6 +25300,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/networkRuleSets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24116,6 +25321,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24136,6 +25342,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/queues@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24156,6 +25363,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/queues/authorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24176,6 +25384,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/topics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24196,6 +25405,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/topics/authorizationRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24216,6 +25426,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/topics/subscriptions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24236,6 +25447,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/topics/subscriptions/rules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24256,6 +25468,7 @@
       "newText": "'Microsoft.ServiceBus/namespaces/virtualnetworkrules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24276,6 +25489,7 @@
       "newText": "'Microsoft.ServiceFabric/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24296,6 +25510,7 @@
       "newText": "'Microsoft.ServiceFabric/clusters/applicationTypes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24316,6 +25531,7 @@
       "newText": "'Microsoft.ServiceFabric/clusters/applicationTypes/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24336,6 +25552,7 @@
       "newText": "'Microsoft.ServiceFabric/clusters/applications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24356,6 +25573,7 @@
       "newText": "'Microsoft.ServiceFabric/clusters/applications/services@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24376,6 +25594,7 @@
       "newText": "'Microsoft.ServiceFabric/managedClusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24396,6 +25615,7 @@
       "newText": "'Microsoft.ServiceFabric/managedClusters/nodeTypes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24416,6 +25636,7 @@
       "newText": "'Microsoft.ServiceFabric/managedclusters/applicationTypes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24436,6 +25657,7 @@
       "newText": "'Microsoft.ServiceFabric/managedclusters/applicationTypes/versions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24456,6 +25678,7 @@
       "newText": "'Microsoft.ServiceFabric/managedclusters/applications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24476,6 +25699,7 @@
       "newText": "'Microsoft.ServiceFabric/managedclusters/applications/services@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24496,6 +25720,7 @@
       "newText": "'Microsoft.ServiceFabricMesh/applications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24516,6 +25741,7 @@
       "newText": "'Microsoft.ServiceFabricMesh/gateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24536,6 +25762,7 @@
       "newText": "'Microsoft.ServiceFabricMesh/networks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24556,6 +25783,7 @@
       "newText": "'Microsoft.ServiceFabricMesh/secrets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24576,6 +25804,7 @@
       "newText": "'Microsoft.ServiceFabricMesh/secrets/values@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24596,6 +25825,7 @@
       "newText": "'Microsoft.ServiceFabricMesh/volumes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24616,6 +25846,7 @@
       "newText": "'Microsoft.ServiceLinker/linkers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24636,6 +25867,7 @@
       "newText": "'Microsoft.SignalRService/SignalR@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24656,6 +25888,7 @@
       "newText": "'Microsoft.SignalRService/signalR@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24676,6 +25909,7 @@
       "newText": "'Microsoft.SignalRService/signalR/customCertificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24696,6 +25930,7 @@
       "newText": "'Microsoft.SignalRService/signalR/customDomains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24716,6 +25951,7 @@
       "newText": "'Microsoft.SignalRService/signalR/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24736,6 +25972,7 @@
       "newText": "'Microsoft.SignalRService/signalR/sharedPrivateLinkResources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24756,6 +25993,7 @@
       "newText": "'Microsoft.SignalRService/webPubSub@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24776,6 +26014,7 @@
       "newText": "'Microsoft.SignalRService/webPubSub/hubs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24796,6 +26035,7 @@
       "newText": "'Microsoft.SignalRService/webPubSub/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24816,6 +26056,7 @@
       "newText": "'Microsoft.SignalRService/webPubSub/sharedPrivateLinkResources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24836,6 +26077,7 @@
       "newText": "'Microsoft.SoftwarePlan/hybridUseBenefits@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24856,6 +26098,7 @@
       "newText": "'Microsoft.Solutions/applianceDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24876,6 +26119,7 @@
       "newText": "'Microsoft.Solutions/appliances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24896,6 +26140,7 @@
       "newText": "'Microsoft.Solutions/applicationDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24916,6 +26161,7 @@
       "newText": "'Microsoft.Solutions/applications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24936,6 +26182,7 @@
       "newText": "'Microsoft.Solutions/jitRequests@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24956,6 +26203,7 @@
       "newText": "'Microsoft.Sql/instancePools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24976,6 +26224,7 @@
       "newText": "'Microsoft.Sql/locations/instanceFailoverGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -24996,6 +26245,7 @@
       "newText": "'Microsoft.Sql/locations/serverTrustGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25016,6 +26266,7 @@
       "newText": "'Microsoft.Sql/managedInstances@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25036,6 +26287,7 @@
       "newText": "'Microsoft.Sql/managedInstances/administrators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25056,6 +26308,7 @@
       "newText": "'Microsoft.Sql/managedInstances/azureADOnlyAuthentications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25076,6 +26329,7 @@
       "newText": "'Microsoft.Sql/managedInstances/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25096,6 +26350,7 @@
       "newText": "'Microsoft.Sql/managedInstances/databases/backupLongTermRetentionPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25116,6 +26371,7 @@
       "newText": "'Microsoft.Sql/managedInstances/databases/backupShortTermRetentionPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25136,6 +26392,7 @@
       "newText": "'Microsoft.Sql/managedInstances/databases/schemas/tables/columns/sensitivityLabels@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25156,6 +26413,7 @@
       "newText": "'Microsoft.Sql/managedInstances/databases/securityAlertPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25176,6 +26434,7 @@
       "newText": "'Microsoft.Sql/managedInstances/databases/transparentDataEncryption@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25196,6 +26455,7 @@
       "newText": "'Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25216,6 +26476,7 @@
       "newText": "'Microsoft.Sql/managedInstances/databases/vulnerabilityAssessments/rules/baselines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25236,6 +26497,7 @@
       "newText": "'Microsoft.Sql/managedInstances/distributedAvailabilityGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25256,6 +26518,7 @@
       "newText": "'Microsoft.Sql/managedInstances/dnsAliases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25276,6 +26539,7 @@
       "newText": "'Microsoft.Sql/managedInstances/encryptionProtector@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25296,6 +26560,7 @@
       "newText": "'Microsoft.Sql/managedInstances/keys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25316,6 +26581,7 @@
       "newText": "'Microsoft.Sql/managedInstances/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25336,6 +26602,7 @@
       "newText": "'Microsoft.Sql/managedInstances/restorableDroppedDatabases/backupShortTermRetentionPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25356,6 +26623,7 @@
       "newText": "'Microsoft.Sql/managedInstances/securityAlertPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25376,6 +26644,7 @@
       "newText": "'Microsoft.Sql/managedInstances/serverTrustCertificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25396,6 +26665,7 @@
       "newText": "'Microsoft.Sql/managedInstances/sqlAgent@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25416,6 +26686,7 @@
       "newText": "'Microsoft.Sql/managedInstances/vulnerabilityAssessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25436,6 +26707,7 @@
       "newText": "'Microsoft.Sql/servers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25456,6 +26728,7 @@
       "newText": "'Microsoft.Sql/servers/administrators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25476,6 +26749,7 @@
       "newText": "'Microsoft.Sql/servers/advancedThreatProtectionSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25496,6 +26770,7 @@
       "newText": "'Microsoft.Sql/servers/advisors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25516,6 +26791,7 @@
       "newText": "'Microsoft.Sql/servers/auditingPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25536,6 +26812,7 @@
       "newText": "'Microsoft.Sql/servers/auditingSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25556,6 +26833,7 @@
       "newText": "'Microsoft.Sql/servers/azureADOnlyAuthentications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25576,6 +26854,7 @@
       "newText": "'Microsoft.Sql/servers/communicationLinks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25596,6 +26875,7 @@
       "newText": "'Microsoft.Sql/servers/connectionPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25616,6 +26896,7 @@
       "newText": "'Microsoft.Sql/servers/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25636,6 +26917,7 @@
       "newText": "'Microsoft.Sql/servers/databases/advancedThreatProtectionSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25656,6 +26938,7 @@
       "newText": "'Microsoft.Sql/servers/databases/advisors@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25676,6 +26959,7 @@
       "newText": "'Microsoft.Sql/servers/databases/auditingPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25696,6 +26980,7 @@
       "newText": "'Microsoft.Sql/servers/databases/auditingSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25716,6 +27001,7 @@
       "newText": "'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25736,6 +27022,7 @@
       "newText": "'Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25756,6 +27043,7 @@
       "newText": "'Microsoft.Sql/servers/databases/connectionPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25776,6 +27064,7 @@
       "newText": "'Microsoft.Sql/servers/databases/dataMaskingPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25796,6 +27085,7 @@
       "newText": "'Microsoft.Sql/servers/databases/dataMaskingPolicies/rules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25816,6 +27106,7 @@
       "newText": "'Microsoft.Sql/servers/databases/extendedAuditingSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25836,6 +27127,7 @@
       "newText": "'Microsoft.Sql/servers/databases/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25856,6 +27148,7 @@
       "newText": "'Microsoft.Sql/servers/databases/geoBackupPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25876,6 +27169,7 @@
       "newText": "'Microsoft.Sql/servers/databases/ledgerDigestUploads@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25896,6 +27190,7 @@
       "newText": "'Microsoft.Sql/servers/databases/maintenanceWindows@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25916,6 +27211,7 @@
       "newText": "'Microsoft.Sql/servers/databases/schemas/tables/columns/sensitivityLabels@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25936,6 +27232,7 @@
       "newText": "'Microsoft.Sql/servers/databases/securityAlertPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25956,6 +27253,7 @@
       "newText": "'Microsoft.Sql/servers/databases/syncGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25976,6 +27274,7 @@
       "newText": "'Microsoft.Sql/servers/databases/syncGroups/syncMembers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -25996,6 +27295,7 @@
       "newText": "'Microsoft.Sql/servers/databases/transparentDataEncryption@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26016,6 +27316,7 @@
       "newText": "'Microsoft.Sql/servers/databases/vulnerabilityAssessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26036,6 +27337,7 @@
       "newText": "'Microsoft.Sql/servers/databases/vulnerabilityAssessments/rules/baselines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26056,6 +27358,7 @@
       "newText": "'Microsoft.Sql/servers/databases/workloadGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26076,6 +27379,7 @@
       "newText": "'Microsoft.Sql/servers/databases/workloadGroups/workloadClassifiers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26096,6 +27400,7 @@
       "newText": "'Microsoft.Sql/servers/devOpsAuditingSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26116,6 +27421,7 @@
       "newText": "'Microsoft.Sql/servers/disasterRecoveryConfiguration@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26136,6 +27442,7 @@
       "newText": "'Microsoft.Sql/servers/dnsAliases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26156,6 +27463,7 @@
       "newText": "'Microsoft.Sql/servers/elasticPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26176,6 +27484,7 @@
       "newText": "'Microsoft.Sql/servers/encryptionProtector@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26196,6 +27505,7 @@
       "newText": "'Microsoft.Sql/servers/extendedAuditingSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26216,6 +27526,7 @@
       "newText": "'Microsoft.Sql/servers/failoverGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26236,6 +27547,7 @@
       "newText": "'Microsoft.Sql/servers/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26256,6 +27568,7 @@
       "newText": "'Microsoft.Sql/servers/ipv6FirewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26276,6 +27589,7 @@
       "newText": "'Microsoft.Sql/servers/jobAgents@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26296,6 +27610,7 @@
       "newText": "'Microsoft.Sql/servers/jobAgents/credentials@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26316,6 +27631,7 @@
       "newText": "'Microsoft.Sql/servers/jobAgents/jobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26336,6 +27652,7 @@
       "newText": "'Microsoft.Sql/servers/jobAgents/jobs/executions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26356,6 +27673,7 @@
       "newText": "'Microsoft.Sql/servers/jobAgents/jobs/steps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26376,6 +27694,7 @@
       "newText": "'Microsoft.Sql/servers/jobAgents/targetGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26396,6 +27715,7 @@
       "newText": "'Microsoft.Sql/servers/keys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26416,6 +27736,7 @@
       "newText": "'Microsoft.Sql/servers/outboundFirewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26436,6 +27757,7 @@
       "newText": "'Microsoft.Sql/servers/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26456,6 +27778,7 @@
       "newText": "'Microsoft.Sql/servers/securityAlertPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26476,6 +27799,7 @@
       "newText": "'Microsoft.Sql/servers/syncAgents@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26496,6 +27820,7 @@
       "newText": "'Microsoft.Sql/servers/virtualNetworkRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26516,6 +27841,7 @@
       "newText": "'Microsoft.Sql/servers/vulnerabilityAssessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26536,6 +27862,7 @@
       "newText": "'Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26556,6 +27883,7 @@
       "newText": "'Microsoft.SqlVirtualMachine/sqlVirtualMachineGroups/availabilityGroupListeners@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26576,6 +27904,7 @@
       "newText": "'Microsoft.SqlVirtualMachine/sqlVirtualMachines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26596,6 +27925,7 @@
       "newText": "'Microsoft.StorSimple/managers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26616,6 +27946,7 @@
       "newText": "'Microsoft.StorSimple/managers/accessControlRecords@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26636,6 +27967,7 @@
       "newText": "'Microsoft.StorSimple/managers/bandwidthSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26656,6 +27988,7 @@
       "newText": "'Microsoft.StorSimple/managers/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26676,6 +28009,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/alertSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26696,6 +28030,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/backupPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26716,6 +28051,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/backupPolicies/schedules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26736,6 +28072,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/backupScheduleGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26756,6 +28093,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/chapSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26776,6 +28114,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/fileservers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26796,6 +28135,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/fileservers/shares@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26816,6 +28156,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/iscsiservers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26836,6 +28177,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/iscsiservers/disks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26856,6 +28198,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/timeSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26876,6 +28219,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/volumeContainers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26896,6 +28240,7 @@
       "newText": "'Microsoft.StorSimple/managers/devices/volumeContainers/volumes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26916,6 +28261,7 @@
       "newText": "'Microsoft.StorSimple/managers/extendedInformation@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26936,6 +28282,7 @@
       "newText": "'Microsoft.StorSimple/managers/storageAccountCredentials@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26956,6 +28303,7 @@
       "newText": "'Microsoft.StorSimple/managers/storageDomains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26976,6 +28324,7 @@
       "newText": "'Microsoft.Storage/storageAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -26996,6 +28345,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/blobServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27016,6 +28366,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/blobServices/containers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27036,6 +28387,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27056,6 +28408,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/encryptionScopes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27076,6 +28429,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/fileServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27096,6 +28450,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/fileServices/shares@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27116,6 +28471,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/inventoryPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27136,6 +28492,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/localUsers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27156,6 +28513,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/managementPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27176,6 +28534,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/objectReplicationPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27196,6 +28555,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27216,6 +28576,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/queueServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27236,6 +28597,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/queueServices/queues@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27256,6 +28618,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/tableServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27276,6 +28639,7 @@
       "newText": "'Microsoft.Storage/storageAccounts/tableServices/tables@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27296,6 +28660,7 @@
       "newText": "'Microsoft.StorageCache/caches@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27316,6 +28681,7 @@
       "newText": "'Microsoft.StorageCache/caches/storageTargets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27336,6 +28702,7 @@
       "newText": "'Microsoft.StoragePool/diskPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27356,6 +28723,7 @@
       "newText": "'Microsoft.StoragePool/diskPools/iscsiTargets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27376,6 +28744,7 @@
       "newText": "'Microsoft.StorageSync/storageSyncServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27396,6 +28765,7 @@
       "newText": "'Microsoft.StorageSync/storageSyncServices/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27416,6 +28786,7 @@
       "newText": "'Microsoft.StorageSync/storageSyncServices/registeredServers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27436,6 +28807,7 @@
       "newText": "'Microsoft.StorageSync/storageSyncServices/syncGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27456,6 +28828,7 @@
       "newText": "'Microsoft.StorageSync/storageSyncServices/syncGroups/cloudEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27476,6 +28849,7 @@
       "newText": "'Microsoft.StorageSync/storageSyncServices/syncGroups/serverEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27496,6 +28870,7 @@
       "newText": "'Microsoft.StreamAnalytics/clusters@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27516,6 +28891,7 @@
       "newText": "'Microsoft.StreamAnalytics/clusters/privateEndpoints@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27536,6 +28912,7 @@
       "newText": "'Microsoft.StreamAnalytics/streamingjobs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27556,6 +28933,7 @@
       "newText": "'Microsoft.StreamAnalytics/streamingjobs/functions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27576,6 +28954,7 @@
       "newText": "'Microsoft.StreamAnalytics/streamingjobs/inputs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27596,6 +28975,7 @@
       "newText": "'Microsoft.StreamAnalytics/streamingjobs/outputs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27616,6 +28996,7 @@
       "newText": "'Microsoft.StreamAnalytics/streamingjobs/transformations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27636,6 +29017,7 @@
       "newText": "'Microsoft.Subscription/aliases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27656,6 +29038,7 @@
       "newText": "'Microsoft.Subscription/policies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27676,6 +29059,7 @@
       "newText": "'Microsoft.Subscription/subscriptionDefinitions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27696,6 +29080,7 @@
       "newText": "'Microsoft.Support/supportTickets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27716,6 +29101,7 @@
       "newText": "'Microsoft.Support/supportTickets/communications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27736,6 +29122,7 @@
       "newText": "'Microsoft.Synapse/privateLinkHubs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27756,6 +29143,7 @@
       "newText": "'Microsoft.Synapse/workspaces@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27776,6 +29164,7 @@
       "newText": "'Microsoft.Synapse/workspaces/administrators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27796,6 +29185,7 @@
       "newText": "'Microsoft.Synapse/workspaces/auditingSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27816,6 +29206,7 @@
       "newText": "'Microsoft.Synapse/workspaces/azureADOnlyAuthentications@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27836,6 +29227,7 @@
       "newText": "'Microsoft.Synapse/workspaces/bigDataPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27856,6 +29248,7 @@
       "newText": "'Microsoft.Synapse/workspaces/dedicatedSQLminimalTlsSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27876,6 +29269,7 @@
       "newText": "'Microsoft.Synapse/workspaces/encryptionProtector@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27896,6 +29290,7 @@
       "newText": "'Microsoft.Synapse/workspaces/extendedAuditingSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27916,6 +29311,7 @@
       "newText": "'Microsoft.Synapse/workspaces/firewallRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27936,6 +29332,7 @@
       "newText": "'Microsoft.Synapse/workspaces/integrationRuntimes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27956,6 +29353,7 @@
       "newText": "'Microsoft.Synapse/workspaces/keys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27976,6 +29374,7 @@
       "newText": "'Microsoft.Synapse/workspaces/kustoPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -27996,6 +29395,7 @@
       "newText": "'Microsoft.Synapse/workspaces/kustoPools/attachedDatabaseConfigurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28016,6 +29416,7 @@
       "newText": "'Microsoft.Synapse/workspaces/kustoPools/databases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28036,6 +29437,7 @@
       "newText": "'Microsoft.Synapse/workspaces/kustoPools/databases/dataConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28056,6 +29458,7 @@
       "newText": "'Microsoft.Synapse/workspaces/kustoPools/databases/principalAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28076,6 +29479,7 @@
       "newText": "'Microsoft.Synapse/workspaces/kustoPools/principalAssignments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28096,6 +29500,7 @@
       "newText": "'Microsoft.Synapse/workspaces/managedIdentitySqlControlSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28116,6 +29521,7 @@
       "newText": "'Microsoft.Synapse/workspaces/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28136,6 +29542,7 @@
       "newText": "'Microsoft.Synapse/workspaces/securityAlertPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28156,6 +29563,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlAdministrators@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28176,6 +29584,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlDatabases@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28196,6 +29605,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28216,6 +29626,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/auditingSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28236,6 +29647,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/dataMaskingPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28256,6 +29668,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/dataMaskingPolicies/rules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28276,6 +29689,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/extendedAuditingSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28296,6 +29710,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/geoBackupPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28316,6 +29731,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/maintenancewindows@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28336,6 +29752,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/metadataSync@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28356,6 +29773,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/schemas/tables/columns/sensitivityLabels@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28376,6 +29794,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/securityAlertPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28396,6 +29815,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/transparentDataEncryption@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28416,6 +29836,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/vulnerabilityAssessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28436,6 +29857,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/vulnerabilityAssessments/rules/baselines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28456,6 +29878,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/workloadGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28476,6 +29899,7 @@
       "newText": "'Microsoft.Synapse/workspaces/sqlPools/workloadGroups/workloadClassifiers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28496,6 +29920,7 @@
       "newText": "'Microsoft.Synapse/workspaces/vulnerabilityAssessments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28516,6 +29941,7 @@
       "newText": "'Microsoft.TestBase/testBaseAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28536,6 +29962,7 @@
       "newText": "'Microsoft.TestBase/testBaseAccounts/customerEvents@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28556,6 +29983,7 @@
       "newText": "'Microsoft.TestBase/testBaseAccounts/packages@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28576,6 +30004,7 @@
       "newText": "'Microsoft.TestBase/testBaseAccounts/packages/favoriteProcesses@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28596,6 +30025,7 @@
       "newText": "'Microsoft.TimeSeriesInsights/environments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28616,6 +30046,7 @@
       "newText": "'Microsoft.TimeSeriesInsights/environments/accessPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28636,6 +30067,7 @@
       "newText": "'Microsoft.TimeSeriesInsights/environments/eventSources@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28656,6 +30088,7 @@
       "newText": "'Microsoft.TimeSeriesInsights/environments/referenceDataSets@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28676,6 +30109,7 @@
       "newText": "'Microsoft.VMwareCloudSimple/dedicatedCloudNodes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28696,6 +30130,7 @@
       "newText": "'Microsoft.VMwareCloudSimple/dedicatedCloudServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28716,6 +30151,7 @@
       "newText": "'Microsoft.VMwareCloudSimple/virtualMachines@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28736,6 +30172,7 @@
       "newText": "'Microsoft.VideoIndexer/accounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28756,6 +30193,7 @@
       "newText": "'Microsoft.VirtualMachineImages/imageTemplates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28776,6 +30214,7 @@
       "newText": "'Microsoft.Web/certificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28796,6 +30235,7 @@
       "newText": "'Microsoft.Web/connectionGateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28816,6 +30256,7 @@
       "newText": "'Microsoft.Web/connections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28836,6 +30277,7 @@
       "newText": "'Microsoft.Web/containerApps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28856,6 +30298,7 @@
       "newText": "'Microsoft.Web/csrs@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28876,6 +30319,7 @@
       "newText": "'Microsoft.Web/customApis@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28896,6 +30340,7 @@
       "newText": "'Microsoft.Web/hostingEnvironments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28916,6 +30361,7 @@
       "newText": "'Microsoft.Web/hostingEnvironments/configurations@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28936,6 +30382,7 @@
       "newText": "'Microsoft.Web/hostingEnvironments/multiRolePools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28956,6 +30403,7 @@
       "newText": "'Microsoft.Web/hostingEnvironments/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28976,6 +30424,7 @@
       "newText": "'Microsoft.Web/hostingEnvironments/workerPools@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -28996,6 +30445,7 @@
       "newText": "'Microsoft.Web/kubeEnvironments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29016,6 +30466,7 @@
       "newText": "'Microsoft.Web/managedHostingEnvironments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29036,6 +30487,7 @@
       "newText": "'Microsoft.Web/publishingUsers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29056,6 +30508,7 @@
       "newText": "'Microsoft.Web/serverfarms@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29076,6 +30529,7 @@
       "newText": "'Microsoft.Web/serverfarms/virtualNetworkConnections/gateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29096,6 +30550,7 @@
       "newText": "'Microsoft.Web/serverfarms/virtualNetworkConnections/routes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29116,6 +30571,7 @@
       "newText": "'Microsoft.Web/sites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29136,6 +30592,7 @@
       "newText": "'Microsoft.Web/sites/backups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29156,6 +30613,7 @@
       "newText": "'Microsoft.Web/sites/basicPublishingCredentialsPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29176,6 +30634,7 @@
       "newText": "'Microsoft.Web/sites/config@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29196,6 +30655,7 @@
       "newText": "'Microsoft.Web/sites/deployments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29216,6 +30676,7 @@
       "newText": "'Microsoft.Web/sites/domainOwnershipIdentifiers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29236,6 +30697,7 @@
       "newText": "'Microsoft.Web/sites/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29256,6 +30718,7 @@
       "newText": "'Microsoft.Web/sites/functions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29276,6 +30739,7 @@
       "newText": "'Microsoft.Web/sites/functions/keys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29296,6 +30760,7 @@
       "newText": "'Microsoft.Web/sites/hostNameBindings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29316,6 +30781,7 @@
       "newText": "'Microsoft.Web/sites/hybridConnectionNamespaces/relays@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29336,6 +30802,7 @@
       "newText": "'Microsoft.Web/sites/hybridconnection@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29356,6 +30823,7 @@
       "newText": "'Microsoft.Web/sites/instances/deployments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29376,6 +30844,7 @@
       "newText": "'Microsoft.Web/sites/instances/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29396,6 +30865,7 @@
       "newText": "'Microsoft.Web/sites/networkConfig@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29416,6 +30886,7 @@
       "newText": "'Microsoft.Web/sites/premieraddons@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29436,6 +30907,7 @@
       "newText": "'Microsoft.Web/sites/privateAccess@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29456,6 +30928,7 @@
       "newText": "'Microsoft.Web/sites/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29476,6 +30949,7 @@
       "newText": "'Microsoft.Web/sites/publicCertificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29496,6 +30970,7 @@
       "newText": "'Microsoft.Web/sites/siteextensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29516,6 +30991,7 @@
       "newText": "'Microsoft.Web/sites/slots@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29536,6 +31012,7 @@
       "newText": "'Microsoft.Web/sites/slots/backups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29556,6 +31033,7 @@
       "newText": "'Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29576,6 +31054,7 @@
       "newText": "'Microsoft.Web/sites/slots/config@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29596,6 +31075,7 @@
       "newText": "'Microsoft.Web/sites/slots/deployments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29616,6 +31096,7 @@
       "newText": "'Microsoft.Web/sites/slots/domainOwnershipIdentifiers@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29636,6 +31117,7 @@
       "newText": "'Microsoft.Web/sites/slots/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29656,6 +31138,7 @@
       "newText": "'Microsoft.Web/sites/slots/functions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29676,6 +31159,7 @@
       "newText": "'Microsoft.Web/sites/slots/functions/keys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29696,6 +31180,7 @@
       "newText": "'Microsoft.Web/sites/slots/hostNameBindings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29716,6 +31201,7 @@
       "newText": "'Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29736,6 +31222,7 @@
       "newText": "'Microsoft.Web/sites/slots/hybridconnection@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29756,6 +31243,7 @@
       "newText": "'Microsoft.Web/sites/slots/instances/deployments@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29776,6 +31264,7 @@
       "newText": "'Microsoft.Web/sites/slots/instances/extensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29796,6 +31285,7 @@
       "newText": "'Microsoft.Web/sites/slots/networkConfig@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29816,6 +31306,7 @@
       "newText": "'Microsoft.Web/sites/slots/premieraddons@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29836,6 +31327,7 @@
       "newText": "'Microsoft.Web/sites/slots/privateAccess@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29856,6 +31348,7 @@
       "newText": "'Microsoft.Web/sites/slots/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29876,6 +31369,7 @@
       "newText": "'Microsoft.Web/sites/slots/publicCertificates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29896,6 +31390,7 @@
       "newText": "'Microsoft.Web/sites/slots/siteextensions@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29916,6 +31411,7 @@
       "newText": "'Microsoft.Web/sites/slots/sourcecontrols@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29936,6 +31432,7 @@
       "newText": "'Microsoft.Web/sites/slots/virtualNetworkConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29956,6 +31453,7 @@
       "newText": "'Microsoft.Web/sites/slots/virtualNetworkConnections/gateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29976,6 +31474,7 @@
       "newText": "'Microsoft.Web/sites/sourcecontrols@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -29996,6 +31495,7 @@
       "newText": "'Microsoft.Web/sites/virtualNetworkConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30016,6 +31516,7 @@
       "newText": "'Microsoft.Web/sites/virtualNetworkConnections/gateways@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30036,6 +31537,7 @@
       "newText": "'Microsoft.Web/sourcecontrols@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30056,6 +31558,7 @@
       "newText": "'Microsoft.Web/staticSites@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30076,6 +31579,7 @@
       "newText": "'Microsoft.Web/staticSites/builds/config@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30096,6 +31600,7 @@
       "newText": "'Microsoft.Web/staticSites/builds/userProvidedFunctionApps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30116,6 +31621,7 @@
       "newText": "'Microsoft.Web/staticSites/config@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30136,6 +31642,7 @@
       "newText": "'Microsoft.Web/staticSites/customDomains@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30156,6 +31663,7 @@
       "newText": "'Microsoft.Web/staticSites/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30176,6 +31684,7 @@
       "newText": "'Microsoft.Web/staticSites/userProvidedFunctionApps@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30196,6 +31705,7 @@
       "newText": "'Microsoft.WindowsESU/multipleActivationKeys@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30216,6 +31726,7 @@
       "newText": "'Microsoft.WindowsIoT/deviceServices@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30236,6 +31747,7 @@
       "newText": "'Microsoft.WorkloadMonitor/notificationSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30256,6 +31768,7 @@
       "newText": "'microsoft.aadiam/azureADMetrics@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30276,6 +31789,7 @@
       "newText": "'microsoft.aadiam/diagnosticSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30296,6 +31810,7 @@
       "newText": "'microsoft.aadiam/privateLinkForAzureAd@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30316,6 +31831,7 @@
       "newText": "'microsoft.aadiam/privateLinkForAzureAd/privateEndpointConnections@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30336,6 +31852,7 @@
       "newText": "'microsoft.alertsManagement/smartDetectorAlertRules@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30356,6 +31873,7 @@
       "newText": "'microsoft.insights/actionGroups@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30376,6 +31894,7 @@
       "newText": "'microsoft.insights/activityLogAlerts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30396,6 +31915,7 @@
       "newText": "'microsoft.insights/components/analyticsItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30416,6 +31936,7 @@
       "newText": "'microsoft.insights/components/linkedStorageAccounts@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30436,6 +31957,7 @@
       "newText": "'microsoft.insights/components/myanalyticsItems@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30456,6 +31978,7 @@
       "newText": "'microsoft.insights/components/pricingPlans@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30476,6 +31999,7 @@
       "newText": "'microsoft.insights/diagnosticSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30496,6 +32020,7 @@
       "newText": "'microsoft.insights/guestDiagnosticSettings@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30516,6 +32041,7 @@
       "newText": "'microsoft.insights/guestDiagnosticSettingsAssociation@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30536,6 +32062,7 @@
       "newText": "'microsoft.insights/privateLinkScopes@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30556,6 +32083,7 @@
       "newText": "'microsoft.insights/workbooks@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30576,6 +32104,7 @@
       "newText": "'microsoft.insights/workbooktemplates@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30596,6 +32125,7 @@
       "newText": "'microsoft.visualstudio/account@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30616,6 +32146,7 @@
       "newText": "'microsoft.visualstudio/account/extension@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30636,6 +32167,7 @@
       "newText": "'microsoft.visualstudio/account/project@$0'"
     },
     "command": {
+      "title": "resource type completion",
       "command": "editor.action.triggerSuggest"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/azFunctions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/azFunctions.json
@@ -50,6 +50,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -70,6 +71,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -90,6 +92,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -110,6 +113,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -130,6 +134,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -150,6 +155,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -170,6 +176,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -190,6 +197,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -210,6 +218,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -230,6 +239,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -267,6 +277,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
@@ -44,6 +44,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -64,6 +65,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -81,6 +83,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -367,6 +370,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -387,6 +391,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -407,6 +412,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -427,6 +433,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -447,6 +454,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -481,6 +489,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -543,6 +552,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -563,6 +573,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -583,6 +594,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -603,6 +615,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -623,6 +636,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -643,6 +657,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -708,6 +723,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -756,6 +772,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -821,6 +838,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -897,6 +915,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -917,6 +936,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -993,6 +1013,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1027,6 +1048,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1061,6 +1083,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1095,6 +1118,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1227,6 +1251,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1247,6 +1272,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1267,6 +1293,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1287,6 +1314,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1335,6 +1363,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1355,6 +1384,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1375,6 +1405,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1437,6 +1468,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1457,6 +1489,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1477,6 +1510,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1497,6 +1531,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1741,6 +1776,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1789,6 +1825,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1823,6 +1860,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1843,6 +1881,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1863,6 +1902,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1883,6 +1923,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1903,6 +1944,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1923,6 +1965,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1957,6 +2000,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1977,6 +2021,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1997,6 +2042,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2017,6 +2063,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2065,6 +2112,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2085,6 +2133,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2105,6 +2154,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2122,6 +2172,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2170,6 +2221,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2221,6 +2273,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2297,6 +2350,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2317,6 +2371,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2351,6 +2406,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2385,6 +2441,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2405,6 +2462,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2425,6 +2483,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2445,6 +2504,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2465,6 +2525,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/sysFunctions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/sysFunctions.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -56,6 +58,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -76,6 +79,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -96,6 +100,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -116,6 +121,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -136,6 +142,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -156,6 +163,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -176,6 +184,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -196,6 +205,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -216,6 +226,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -236,6 +247,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -256,6 +268,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -276,6 +289,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -296,6 +310,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -316,6 +331,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -336,6 +352,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -356,6 +373,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -376,6 +394,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -396,6 +415,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -416,6 +436,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -436,6 +457,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -456,6 +478,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -476,6 +499,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -496,6 +520,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -516,6 +541,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -536,6 +562,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -556,6 +583,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -576,6 +604,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -596,6 +625,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -616,6 +646,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -653,6 +684,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -673,6 +705,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -693,6 +726,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -713,6 +747,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -733,6 +768,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -753,6 +789,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -773,6 +810,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -793,6 +831,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -813,6 +852,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -833,6 +873,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -853,6 +894,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -873,6 +915,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -893,6 +936,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -913,6 +957,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -933,6 +978,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -953,6 +999,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -973,6 +1020,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -993,6 +1041,7 @@
       "newText": "utcNow($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/childDotFileCompletions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/childDotFileCompletions.json
@@ -27,6 +27,7 @@
       "newText": "'./ChildModules/folder with space/$0'"
     },
     "command": {
+      "title": "module path completion",
       "command": "editor.action.triggerSuggest"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/childFileCompletions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/childFileCompletions.json
@@ -27,6 +27,7 @@
       "newText": "'ChildModules/folder with space/$0'"
     },
     "command": {
+      "title": "module path completion",
       "command": "editor.action.triggerSuggest"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/cwdDotFileCompletions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/cwdDotFileCompletions.json
@@ -13,6 +13,7 @@
       "newText": "'./ChildModules/$0'"
     },
     "command": {
+      "title": "module path completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30,6 +31,7 @@
       "newText": "'./Completions/$0'"
     },
     "command": {
+      "title": "module path completion",
       "command": "editor.action.triggerSuggest"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/cwdFileCompletions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/cwdFileCompletions.json
@@ -13,6 +13,7 @@
       "newText": "'ChildModules/$0'"
     },
     "command": {
+      "title": "module path completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -30,6 +31,7 @@
       "newText": "'Completions/$0'"
     },
     "command": {
+      "title": "module path completion",
       "command": "editor.action.triggerSuggest"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -78,6 +79,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -109,6 +111,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -129,6 +132,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -149,6 +153,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +174,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -189,6 +195,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -265,6 +272,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -341,6 +349,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -361,6 +370,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -423,6 +433,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -443,6 +454,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -463,6 +475,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -483,6 +496,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -503,6 +517,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -596,6 +611,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -630,6 +646,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -947,6 +964,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -967,6 +985,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -987,6 +1006,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1007,6 +1027,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1041,6 +1062,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1061,6 +1083,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1095,6 +1118,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1143,6 +1167,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1163,6 +1188,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1214,6 +1240,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1234,6 +1261,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1254,6 +1282,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1274,6 +1303,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1294,6 +1324,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1314,6 +1345,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1334,6 +1366,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1354,6 +1387,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1374,6 +1408,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2164,6 +2199,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2198,6 +2234,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2232,6 +2269,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2252,6 +2290,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2272,6 +2311,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2292,6 +2332,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2312,6 +2353,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2332,6 +2374,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2509,6 +2552,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2529,6 +2573,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2549,6 +2594,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2569,6 +2615,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2589,6 +2636,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2609,6 +2657,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2629,6 +2678,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2646,6 +2696,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2666,6 +2717,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2703,6 +2755,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2723,6 +2776,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2743,6 +2797,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2763,6 +2818,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2783,6 +2839,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2803,6 +2860,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2837,6 +2895,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2857,6 +2916,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2877,6 +2937,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -78,6 +79,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -109,6 +111,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -129,6 +132,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -149,6 +153,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +174,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -189,6 +195,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -265,6 +272,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -341,6 +349,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -361,6 +370,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -423,6 +433,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -443,6 +454,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -463,6 +475,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -483,6 +496,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -503,6 +517,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -596,6 +611,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -630,6 +646,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -947,6 +964,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -967,6 +985,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -987,6 +1006,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1007,6 +1027,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1041,6 +1062,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1061,6 +1083,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1095,6 +1118,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1143,6 +1167,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1163,6 +1188,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1214,6 +1240,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1234,6 +1261,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1254,6 +1282,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1274,6 +1303,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1294,6 +1324,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1314,6 +1345,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1334,6 +1366,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1354,6 +1387,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1374,6 +1408,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2164,6 +2199,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2198,6 +2234,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2232,6 +2269,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2252,6 +2290,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2272,6 +2311,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2292,6 +2332,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2312,6 +2353,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2332,6 +2374,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2509,6 +2552,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2529,6 +2573,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2549,6 +2594,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2569,6 +2615,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2589,6 +2636,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2609,6 +2657,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2629,6 +2678,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2646,6 +2696,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2666,6 +2717,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2703,6 +2755,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2723,6 +2776,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2743,6 +2797,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2763,6 +2818,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2783,6 +2839,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2803,6 +2860,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2837,6 +2895,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2857,6 +2916,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2877,6 +2937,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -50,6 +51,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -81,6 +83,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -101,6 +104,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -121,6 +125,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -141,6 +146,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -161,6 +167,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -181,6 +188,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -201,6 +209,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -221,6 +230,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -241,6 +251,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -261,6 +272,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -281,6 +293,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -301,6 +314,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -321,6 +335,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -358,6 +373,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -378,6 +394,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -415,6 +432,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -435,6 +453,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -491,6 +510,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -511,6 +531,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -545,6 +566,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -565,6 +587,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -585,6 +608,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -605,6 +629,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -625,6 +650,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -662,6 +688,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -682,6 +709,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -702,6 +730,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -722,6 +751,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -742,6 +772,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -762,6 +793,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -782,6 +814,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -802,6 +835,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -822,6 +856,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -842,6 +877,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -862,6 +898,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -882,6 +919,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -902,6 +940,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -922,6 +961,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -942,6 +982,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -962,6 +1003,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -982,6 +1024,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1002,6 +1045,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1022,6 +1066,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1042,6 +1087,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1062,6 +1108,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1082,6 +1129,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1102,6 +1150,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1122,6 +1171,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1139,6 +1189,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1159,6 +1210,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1196,6 +1248,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1230,6 +1283,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1250,6 +1304,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1270,6 +1325,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1290,6 +1346,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1310,6 +1367,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1330,6 +1388,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1350,6 +1409,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1370,6 +1430,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -67,6 +69,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -87,6 +90,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -107,6 +111,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -127,6 +132,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -147,6 +153,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -167,6 +174,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -187,6 +195,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -207,6 +216,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -227,6 +237,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -247,6 +258,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -267,6 +279,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -287,6 +300,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -307,6 +321,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -344,6 +359,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -364,6 +380,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -401,6 +418,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -435,6 +453,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -455,6 +474,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -475,6 +495,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -509,6 +530,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -529,6 +551,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -549,6 +572,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -569,6 +593,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -589,6 +614,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -626,6 +652,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -646,6 +673,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -666,6 +694,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -686,6 +715,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -706,6 +736,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -726,6 +757,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -746,6 +778,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -766,6 +799,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -786,6 +820,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -806,6 +841,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -826,6 +862,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -846,6 +883,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -866,6 +904,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -886,6 +925,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -906,6 +946,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -926,6 +967,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -946,6 +988,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -966,6 +1009,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -986,6 +1030,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1006,6 +1051,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1026,6 +1072,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1046,6 +1093,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1066,6 +1114,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1086,6 +1135,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1103,6 +1153,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1123,6 +1174,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1160,6 +1212,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1194,6 +1247,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1214,6 +1268,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1234,6 +1289,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1268,6 +1324,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1288,6 +1345,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1308,6 +1366,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1328,6 +1387,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1348,6 +1408,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/decorators.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/decorators.json
@@ -16,6 +16,7 @@
       "newText": "allowed($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "batchSize($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -56,6 +58,7 @@
       "newText": "description($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -76,6 +79,7 @@
       "newText": "maxLength($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -96,6 +100,7 @@
       "newText": "maxValue($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -116,6 +121,7 @@
       "newText": "metadata($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -136,6 +142,7 @@
       "newText": "minLength($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -156,6 +163,7 @@
       "newText": "minValue($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/decoratorsPlusNamespace.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/decoratorsPlusNamespace.json
@@ -16,6 +16,7 @@
       "newText": "allowed($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "batchSize($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -56,6 +58,7 @@
       "newText": "description($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -76,6 +79,7 @@
       "newText": "maxLength($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -96,6 +100,7 @@
       "newText": "maxValue($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -116,6 +121,7 @@
       "newText": "metadata($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -136,6 +142,7 @@
       "newText": "minLength($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -156,6 +163,7 @@
       "newText": "minValue($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -190,6 +198,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -67,6 +69,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -87,6 +90,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -107,6 +111,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -127,6 +132,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -147,6 +153,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -167,6 +174,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -187,6 +195,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -207,6 +216,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -227,6 +237,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -247,6 +258,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -267,6 +279,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -287,6 +300,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -307,6 +321,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -344,6 +359,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -364,6 +380,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -401,6 +418,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -421,6 +439,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -441,6 +460,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -461,6 +481,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -495,6 +516,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -515,6 +537,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -535,6 +558,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -555,6 +579,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -575,6 +600,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -612,6 +638,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -632,6 +659,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -652,6 +680,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -672,6 +701,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -692,6 +722,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -712,6 +743,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -732,6 +764,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -752,6 +785,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +806,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +827,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +848,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +869,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +890,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -872,6 +911,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -892,6 +932,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -912,6 +953,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -932,6 +974,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -952,6 +995,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -972,6 +1016,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -992,6 +1037,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1012,6 +1058,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1032,6 +1079,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1052,6 +1100,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1072,6 +1121,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1089,6 +1139,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1109,6 +1160,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1146,6 +1198,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1180,6 +1233,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1200,6 +1254,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1220,6 +1275,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1240,6 +1296,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1260,6 +1317,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1280,6 +1338,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1300,6 +1359,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1320,6 +1380,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/Completions/symbols.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -67,6 +69,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -87,6 +90,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -107,6 +111,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -127,6 +132,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -147,6 +153,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -167,6 +174,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -187,6 +195,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -207,6 +216,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -227,6 +237,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -247,6 +258,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -267,6 +279,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -287,6 +300,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -307,6 +321,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -344,6 +359,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -364,6 +380,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -401,6 +418,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -421,6 +439,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -441,6 +460,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -461,6 +481,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -495,6 +516,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -515,6 +537,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -535,6 +558,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -555,6 +579,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -575,6 +600,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -612,6 +638,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -632,6 +659,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -652,6 +680,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -672,6 +701,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -692,6 +722,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -712,6 +743,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -732,6 +764,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -752,6 +785,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +806,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +827,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +848,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +869,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +890,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -872,6 +911,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -892,6 +932,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -912,6 +953,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -932,6 +974,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -952,6 +995,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -972,6 +1016,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -992,6 +1037,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1012,6 +1058,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1032,6 +1079,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1052,6 +1100,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1072,6 +1121,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1089,6 +1139,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1109,6 +1160,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1146,6 +1198,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1180,6 +1233,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1200,6 +1254,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1220,6 +1275,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1240,6 +1296,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1260,6 +1317,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1280,6 +1338,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1300,6 +1359,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1320,6 +1380,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -44,6 +44,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -64,6 +65,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -81,6 +83,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -129,6 +132,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -149,6 +153,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +174,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -189,6 +195,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -223,6 +230,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -257,6 +265,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -277,6 +286,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -297,6 +307,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -317,6 +328,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -337,6 +349,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -357,6 +370,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -377,6 +391,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -442,6 +457,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -490,6 +506,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -541,6 +558,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -575,6 +593,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -595,6 +614,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -615,6 +635,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -663,6 +684,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -683,6 +705,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -703,6 +726,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -765,6 +789,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -785,6 +810,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -805,6 +831,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -825,6 +852,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -845,6 +873,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -865,6 +894,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -885,6 +915,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -947,6 +978,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -967,6 +999,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -987,6 +1020,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1007,6 +1041,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1240,6 +1275,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1372,6 +1408,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1392,6 +1429,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1412,6 +1450,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1432,6 +1471,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1452,6 +1492,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1472,6 +1513,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1492,6 +1534,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1557,6 +1600,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1619,6 +1663,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1639,6 +1684,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1659,6 +1705,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1679,6 +1726,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1699,6 +1747,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1719,6 +1768,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1736,6 +1786,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1756,6 +1807,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1793,6 +1845,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1813,6 +1866,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1833,6 +1887,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1895,6 +1950,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1929,6 +1985,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1949,6 +2006,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1969,6 +2027,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1989,6 +2048,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2009,6 +2069,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2029,6 +2090,7 @@
       "newText": "utcNow($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -50,6 +51,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -81,6 +83,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -129,6 +132,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -149,6 +153,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +174,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -189,6 +195,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -209,6 +216,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -243,6 +251,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -263,6 +272,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -283,6 +293,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -303,6 +314,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -323,6 +335,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -343,6 +356,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -363,6 +377,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -428,6 +443,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -476,6 +492,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -527,6 +544,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -575,6 +593,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -595,6 +614,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -615,6 +635,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -663,6 +684,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -683,6 +705,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -703,6 +726,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -765,6 +789,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -785,6 +810,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -805,6 +831,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -825,6 +852,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -845,6 +873,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -865,6 +894,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -885,6 +915,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -947,6 +978,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -967,6 +999,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -987,6 +1020,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1007,6 +1041,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1240,6 +1275,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1372,6 +1408,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1392,6 +1429,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1412,6 +1450,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1432,6 +1471,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1452,6 +1492,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1472,6 +1513,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1492,6 +1534,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1557,6 +1600,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1619,6 +1663,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1639,6 +1684,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1659,6 +1705,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1679,6 +1726,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1699,6 +1747,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1719,6 +1768,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1736,6 +1786,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1756,6 +1807,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1793,6 +1845,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1813,6 +1866,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1833,6 +1887,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1895,6 +1950,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1943,6 +1999,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1963,6 +2020,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1983,6 +2041,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2003,6 +2062,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2023,6 +2083,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2043,6 +2104,7 @@
       "newText": "utcNow($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/intParameterDecorators.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/intParameterDecorators.json
@@ -16,6 +16,7 @@
       "newText": "allowed($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "description($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -56,6 +58,7 @@
       "newText": "maxValue($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -76,6 +79,7 @@
       "newText": "metadata($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -96,6 +100,7 @@
       "newText": "minValue($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/intParameterDecoratorsPlusNamespace.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/intParameterDecoratorsPlusNamespace.json
@@ -16,6 +16,7 @@
       "newText": "allowed($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "description($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -56,6 +58,7 @@
       "newText": "maxValue($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -76,6 +79,7 @@
       "newText": "metadata($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -96,6 +100,7 @@
       "newText": "minValue($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -113,6 +118,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -50,6 +51,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -81,6 +83,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -129,6 +132,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -149,6 +153,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +174,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -189,6 +195,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -223,6 +230,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -257,6 +265,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -277,6 +286,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -297,6 +307,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -317,6 +328,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -337,6 +349,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -357,6 +370,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -377,6 +391,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -428,6 +443,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -476,6 +492,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -527,6 +544,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -561,6 +579,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -581,6 +600,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -601,6 +621,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -649,6 +670,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -669,6 +691,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -689,6 +712,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -751,6 +775,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -771,6 +796,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -791,6 +817,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -811,6 +838,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -831,6 +859,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -851,6 +880,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -871,6 +901,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -933,6 +964,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -953,6 +985,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -973,6 +1006,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -993,6 +1027,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1226,6 +1261,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1358,6 +1394,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1378,6 +1415,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1398,6 +1436,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1418,6 +1457,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1438,6 +1478,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1458,6 +1499,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1478,6 +1520,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1543,6 +1586,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1605,6 +1649,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1625,6 +1670,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1645,6 +1691,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1665,6 +1712,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1685,6 +1733,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1705,6 +1754,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1722,6 +1772,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1742,6 +1793,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1779,6 +1831,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1799,6 +1852,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1819,6 +1873,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1881,6 +1936,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1915,6 +1971,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1935,6 +1992,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1955,6 +2013,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1975,6 +2034,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1995,6 +2055,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2015,6 +2076,7 @@
       "newText": "utcNow($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -50,6 +51,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -81,6 +83,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -129,6 +132,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -149,6 +153,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +174,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -189,6 +195,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -223,6 +230,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -257,6 +265,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -277,6 +286,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -297,6 +307,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -317,6 +328,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -337,6 +349,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -357,6 +370,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -377,6 +391,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -442,6 +457,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -490,6 +506,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -541,6 +558,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -575,6 +593,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -595,6 +614,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -615,6 +635,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -663,6 +684,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -683,6 +705,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -703,6 +726,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -765,6 +789,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -785,6 +810,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -805,6 +831,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -825,6 +852,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -845,6 +873,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -865,6 +894,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -885,6 +915,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -947,6 +978,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -967,6 +999,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -987,6 +1020,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1007,6 +1041,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1226,6 +1261,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1358,6 +1394,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1378,6 +1415,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1398,6 +1436,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1418,6 +1457,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1438,6 +1478,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1458,6 +1499,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1478,6 +1520,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1543,6 +1586,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1605,6 +1649,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1625,6 +1670,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1645,6 +1691,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1665,6 +1712,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1685,6 +1733,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1705,6 +1754,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1722,6 +1772,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1742,6 +1793,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1779,6 +1831,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1799,6 +1852,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1819,6 +1873,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1881,6 +1936,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1915,6 +1971,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1935,6 +1992,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1955,6 +2013,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1975,6 +2034,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1995,6 +2055,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2015,6 +2076,7 @@
       "newText": "utcNow($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/stringParameterDecorators.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/stringParameterDecorators.json
@@ -16,6 +16,7 @@
       "newText": "allowed($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "description($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -56,6 +58,7 @@
       "newText": "maxLength($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -76,6 +79,7 @@
       "newText": "metadata($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -96,6 +100,7 @@
       "newText": "minLength($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/stringParameterDecoratorsPlusNamespace.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/stringParameterDecoratorsPlusNamespace.json
@@ -16,6 +16,7 @@
       "newText": "allowed($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -36,6 +37,7 @@
       "newText": "description($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -56,6 +58,7 @@
       "newText": "maxLength($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -76,6 +79,7 @@
       "newText": "metadata($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -96,6 +100,7 @@
       "newText": "minLength($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -130,6 +135,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +170,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -220,6 +222,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -359,6 +362,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -379,6 +383,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -399,6 +404,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -436,6 +442,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -473,6 +480,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -629,6 +637,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -649,6 +658,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -768,6 +778,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -788,6 +799,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -808,6 +820,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -828,6 +841,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -848,6 +862,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1813,6 +1828,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1847,6 +1863,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2289,6 +2306,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2309,6 +2327,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2399,6 +2418,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2419,6 +2439,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2470,6 +2491,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2490,6 +2512,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2524,6 +2547,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2883,6 +2907,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2903,6 +2928,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2923,6 +2949,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2943,6 +2970,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2963,6 +2991,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3011,6 +3040,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3031,6 +3061,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3164,6 +3195,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3184,6 +3216,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3204,6 +3237,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3224,6 +3258,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4380,6 +4415,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4400,6 +4436,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4471,6 +4508,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4491,6 +4529,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4528,6 +4567,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4548,6 +4588,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4568,6 +4609,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4588,6 +4630,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5283,6 +5326,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5303,6 +5347,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5357,6 +5402,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5377,6 +5423,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5414,6 +5461,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5434,6 +5482,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5454,6 +5503,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5471,6 +5521,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5505,6 +5556,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5559,6 +5611,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5579,6 +5632,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5599,6 +5653,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5636,6 +5691,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5673,6 +5729,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5693,6 +5750,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5713,6 +5771,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5733,6 +5792,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5753,6 +5813,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -155,6 +156,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -206,6 +208,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -345,6 +348,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -365,6 +369,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -385,6 +390,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -422,6 +428,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -442,6 +449,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -598,6 +606,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -618,6 +627,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -737,6 +747,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -757,6 +768,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -777,6 +789,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -797,6 +810,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -817,6 +831,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1782,6 +1797,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1816,6 +1832,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2258,6 +2275,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2292,6 +2310,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2346,6 +2365,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2366,6 +2386,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2434,6 +2455,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2454,6 +2476,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2488,6 +2511,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2847,6 +2871,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2867,6 +2892,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2887,6 +2913,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2907,6 +2934,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2927,6 +2955,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2975,6 +3004,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2995,6 +3025,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3128,6 +3159,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3148,6 +3180,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3168,6 +3201,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3188,6 +3222,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4344,6 +4379,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4364,6 +4400,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4435,6 +4472,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4455,6 +4493,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4492,6 +4531,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4512,6 +4552,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4532,6 +4573,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4552,6 +4594,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5247,6 +5290,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5267,6 +5311,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5321,6 +5366,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5341,6 +5387,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5378,6 +5425,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5398,6 +5446,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5418,6 +5467,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5435,6 +5485,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5469,6 +5520,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5523,6 +5575,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5543,6 +5596,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5563,6 +5617,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5600,6 +5655,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5651,6 +5707,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5671,6 +5728,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5691,6 +5749,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5711,6 +5770,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5731,6 +5791,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -58,6 +58,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -197,6 +198,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -248,6 +250,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -387,6 +390,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -407,6 +411,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -427,6 +432,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -464,6 +470,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -501,6 +508,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -657,6 +665,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -677,6 +686,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -796,6 +806,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -816,6 +827,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -836,6 +848,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -856,6 +869,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -876,6 +890,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1841,6 +1856,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1875,6 +1891,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2317,6 +2334,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2337,6 +2355,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2391,6 +2410,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2411,6 +2431,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2462,6 +2483,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2482,6 +2504,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2516,6 +2539,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2875,6 +2899,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2895,6 +2920,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2915,6 +2941,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2935,6 +2962,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2955,6 +2983,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3003,6 +3032,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3023,6 +3053,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3156,6 +3187,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3176,6 +3208,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3196,6 +3229,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3216,6 +3250,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4372,6 +4407,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4392,6 +4428,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4463,6 +4500,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4483,6 +4521,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4520,6 +4559,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4540,6 +4580,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4560,6 +4601,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4580,6 +4622,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5275,6 +5318,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5295,6 +5339,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5349,6 +5394,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5369,6 +5415,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5406,6 +5453,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5426,6 +5474,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5446,6 +5495,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5463,6 +5513,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5497,6 +5548,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5551,6 +5603,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5571,6 +5624,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5591,6 +5645,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5628,6 +5683,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5665,6 +5721,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5685,6 +5742,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5705,6 +5763,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5725,6 +5784,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5745,6 +5805,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -286,6 +286,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -425,6 +426,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -476,6 +478,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -615,6 +618,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -635,6 +639,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -655,6 +660,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -692,6 +698,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -729,6 +736,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -885,6 +893,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -905,6 +914,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1024,6 +1034,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1044,6 +1055,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1064,6 +1076,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1084,6 +1097,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1104,6 +1118,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2055,6 +2070,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2089,6 +2105,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2531,6 +2548,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2551,6 +2569,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2605,6 +2624,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2625,6 +2645,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2693,6 +2714,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2713,6 +2735,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2747,6 +2770,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3106,6 +3130,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3126,6 +3151,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3146,6 +3172,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3166,6 +3193,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3186,6 +3214,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3234,6 +3263,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3254,6 +3284,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3387,6 +3418,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3407,6 +3439,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3427,6 +3460,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3447,6 +3481,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4603,6 +4638,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4623,6 +4659,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4694,6 +4731,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4714,6 +4752,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4751,6 +4790,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4771,6 +4811,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4791,6 +4832,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4811,6 +4853,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5506,6 +5549,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5526,6 +5570,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5580,6 +5625,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5600,6 +5646,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5637,6 +5684,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5657,6 +5705,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5677,6 +5726,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5694,6 +5744,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5728,6 +5779,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5782,6 +5834,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5802,6 +5855,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5822,6 +5876,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5859,6 +5914,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5896,6 +5952,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5916,6 +5973,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5936,6 +5994,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5956,6 +6015,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5976,6 +6036,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -286,6 +286,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -425,6 +426,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -476,6 +478,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -615,6 +618,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -635,6 +639,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -655,6 +660,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -692,6 +698,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -729,6 +736,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -885,6 +893,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -905,6 +914,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1024,6 +1034,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1044,6 +1055,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1064,6 +1076,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1084,6 +1097,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1104,6 +1118,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2055,6 +2070,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2089,6 +2105,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2531,6 +2548,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2551,6 +2569,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2605,6 +2624,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2625,6 +2645,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2693,6 +2714,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2713,6 +2735,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2747,6 +2770,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3106,6 +3130,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3126,6 +3151,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3146,6 +3172,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3166,6 +3193,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3186,6 +3214,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3234,6 +3263,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3254,6 +3284,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3387,6 +3418,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3407,6 +3439,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3427,6 +3460,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3447,6 +3481,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4603,6 +4638,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4623,6 +4659,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4694,6 +4731,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4714,6 +4752,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4751,6 +4790,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4771,6 +4811,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4791,6 +4832,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4811,6 +4853,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5506,6 +5549,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5526,6 +5570,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5580,6 +5625,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5600,6 +5646,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5637,6 +5684,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5657,6 +5705,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5677,6 +5726,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5694,6 +5744,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5728,6 +5779,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5782,6 +5834,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5802,6 +5855,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5822,6 +5876,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5859,6 +5914,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5896,6 +5952,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5916,6 +5973,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5936,6 +5994,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5956,6 +6015,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5976,6 +6036,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -286,6 +286,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -425,6 +426,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -476,6 +478,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -615,6 +618,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -635,6 +639,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -655,6 +660,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -692,6 +698,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -729,6 +736,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -885,6 +893,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -905,6 +914,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1024,6 +1034,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1044,6 +1055,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1064,6 +1076,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1084,6 +1097,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1104,6 +1118,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2055,6 +2070,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2089,6 +2105,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2531,6 +2548,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2551,6 +2569,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2605,6 +2624,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2625,6 +2645,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2693,6 +2714,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2713,6 +2735,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2747,6 +2770,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3106,6 +3130,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3126,6 +3151,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3146,6 +3172,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3166,6 +3193,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3186,6 +3214,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3234,6 +3263,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3254,6 +3284,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3387,6 +3418,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3407,6 +3439,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3427,6 +3460,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3447,6 +3481,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4603,6 +4638,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4623,6 +4659,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4694,6 +4731,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4714,6 +4752,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4751,6 +4790,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4771,6 +4811,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4791,6 +4832,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4811,6 +4853,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5506,6 +5549,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5526,6 +5570,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5580,6 +5625,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5600,6 +5646,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5637,6 +5684,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5657,6 +5705,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5677,6 +5726,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5694,6 +5744,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5728,6 +5779,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5782,6 +5834,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5802,6 +5855,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5822,6 +5876,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5859,6 +5914,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5896,6 +5952,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5916,6 +5973,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5936,6 +5994,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5956,6 +6015,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5976,6 +6036,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -286,6 +286,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -425,6 +426,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -476,6 +478,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -615,6 +618,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -635,6 +639,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -655,6 +660,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -692,6 +698,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -729,6 +736,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -885,6 +893,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -905,6 +914,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1024,6 +1034,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1044,6 +1055,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1064,6 +1076,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1084,6 +1097,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1104,6 +1118,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2055,6 +2070,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2089,6 +2105,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2531,6 +2548,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2551,6 +2569,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2605,6 +2624,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2625,6 +2645,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2693,6 +2714,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2713,6 +2735,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2747,6 +2770,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3106,6 +3130,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3126,6 +3151,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3146,6 +3172,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3166,6 +3193,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3186,6 +3214,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3234,6 +3263,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3254,6 +3284,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3387,6 +3418,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3407,6 +3439,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3427,6 +3460,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3447,6 +3481,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4603,6 +4638,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4623,6 +4659,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4694,6 +4731,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4714,6 +4752,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4751,6 +4790,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4771,6 +4811,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4791,6 +4832,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4811,6 +4853,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5506,6 +5549,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5526,6 +5570,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5580,6 +5625,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5600,6 +5646,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5637,6 +5684,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5657,6 +5705,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5677,6 +5726,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5694,6 +5744,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5728,6 +5779,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5782,6 +5834,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5802,6 +5855,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5822,6 +5876,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5859,6 +5914,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5896,6 +5952,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5916,6 +5973,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5936,6 +5994,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5956,6 +6015,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5976,6 +6036,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -34,6 +34,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -173,6 +174,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -224,6 +226,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -363,6 +366,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -383,6 +387,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -403,6 +408,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -440,6 +446,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -477,6 +484,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -633,6 +641,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -653,6 +662,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +782,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +803,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +824,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +845,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +866,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1817,6 +1832,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1851,6 +1867,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2293,6 +2310,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2313,6 +2331,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2367,6 +2386,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2387,6 +2407,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2455,6 +2476,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2475,6 +2497,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2509,6 +2532,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2868,6 +2892,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2888,6 +2913,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2908,6 +2934,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2928,6 +2955,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2948,6 +2976,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2996,6 +3025,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3016,6 +3046,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3149,6 +3180,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3169,6 +3201,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3189,6 +3222,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3209,6 +3243,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4351,6 +4386,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4371,6 +4407,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4442,6 +4479,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4462,6 +4500,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4499,6 +4538,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4519,6 +4559,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4539,6 +4580,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4559,6 +4601,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5254,6 +5297,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5274,6 +5318,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5328,6 +5373,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5348,6 +5394,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5385,6 +5432,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5405,6 +5453,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5425,6 +5474,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5442,6 +5492,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5476,6 +5527,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5530,6 +5582,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5550,6 +5603,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5570,6 +5624,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5607,6 +5662,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5644,6 +5700,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5664,6 +5721,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5684,6 +5742,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5704,6 +5763,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5724,6 +5784,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -34,6 +34,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -173,6 +174,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -224,6 +226,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -363,6 +366,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -383,6 +387,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -403,6 +408,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -440,6 +446,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -477,6 +484,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -633,6 +641,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -653,6 +662,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +782,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +803,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +824,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +845,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +866,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1817,6 +1832,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1851,6 +1867,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2293,6 +2310,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2313,6 +2331,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2367,6 +2386,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2387,6 +2407,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2455,6 +2476,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2475,6 +2497,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2509,6 +2532,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2868,6 +2892,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2888,6 +2913,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2908,6 +2934,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2928,6 +2955,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2948,6 +2976,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2996,6 +3025,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3016,6 +3046,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3149,6 +3180,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3169,6 +3201,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3189,6 +3222,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3209,6 +3243,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4351,6 +4386,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4371,6 +4407,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4442,6 +4479,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4462,6 +4500,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4499,6 +4538,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4519,6 +4559,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4539,6 +4580,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4559,6 +4601,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5254,6 +5297,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5274,6 +5318,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5328,6 +5373,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5348,6 +5394,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5385,6 +5432,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5405,6 +5453,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5425,6 +5474,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5442,6 +5492,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5476,6 +5527,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5530,6 +5582,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5550,6 +5603,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5570,6 +5624,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5607,6 +5662,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5644,6 +5700,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5664,6 +5721,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5684,6 +5742,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5704,6 +5763,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5724,6 +5784,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -34,6 +34,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -173,6 +174,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -224,6 +226,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -363,6 +366,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -383,6 +387,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -403,6 +408,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -440,6 +446,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -477,6 +484,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -633,6 +641,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -653,6 +662,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +782,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +803,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +824,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +845,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +866,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1817,6 +1832,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1851,6 +1867,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2293,6 +2310,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2313,6 +2331,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2367,6 +2386,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2387,6 +2407,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2455,6 +2476,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2475,6 +2497,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2509,6 +2532,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2868,6 +2892,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2888,6 +2913,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2908,6 +2934,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2928,6 +2955,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2948,6 +2976,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2996,6 +3025,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3016,6 +3046,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3149,6 +3180,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3169,6 +3201,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3189,6 +3222,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3209,6 +3243,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4351,6 +4386,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4371,6 +4407,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4442,6 +4479,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4462,6 +4500,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4499,6 +4538,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4519,6 +4559,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4539,6 +4580,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4559,6 +4601,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5254,6 +5297,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5274,6 +5318,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5328,6 +5373,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5348,6 +5394,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5385,6 +5432,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5405,6 +5453,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5425,6 +5474,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5442,6 +5492,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5476,6 +5527,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5530,6 +5582,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5550,6 +5603,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5570,6 +5624,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5607,6 +5662,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5644,6 +5700,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5664,6 +5721,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5684,6 +5742,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5704,6 +5763,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5724,6 +5784,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -34,6 +34,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -173,6 +174,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -224,6 +226,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -363,6 +366,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -383,6 +387,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -403,6 +408,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -440,6 +446,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -477,6 +484,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -633,6 +641,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -653,6 +662,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +782,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +803,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +824,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +845,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +866,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1817,6 +1832,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1851,6 +1867,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2293,6 +2310,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2313,6 +2331,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2367,6 +2386,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2387,6 +2407,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2455,6 +2476,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2475,6 +2497,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2509,6 +2532,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2868,6 +2892,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2888,6 +2913,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2908,6 +2934,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2928,6 +2955,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2948,6 +2976,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2996,6 +3025,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3016,6 +3046,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3149,6 +3180,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3169,6 +3201,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3189,6 +3222,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3209,6 +3243,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4351,6 +4386,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4371,6 +4407,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4442,6 +4479,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4462,6 +4500,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4499,6 +4538,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4519,6 +4559,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4539,6 +4580,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4559,6 +4601,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5254,6 +5297,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5274,6 +5318,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5328,6 +5373,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5348,6 +5394,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5385,6 +5432,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5405,6 +5453,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5425,6 +5474,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5442,6 +5492,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5476,6 +5527,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5530,6 +5582,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5550,6 +5603,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5570,6 +5624,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5607,6 +5662,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5644,6 +5700,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5664,6 +5721,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5684,6 +5742,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5704,6 +5763,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5724,6 +5784,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -520,6 +520,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -659,6 +660,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -710,6 +712,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -849,6 +852,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -869,6 +873,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -889,6 +894,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -926,6 +932,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -963,6 +970,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1119,6 +1127,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1139,6 +1148,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1258,6 +1268,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1278,6 +1289,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1298,6 +1310,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1318,6 +1331,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1338,6 +1352,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2303,6 +2318,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2337,6 +2353,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2779,6 +2796,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2799,6 +2817,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2853,6 +2872,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2873,6 +2893,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2941,6 +2962,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2961,6 +2983,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2995,6 +3018,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3354,6 +3378,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3374,6 +3399,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3394,6 +3420,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3414,6 +3441,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3434,6 +3462,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3482,6 +3511,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3502,6 +3532,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3635,6 +3666,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3655,6 +3687,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3675,6 +3708,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3695,6 +3729,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4837,6 +4872,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4857,6 +4893,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4928,6 +4965,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4948,6 +4986,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4985,6 +5024,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5005,6 +5045,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5025,6 +5066,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5045,6 +5087,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5740,6 +5783,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5760,6 +5804,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5814,6 +5859,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5834,6 +5880,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5871,6 +5918,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5891,6 +5939,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5911,6 +5960,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5928,6 +5978,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5962,6 +6013,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6016,6 +6068,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6036,6 +6089,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6056,6 +6110,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6093,6 +6148,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6130,6 +6186,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6150,6 +6207,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6170,6 +6228,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6190,6 +6249,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6210,6 +6270,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -520,6 +520,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -659,6 +660,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -710,6 +712,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -849,6 +852,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -869,6 +873,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -889,6 +894,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -926,6 +932,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -963,6 +970,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1119,6 +1127,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1139,6 +1148,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1258,6 +1268,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1278,6 +1289,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1298,6 +1310,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1318,6 +1331,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1338,6 +1352,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2303,6 +2318,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2337,6 +2353,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2779,6 +2796,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2799,6 +2817,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2853,6 +2872,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2873,6 +2893,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2941,6 +2962,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2961,6 +2983,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2995,6 +3018,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3354,6 +3378,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3374,6 +3399,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3394,6 +3420,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3414,6 +3441,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3434,6 +3462,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3482,6 +3511,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3502,6 +3532,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3635,6 +3666,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3655,6 +3687,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3675,6 +3708,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3695,6 +3729,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4837,6 +4872,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4857,6 +4893,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4928,6 +4965,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4948,6 +4986,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4985,6 +5024,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5005,6 +5045,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5025,6 +5066,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5045,6 +5087,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5740,6 +5783,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5760,6 +5804,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5814,6 +5859,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5834,6 +5880,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5871,6 +5918,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5891,6 +5939,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5911,6 +5960,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5928,6 +5978,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5962,6 +6013,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6016,6 +6068,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6036,6 +6089,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6056,6 +6110,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6093,6 +6148,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6130,6 +6186,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6150,6 +6207,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6170,6 +6228,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6190,6 +6249,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6210,6 +6270,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -520,6 +520,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -659,6 +660,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -710,6 +712,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -849,6 +852,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -869,6 +873,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -889,6 +894,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -926,6 +932,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -963,6 +970,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1119,6 +1127,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1139,6 +1148,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1258,6 +1268,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1278,6 +1289,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1298,6 +1310,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1318,6 +1331,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1338,6 +1352,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2303,6 +2318,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2337,6 +2353,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2779,6 +2796,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2799,6 +2817,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2853,6 +2872,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2873,6 +2893,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2941,6 +2962,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2961,6 +2983,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2995,6 +3018,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3354,6 +3378,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3374,6 +3399,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3394,6 +3420,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3414,6 +3441,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3434,6 +3462,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3482,6 +3511,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3502,6 +3532,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3635,6 +3666,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3655,6 +3687,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3675,6 +3708,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3695,6 +3729,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4837,6 +4872,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4857,6 +4893,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4928,6 +4965,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4948,6 +4986,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4985,6 +5024,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5005,6 +5045,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5025,6 +5066,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5045,6 +5087,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5740,6 +5783,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5760,6 +5804,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5814,6 +5859,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5834,6 +5880,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5871,6 +5918,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5891,6 +5939,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5911,6 +5960,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5928,6 +5978,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5962,6 +6013,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6016,6 +6068,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6036,6 +6089,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6056,6 +6110,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6093,6 +6148,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6130,6 +6186,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6150,6 +6207,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6170,6 +6228,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6190,6 +6249,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6210,6 +6270,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -520,6 +520,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -659,6 +660,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -710,6 +712,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -849,6 +852,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -869,6 +873,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -889,6 +894,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -926,6 +932,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -963,6 +970,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1119,6 +1127,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1139,6 +1148,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1258,6 +1268,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1278,6 +1289,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1298,6 +1310,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1318,6 +1331,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1338,6 +1352,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2303,6 +2318,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2337,6 +2353,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2779,6 +2796,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2799,6 +2817,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2853,6 +2872,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2873,6 +2893,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2941,6 +2962,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2961,6 +2983,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2995,6 +3018,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3354,6 +3378,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3374,6 +3399,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3394,6 +3420,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3414,6 +3441,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3434,6 +3462,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3482,6 +3511,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3502,6 +3532,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3635,6 +3666,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3655,6 +3687,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3675,6 +3708,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3695,6 +3729,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4837,6 +4872,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4857,6 +4893,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4928,6 +4965,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4948,6 +4986,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4985,6 +5024,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5005,6 +5045,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5025,6 +5066,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5045,6 +5087,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5740,6 +5783,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5760,6 +5804,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5814,6 +5859,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5834,6 +5880,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5871,6 +5918,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5891,6 +5939,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5911,6 +5960,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5928,6 +5978,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5962,6 +6013,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6016,6 +6068,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6036,6 +6089,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6056,6 +6110,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6093,6 +6148,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6130,6 +6186,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6150,6 +6207,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6170,6 +6228,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6190,6 +6249,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -6210,6 +6270,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -44,6 +44,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -183,6 +184,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -234,6 +236,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -373,6 +376,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -393,6 +397,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -413,6 +418,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -450,6 +456,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -487,6 +494,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -643,6 +651,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -663,6 +672,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -782,6 +792,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -802,6 +813,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -822,6 +834,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -842,6 +855,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -862,6 +876,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1810,6 +1825,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1844,6 +1860,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2286,6 +2303,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2306,6 +2324,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2360,6 +2379,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2380,6 +2400,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2448,6 +2469,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2468,6 +2490,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2502,6 +2525,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2861,6 +2885,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2881,6 +2906,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2901,6 +2927,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2921,6 +2948,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2941,6 +2969,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2989,6 +3018,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3009,6 +3039,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3142,6 +3173,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3162,6 +3194,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3182,6 +3215,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3202,6 +3236,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4358,6 +4393,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4378,6 +4414,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4449,6 +4486,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4469,6 +4507,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4506,6 +4545,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4526,6 +4566,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4546,6 +4587,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4566,6 +4608,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5261,6 +5304,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5281,6 +5325,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5335,6 +5380,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5355,6 +5401,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5392,6 +5439,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5412,6 +5460,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5432,6 +5481,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5449,6 +5499,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5483,6 +5534,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5537,6 +5589,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5557,6 +5610,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5577,6 +5631,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5614,6 +5669,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5651,6 +5707,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5671,6 +5728,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5691,6 +5749,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5711,6 +5770,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5731,6 +5791,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -44,6 +44,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -183,6 +184,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -234,6 +236,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -373,6 +376,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -393,6 +397,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -413,6 +418,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -450,6 +456,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -487,6 +494,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -643,6 +651,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -663,6 +672,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -782,6 +792,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -802,6 +813,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -822,6 +834,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -842,6 +855,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -862,6 +876,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1810,6 +1825,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1844,6 +1860,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2286,6 +2303,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2306,6 +2324,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2360,6 +2379,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2380,6 +2400,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2448,6 +2469,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2468,6 +2490,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2502,6 +2525,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2861,6 +2885,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2881,6 +2906,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2901,6 +2927,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2921,6 +2948,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2941,6 +2969,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2989,6 +3018,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3009,6 +3039,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3142,6 +3173,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3162,6 +3194,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3182,6 +3215,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3202,6 +3236,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4358,6 +4393,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4378,6 +4414,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4449,6 +4486,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4469,6 +4507,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4506,6 +4545,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4526,6 +4566,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4546,6 +4587,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4566,6 +4608,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5261,6 +5304,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5281,6 +5325,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5335,6 +5380,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5355,6 +5401,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5392,6 +5439,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5412,6 +5460,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5432,6 +5481,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5449,6 +5499,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5483,6 +5534,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5537,6 +5589,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5571,6 +5624,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5591,6 +5645,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5628,6 +5683,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5665,6 +5721,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5685,6 +5742,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5705,6 +5763,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5725,6 +5784,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5745,6 +5805,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -44,6 +44,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -183,6 +184,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -234,6 +236,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -373,6 +376,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -393,6 +397,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -413,6 +418,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -450,6 +456,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -487,6 +494,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -643,6 +651,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -663,6 +672,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -782,6 +792,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -802,6 +813,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -822,6 +834,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -842,6 +855,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -862,6 +876,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1810,6 +1825,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1844,6 +1860,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2286,6 +2303,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2306,6 +2324,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2360,6 +2379,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2380,6 +2400,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2448,6 +2469,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2468,6 +2490,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2502,6 +2525,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2861,6 +2885,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2881,6 +2906,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2901,6 +2927,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2921,6 +2948,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2941,6 +2969,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2989,6 +3018,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3009,6 +3039,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3142,6 +3173,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3162,6 +3194,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3182,6 +3215,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3202,6 +3236,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4358,6 +4393,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4378,6 +4414,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4449,6 +4486,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4469,6 +4507,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4506,6 +4545,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4526,6 +4566,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4546,6 +4587,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4566,6 +4608,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5261,6 +5304,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5281,6 +5325,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5335,6 +5380,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5355,6 +5401,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5392,6 +5439,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5412,6 +5460,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5432,6 +5481,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5449,6 +5499,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5483,6 +5534,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5537,6 +5589,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5571,6 +5624,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5591,6 +5645,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5628,6 +5683,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5665,6 +5721,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5685,6 +5742,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5705,6 +5763,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5725,6 +5784,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5745,6 +5805,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -44,6 +44,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -183,6 +184,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -234,6 +236,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -373,6 +376,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -393,6 +397,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -413,6 +418,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -450,6 +456,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -487,6 +494,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -643,6 +651,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -663,6 +672,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -782,6 +792,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -802,6 +813,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -822,6 +834,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -842,6 +855,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -862,6 +876,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1810,6 +1825,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1844,6 +1860,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2286,6 +2303,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2306,6 +2324,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2360,6 +2379,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2380,6 +2400,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2448,6 +2469,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2468,6 +2490,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2502,6 +2525,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2861,6 +2885,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2881,6 +2906,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2901,6 +2927,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2921,6 +2948,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2941,6 +2969,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2989,6 +3018,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3009,6 +3039,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3142,6 +3173,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3162,6 +3194,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3182,6 +3215,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3202,6 +3236,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4358,6 +4393,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4378,6 +4414,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4449,6 +4486,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4469,6 +4507,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4506,6 +4545,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4526,6 +4566,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4546,6 +4587,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4566,6 +4608,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5261,6 +5304,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5281,6 +5325,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5335,6 +5380,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5355,6 +5401,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5392,6 +5439,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5412,6 +5460,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5432,6 +5481,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5449,6 +5499,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5483,6 +5534,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5537,6 +5589,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5557,6 +5610,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5577,6 +5631,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5614,6 +5669,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5651,6 +5707,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5671,6 +5728,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5691,6 +5749,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5711,6 +5770,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5731,6 +5791,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -34,6 +34,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -173,6 +174,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -224,6 +226,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -363,6 +366,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -383,6 +387,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -403,6 +408,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -440,6 +446,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -477,6 +484,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -633,6 +641,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -653,6 +662,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +782,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +803,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +824,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +845,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +866,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1803,6 +1818,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1837,6 +1853,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2279,6 +2296,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2299,6 +2317,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2353,6 +2372,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2373,6 +2393,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2441,6 +2462,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2461,6 +2483,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2495,6 +2518,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2854,6 +2878,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2874,6 +2899,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2894,6 +2920,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2914,6 +2941,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2934,6 +2962,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2982,6 +3011,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3002,6 +3032,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3135,6 +3166,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3155,6 +3187,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3175,6 +3208,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3195,6 +3229,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4351,6 +4386,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4371,6 +4407,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4442,6 +4479,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4462,6 +4500,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4499,6 +4538,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4519,6 +4559,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4539,6 +4580,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4559,6 +4601,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5254,6 +5297,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5274,6 +5318,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5328,6 +5373,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5348,6 +5394,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5385,6 +5432,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5405,6 +5453,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5425,6 +5474,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5442,6 +5492,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5476,6 +5527,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5530,6 +5582,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5550,6 +5603,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5570,6 +5624,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5607,6 +5662,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5644,6 +5700,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5664,6 +5721,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5684,6 +5742,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5704,6 +5763,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5724,6 +5784,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -34,6 +34,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -173,6 +174,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -224,6 +226,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -363,6 +366,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -383,6 +387,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -403,6 +408,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -440,6 +446,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -477,6 +484,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -633,6 +641,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -653,6 +662,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +782,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +803,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +824,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +845,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +866,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1803,6 +1818,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1837,6 +1853,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2279,6 +2296,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2299,6 +2317,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2353,6 +2372,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2373,6 +2393,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2441,6 +2462,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2461,6 +2483,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2495,6 +2518,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2854,6 +2878,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2874,6 +2899,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2894,6 +2920,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2914,6 +2941,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2934,6 +2962,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2982,6 +3011,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3002,6 +3032,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3135,6 +3166,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3155,6 +3187,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3175,6 +3208,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3195,6 +3229,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4351,6 +4386,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4371,6 +4407,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4442,6 +4479,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4462,6 +4500,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4499,6 +4538,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4519,6 +4559,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4539,6 +4580,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4559,6 +4601,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5254,6 +5297,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5274,6 +5318,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5328,6 +5373,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5348,6 +5394,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5385,6 +5432,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5405,6 +5453,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5425,6 +5474,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5442,6 +5492,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5476,6 +5527,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5530,6 +5582,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5550,6 +5603,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5570,6 +5624,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5607,6 +5662,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5644,6 +5700,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5664,6 +5721,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5684,6 +5742,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5704,6 +5763,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5724,6 +5784,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -34,6 +34,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -173,6 +174,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -224,6 +226,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -363,6 +366,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -383,6 +387,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -403,6 +408,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -440,6 +446,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -477,6 +484,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -633,6 +641,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -653,6 +662,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +782,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +803,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +824,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +845,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +866,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1803,6 +1818,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1837,6 +1853,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2279,6 +2296,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2299,6 +2317,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2353,6 +2372,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2373,6 +2393,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2441,6 +2462,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2461,6 +2483,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2495,6 +2518,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2854,6 +2878,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2874,6 +2899,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2894,6 +2920,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2914,6 +2941,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2934,6 +2962,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2982,6 +3011,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3002,6 +3032,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3135,6 +3166,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3155,6 +3187,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3175,6 +3208,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3195,6 +3229,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4351,6 +4386,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4371,6 +4407,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4442,6 +4479,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4462,6 +4500,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4499,6 +4538,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4519,6 +4559,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4539,6 +4580,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4559,6 +4601,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5254,6 +5297,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5274,6 +5318,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5328,6 +5373,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5348,6 +5394,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5385,6 +5432,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5405,6 +5453,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5425,6 +5474,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5442,6 +5492,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5476,6 +5527,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5530,6 +5582,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5550,6 +5603,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5570,6 +5624,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5607,6 +5662,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5644,6 +5700,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5664,6 +5721,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5684,6 +5742,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5704,6 +5763,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5724,6 +5784,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -34,6 +34,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -173,6 +174,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -224,6 +226,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -363,6 +366,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -383,6 +387,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -403,6 +408,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -440,6 +446,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -477,6 +484,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -633,6 +641,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -653,6 +662,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -772,6 +782,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -792,6 +803,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -812,6 +824,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -832,6 +845,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -852,6 +866,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1803,6 +1818,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1837,6 +1853,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2279,6 +2296,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2299,6 +2317,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2353,6 +2372,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2373,6 +2393,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2441,6 +2462,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2461,6 +2483,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2495,6 +2518,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2854,6 +2878,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2874,6 +2899,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2894,6 +2920,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2914,6 +2941,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2934,6 +2962,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2982,6 +3011,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3002,6 +3032,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3135,6 +3166,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3155,6 +3187,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3175,6 +3208,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3195,6 +3229,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4351,6 +4386,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4371,6 +4407,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4442,6 +4479,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4462,6 +4500,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4499,6 +4538,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4519,6 +4559,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4539,6 +4580,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4559,6 +4601,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5254,6 +5297,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5274,6 +5318,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5328,6 +5373,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5348,6 +5394,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5385,6 +5432,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5405,6 +5453,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5425,6 +5474,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5442,6 +5492,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5476,6 +5527,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5530,6 +5582,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5550,6 +5603,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5570,6 +5624,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5607,6 +5662,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5644,6 +5700,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5664,6 +5721,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5684,6 +5742,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5704,6 +5763,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5724,6 +5784,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -155,6 +156,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -206,6 +208,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -345,6 +348,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -365,6 +369,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -385,6 +390,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -422,6 +428,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -459,6 +466,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -615,6 +623,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -635,6 +644,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -754,6 +764,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -774,6 +785,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -794,6 +806,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -814,6 +827,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -834,6 +848,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1799,6 +1814,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1833,6 +1849,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2275,6 +2292,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2295,6 +2313,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2349,6 +2368,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2369,6 +2389,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2420,6 +2441,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2440,6 +2462,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2474,6 +2497,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2833,6 +2857,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2853,6 +2878,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2873,6 +2899,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2893,6 +2920,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2913,6 +2941,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2961,6 +2990,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2981,6 +3011,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3114,6 +3145,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3134,6 +3166,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3154,6 +3187,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3174,6 +3208,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4330,6 +4365,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4350,6 +4386,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4421,6 +4458,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4441,6 +4479,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4478,6 +4517,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4498,6 +4538,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4518,6 +4559,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4538,6 +4580,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5233,6 +5276,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5253,6 +5297,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5307,6 +5352,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5327,6 +5373,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5364,6 +5411,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5384,6 +5432,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5404,6 +5453,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5421,6 +5471,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5455,6 +5506,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5509,6 +5561,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5529,6 +5582,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5549,6 +5603,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5586,6 +5641,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5623,6 +5679,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5643,6 +5700,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5663,6 +5721,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5683,6 +5742,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5703,6 +5763,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -155,6 +156,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -206,6 +208,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -345,6 +348,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -365,6 +369,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -385,6 +390,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -422,6 +428,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -459,6 +466,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -615,6 +623,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -635,6 +644,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -754,6 +764,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -774,6 +785,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -794,6 +806,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -814,6 +827,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -834,6 +848,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1799,6 +1814,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1833,6 +1849,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2275,6 +2292,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2295,6 +2313,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2349,6 +2368,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2369,6 +2389,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2420,6 +2441,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2440,6 +2462,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2474,6 +2497,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2833,6 +2857,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2853,6 +2878,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2873,6 +2899,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2893,6 +2920,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2913,6 +2941,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2961,6 +2990,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2981,6 +3011,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3114,6 +3145,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3134,6 +3166,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3154,6 +3187,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3174,6 +3208,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4330,6 +4365,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4350,6 +4386,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4421,6 +4458,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4441,6 +4479,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4478,6 +4517,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4498,6 +4538,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4548,6 +4589,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4568,6 +4610,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5263,6 +5306,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5283,6 +5327,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5337,6 +5382,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5357,6 +5403,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5394,6 +5441,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5414,6 +5462,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5434,6 +5483,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5451,6 +5501,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5485,6 +5536,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5539,6 +5591,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5559,6 +5612,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5579,6 +5633,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5616,6 +5671,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5653,6 +5709,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5673,6 +5730,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5693,6 +5751,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5713,6 +5772,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5733,6 +5793,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -142,6 +142,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -281,6 +282,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -332,6 +334,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -471,6 +474,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -491,6 +495,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -511,6 +516,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -548,6 +554,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -585,6 +592,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -741,6 +749,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -761,6 +770,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -880,6 +890,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -900,6 +911,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -920,6 +932,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -940,6 +953,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -960,6 +974,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1925,6 +1940,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1959,6 +1975,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2401,6 +2418,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2421,6 +2439,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2475,6 +2494,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2495,6 +2515,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2563,6 +2584,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2583,6 +2605,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2617,6 +2640,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2976,6 +3000,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2996,6 +3021,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3016,6 +3042,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3036,6 +3063,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3056,6 +3084,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3104,6 +3133,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3124,6 +3154,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3257,6 +3288,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3277,6 +3309,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3297,6 +3330,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3317,6 +3351,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4473,6 +4508,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4493,6 +4529,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4547,6 +4584,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4567,6 +4605,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4604,6 +4643,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4624,6 +4664,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4644,6 +4685,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4664,6 +4706,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5359,6 +5402,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5379,6 +5423,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5433,6 +5478,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5453,6 +5499,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5490,6 +5537,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5510,6 +5558,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5530,6 +5579,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5547,6 +5597,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5581,6 +5632,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5635,6 +5687,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5655,6 +5708,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5675,6 +5729,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5712,6 +5767,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5749,6 +5805,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5769,6 +5826,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5789,6 +5847,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5809,6 +5868,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5829,6 +5889,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -16,6 +16,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -155,6 +156,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -206,6 +208,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -345,6 +348,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -365,6 +369,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -385,6 +390,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -422,6 +428,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -459,6 +466,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -615,6 +623,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -635,6 +644,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -754,6 +764,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -774,6 +785,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -794,6 +806,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -814,6 +827,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -834,6 +848,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1799,6 +1814,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1833,6 +1849,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2275,6 +2292,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2295,6 +2313,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2349,6 +2368,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2369,6 +2389,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2437,6 +2458,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2457,6 +2479,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2491,6 +2514,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2850,6 +2874,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2870,6 +2895,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2890,6 +2916,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2910,6 +2937,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2930,6 +2958,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2978,6 +3007,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2998,6 +3028,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3131,6 +3162,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3151,6 +3183,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3171,6 +3204,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3191,6 +3225,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4347,6 +4382,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4367,6 +4403,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4438,6 +4475,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4458,6 +4496,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4495,6 +4534,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4515,6 +4555,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4535,6 +4576,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4555,6 +4597,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5250,6 +5293,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5270,6 +5314,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5324,6 +5369,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5344,6 +5390,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5381,6 +5428,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5401,6 +5449,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5421,6 +5470,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5438,6 +5488,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5472,6 +5523,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5526,6 +5578,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5546,6 +5599,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5566,6 +5620,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5603,6 +5658,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5640,6 +5696,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5660,6 +5717,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5680,6 +5738,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5700,6 +5759,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5720,6 +5780,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +170,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -220,6 +222,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -359,6 +362,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -379,6 +383,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -399,6 +404,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -436,6 +442,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -473,6 +480,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -629,6 +637,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -649,6 +658,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -768,6 +778,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -788,6 +799,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -808,6 +820,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -828,6 +841,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -848,6 +862,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1813,6 +1828,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1847,6 +1863,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2289,6 +2306,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2309,6 +2327,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2363,6 +2382,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2383,6 +2403,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2451,6 +2472,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2471,6 +2493,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2505,6 +2528,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2864,6 +2888,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2884,6 +2909,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2904,6 +2930,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2924,6 +2951,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2944,6 +2972,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2992,6 +3021,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3012,6 +3042,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3145,6 +3176,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3165,6 +3197,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3185,6 +3218,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3205,6 +3239,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4361,6 +4396,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4381,6 +4417,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4435,6 +4472,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4455,6 +4493,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4492,6 +4531,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4512,6 +4552,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4532,6 +4573,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4552,6 +4594,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5247,6 +5290,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5267,6 +5311,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5321,6 +5366,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5341,6 +5387,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5378,6 +5425,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5398,6 +5446,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5418,6 +5467,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5435,6 +5485,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5469,6 +5520,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5523,6 +5575,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5543,6 +5596,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5563,6 +5617,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5600,6 +5655,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5637,6 +5693,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5657,6 +5714,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5677,6 +5735,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5697,6 +5756,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5717,6 +5777,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +170,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -220,6 +222,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -359,6 +362,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -379,6 +383,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -399,6 +404,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -436,6 +442,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -473,6 +480,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -629,6 +637,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -649,6 +658,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -768,6 +778,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -788,6 +799,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -808,6 +820,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -828,6 +841,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -848,6 +862,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1813,6 +1828,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1847,6 +1863,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2289,6 +2306,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2309,6 +2327,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2363,6 +2382,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2383,6 +2403,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2451,6 +2472,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2471,6 +2493,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2505,6 +2528,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2864,6 +2888,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2884,6 +2909,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2904,6 +2930,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2924,6 +2951,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2944,6 +2972,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2992,6 +3021,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3012,6 +3042,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3145,6 +3176,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3165,6 +3197,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3185,6 +3218,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3205,6 +3239,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4361,6 +4396,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4381,6 +4417,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4435,6 +4472,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4455,6 +4493,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4492,6 +4531,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4512,6 +4552,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4532,6 +4573,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4552,6 +4594,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5247,6 +5290,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5267,6 +5311,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5321,6 +5366,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5341,6 +5387,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5378,6 +5425,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5398,6 +5446,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5418,6 +5467,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5435,6 +5485,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5469,6 +5520,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5523,6 +5575,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5543,6 +5596,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5563,6 +5617,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5600,6 +5655,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5637,6 +5693,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5657,6 +5714,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5677,6 +5735,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5697,6 +5756,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5717,6 +5777,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +170,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -220,6 +222,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -359,6 +362,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -379,6 +383,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -399,6 +404,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -436,6 +442,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -473,6 +480,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -629,6 +637,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -649,6 +658,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -768,6 +778,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -788,6 +799,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -808,6 +820,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -828,6 +841,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -848,6 +862,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1813,6 +1828,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1847,6 +1863,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2289,6 +2306,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2309,6 +2327,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2363,6 +2382,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2383,6 +2403,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2451,6 +2472,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2471,6 +2493,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2505,6 +2528,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2864,6 +2888,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2884,6 +2909,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2904,6 +2930,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2924,6 +2951,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2944,6 +2972,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2992,6 +3021,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3012,6 +3042,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3145,6 +3176,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3165,6 +3197,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3185,6 +3218,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3205,6 +3239,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4361,6 +4396,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4381,6 +4417,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4452,6 +4489,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4472,6 +4510,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4509,6 +4548,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4529,6 +4569,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4549,6 +4590,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4569,6 +4611,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5278,6 +5321,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5298,6 +5342,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5352,6 +5397,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5386,6 +5432,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5423,6 +5470,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5443,6 +5491,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5463,6 +5512,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5480,6 +5530,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5514,6 +5565,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5568,6 +5620,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5588,6 +5641,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5608,6 +5662,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5645,6 +5700,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5682,6 +5738,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5702,6 +5759,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5722,6 +5780,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5742,6 +5801,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5762,6 +5822,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +170,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -220,6 +222,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -359,6 +362,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -379,6 +383,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -399,6 +404,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -436,6 +442,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -473,6 +480,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -629,6 +637,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -649,6 +658,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -768,6 +778,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -788,6 +799,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -808,6 +820,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -828,6 +841,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -848,6 +862,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1813,6 +1828,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1847,6 +1863,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2289,6 +2306,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2309,6 +2327,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2399,6 +2418,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2419,6 +2439,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2487,6 +2508,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2507,6 +2529,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2541,6 +2564,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2914,6 +2938,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2934,6 +2959,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2954,6 +2980,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2974,6 +3001,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2994,6 +3022,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3042,6 +3071,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3062,6 +3092,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3195,6 +3226,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3215,6 +3247,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3235,6 +3268,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3255,6 +3289,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4411,6 +4446,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4431,6 +4467,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4502,6 +4539,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4522,6 +4560,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4559,6 +4598,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4579,6 +4619,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4599,6 +4640,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4619,6 +4661,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5314,6 +5357,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5334,6 +5378,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5388,6 +5433,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5408,6 +5454,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5445,6 +5492,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5465,6 +5513,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5485,6 +5534,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5502,6 +5552,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5536,6 +5587,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5590,6 +5642,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5610,6 +5663,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5630,6 +5684,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5667,6 +5722,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5704,6 +5760,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5724,6 +5781,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5744,6 +5802,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5764,6 +5823,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5784,6 +5844,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +170,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -220,6 +222,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -359,6 +362,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -379,6 +383,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -399,6 +404,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -436,6 +442,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -473,6 +480,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -629,6 +637,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -649,6 +658,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -768,6 +778,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -788,6 +799,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -808,6 +820,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -828,6 +841,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -848,6 +862,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1813,6 +1828,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1847,6 +1863,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2289,6 +2306,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2309,6 +2327,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2363,6 +2382,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2383,6 +2403,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2451,6 +2472,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2471,6 +2493,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2505,6 +2528,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2878,6 +2902,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2898,6 +2923,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2918,6 +2944,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2938,6 +2965,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2958,6 +2986,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3006,6 +3035,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3026,6 +3056,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3159,6 +3190,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3179,6 +3211,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3199,6 +3232,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3219,6 +3253,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4375,6 +4410,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4395,6 +4431,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4466,6 +4503,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4486,6 +4524,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4523,6 +4562,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4543,6 +4583,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4563,6 +4604,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4583,6 +4625,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5278,6 +5321,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5298,6 +5342,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5352,6 +5397,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5372,6 +5418,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5409,6 +5456,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5429,6 +5477,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5449,6 +5498,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5466,6 +5516,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5500,6 +5551,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5554,6 +5606,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5574,6 +5627,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5594,6 +5648,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5631,6 +5686,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5668,6 +5724,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5688,6 +5745,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5708,6 +5766,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5728,6 +5787,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5748,6 +5808,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -30,6 +30,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -169,6 +170,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -220,6 +222,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -359,6 +362,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -379,6 +383,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -399,6 +404,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -436,6 +442,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -473,6 +480,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -629,6 +637,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -649,6 +658,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -768,6 +778,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -788,6 +799,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -808,6 +820,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -828,6 +841,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -848,6 +862,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1813,6 +1828,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1847,6 +1863,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2289,6 +2306,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2309,6 +2327,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2363,6 +2382,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2383,6 +2403,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2451,6 +2472,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2471,6 +2493,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2505,6 +2528,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2864,6 +2888,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2884,6 +2909,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2904,6 +2930,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2924,6 +2951,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2944,6 +2972,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2992,6 +3021,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3012,6 +3042,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3145,6 +3176,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3165,6 +3197,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3185,6 +3218,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -3205,6 +3239,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4361,6 +4396,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4381,6 +4417,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4452,6 +4489,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4472,6 +4510,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4509,6 +4548,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4529,6 +4569,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4549,6 +4590,7 @@
       "newText": "resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -4569,6 +4611,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5278,6 +5321,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5298,6 +5342,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5352,6 +5397,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5372,6 +5418,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5409,6 +5456,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5429,6 +5477,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5449,6 +5498,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5466,6 +5516,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -5500,6 +5551,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5554,6 +5606,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5574,6 +5627,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5594,6 +5648,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5631,6 +5686,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5668,6 +5724,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5688,6 +5745,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5708,6 +5766,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5728,6 +5787,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -5748,6 +5808,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/description.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/description.json
@@ -16,6 +16,7 @@
       "newText": "description($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -44,6 +44,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -64,6 +65,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -81,6 +83,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -101,6 +104,7 @@
       "newText": "az.resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -163,6 +167,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -183,6 +188,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -203,6 +209,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -237,6 +244,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -257,6 +265,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -277,6 +286,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -297,6 +307,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -317,6 +328,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -337,6 +349,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -357,6 +370,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -377,6 +391,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -397,6 +412,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -448,6 +464,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -468,6 +485,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -519,6 +537,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -539,6 +558,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -573,6 +593,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -593,6 +614,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -627,6 +649,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -703,6 +726,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -723,6 +747,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -799,6 +824,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -819,6 +845,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -940,6 +967,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -960,6 +988,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -980,6 +1009,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1000,6 +1030,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1020,6 +1051,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1054,6 +1086,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1074,6 +1107,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1094,6 +1128,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1114,6 +1149,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1414,6 +1450,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1434,6 +1471,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1454,6 +1492,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1474,6 +1513,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1494,6 +1534,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1514,6 +1555,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1548,6 +1590,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1652,6 +1695,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1686,6 +1730,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1706,6 +1751,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1726,6 +1772,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1746,6 +1793,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1766,6 +1814,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1786,6 +1835,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1803,6 +1853,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1823,6 +1874,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1860,6 +1912,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1936,6 +1989,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1956,6 +2010,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1976,6 +2031,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1996,6 +2052,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2016,6 +2073,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2036,6 +2094,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2056,6 +2115,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2076,6 +2136,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
@@ -44,6 +44,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -64,6 +65,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -81,6 +83,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -101,6 +104,7 @@
       "newText": "az.resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -163,6 +167,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -183,6 +188,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -203,6 +209,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -237,6 +244,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -257,6 +265,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -277,6 +286,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -297,6 +307,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -317,6 +328,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -337,6 +349,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -357,6 +370,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -377,6 +391,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -397,6 +412,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -448,6 +464,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -468,6 +485,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -519,6 +537,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -539,6 +558,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -609,6 +629,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -629,6 +650,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -663,6 +685,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -739,6 +762,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -759,6 +783,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -835,6 +860,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -855,6 +881,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -976,6 +1003,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -996,6 +1024,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1016,6 +1045,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1036,6 +1066,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1056,6 +1087,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1090,6 +1122,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1110,6 +1143,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1130,6 +1164,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1150,6 +1185,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1450,6 +1486,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1470,6 +1507,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1490,6 +1528,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1510,6 +1549,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1530,6 +1570,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1550,6 +1591,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1584,6 +1626,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1688,6 +1731,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1722,6 +1766,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1742,6 +1787,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1762,6 +1808,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1782,6 +1829,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1802,6 +1850,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1822,6 +1871,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1839,6 +1889,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1859,6 +1910,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1896,6 +1948,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1972,6 +2025,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1992,6 +2046,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2012,6 +2067,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2032,6 +2088,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2052,6 +2109,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2072,6 +2130,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2092,6 +2151,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2112,6 +2172,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/sysAndDescription.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/sysAndDescription.json
@@ -16,6 +16,7 @@
       "newText": "description($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -33,6 +34,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   }

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -62,6 +62,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -82,6 +83,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -99,6 +101,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -119,6 +122,7 @@
       "newText": "az.resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -181,6 +185,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -201,6 +206,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -221,6 +227,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -255,6 +262,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -275,6 +283,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -295,6 +304,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -315,6 +325,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -335,6 +346,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -355,6 +367,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -375,6 +388,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -395,6 +409,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -415,6 +430,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -466,6 +482,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -486,6 +503,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -537,6 +555,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -557,6 +576,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -591,6 +611,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -611,6 +632,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -645,6 +667,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -721,6 +744,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -741,6 +765,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -817,6 +842,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -837,6 +863,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -958,6 +985,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -978,6 +1006,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -998,6 +1027,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1018,6 +1048,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1038,6 +1069,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1072,6 +1104,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1092,6 +1125,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1112,6 +1146,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1132,6 +1167,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1432,6 +1468,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1452,6 +1489,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1472,6 +1510,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1492,6 +1531,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1512,6 +1552,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1532,6 +1573,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1566,6 +1608,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1670,6 +1713,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1704,6 +1748,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1724,6 +1769,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1744,6 +1790,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1764,6 +1811,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1784,6 +1832,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1804,6 +1853,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1821,6 +1871,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -1841,6 +1892,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1878,6 +1930,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1954,6 +2007,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1974,6 +2028,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1994,6 +2049,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2014,6 +2070,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2034,6 +2091,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2054,6 +2112,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2074,6 +2133,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2094,6 +2154,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
@@ -114,6 +114,7 @@
       "newText": "any($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -148,6 +149,7 @@
       "newText": "array($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -277,6 +279,7 @@
       "newText": "az."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -297,6 +300,7 @@
       "newText": "az.resourceGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -317,6 +321,7 @@
       "newText": "base64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -337,6 +342,7 @@
       "newText": "base64ToJson($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -357,6 +363,7 @@
       "newText": "base64ToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -377,6 +384,7 @@
       "newText": "bool($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -439,6 +447,7 @@
       "newText": "coalesce($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -459,6 +468,7 @@
       "newText": "concat($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -479,6 +489,7 @@
       "newText": "contains($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -555,6 +566,7 @@
       "newText": "dataUri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -575,6 +587,7 @@
       "newText": "dataUriToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -595,6 +608,7 @@
       "newText": "dateTimeAdd($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -615,6 +629,7 @@
       "newText": "dateTimeFromEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -635,6 +650,7 @@
       "newText": "dateTimeToEpoch($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -714,6 +730,7 @@
       "newText": "empty($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -748,6 +765,7 @@
       "newText": "endsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -813,6 +831,7 @@
       "newText": "extensionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -833,6 +852,7 @@
       "newText": "first($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -889,6 +909,7 @@
       "newText": "format($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -979,6 +1000,7 @@
       "newText": "guid($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1041,6 +1063,7 @@
       "newText": "indexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1061,6 +1084,7 @@
       "newText": "int($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1165,6 +1189,7 @@
       "newText": "intersection($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1241,6 +1266,7 @@
       "newText": "items($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1261,6 +1287,7 @@
       "newText": "json($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1281,6 +1308,7 @@
       "newText": "last($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1301,6 +1329,7 @@
       "newText": "lastIndexOf($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1321,6 +1350,7 @@
       "newText": "length($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1369,6 +1399,7 @@
       "newText": "loadFileAsBase64($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1389,6 +1420,7 @@
       "newText": "loadTextContent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1437,6 +1469,7 @@
       "newText": "managementGroup($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1457,6 +1490,7 @@
       "newText": "managementGroupResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1477,6 +1511,7 @@
       "newText": "max($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1497,6 +1532,7 @@
       "newText": "min($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -1993,6 +2029,7 @@
       "newText": "padLeft($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2027,6 +2064,7 @@
       "newText": "pickZones($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2117,6 +2155,7 @@
       "newText": "providers($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2137,6 +2176,7 @@
       "newText": "range($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2157,6 +2197,7 @@
       "newText": "reference($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2177,6 +2218,7 @@
       "newText": "replace($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2239,6 +2281,7 @@
       "newText": "resourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2301,6 +2344,7 @@
       "newText": "skip($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2335,6 +2379,7 @@
       "newText": "split($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2355,6 +2400,7 @@
       "newText": "startsWith($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2375,6 +2421,7 @@
       "newText": "string($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2409,6 +2456,7 @@
       "newText": "subscription($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2429,6 +2477,7 @@
       "newText": "subscriptionResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2449,6 +2498,7 @@
       "newText": "substring($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2466,6 +2516,7 @@
       "newText": "sys."
     },
     "command": {
+      "title": "symbol completion",
       "command": "editor.action.triggerSuggest"
     }
   },
@@ -2486,6 +2537,7 @@
       "newText": "take($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2565,6 +2617,7 @@
       "newText": "tenantResourceId($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2585,6 +2638,7 @@
       "newText": "toLower($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2605,6 +2659,7 @@
       "newText": "toUpper($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2625,6 +2680,7 @@
       "newText": "trim($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2645,6 +2701,7 @@
       "newText": "union($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2665,6 +2722,7 @@
       "newText": "uniqueString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2713,6 +2771,7 @@
       "newText": "uri($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2733,6 +2792,7 @@
       "newText": "uriComponent($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },
@@ -2753,6 +2813,7 @@
       "newText": "uriComponentToString($0)"
     },
     "command": {
+      "title": "signature help",
       "command": "editor.action.triggerParameterHints"
     }
   },

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -372,7 +372,7 @@ namespace Bicep.LanguageServer.Completions
                         context.ReplacementRange,
                         CompletionItemKind.Folder,
                         CompletionPriority.Low)
-                    .WithCommand(new Command { Name = EditorCommands.RequestCompletions })
+                    .WithCommand(new Command { Name = EditorCommands.RequestCompletions, Title = "module path completion" })
                     .Build());
 
             return bicepFileItems.Concat(armTemplateFileItems).Concat(dirItems);
@@ -1196,7 +1196,7 @@ namespace Bicep.LanguageServer.Completions
                 return CompletionItemBuilder.Create(CompletionItemKind.Class, insertText)
                     .WithSnippetEdit(replacementRange, $"{insertText.Substring(0, insertText.Length - 1)}@$0'")
                     .WithDocumentation($"Type: `{resourceType.FormatType()}`{MarkdownNewLine}`")
-                    .WithCommand(new Command { Name = EditorCommands.RequestCompletions })
+                    .WithCommand(new Command { Name = EditorCommands.RequestCompletions, Title = "resource type completion" })
                     // 8 hex digits is probably overkill :)
                     .WithSortText(index.ToString("x8"))
                     .Build();
@@ -1304,7 +1304,7 @@ namespace Bicep.LanguageServer.Completions
                 if (hasParameters)
                 {
                     // if parameters may need to be specified, automatically request signature help
-                    completion.WithCommand(new Command { Name = EditorCommands.SignatureHelp });
+                    completion.WithCommand(new Command { Name = EditorCommands.SignatureHelp, Title = "signature help" });
                 }
 
                 ImmutableArray<FunctionOverload> overloads = function.Overloads;
@@ -1329,7 +1329,7 @@ namespace Bicep.LanguageServer.Completions
                 return completion
                     .WithDetail(insertText)
                     .WithPlainTextEdit(replacementRange, insertText + ".")
-                    .WithCommand(new Command { Name = EditorCommands.RequestCompletions })
+                    .WithCommand(new Command { Name = EditorCommands.RequestCompletions, Title = "symbol completion" })
                     .Build();
             }
 


### PR DESCRIPTION
This is a prerequisite for porting bicep language server to VS

Per lsp spec(https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#command) and VSLsp, title in command should not be null. We need to add title to commands so we can support the relevant features(completion and signature help) in VS as well.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6911)