### PR TITLE
Added Bicep snippet for role assignment

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -2246,7 +2246,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: ${2:'name'}\n  properties: {\n    roleDefinitionId: ${3:'roleDefinitionId'}\n principalId: ${4:'principalId'}\n  principalType: ${5:'ServicePrincipal'|'Group'|'User'}\n }\n   }\n"
+      "newText": "resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: ${2:'name'}\n  properties: {\n    roleDefinitionId: ${3:'roleDefinitionId'}\n principalId: ${4:'principalId'}\n  principalType: {5:|'ServicePrincipal','Group','User'|}\n }\n   }\n"
     },
     "command": {
       "title": "top level snippet completion",

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -2232,6 +2232,36 @@
     }
   },
   {
+    "label": "res-role-assignment",
+    "kind": "snippet",
+    "detail": "Role Assignment",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: 'name'\n  properties: {\n    roleDefinitionId: 'roleDefinitionId'\n principalId: 'principalId'\n  principalType: 'ServicePrincipal'\n }\n   }\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-policyset-definition",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: ${2:'name'}\n  properties: {\n    roleDefinitionId: ${3:'roleDefinitionId'}\n principalId: ${4:'principalId'}\n  principalType: ${5:'ServicePrincipal'|'Group'|'User'}\n }\n   }\n"
+    },
+    "command": {
+      "title": "top level snippet completion",
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "snippet/toplevel",
+          "Properties": {
+            "name": "res-role-assignment"
+          }
+        }
+      ]
+    }
+  },
+  {
     "label": "res-recovery-service-vault",
     "kind": "snippet",
     "detail": "Recovery Service Vault",

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -2246,7 +2246,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: ${2:'name'}\n  properties: {\n    roleDefinitionId: ${3:'roleDefinitionId'}\n principalId: ${4:'principalId'}\n  principalType: {5:|'ServicePrincipal','Group','User'|}\n }\n   }\n"
+      "newText": "resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: ${2:'name'}\n  properties: {\n    roleDefinitionId: ${3:'roleDefinitionId'}\n principalId: ${4:'principalId'}\n  principalType: {5|'ServicePrincipal','Group','User'|}\n }\n   }\n"
     },
     "command": {
       "title": "top level snippet completion",

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -2232,36 +2232,6 @@
     }
   },
   {
-    "label": "res-role-assignment",
-    "kind": "snippet",
-    "detail": "Role Assignment",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\nresource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: 'name'\n  properties: {\n    roleDefinitionId: 'roleDefinitionId'\n principalId: 'principalId'\n  principalType: 'ServicePrincipal'\n }\n   }\n```"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_res-role-assignment",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: ${2:'name'}\n  properties: {\n    roleDefinitionId: ${3:'roleDefinitionId'}\n principalId: ${4:'principalId'}\n  principalType: {5|'ServicePrincipal','Group','User'|}\n }\n   }\n"
-    },
-    "command": {
-      "title": "top level snippet completion",
-      "command": "bicep.Telemetry",
-      "arguments": [
-        {
-          "EventName": "snippet/toplevel",
-          "Properties": {
-            "name": "res-role-assignment"
-          }
-        }
-      ]
-    }
-  },
-  {
     "label": "res-recovery-service-vault",
     "kind": "snippet",
     "detail": "Recovery Service Vault",
@@ -2346,6 +2316,36 @@
           "EventName": "snippet/toplevel",
           "Properties": {
             "name": "res-rg"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "label": "res-role-assignment",
+    "kind": "snippet",
+    "detail": "",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: 'name'\n  properties: {\n    roleDefinitionId: 'roleDefinitionId'\n    principalId: 'principalId'\n    principalType: 'ServicePrincipal'\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-role-assignment",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {\n  name: ${2:'name'}\n  properties: {\n    roleDefinitionId: ${3:'roleDefinitionId'}\n    principalId: ${4:'principalId'}\n    principalType: ${5|'ServicePrincipal','Group','User'|}\n  }\n}\n"
+    },
+    "command": {
+      "title": "top level snippet completion",
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "snippet/toplevel",
+          "Properties": {
+            "name": "res-role-assignment"
           }
         }
       ]

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -2241,7 +2241,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_res-policyset-definition",
+    "sortText": "2_res-role-assignment",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-role-assignment/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-role-assignment/main.bicep
@@ -1,0 +1,7 @@
+// $1 = roleAssignment
+// $2 = 'name'
+// $3 = 'roleDefinitionId'
+// $4 = 'principalId'
+// $5 = 'ServicePrincipal'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-role-assignment/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-role-assignment/main.combined.bicep
@@ -12,3 +12,5 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-prev
     principalType: 'ServicePrincipal'
   }
 }
+// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-role-assignment/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-role-assignment/main.combined.bicep
@@ -1,0 +1,14 @@
+// $1 = roleAssignment
+// $2 = 'name'
+// $3 = 'roleDefinitionId'
+// $4 = 'principalId'
+// $5 = 'ServicePrincipal'
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
+  name: 'name'
+  properties: {
+    roleDefinitionId: 'roleDefinitionId'
+    principalId: 'principalId'
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-role-assignment.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-role-assignment.bicep
@@ -1,0 +1,8 @@
+resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
+  name: /*${2:'name'}*/'name'
+  properties: {
+    roleDefinitionId: /*${3:'roleDefinitionId'}*/'roleDefinitionId'
+    principalId: /*${4:'principalId'}*/'principalId'
+    principalType: /*${5:|'ServicePrincipal','Group','User'|}*/'ServicePrincipal'
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-role-assignment.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-role-assignment.bicep
@@ -3,6 +3,6 @@ resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01
   properties: {
     roleDefinitionId: /*${3:'roleDefinitionId'}*/'roleDefinitionId'
     principalId: /*${4:'principalId'}*/'principalId'
-    principalType: /*${5:|'ServicePrincipal','Group','User'|}*/'ServicePrincipal'
+    principalType: /*${5|'ServicePrincipal','Group','User'|}*/'ServicePrincipal'
   }
 }

--- a/src/Bicep.LangServer/Snippets/Templates/res-role-assignment.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-role-assignment.bicep
@@ -1,4 +1,4 @@
-resource ${1:roleAssignment} 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
+resource /*${1:roleAssignment}*/roleAssignment 'Microsoft.Authorization/roleAssignments@2020-10-01-preview' = {
   name: /*${2:'name'}*/'name'
   properties: {
     roleDefinitionId: /*${3:'roleDefinitionId'}*/'roleDefinitionId'


### PR DESCRIPTION
Added the res-role-assignment snippet.

## Contributing a snippet

* [x] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```

### Question for the team

What is does the last item in the checklist mean? The tests ran without errors, but is there a way to test the snippet locally?