### PR TITLE
Preserve literal elements in string union types

### DIFF
--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.symbols.bicep
@@ -308,7 +308,7 @@ var isTrue = sys.max(1, 2) == 3
 var isFalse = !isTrue
 //@[4:11) Variable isFalse. Type: bool. Declaration start char: 0, length: 21
 var someText = isTrue ? sys.concat('a', sys.concat('b', 'c')) : 'someText'
-//@[4:12) Variable someText. Type: string. Declaration start char: 0, length: 74
+//@[4:12) Variable someText. Type: 'someText' | string. Declaration start char: 0, length: 74
 
 // Bicep functions that cannot be converted into ARM functions
 var scopesWithoutArmRepresentation = {

--- a/src/Bicep.Core.UnitTests/TypeSystem/UnionTypeTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/UnionTypeTests.cs
@@ -108,6 +108,8 @@ namespace Bicep.Core.UnitTests.TypeSystem
         public void UnionsOfStringsAndStringLiteralTypesShouldNotDropLiterals()
         {
             TypeHelper.CreateTypeUnion(LanguageConstants.String, new StringLiteralType("hello"), new StringLiteralType("there")).Name.Should().Be("'hello' | 'there' | string");
+            
+            TypeHelper.CreateTypeUnion(LanguageConstants.String, new StringLiteralType("hello"), new StringLiteralType("there"), LanguageConstants.String).Name.Should().Be("'hello' | 'there' | string");
 
             TypeHelper.CreateTypeUnion(LanguageConstants.String, new StringLiteralType("hello"), LanguageConstants.Bool, new StringLiteralType("there")).Name.Should().Be("'hello' | 'there' | bool | string");
         }

--- a/src/Bicep.Core.UnitTests/TypeSystem/UnionTypeTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/UnionTypeTests.cs
@@ -105,11 +105,11 @@ namespace Bicep.Core.UnitTests.TypeSystem
         }
 
         [TestMethod]
-        public void UnionsOfStringsAndStringLiteralTypesShouldProduceStringType()
+        public void UnionsOfStringsAndStringLiteralTypesShouldNotDropLiterals()
         {
-            TypeHelper.CreateTypeUnion(LanguageConstants.String, new StringLiteralType("hello"), new StringLiteralType("there")).Should().BeSameAs(LanguageConstants.String);
+            TypeHelper.CreateTypeUnion(LanguageConstants.String, new StringLiteralType("hello"), new StringLiteralType("there")).Name.Should().Be("'hello' | 'there' | string");
 
-            TypeHelper.CreateTypeUnion(LanguageConstants.String, new StringLiteralType("hello"), LanguageConstants.Bool, new StringLiteralType("there")).Name.Should().Be("bool | string");
+            TypeHelper.CreateTypeUnion(LanguageConstants.String, new StringLiteralType("hello"), LanguageConstants.Bool, new StringLiteralType("there")).Name.Should().Be("'hello' | 'there' | bool | string");
         }
 
         [TestMethod]
@@ -132,4 +132,3 @@ namespace Bicep.Core.UnitTests.TypeSystem
         }
     }
 }
-

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -67,11 +67,6 @@ namespace Bicep.Core.TypeSystem
             }
 
             IEnumerable<ITypeReference> intermediateMembers = flattenedMembers;
-            if (flattenedMembers.Any(member => member.Type == LanguageConstants.String))
-            {
-                // the union has the base "string" type, so we can drop all string literal types from it
-                intermediateMembers = intermediateMembers.Where(member => member.Type is not StringLiteralType);
-            }
 
             if (flattenedMembers.Any(member => member.Type == LanguageConstants.Array))
             {


### PR DESCRIPTION
This PR removes an optimization in the type loader that cast union types with a mixture of string literals and `string` down to the base string type. The purpose of this change is to enable completions on extensible enums (which take the form of `'some' | 'literal' | 'values' | string`); type checking is unaffected, as `'some' | 'literal' | 'values' | string` and `string` have the same domain.

This is a companion to (but not dependent on) https://github.com/Azure/bicep-types-az/pull/828

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6933)