### PR TITLE
Added codegen for ternary operator in parent property.

### DIFF
--- a/src/Bicep.Core/Semantics/Metadata/DeclaredResourceMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/DeclaredResourceMetadata.cs
@@ -14,7 +14,8 @@ namespace Bicep.Core.Semantics.Metadata
         ResourceType Type,
         bool IsExistingResource,
         ResourceSymbol Symbol,
-        ResourceMetadataParent? Parent)
+        ResourceMetadataParent? Parent,
+        TernaryOperationSyntax? TernaryOperationSyntax)
         : ResourceMetadata(Type, IsExistingResource)
     {
         private readonly ImmutableDictionary<string, SyntaxBase> UniqueIdentifiers = GetUniqueIdentifiers(Type, Symbol);


### PR DESCRIPTION
Fixes #5461

### Current Behavior
Currently, in a Bicep file, a resource that has a `parent` property containing a ternary operator does not have codegen for it in the json ARM template.

Example resource in Bicep file:
```
resource container_ActorColdStorage 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2021-07-01-preview' = {
  parent: deployServerlessCosmosDb? PassDb: QPDB
  name: 'ActorColdStorage'
  properties: {
    resource: {
      id: 'ActorColdStorage'
      partitionKey: {
        paths: [
          '/Type'
        ]
        kind: 'Hash'
      }
      conflictResolutionPolicy: {
        mode: 'LastWriterWins'
        conflictResolutionPath: '/_ts'
      }
    }
  }
}
```

The codegen for the resource's name should look like this: 
```
{
      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
      "apiVersion": "2021-07-01-preview",
      "name": "[if(variables('deployServerlessCosmosDb'), format('{0}/{1}/{2}', 'cosmosdbname', 'PassDb', 'ActorColdStorage'), format('{0}/{1}/{2}', 'cosmosdbname', 'QPDB', 'ActorColdStorage'))]",
      "properties": {
        "resource": {
          "id": "ActorColdStorage",
          "partitionKey": {
            "paths": [
              "/Type"
            ],
            "kind": "Hash"
          },
          "conflictResolutionPolicy": {
            "mode": "LastWriterWins",
            "conflictResolutionPath": "/_ts"
          }
        }
      },
      "dependsOn": [
        "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', 'cosmosdbname', 'PassDb')]"
      ]
    }
```

This is because of two primary reasons:
1) An entry for the resource is not created in the ResourceMetadataCache because there is no logic to process the ternary operator, specifically the BooleanLiteralSyntax. https://github.com/Azure/bicep/blob/7d2b7818e0bd0432560f46713a8584dc21fa12bc/src/Bicep.Core/Semantics/Metadata/ResourceMetadataCache.cs#L58
2) There is no logic to create the `if(condition, format(trueExpression), format(falseExpression))` function


### The Fix
1) Added logic to evaluate the ConditionExpression of the ternary operator correctly.
2) Added logic to format the `if` FunctionExpression properly

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/6964)