### PR TITLE
Update walkthrough

### DIFF
--- a/src/vscode-bicep/media/walkthroughs/gettingStarted/2_Type_Params.md
+++ b/src/vscode-bicep/media/walkthroughs/gettingStarted/2_Type_Params.md
@@ -6,7 +6,7 @@ param location string = resourceGroup().location
 ```
 * Next, create a parameter named 'appPlanName':
 ```bicep
-param appPlanName string = 'myAppPlanName'
+param appPlanName string = 'myappplanname'
 ```
 
 These parameters will be used to fill in attributes in your resources.

--- a/src/vscode-bicep/media/walkthroughs/gettingStarted/2_Type_Params.md
+++ b/src/vscode-bicep/media/walkthroughs/gettingStarted/2_Type_Params.md
@@ -6,7 +6,7 @@ param location string = resourceGroup().location
 ```
 * Next, create a parameter named 'appPlanName':
 ```bicep
-param appPlanName string = 'myappplanname'
+param appPlanName string = '${uniqueString(resourceGroup().id)}plan'
 ```
 
 These parameters will be used to fill in attributes in your resources.

--- a/src/vscode-bicep/src/commands/gettingStarted/WalkthroughCopyToClipboardCommand.ts
+++ b/src/vscode-bicep/src/commands/gettingStarted/WalkthroughCopyToClipboardCommand.ts
@@ -7,7 +7,7 @@ import { Command } from "../types";
 
 const paramsCode =
   "param location string = resourceGroup().location\n" +
-  "param appPlanName string = 'myappplanname'\n" +
+  "param appPlanName string = '${uniqueString(resourceGroup().id)}plan'\n" +
   "\n";
 
 const resourcesCode = `

--- a/src/vscode-bicep/src/commands/gettingStarted/WalkthroughCopyToClipboardCommand.ts
+++ b/src/vscode-bicep/src/commands/gettingStarted/WalkthroughCopyToClipboardCommand.ts
@@ -7,7 +7,7 @@ import { Command } from "../types";
 
 const paramsCode =
   "param location string = resourceGroup().location\n" +
-  "param appPlanName string = 'myAppPlanName'\n" +
+  "param appPlanName string = 'myappplanname'\n" +
   "\n";
 
 const resourcesCode = `

--- a/src/vscode-bicep/src/commands/gettingStarted/WalkthroughCreateBicepFileCommand.ts
+++ b/src/vscode-bicep/src/commands/gettingStarted/WalkthroughCreateBicepFileCommand.ts
@@ -29,7 +29,7 @@ async function createAndOpenBicepFile(
   const folder: Uri =
     (workspace.workspaceFolders
       ? workspace.workspaceFolders[0].uri
-      : undefined) ?? Uri.file(os.tmpdir());
+      : undefined) ?? Uri.file(os.homedir());
   const uri: Uri | undefined = await window.showSaveDialog({
     title: "Save new Bicep file",
     defaultUri: Uri.joinPath(folder, "main"),


### PR DESCRIPTION
Fixes #6972
1) app name plan should be lower-cased and globally unique
2) use home dir instead of temp for creating new bicep files if no workspace open

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7004)