### PR TITLE
Bicep deploy - additional params support

### DIFF
--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -51,6 +51,9 @@ namespace Bicep.Core
         public const string ForKeyword = "for";
         public const string InKeyword = "in";
 
+        public const string arrayType = "array";
+        public const string objectType = "object";
+
         public const string TargetScopeTypeTenant = "tenant";
         public const string TargetScopeTypeManagementGroup = "managementGroup";
         public const string TargetScopeTypeSubscription = "subscription";
@@ -142,12 +145,12 @@ namespace Bicep.Core
         public static readonly TypeSymbol LooseString = new PrimitiveType(TypeNameString, TypeSymbolValidationFlags.AllowLooseStringAssignment);
         // SecureString should be regarded as equal to the 'string' type, but with different validation behavior
         public static readonly TypeSymbol SecureString = new PrimitiveType(TypeNameString, TypeSymbolValidationFlags.AllowLooseStringAssignment | TypeSymbolValidationFlags.IsSecure);
-        public static readonly TypeSymbol Object = new ObjectType("object", TypeSymbolValidationFlags.Default, Enumerable.Empty<TypeProperty>(), LanguageConstants.Any);
-        public static readonly TypeSymbol SecureObject = new ObjectType("object", TypeSymbolValidationFlags.Default | TypeSymbolValidationFlags.IsSecure, Enumerable.Empty<TypeProperty>(), LanguageConstants.Any);
+        public static readonly TypeSymbol Object = new ObjectType(objectType, TypeSymbolValidationFlags.Default, Enumerable.Empty<TypeProperty>(), LanguageConstants.Any);
+        public static readonly TypeSymbol SecureObject = new ObjectType(objectType, TypeSymbolValidationFlags.Default | TypeSymbolValidationFlags.IsSecure, Enumerable.Empty<TypeProperty>(), LanguageConstants.Any);
         public static readonly TypeSymbol Int = new PrimitiveType("int", TypeSymbolValidationFlags.Default);
         public static readonly TypeSymbol Bool = new PrimitiveType("bool", TypeSymbolValidationFlags.Default);
         public static readonly TypeSymbol Null = new PrimitiveType(NullKeyword, TypeSymbolValidationFlags.Default);
-        public static readonly TypeSymbol Array = new ArrayType("array");
+        public static readonly TypeSymbol Array = new ArrayType(arrayType);
         //Type for available loadTextContent encoding
 
         public static readonly ImmutableArray<(string name, Encoding encoding)> SupportedEncodings = new[]{

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -51,8 +51,8 @@ namespace Bicep.Core
         public const string ForKeyword = "for";
         public const string InKeyword = "in";
 
-        public const string arrayType = "array";
-        public const string objectType = "object";
+        public const string ArrayType = "array";
+        public const string ObjectType = "object";
 
         public const string TargetScopeTypeTenant = "tenant";
         public const string TargetScopeTypeManagementGroup = "managementGroup";
@@ -145,12 +145,12 @@ namespace Bicep.Core
         public static readonly TypeSymbol LooseString = new PrimitiveType(TypeNameString, TypeSymbolValidationFlags.AllowLooseStringAssignment);
         // SecureString should be regarded as equal to the 'string' type, but with different validation behavior
         public static readonly TypeSymbol SecureString = new PrimitiveType(TypeNameString, TypeSymbolValidationFlags.AllowLooseStringAssignment | TypeSymbolValidationFlags.IsSecure);
-        public static readonly TypeSymbol Object = new ObjectType(objectType, TypeSymbolValidationFlags.Default, Enumerable.Empty<TypeProperty>(), LanguageConstants.Any);
-        public static readonly TypeSymbol SecureObject = new ObjectType(objectType, TypeSymbolValidationFlags.Default | TypeSymbolValidationFlags.IsSecure, Enumerable.Empty<TypeProperty>(), LanguageConstants.Any);
+        public static readonly TypeSymbol Object = new ObjectType(ObjectType, TypeSymbolValidationFlags.Default, Enumerable.Empty<TypeProperty>(), LanguageConstants.Any);
+        public static readonly TypeSymbol SecureObject = new ObjectType(ObjectType, TypeSymbolValidationFlags.Default | TypeSymbolValidationFlags.IsSecure, Enumerable.Empty<TypeProperty>(), LanguageConstants.Any);
         public static readonly TypeSymbol Int = new PrimitiveType("int", TypeSymbolValidationFlags.Default);
         public static readonly TypeSymbol Bool = new PrimitiveType("bool", TypeSymbolValidationFlags.Default);
         public static readonly TypeSymbol Null = new PrimitiveType(NullKeyword, TypeSymbolValidationFlags.Default);
-        public static readonly TypeSymbol Array = new ArrayType(arrayType);
+        public static readonly TypeSymbol Array = new ArrayType(ArrayType);
         //Type for available loadTextContent encoding
 
         public static readonly ImmutableArray<(string name, Encoding encoding)> SupportedEncodings = new[]{

--- a/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.LanguageServer;
 using Bicep.LanguageServer.Deploy;
+using Bicep.LanguageServer.Handlers;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -52,6 +54,9 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 scope,
                 string.Empty,
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
                 new DeploymentOperationsCache());
@@ -83,6 +88,9 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 LanguageConstants.TargetScopeTypeSubscription,
                 location,
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
                 new DeploymentOperationsCache());
@@ -113,6 +121,9 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 LanguageConstants.TargetScopeTypeManagementGroup,
                 location,
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
                 new DeploymentOperationsCache());
@@ -144,6 +155,9 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 LanguageConstants.TargetScopeTypeTenant,
                 string.Empty,
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
                 new DeploymentOperationsCache());
@@ -192,6 +206,9 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 scope,
                 location,
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 deployId,
                 new DeploymentOperationsCache());
@@ -226,22 +243,26 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeSubscription))
                 .Returns(deploymentCollection);
             var documentPath = "some_path";
+            var parametersFilePath = @"c:\parameter.json";
 
             var bicepDeployStartResponse = await DeploymentHelper.StartDeploymentAsync(
                 deploymentCollectionProvider.Object,
                 CreateMockArmClient(),
                 documentPath,
                 template,
-                @"c:\parameter.json",
+                parametersFilePath,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeSubscription,
                 "eastus",
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
                 new DeploymentOperationsCache());
 
-            var expectedDeploymentOutputMessage = string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, @"Could not find file");
+            var expectedDeploymentOutputMessage = string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, parametersFilePath, @"Could not find file");
 
             bicepDeployStartResponse.isSuccess.Should().BeFalse();
             bicepDeployStartResponse.outputMessage.Should().Contain(expectedDeploymentOutputMessage);
@@ -281,11 +302,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 LanguageConstants.TargetScopeTypeSubscription,
                 "eastus",
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
                 new DeploymentOperationsCache());
 
-            var expectedDeploymentOutputMessage = string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, @"'i' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0.");
+            var expectedDeploymentOutputMessage = string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, parametersFilePath, @"Unexpected character encountered while parsing value: i. Path '', line 0, position 0.");
 
             bicepDeployStartResponse.isSuccess.Should().BeFalse();
             bicepDeployStartResponse.outputMessage.Should().Be(expectedDeploymentOutputMessage);
@@ -323,6 +347,9 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "",
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
                 new DeploymentOperationsCache());
@@ -366,6 +393,9 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "",
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
                 new DeploymentOperationsCache());
@@ -417,6 +447,9 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "",
                 string.Empty,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
                 new DeploymentOperationsCache());
@@ -472,6 +505,9 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 LanguageConstants.TargetScopeTypeSubscription,
                 "eastus",
                 deployId,
+                string.Empty,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "deployment_name",
                 deploymentOperationsCache);

--- a/src/Bicep.LangServer.UnitTests/Deploy/DeploymentParametersHelperTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Deploy/DeploymentParametersHelperTests.cs
@@ -1,0 +1,489 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.LanguageServer.Deploy;
+using Bicep.LanguageServer.Handlers;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.LangServer.UnitTests.Deploy
+{
+    [TestClass]
+    public class DeploymentParametersHelperTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithEmptyBicepUpdatedDeploymentParameters_ShouldReturnParametersFileContentsAsIs()
+        {
+            var parametersFileContents = @"{
+  ""location"": {
+    ""value"": ""westus""
+  }
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty);
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
+
+            var result = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "parameters.json",
+                parametersFilePath,
+                ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>());
+
+            result.Should().BeEquivalentToIgnoringNewlines(parametersFileContents);
+        }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithNonEmptyBicepUpdatedDeploymentParameters_ShouldReturnUpdatedParametersFileContents()
+        {
+            var parametersFileContents = @"{
+  ""location"": {
+    ""value"": ""westus""
+  },
+  ""name"": {
+    ""value"": ""test""
+  }
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty);
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
+            var bicepUpdatedDeploymentParameter1 = new BicepUpdatedDeploymentParameter("location", "eastus", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameter2 = new BicepUpdatedDeploymentParameter("sku", "testSku", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameters =
+                new List<BicepUpdatedDeploymentParameter> { bicepUpdatedDeploymentParameter1, bicepUpdatedDeploymentParameter2 };
+
+            var result = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "parameters.json",
+                parametersFilePath,
+                ParametersFileUpdateOption.None,
+                bicepUpdatedDeploymentParameters);
+            var expected = @"{
+  ""sku"": {
+    ""value"": ""testSku""
+  },
+  ""location"": {
+    ""value"": ""westus""
+  },
+  ""name"": {
+    ""value"": ""test""
+  }
+}";
+
+            result.Should().BeEquivalentToIgnoringNewlines(expected);
+        }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithNonEmptyBicepUpdatedDeploymentParametersAndNoParametersFile_ShouldCreateParametersFile()
+        {
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty, testOutputPath);
+            var bicepUpdatedDeploymentParameter1 = new BicepUpdatedDeploymentParameter("location", "eastus", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameter2 = new BicepUpdatedDeploymentParameter("sku", "testSku", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameters =
+                new List<BicepUpdatedDeploymentParameter> { bicepUpdatedDeploymentParameter1, bicepUpdatedDeploymentParameter2 };
+
+            var result = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "input.parameters.json",
+                string.Empty,
+                ParametersFileUpdateOption.Create,
+                bicepUpdatedDeploymentParameters);
+            var expectedParametersFileContentsWrittenToDisk = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""sku"": {
+      ""value"": ""testSku""
+    },
+    ""location"": {
+      ""value"": ""eastus""
+    }
+  }
+}";
+            var expectedParametersFileContentsUsedInDeployment = @"{
+  ""sku"": {
+    ""value"": ""testSku""
+  },
+  ""location"": {
+    ""value"": ""eastus""
+  }
+}";
+
+
+            result.Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContentsUsedInDeployment);
+
+            var expectedParametersFilePath = Path.Combine(testOutputPath, "input.parameters.json");
+            File.Exists(expectedParametersFilePath).Should().BeTrue();
+            File.ReadAllText(expectedParametersFilePath).Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContentsWrittenToDisk);
+        }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithNonEmptyBicepUpdatedDeploymentParametersAndParametersFile_ShouldUpdateParametersFile()
+        {
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty, testOutputPath);
+            var parametersFileContents = @"{
+  ""location"": {
+    ""value"": ""eastus""
+  },
+  ""sku"": {
+    ""value"": ""testSku""
+  }
+}";
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "input.parameters.json", parametersFileContents, testOutputPath);
+            var bicepUpdatedDeploymentParameter1 = new BicepUpdatedDeploymentParameter("name", "test", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameter2 = new BicepUpdatedDeploymentParameter("id", "testId", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameters =
+                new List<BicepUpdatedDeploymentParameter> { bicepUpdatedDeploymentParameter1, bicepUpdatedDeploymentParameter2 };
+
+            var result = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "input.parameters.json",
+                parametersFilePath,
+                ParametersFileUpdateOption.Update,
+                bicepUpdatedDeploymentParameters);
+            var expectedParametersFileContents = @"{
+  ""id"": {
+    ""value"": ""testId""
+  },
+  ""name"": {
+    ""value"": ""test""
+  },
+  ""location"": {
+    ""value"": ""eastus""
+  },
+  ""sku"": {
+    ""value"": ""testSku""
+  }
+}";
+
+            result.Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContents);
+            File.ReadAllText(parametersFilePath).Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContents);
+        }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithInvalidParametersFile_ShouldThrowException()
+        {
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty, testOutputPath);
+            var parametersFileContents = @"{
+  ""location"": {
+    ""value"": ""eastus""
+  },
+  ""sku"": {
+    ""value"": ""testSku""";
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "input.parameters.json", parametersFileContents, testOutputPath);
+            var bicepUpdatedDeploymentParameter1 = new BicepUpdatedDeploymentParameter("name", "test", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameter2 = new BicepUpdatedDeploymentParameter("id", "testId", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameters =
+                new List<BicepUpdatedDeploymentParameter> { bicepUpdatedDeploymentParameter1, bicepUpdatedDeploymentParameter2 };
+
+            Action action = () => DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "input.parameters.json",
+                parametersFilePath,
+                ParametersFileUpdateOption.Update,
+                bicepUpdatedDeploymentParameters);
+
+            action.Should().Throw<Exception>();
+        }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithParametersOfTypeIntAndBool_ShouldDoAppropriateConversionAndUpdateParametersFile()
+        {
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty, testOutputPath);
+            var parametersFileContents = @"{
+  ""location"": {
+    ""value"": ""eastus""
+  }
+}";
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "input.parameters.json", parametersFileContents, testOutputPath);
+            var bicepUpdatedDeploymentParameter1 = new BicepUpdatedDeploymentParameter("id", "test", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameter2 = new BicepUpdatedDeploymentParameter("isSku", "false", false, ParameterType.Bool);
+            var bicepUpdatedDeploymentParameter3 = new BicepUpdatedDeploymentParameter("count", "2", false, ParameterType.Int);
+            var bicepUpdatedDeploymentParameters =
+                new List<BicepUpdatedDeploymentParameter> {  bicepUpdatedDeploymentParameter1, bicepUpdatedDeploymentParameter2, bicepUpdatedDeploymentParameter3 };
+
+            var result = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "input.parameters.json",
+                parametersFilePath,
+                ParametersFileUpdateOption.Update,
+                bicepUpdatedDeploymentParameters);
+            var expectedParametersFileContents = @"{
+  ""count"": {
+    ""value"": 2
+  },
+  ""isSku"": {
+    ""value"": false
+  },
+  ""id"": {
+    ""value"": ""test""
+  },
+  ""location"": {
+    ""value"": ""eastus""
+  }
+}";
+
+            result.Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContents);
+            File.ReadAllText(parametersFilePath).Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContents);
+        }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithBicepDeploymentParameterThatIsAlreadyInParametersFile_DoesNothing()
+        {
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty, testOutputPath);
+            var parametersFileContents = @"{
+  ""location"": {
+    ""value"": ""eastus""
+  },
+  ""sku"": {
+    ""value"": ""testSku""
+  }
+}";
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "input.parameters.json", parametersFileContents, testOutputPath);
+            var bicepUpdatedDeploymentParameter = new BicepUpdatedDeploymentParameter("location", "westus", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameters =
+                new List<BicepUpdatedDeploymentParameter> { bicepUpdatedDeploymentParameter };
+
+            var result = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "input.parameters.json",
+                parametersFilePath,
+                ParametersFileUpdateOption.Update,
+                bicepUpdatedDeploymentParameters);
+
+            result.Should().BeEquivalentToIgnoringNewlines(parametersFileContents);
+        }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithArmTemplateStyleParametersFile_ShouldUpdateParametersFile()
+        {
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty, testOutputPath);
+            var parametersFileContents = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""location"": {
+      ""value"": ""eastus""
+    }
+  }
+}";
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "input.parameters.json", parametersFileContents, testOutputPath);
+            var bicepUpdatedDeploymentParameter1 = new BicepUpdatedDeploymentParameter("name", "test", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameter2 = new BicepUpdatedDeploymentParameter("isSku", "true", false, ParameterType.Bool);
+            var bicepUpdatedDeploymentParameter3 = new BicepUpdatedDeploymentParameter("count", "3", false, ParameterType.Int);
+            var bicepUpdatedDeploymentParameters =
+                new List<BicepUpdatedDeploymentParameter> { bicepUpdatedDeploymentParameter1, bicepUpdatedDeploymentParameter2, bicepUpdatedDeploymentParameter3 };
+
+            var result = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "input.parameters.json",
+                parametersFilePath,
+                ParametersFileUpdateOption.Update,
+                bicepUpdatedDeploymentParameters);
+            var expectedParametersFileContentsWrittenToDisk = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""count"": {
+      ""value"": 3
+    },
+    ""isSku"": {
+      ""value"": true
+    },
+    ""name"": {
+      ""value"": ""test""
+    },
+    ""location"": {
+      ""value"": ""eastus""
+    }
+  }
+}";
+            var expectedParametersFileUsedInDeployment = @"{
+  ""count"": {
+    ""value"": 3
+  },
+  ""isSku"": {
+    ""value"": true
+  },
+  ""name"": {
+    ""value"": ""test""
+  },
+  ""location"": {
+    ""value"": ""eastus""
+  }
+}";
+
+            result.Should().BeEquivalentToIgnoringNewlines(expectedParametersFileUsedInDeployment);
+            File.ReadAllText(parametersFilePath).Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContentsWrittenToDisk);
+        }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithNonEmptyBicepUpdatedDeploymentParametersAndParametersFileWithComments_ShouldNotRemoveComments()
+        {
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty, testOutputPath);
+            var parametersFileContents = @"{
+  // comment 1
+  ""location"": {
+    ""value"": ""eastus""
+  },
+  ""sku"": {
+    ""value"": ""testSku""
+  }
+  // comment 2
+}";
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "input.parameters.jsonc", parametersFileContents, testOutputPath);
+            var bicepUpdatedDeploymentParameter1 = new BicepUpdatedDeploymentParameter("name", "test", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameter2 = new BicepUpdatedDeploymentParameter("id", "testId", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameters =
+                new List<BicepUpdatedDeploymentParameter> { bicepUpdatedDeploymentParameter1, bicepUpdatedDeploymentParameter2 };
+
+            var result = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "input.parameters.jsonc",
+                parametersFilePath,
+                ParametersFileUpdateOption.Update,
+                bicepUpdatedDeploymentParameters);
+            var expectedParametersFileContentsWrittenToDisk = @"{
+  ""id"": {
+    ""value"": ""testId""
+  },
+  ""name"": {
+    ""value"": ""test""
+  },
+  // comment 1
+  ""location"": {
+    ""value"": ""eastus""
+  },
+  ""sku"": {
+    ""value"": ""testSku""
+  }
+  // comment 2
+}";
+            var expectedParametersFileContentsUsedInDeployments = @"{
+  ""id"": {
+    ""value"": ""testId""
+  },
+  ""name"": {
+    ""value"": ""test""
+  },
+  ""location"": {
+    ""value"": ""eastus""
+  },
+  ""sku"": {
+    ""value"": ""testSku""
+  }
+}";
+
+            result.Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContentsUsedInDeployments);
+            File.ReadAllText(parametersFilePath).Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContentsWrittenToDisk);
+        }
+
+        [TestMethod]
+        public void GetUpdatedParametersFileContents_WithOverwriteOptionAndParametersFileWithSameNameInCurrentDirectory_ShouldOverwriteParametersFile()
+        {
+            var testOutputPath = Path.Combine(TestContext.ResultsDirectory, Guid.NewGuid().ToString());
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty, testOutputPath);
+            var parametersFileContents = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""location"": {
+      ""value"": ""eastus""
+    }
+  }
+}";
+            FileHelper.SaveResultFile(TestContext, "input.parameters.json", parametersFileContents, testOutputPath);
+            var bicepUpdatedDeploymentParameter1 = new BicepUpdatedDeploymentParameter("location", "westus", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameter2 = new BicepUpdatedDeploymentParameter("sku", "testSku", false, ParameterType.String);
+            var bicepUpdatedDeploymentParameters =
+                new List<BicepUpdatedDeploymentParameter> { bicepUpdatedDeploymentParameter1, bicepUpdatedDeploymentParameter2 };
+
+            var result = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                bicepFilePath,
+                "input.parameters.json",
+                string.Empty,
+                ParametersFileUpdateOption.Create,
+                bicepUpdatedDeploymentParameters);
+            var expectedParametersFileContentsWrittenToDisk = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""sku"": {
+      ""value"": ""testSku""
+    },
+    ""location"": {
+      ""value"": ""westus""
+    }
+  }
+}";
+            var expectedParametersFileContentsUsedInDeployment = @"{
+  ""sku"": {
+    ""value"": ""testSku""
+  },
+  ""location"": {
+    ""value"": ""westus""
+  }
+}";
+
+
+            result.Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContentsUsedInDeployment);
+
+            var expectedParametersFilePath = Path.Combine(testOutputPath, "input.parameters.json");
+            File.Exists(expectedParametersFilePath).Should().BeTrue();
+            File.ReadAllText(expectedParametersFilePath).Should().BeEquivalentToIgnoringNewlines(expectedParametersFileContentsWrittenToDisk);
+        }
+
+        [TestMethod]
+        public void UpdateJObjectBasedOnParameterType_WithValidInputOfTypeInt_ReturnsUpdatedJObject()
+        {
+            var result = DeploymentParametersHelper.UpdateJObjectBasedOnParameterType(ParameterType.Int, "1", JObject.Parse("{}"));
+
+            result.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": 1
+}");
+        }
+
+        [TestMethod]
+        public void UpdateJObjectBasedOnParameterType_WithValidInputOfTypeBool_ReturnsUpdatedJObject()
+        {
+            var result = DeploymentParametersHelper.UpdateJObjectBasedOnParameterType(ParameterType.Bool, "true", JObject.Parse("{}"));
+
+            result.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": true
+}");
+        }
+
+        [TestMethod]
+        public void UpdateJObjectBasedOnParameterType_WithValidInputOfTypeString_ReturnsUpdatedJObject()
+        {
+            var result = DeploymentParametersHelper.UpdateJObjectBasedOnParameterType(ParameterType.String, "test", JObject.Parse("{}"));
+
+            result.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": ""test""
+}");
+        }
+
+        [TestMethod]
+        public void UpdateJObjectBasedOnParameterType_WithInvalidInput_ThrowsException()
+        {
+            Action action = () => DeploymentParametersHelper.UpdateJObjectBasedOnParameterType(ParameterType.Int, "test", JObject.Parse("{}"));
+
+            action.Should().Throw<Exception>();
+        }
+    }
+}

--- a/src/Bicep.LangServer.UnitTests/Deploy/DeploymentParametersHelperTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Deploy/DeploymentParametersHelperTests.cs
@@ -101,20 +101,20 @@ namespace Bicep.LangServer.UnitTests.Deploy
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
   ""contentVersion"": ""1.0.0.0"",
   ""parameters"": {
-    ""sku"": {
-      ""value"": ""testSku""
-    },
     ""location"": {
       ""value"": ""eastus""
+    },
+    ""sku"": {
+      ""value"": ""testSku""
     }
   }
 }";
             var expectedParametersFileContentsUsedInDeployment = @"{
-  ""sku"": {
-    ""value"": ""testSku""
-  },
   ""location"": {
     ""value"": ""eastus""
+  },
+  ""sku"": {
+    ""value"": ""testSku""
   }
 }";
 
@@ -152,11 +152,11 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 ParametersFileUpdateOption.Update,
                 bicepUpdatedDeploymentParameters);
             var expectedParametersFileContents = @"{
-  ""id"": {
-    ""value"": ""testId""
-  },
   ""name"": {
     ""value"": ""test""
+  },
+  ""id"": {
+    ""value"": ""testId""
   },
   ""location"": {
     ""value"": ""eastus""
@@ -221,14 +221,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 ParametersFileUpdateOption.Update,
                 bicepUpdatedDeploymentParameters);
             var expectedParametersFileContents = @"{
-  ""count"": {
-    ""value"": 2
+  ""id"": {
+    ""value"": ""test""
   },
   ""isSku"": {
     ""value"": false
   },
-  ""id"": {
-    ""value"": ""test""
+  ""count"": {
+    ""value"": 2
   },
   ""location"": {
     ""value"": ""eastus""
@@ -298,14 +298,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
   ""contentVersion"": ""1.0.0.0"",
   ""parameters"": {
-    ""count"": {
-      ""value"": 3
+    ""name"": {
+      ""value"": ""test""
     },
     ""isSku"": {
       ""value"": true
     },
-    ""name"": {
-      ""value"": ""test""
+    ""count"": {
+      ""value"": 3
     },
     ""location"": {
       ""value"": ""eastus""
@@ -313,14 +313,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
   }
 }";
             var expectedParametersFileUsedInDeployment = @"{
-  ""count"": {
-    ""value"": 3
+  ""name"": {
+    ""value"": ""test""
   },
   ""isSku"": {
     ""value"": true
   },
-  ""name"": {
-    ""value"": ""test""
+  ""count"": {
+    ""value"": 3
   },
   ""location"": {
     ""value"": ""eastus""
@@ -359,11 +359,11 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 ParametersFileUpdateOption.Update,
                 bicepUpdatedDeploymentParameters);
             var expectedParametersFileContentsWrittenToDisk = @"{
-  ""id"": {
-    ""value"": ""testId""
-  },
   ""name"": {
     ""value"": ""test""
+  },
+  ""id"": {
+    ""value"": ""testId""
   },
   // comment 1
   ""location"": {
@@ -375,11 +375,11 @@ namespace Bicep.LangServer.UnitTests.Deploy
   // comment 2
 }";
             var expectedParametersFileContentsUsedInDeployments = @"{
-  ""id"": {
-    ""value"": ""testId""
-  },
   ""name"": {
     ""value"": ""test""
+  },
+  ""id"": {
+    ""value"": ""testId""
   },
   ""location"": {
     ""value"": ""eastus""
@@ -423,20 +423,20 @@ namespace Bicep.LangServer.UnitTests.Deploy
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
   ""contentVersion"": ""1.0.0.0"",
   ""parameters"": {
-    ""sku"": {
-      ""value"": ""testSku""
-    },
     ""location"": {
       ""value"": ""westus""
+    },
+    ""sku"": {
+      ""value"": ""testSku""
     }
   }
 }";
             var expectedParametersFileContentsUsedInDeployment = @"{
-  ""sku"": {
-    ""value"": ""testSku""
-  },
   ""location"": {
     ""value"": ""westus""
+  },
+  ""sku"": {
+    ""value"": ""testSku""
   }
 }";
 

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
@@ -493,7 +493,7 @@ param testProperties object";
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
             result.deploymentParameters.Should().BeEmpty();
-            result.errorMessage.Should().BeEquivalentToIgnoringNewlines("Parameters of type array or object should either contain a default value or must be specified in parameters.json file. Please update the value for following parameters: testProperties");
+            result.errorMessage.Should().BeEquivalentToIgnoringNewlines(string.Format(LangServerResources.MissingParamValueForArrayOrObjectType, "testProperties"));
         }
 
         [TestMethod]

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
@@ -1,0 +1,857 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bicep.Core.Syntax;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Mock;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.LanguageServer;
+using Bicep.LanguageServer.Deploy;
+using Bicep.LanguageServer.Handlers;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+
+namespace Bicep.LangServer.UnitTests.Handlers
+{
+    [TestClass]
+    public class BicepDeploymentParametersHandlerTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        private readonly ISerializer Serializer = StrictMock.Of<ISerializer>().Object;
+
+        [TestMethod]
+        public async Task Handle_WithNoParamsInSourceFile_ShouldReturnEmptyListOfUpdatedDeploymentParameters()
+        {
+            var bicepFileContents = @"var test = 'abc'";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.20.27533"",
+      ""templateHash"": ""6882627226792194393""
+    }
+  },
+  ""variables"": {
+    ""test"": ""abc""
+  },
+  ""resources"": []
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().BeEmpty();
+            result.errorMessage.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task Handle_WithUnusedParamInSourceFile_ShouldReturnEmptyListOfUpdatedDeploymentParameters()
+        {
+            var bicepFileContents = @"param test string = 'abc'";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.18.56646"",
+      ""templateHash"": ""2028391450931931217""
+    }
+  },
+  ""parameters"": {
+    ""test"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""abc""
+    }
+  },
+  ""resources"": []
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().BeEmpty();
+            result.errorMessage.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task Handle_WithOnlyDefaultValues_ShouldReturnUpdatedDeploymentParameters()
+        {
+            var bicepFileContents = @"param name string = 'test'
+param location string = 'global
+resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: name
+  location: location
+}";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.18.56646"",
+      ""templateHash"": ""3422964353444461889""
+    }
+  },
+  ""parameters"": {
+    ""name"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""test""
+    },
+    ""location"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""global""
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Network/dnsZones"",
+      ""apiVersion"": ""2018-05-01"",
+      ""name"": ""[parameters('name')]"",
+      ""location"": ""[parameters('location')]""
+    }
+  ]
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().SatisfyRespectively(
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("name");
+                    updatedParam.value.Should().Be("test");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeFalse();
+                },
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("location");
+                    updatedParam.value.Should().Be("global");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeFalse();
+                });
+            result.errorMessage.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task Handle_WithDefaultValuesAndParametersFile_ShouldReturnUpdatedDeploymentParameters()
+        {
+            var bicepFileContents = @"param name string = 'test'
+param location string
+resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: name
+  location: location
+}";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.18.56646"",
+      ""templateHash"": ""3422964353444461889""
+    }
+  },
+  ""parameters"": {
+    ""name"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""test""
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Network/dnsZones"",
+      ""apiVersion"": ""2018-05-01"",
+      ""name"": ""[parameters('name')]"",
+      ""location"": ""[parameters('location')]""
+    }
+  ]
+}";
+            var parametersFileContents = @"{
+    ""location"": {
+      ""value"": ""westus""
+    }
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, parametersFilePath, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().SatisfyRespectively(
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("name");
+                    updatedParam.value.Should().Be("test");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeFalse();
+                });
+            result.errorMessage.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task Handle_WithMissingParametersFileAndDefaultValue_ShouldReturnUpdatedDeploymentParameters()
+        {
+            var bicepFileContents = @"param name string = 'test'
+param location string
+resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: name
+  location: location
+}";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.18.56646"",
+      ""templateHash"": ""3422964353444461889""
+    }
+  },
+  ""parameters"": {
+    ""name"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""test""
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Network/dnsZones"",
+      ""apiVersion"": ""2018-05-01"",
+      ""name"": ""[parameters('name')]"",
+      ""location"": ""[parameters('location')]""
+    }
+  ]
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().SatisfyRespectively(
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("name");
+                    updatedParam.value.Should().Be("test");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeFalse();
+                },
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("location");
+                    updatedParam.value.Should().BeNull();
+                    updatedParam.isMissingParam.Should().BeTrue();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeFalse();
+                });
+            result.errorMessage.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task Handle_ParameterWithDefaultValueAndEntryInParametersFile_ShouldIgnoreParameter()
+        {
+            var bicepFileContents = @"param name string = 'test'
+param location string = 'eastus'
+resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: name
+  location: location
+}";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.18.56646"",
+      ""templateHash"": ""3422964353444461889""
+    }
+  },
+  ""parameters"": {
+    ""name"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""test""
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Network/dnsZones"",
+      ""apiVersion"": ""2018-05-01"",
+      ""name"": ""[parameters('name')]"",
+      ""location"": ""[parameters('location')]""
+    }
+  ]
+}";
+            var parametersFileContents = @"{
+    ""location"": {
+      ""value"": ""westus""
+    }
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, parametersFilePath, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().SatisfyRespectively(
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("name");
+                    updatedParam.value.Should().Be("test");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeFalse();
+                });
+            result.errorMessage.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task Handle_WithParameterOfTypeObjectAndDefaultValue_ShouldReturnEmptyListOfUpdatedDeploymentParameters()
+        {
+            var bicepFileContents = @"resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@2018-11-01-preview' = {
+  name: 'name/policyArtifact'
+  kind: 'policyAssignment'
+  properties: testProperties
+}
+param testProperties object = {
+  displayName: 'Blocked Resource Types policy definition'
+  description: 'Block certain resource types'
+}";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.44.5715"",
+      ""templateHash"": ""15862569082920623108""
+    }
+  },
+  ""parameters"": {
+    ""testProperties"": {
+      ""type"": ""object"",
+      ""defaultValue"": {
+        ""displayName"": ""Blocked Resource Types policy definition"",
+        ""description"": ""Block certain resource types""
+      }
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Blueprint/blueprints/artifacts"",
+      ""apiVersion"": ""2018-11-01-preview"",
+      ""name"": ""name/policyArtifact"",
+      ""kind"": ""policyAssignment"",
+      ""properties"": ""[parameters('testProperties')]""
+    }
+  ]
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().BeEmpty();
+            result.errorMessage.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task Handle_WithParameterOfTypeArrayAndDefaultValue_ShouldReturnEmptyListOfUpdatedDeploymentParameters()
+        {
+            var bicepFileContents = @"resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@2018-11-01-preview' = {
+  name: 'name/policyArtifact'
+  kind: 'policyAssignment'
+  allowedOrigins: allowedOrigins
+}
+param allowedOrigins array = [
+  'https://foo.com'
+  'https://bar.com'
+]";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.44.5715"",
+      ""templateHash"": ""15862569082920623108""
+    }
+  },
+  ""parameters"": {
+    ""testProperties"": {
+      ""type"": ""object"",
+      ""defaultValue"": {
+        ""displayName"": ""Blocked Resource Types policy definition"",
+        ""description"": ""Block certain resource types""
+      }
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Blueprint/blueprints/artifacts"",
+      ""apiVersion"": ""2018-11-01-preview"",
+      ""name"": ""name/policyArtifact"",
+      ""kind"": ""policyAssignment"",
+      ""properties"": ""[parameters('testProperties')]""
+    }
+  ]
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().BeEmpty();
+            result.errorMessage.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task Handle_WithParameterOfTypeObjectAndNoDefaultValue_ShouldReturnBicepDeploymentParametersResponseWithErrorMessage()
+        {
+            var bicepFileContents = @"resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@2018-11-01-preview' = {
+  name: 'name/policyArtifact'
+  kind: 'policyAssignment'
+  properties: testProperties
+}
+param testProperties object";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.44.5715"",
+      ""templateHash"": ""15862569082920623108""
+    }
+  },
+  ""parameters"": {
+    ""testProperties"": {
+      ""type"": ""object"",
+      ""defaultValue"": {
+        ""displayName"": ""Blocked Resource Types policy definition"",
+        ""description"": ""Block certain resource types""
+      }
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Blueprint/blueprints/artifacts"",
+      ""apiVersion"": ""2018-11-01-preview"",
+      ""name"": ""name/policyArtifact"",
+      ""kind"": ""policyAssignment"",
+      ""properties"": ""[parameters('testProperties')]""
+    }
+  ]
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().BeEmpty();
+            result.errorMessage.Should().BeEquivalentToIgnoringNewlines("Parameters of type array or object should either contain a default value or must be specified in parameters.json file. Please update the value for following parameters: testProperties");
+        }
+
+        [TestMethod]
+        public async Task Handle_ParameterWithDefaultValuesOfTypeExpression_ShouldReturnUpdatedDeploymentParametersWithIsExpressionSetToTrue()
+        {
+            var bicepFileContents = @"param location string = resourceGroup().location
+param policyDefinitionId string = resourceId('Microsoft.Network/virtualNetworks/subnets', 'virtualNetworkName_var', 'subnet1Name')
+resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@2018-11-01-preview' = {
+  name: 'name/policyArtifact'
+  kind: 'policyAssignment'
+  location: location
+  properties: {
+    policyDefinitionId: policyDefinitionId
+  }
+}";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.46.5435"",
+      ""templateHash"": ""8792531277105895125""
+    }
+  },
+  ""parameters"": {
+    ""location"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""[resourceGroup().location]""
+    },
+    ""policyDefinitionId"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""[resourceId('Microsoft.Network/virtualNetworks/subnets', 'virtualNetworkName_var', 'subnet1Name')]""
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Blueprint/blueprints/artifacts"",
+      ""apiVersion"": ""2018-11-01-preview"",
+      ""name"": ""name/policyArtifact"",
+      ""kind"": ""policyAssignment"",
+      ""location"": ""[parameters('location')]"",
+      ""properties"": {
+        ""policyDefinitionId"": ""[parameters('policyDefinitionId')]""
+      }
+    }
+  ]
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().SatisfyRespectively(
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("location");
+                    updatedParam.value.Should().Be("resourceGroup().location");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeTrue();
+                    updatedParam.isSecure.Should().BeFalse();
+                },
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("policyDefinitionId");
+                    updatedParam.value.Should().Be("resourceId('Microsoft.Network/virtualNetworks/subnets', 'virtualNetworkName_var', 'subnet1Name')");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeTrue();
+                    updatedParam.isSecure.Should().BeFalse();
+                });
+            result.errorMessage.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task Handle_WithInvalidParametersFileContents_ShouldReturnBicepDeploymentParametersResponseWithErrorMessage()
+        {
+            var bicepFileContents = @"param name string = 'test'
+param location string = 'eastus'
+resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: name
+  location: location
+}";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.18.56646"",
+      ""templateHash"": ""3422964353444461889""
+    }
+  },
+  ""parameters"": {
+    ""name"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""test""
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Network/dnsZones"",
+      ""apiVersion"": ""2018-05-01"",
+      ""name"": ""[parameters('name')]"",
+      ""location"": ""[parameters('location')]""
+    }
+  ]
+}";
+            var parametersFileContents = @"{
+    ""location"": {
+      ""value"": ""westus""
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, parametersFilePath, template, CancellationToken.None);
+
+            result.errorMessage.Should().NotBeNull();
+            result.errorMessage.Should().Be(string.Format(LangServerResources.InvalidParameterFile, parametersFilePath, "Unexpected end of content while loading JObject. Path 'location', line 4, position 1."));
+        }
+
+        [TestMethod]
+        public async Task Handle_WithSecureParams_ShouldReturnUpdatedDeploymentParametersWithIsSecureSetToTrue()
+        {
+            var bicepFileContents = @"@secure()
+param adminUsername string = 'abc'
+@secure()
+param location string
+param zoneType string = 'Private'
+resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: adminUsername
+  location: location
+  properties:{
+    zoneType: zoneType
+  }
+}";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.68.62354"",
+      ""templateHash"": ""2266028446417982813""
+    }
+  },
+  ""parameters"": {
+    ""adminUsername"": {
+      ""type"": ""secureString"",
+      ""defaultValue"": ""abc""
+    },
+    ""location"": {
+      ""type"": ""secureString""
+    },
+    ""zoneType"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""Private""
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Network/dnsZones"",
+      ""apiVersion"": ""2018-05-01"",
+      ""name"": ""[parameters('adminUsername')]"",
+      ""location"": ""[parameters('location')]"",
+      ""properties"": {
+        ""zoneType"": ""[parameters('zoneType')]""
+      }
+    }
+  ]
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            result.deploymentParameters.Should().SatisfyRespectively(
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("adminUsername");
+                    updatedParam.value.Should().Be("abc");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeTrue();
+                },
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("location");
+                    updatedParam.value.Should().BeNull();
+                    updatedParam.isMissingParam.Should().BeTrue();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeTrue();
+                },
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("zoneType");
+                    updatedParam.value.Should().Be("Private");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeFalse();
+                });
+            result.errorMessage.Should().BeNull();
+        }
+
+        [DataTestMethod]
+        [DataRow("param test string = 'test'", ParameterType.String)]
+        [DataRow("param test int = 1", ParameterType.Int)]
+        [DataRow("param test bool = true", ParameterType.Bool)]
+        [DataRow(@"param test array = [
+  1
+  2
+]", ParameterType.Array)]
+        [DataRow(@"param test object = {
+  displayName: 'Blocked Resource Types policy definition'
+  description: 'Block certain resource types'
+}", ParameterType.Object)]
+        [DataRow("param test ", null)]
+        public void VerifyParameterType(string bicepFileContents, ParameterType? expected)
+        {
+            var programSyntax = ParserHelper.Parse(bicepFileContents);
+            programSyntax.Should().NotBeNull();
+
+            var parameterDeclarationSyntax = programSyntax.Declarations.First() as ParameterDeclarationSyntax;
+            parameterDeclarationSyntax.Should().NotBeNull();
+
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = bicepDeploymentParametersHandler.GetParameterType(parameterDeclarationSyntax!);
+
+            result.Should().Be(expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("    ")]
+        [DataRow("some_path")]
+        public void GetParametersInfoFromProvidedFile_WithInvalidInput_ShouldReturnNull(string parametersFilePath)
+        {
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, string.Empty, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = bicepDeploymentParametersHandler.GetParametersInfoFromProvidedFile(parametersFilePath);
+
+            result.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetParametersInfoFromProvidedFile_WithNonArmTemplateFormatParametersFile_ShouldReturnParametersInfo()
+        {
+            var parametersFileContents = @"{
+    ""location"": {
+      ""value"": ""westus""
+    },
+    ""sku"": {
+      ""value"": 1
+    }
+}";
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, string.Empty, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = bicepDeploymentParametersHandler.GetParametersInfoFromProvidedFile(parametersFilePath);
+
+            result.Should().NotBeNull();
+            result!.Should().ContainKey("location");
+            result!.Should().ContainKey("sku");
+
+            var locationObject = result!["location"] as JObject;
+
+            locationObject!.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": ""westus""
+}");
+
+            var skuObject = result!["sku"] as JObject;
+            skuObject!.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": 1
+}");
+        }
+
+        [TestMethod]
+        public void GetParametersInfoFromProvidedFile_WithArmTemplateFormatParametersFile_ShouldReturnParametersInfo()
+        {
+            var parametersFileContents = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""exampleString"": {
+      ""value"": ""test string""
+    },
+    ""exampleInt"": {
+      ""value"": 4
+    },
+    ""exampleBool"": {
+      ""value"": true
+    },
+    ""exampleArray"": {
+      ""value"": [
+        ""value 1"",
+        ""value 2""
+      ]
+    },
+    ""exampleObject"": {
+      ""value"": {
+        ""property1"": ""value1"",
+        ""property2"": ""value2""
+      }
+    }
+  }
+}";
+            var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, string.Empty, true);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+
+            var result = bicepDeploymentParametersHandler.GetParametersInfoFromProvidedFile(parametersFilePath);
+
+            result.Should().NotBeNull();
+            result!.Count().Should().Be(5);
+            result!.Should().ContainKey("exampleString");
+            result!.Should().ContainKey("exampleInt");
+            result!.Should().ContainKey("exampleBool");
+            result!.Should().ContainKey("exampleArray");
+            result!.Should().ContainKey("exampleObject");
+
+            var exampleStringObject = result!["exampleString"] as JObject;
+            exampleStringObject!.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": ""test string""
+}");
+
+            var exampleIntObject = result!["exampleInt"] as JObject;
+            exampleIntObject!.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": 4
+}");
+            var exampleBoolObject = result!["exampleBool"] as JObject;
+            exampleBoolObject!.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": true
+}");
+            var exampleArrayObject = result!["exampleArray"] as JObject;
+            exampleArrayObject!.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": [
+    ""value 1"",
+    ""value 2""
+  ]
+}");
+            var exampleObject = result!["exampleObject"] as JObject;
+            exampleObject!.ToString().Should().BeEquivalentToIgnoringNewlines(@"{
+  ""value"": {
+    ""property1"": ""value1"",
+    ""property2"": ""value2""
+  }
+}");
+        }
+    }
+}

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
@@ -59,7 +59,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         }
 
         [TestMethod]
-        public async Task Handle_WithUnusedParamInSourceFile_ShouldReturnEmptyListOfUpdatedDeploymentParameters()
+        public async Task Handle_WithUnusedParamInSourceFile_ShouldReturnUpdatedDeploymentParameters()
         {
             var bicepFileContents = @"param test string = 'abc'";
             var template = @"{
@@ -87,7 +87,15 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
-            result.deploymentParameters.Should().BeEmpty();
+            result.deploymentParameters.Should().SatisfyRespectively(
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("test");
+                    updatedParam.value.Should().Be("abc");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeFalse();
+                    updatedParam.isSecure.Should().BeFalse();
+                });
             result.errorMessage.Should().BeNull();
         }
 

--- a/src/Bicep.LangServer/Deploy/DeploymentHelper.cs
+++ b/src/Bicep.LangServer/Deploy/DeploymentHelper.cs
@@ -146,17 +146,24 @@ namespace Bicep.LanguageServer.Deploy
                 return new BicepDeploymentWaitForCompletionResponse(false, string.Format(LangServerResources.DeploymentFailedMessage, documentPath));
             }
 
-            var response = await deploymentResourceOperation.WaitForCompletionAsync();
-
-            var status = response.GetRawResponse().Status;
-
-            if (status == 200 || status == 201)
+            try
             {
-                return new BicepDeploymentWaitForCompletionResponse(true, string.Format(LangServerResources.DeploymentSucceededMessage, documentPath));
+                var response = await deploymentResourceOperation.WaitForCompletionAsync();
+
+                var status = response.GetRawResponse().Status;
+
+                if (status == 200 || status == 201)
+                {
+                    return new BicepDeploymentWaitForCompletionResponse(true, string.Format(LangServerResources.DeploymentSucceededMessage, documentPath));
+                }
+                else
+                {
+                    return new BicepDeploymentWaitForCompletionResponse(false, string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, response.ToString()));
+                }
             }
-            else
+            catch (Exception e)
             {
-                return new BicepDeploymentWaitForCompletionResponse(false, string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, response.ToString()));
+                return new BicepDeploymentWaitForCompletionResponse(false, string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, e.Message));
             }
         }
     }

--- a/src/Bicep.LangServer/Deploy/DeploymentParametersHelper.cs
+++ b/src/Bicep.LangServer/Deploy/DeploymentParametersHelper.cs
@@ -57,7 +57,7 @@ namespace Bicep.LanguageServer.Deploy
 
                 var jObject = GetParametersObjectValue(updatedParametersFile, out bool isArmStyleTemplate);
 
-                foreach (var updatedDeploymentParameter in updatedDeploymentParameters)
+                foreach (var updatedDeploymentParameter in updatedDeploymentParameters.Reverse())
                 {
                     var name = updatedDeploymentParameter.name;
 

--- a/src/Bicep.LangServer/Deploy/DeploymentParametersHelper.cs
+++ b/src/Bicep.LangServer/Deploy/DeploymentParametersHelper.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Bicep.LanguageServer.Configuration;
+using Bicep.LanguageServer.Handlers;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.LanguageServer.Deploy
+{
+    public class DeploymentParametersHelper
+    {
+        // Per documentation here- https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameter-files
+        // parameters file should be of below format:
+        //{
+        //  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+        //  "contentVersion": "1.0.0.0",
+        //  "parameters": {
+        //    "<first-parameter-name>": {
+        //      "value": "<first-value>"
+        //    },
+        //    "<second-parameter-name>": {
+        //      "value": "<second-value>"
+        //    }
+        //  }
+        //}
+        // However, azure-sdk-for-net expects parameters to be of name and value pairs:
+        // https://github.com/Azure/azure-sdk-for-net/blob/1e25b1bfc9b54df35d907aa7b2c10ff07082e845/sdk/resources/Azure.ResourceManager.Resources/src/Generated/Models/ArmDeploymentProperties.cs#L27
+        // We'll work around the above issue by first detecting the format of the file.
+        // If it's in the format descibed in the docs, we'll extract the parameters value and use that for actual deployment.
+        // If the user chose to create a new parameters file during the deployment flow, we'll follow the format
+        // mentioned in the docs as a best practise.
+        public static string GetUpdatedParametersFileContents(
+                string documentPath,
+                string parametersFileName,
+                string parametersFilePath,
+                ParametersFileUpdateOption updateOrCreateParametersFile,
+                IEnumerable<BicepUpdatedDeploymentParameter> updatedDeploymentParameters)
+        {
+            try
+            {
+                // Parameter file follows format mentioned here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameter-files
+                var armSchemaStyleParametersFile = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+  }
+}";
+                // We will send across the secure param values to the azure sdk that handles deployment,
+                // but will avoid writing it to the parameters file for security reasons
+                var updatedParametersFile = !string.IsNullOrWhiteSpace(parametersFilePath) ?
+                    File.ReadAllText(parametersFilePath) : armSchemaStyleParametersFile;
+                var updatedParametersFileWithoutSecureParams = updatedParametersFile;
+
+                var jObject = GetParametersObjectValue(updatedParametersFile, out bool isArmStyleTemplate);
+
+                foreach (var updatedDeploymentParameter in updatedDeploymentParameters)
+                {
+                    var name = updatedDeploymentParameter.name;
+
+                    // Check to make sure parameters mentioned in parameters file are not overwritten
+                    if (jObject.ContainsKey(name))
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        var jsonEditor = new JsonEditor(updatedParametersFile);
+
+                        var propertyPaths = new List<string>();
+                        if (isArmStyleTemplate)
+                        {
+                            propertyPaths.Add("parameters");
+                            propertyPaths.Add(name);
+                        }
+                        else
+                        {
+                            propertyPaths.Add(name);
+                        }
+
+                        var valueObject = UpdateJObjectBasedOnParameterType(
+                            updatedDeploymentParameter.parameterType,
+                            updatedDeploymentParameter.value,
+                            JObject.Parse("{}"));
+
+                        (int line, int column, string text)? insertion = jsonEditor.InsertIfNotExist(propertyPaths.ToArray(), valueObject);
+
+                        if (insertion.HasValue)
+                        {
+                            var (line, column, insertText) = insertion.Value;
+
+                            updatedParametersFile = JsonEditor.ApplyInsertion(updatedParametersFile, (line, column, insertText));
+
+                            if (!updatedDeploymentParameter.isSecure)
+                            {
+                                updatedParametersFileWithoutSecureParams = JsonEditor.ApplyInsertion(updatedParametersFileWithoutSecureParams, (line, column, insertText));
+                            }
+                        }
+                    }
+                }
+
+                if (updatedDeploymentParameters.Any())
+                {
+                    if (updateOrCreateParametersFile == ParametersFileUpdateOption.Update)
+                    {
+                        File.WriteAllText(parametersFilePath, updatedParametersFileWithoutSecureParams);
+                    }
+                    // ParametersFileCreateOrUpdate will have a value of "Overwrite" only if the parameters
+                    // file with name <bicep_file_name>.parameters.json already exists and user chose to
+                    // overwrite it with values from this deployment
+                    else if (updateOrCreateParametersFile == ParametersFileUpdateOption.Create ||
+                        updateOrCreateParametersFile == ParametersFileUpdateOption.Overwrite)
+                    {
+                        var directoryContainingBicepFile = Path.GetDirectoryName(documentPath);
+                        if (directoryContainingBicepFile is not null)
+                        {
+                            File.WriteAllText(Path.Combine(directoryContainingBicepFile, parametersFileName), updatedParametersFileWithoutSecureParams);
+                        }
+                    }
+                }
+
+                var updatedJObject = GetParametersObjectValue(updatedParametersFile, out _);
+
+                return updatedJObject.ToString();
+            }
+            catch (Exception e)
+            {
+                throw new Exception(string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, parametersFilePath, e.Message));
+            }
+        }
+
+        public static JObject UpdateJObjectBasedOnParameterType(ParameterType? parameterType, string? value, JObject valueObject)
+        {
+            if (parameterType is not null)
+            {
+                if (parameterType == ParameterType.Int &&
+                    value is not null &&
+                    value.GetType() != typeof(int))
+                {
+                    var updatedValue = int.Parse(value);
+                    valueObject.Add("value", updatedValue);
+
+                    return valueObject;
+                }
+                else if (parameterType == ParameterType.Bool &&
+                    value is not null &&
+                    value.GetType() != typeof(bool))
+                {
+                    var updatedValue = bool.Parse(value);
+                    valueObject.Add("value", updatedValue);
+
+                    return valueObject;
+                }
+            }
+
+            valueObject.Add("value", value);
+
+            return valueObject;
+        }
+
+        private static JObject GetParametersObjectValue(string text, out bool isArmStyleTemplate)
+        {
+            isArmStyleTemplate = false;
+            var jObject = JObject.Parse(text);
+            if (jObject.ContainsKey("$schema") && jObject.ContainsKey("contentVersion") && jObject.ContainsKey("parameters"))
+            {
+                isArmStyleTemplate = true;
+                var parametersObject = jObject["parameters"];
+                if (parametersObject is not null)
+                {
+                    return JObject.Parse(parametersObject.ToString());
+                }
+            }
+
+            return jObject;
+        }
+    }
+}

--- a/src/Bicep.LangServer/Deploy/ParameterType.cs
+++ b/src/Bicep.LangServer/Deploy/ParameterType.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.LanguageServer.Deploy
+{
+    public enum ParameterType
+    {
+        Array = 1,
+        Bool = 2,
+        Int = 3,
+        Object = 4,
+        String = 5
+    }
+}

--- a/src/Bicep.LangServer/Deploy/ParametersFileUpdateOption.cs
+++ b/src/Bicep.LangServer/Deploy/ParametersFileUpdateOption.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.LanguageServer.Deploy
+{
+    public enum ParametersFileUpdateOption
+    {
+        Create = 1,
+        None = 2,
+        Overwrite = 3,
+        Update = 4,
+    }
+}

--- a/src/Bicep.LangServer/Deploy/ParametersFileUpdateOption.cs
+++ b/src/Bicep.LangServer/Deploy/ParametersFileUpdateOption.cs
@@ -5,9 +5,15 @@ namespace Bicep.LanguageServer.Deploy
 {
     public enum ParametersFileUpdateOption
     {
+        // If the user did not provide a parameters file to be used during deployment and chose to create one at the end of deployment flow
         Create = 1,
+        // User select "No" to create/update parameters file at the end of deployment flow
         None = 2,
+        // If the user did not provide a parameters file to be used in deployment, but chose to create one at the end of the flow and
+        // file with name <bicep_file_name>.parameters.json already exists in the same folder as bicep file
         Overwrite = 3,
+        // If the user provided a file to be used during deployment and chose to update it with valuses from current deployment at the
+        // end of deployment flow
         Update = 4,
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -214,8 +214,7 @@ namespace Bicep.LanguageServer.Handlers
             }
 
             var semanticModel = compilationContext.Compilation.GetEntrypointSemanticModel();
-            return semanticModel.Root.ParameterDeclarations
-                .Where(sym => semanticModel.FindReferences(sym).OfType<VariableAccessSyntax>().Any());
+            return semanticModel.Root.ParameterDeclarations;
         }
 
         private bool IsOfTypeArrayOrObject(ParameterType? parameterType)

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -54,7 +54,8 @@ namespace Bicep.LanguageServer.Handlers
 
             try
             {
-                var parametersFromProvidedParametersFile = GetParametersInfoFromProvidedFile(parametersFilePath);
+                var parametersFromProvidedParametersFile = GetParametersInfoFromProvidedFile(parametersFilePath)
+                    ?? new Dictionary<string, dynamic>();
                 var templateObj = JObject.Parse(template);
                 var defaultParametersFromTemplate = templateObj["parameters"];
 
@@ -70,7 +71,7 @@ namespace Bicep.LanguageServer.Handlers
 
                     if (modifier is null)
                     {
-                        if (parametersFromProvidedParametersFile is null || !parametersFromProvidedParametersFile.ContainsKey(parameterName))
+                        if (!parametersFromProvidedParametersFile.ContainsKey(parameterName))
                         {
                             if (IsOfTypeArrayOrObject(parameterType))
                             {
@@ -102,7 +103,7 @@ namespace Bicep.LanguageServer.Handlers
                         // - is also mentioned in parameters file
                         // then the value specified in the parameters file will take precedence.
                         // We will not provide an option to override in the UI
-                        if (parametersFromProvidedParametersFile is not null && parametersFromProvidedParametersFile.ContainsKey(parameterName))
+                        if (parametersFromProvidedParametersFile.ContainsKey(parameterName))
                         {
                             continue;
                         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -19,7 +19,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public record BicepDeploymentParametersResponse(List<BicepDeploymentParameter> deploymentParameters, bool parametersFileExists, string parametersFileName, string? errorMessage);
+    public record BicepDeploymentParametersResponse(List<BicepDeploymentParameter> deploymentParameters, string parametersFileName, string? errorMessage);
 
     public record BicepDeploymentParameter(string name, string? value, bool isMissingParam, bool isExpression, bool isSecure, ParameterType? parameterType);
 
@@ -50,8 +50,7 @@ namespace Bicep.LanguageServer.Handlers
 
         private BicepDeploymentParametersResponse GetUpdatedParams(string documentPath, string parametersFilePath, string template)
         {
-            var parametersFileExists = !string.IsNullOrWhiteSpace(parametersFilePath) && File.Exists(parametersFilePath);
-            var parametersFileName = GetParameterFileName(documentPath, parametersFileExists, parametersFilePath);
+            var parametersFileName = GetParameterFileName(documentPath, parametersFilePath);
 
             try
             {
@@ -132,14 +131,13 @@ namespace Bicep.LanguageServer.Handlers
 
                 return new BicepDeploymentParametersResponse(
                     updatedDeploymentParameters,
-                    parametersFileExists,
                     parametersFileName,
                     GetErrorMessageForMissingArrayOrObjectTypes(missingArrayOrObjectTypes));
 
             }
             catch (Exception e)
             {
-                return new BicepDeploymentParametersResponse(new List<BicepDeploymentParameter>(), parametersFileExists, parametersFileName, e.Message);
+                return new BicepDeploymentParametersResponse(new List<BicepDeploymentParameter>(), parametersFileName, e.Message);
             }
         }
 
@@ -153,8 +151,10 @@ namespace Bicep.LanguageServer.Handlers
                 expressionSyntax is not BooleanLiteralSyntax;
         }
 
-        private string GetParameterFileName(string documentPath, bool parametersFileExists, string parametersFilePath)
+        private string GetParameterFileName(string documentPath, string parametersFilePath)
         {
+            var parametersFileExists = !string.IsNullOrWhiteSpace(parametersFilePath) && File.Exists(parametersFilePath);
+
             if (parametersFileExists)
             {
                 return Path.GetFileName(parametersFilePath);

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
+using Bicep.LanguageServer.CompilationManager;
+using Bicep.LanguageServer.Deploy;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+
+namespace Bicep.LanguageServer.Handlers
+{
+    public record BicepDeploymentParametersResponse(List<BicepDeploymentParameter> deploymentParameters, bool parametersFileExists, string parametersFileName, string? errorMessage);
+
+    public record BicepDeploymentParameter(string name, string? value, bool isMissingParam, bool isExpression, bool isSecure, ParameterType? parameterType);
+
+    /// <summary>
+    /// Handles getDeploymentParameters LSP request.
+    /// The BicepDeploymentParametersHandler returns information about deployment parameters, parameters file name and error message, if any.
+    /// List of <see cref="BicepDeploymentParameter"/>, included in the response has informtion about the parameter e.g. name , value, if the parameter has
+    /// @secure() decorator, if it's missing default value/is not present in parameters file, is an expression etc
+    /// The above information will be used to display appropriate controls in UI.
+    /// </summary>
+    public class BicepDeploymentParametersHandler : ExecuteTypedResponseCommandHandlerBase<string, string, string, BicepDeploymentParametersResponse>
+    {
+        private readonly ICompilationManager compilationManager;
+
+        public BicepDeploymentParametersHandler(
+            ICompilationManager compilationManager,
+            ISerializer serializer)
+            : base(LangServerConstants.GetDeploymentParametersCommand, serializer)
+        {
+            this.compilationManager = compilationManager;
+        }
+
+        public override Task<BicepDeploymentParametersResponse> Handle(string documentPath, string parametersFilePath, string template, CancellationToken cancellationToken)
+        {
+            var updatedParams = GetUpdatedParams(documentPath, parametersFilePath, template);
+            return Task.FromResult(updatedParams);
+        }
+
+        private BicepDeploymentParametersResponse GetUpdatedParams(string documentPath, string parametersFilePath, string template)
+        {
+            var parametersFileExists = !string.IsNullOrWhiteSpace(parametersFilePath) && File.Exists(parametersFilePath);
+            var parametersFileName = GetParameterFileName(documentPath, parametersFileExists, parametersFilePath);
+
+            try
+            {
+                var parametersFromProvidedParametersFile = GetParametersInfoFromProvidedFile(parametersFilePath);
+                var templateObj = JObject.Parse(template);
+                var defaultParametersFromTemplate = templateObj["parameters"];
+
+                var missingArrayOrObjectTypes = new List<string>();
+                var updatedDeploymentParameters = new List<BicepDeploymentParameter>();
+
+                foreach (var parameterSymbol in GetParameterSymbols(documentPath))
+                {
+                    var parameterDeclarationSyntax = parameterSymbol.DeclaringParameter;
+                    var modifier = parameterDeclarationSyntax.Modifier;
+                    var parameterName = parameterSymbol.Name;
+                    var parameterType = GetParameterType(parameterDeclarationSyntax);
+
+                    if (modifier is null)
+                    {
+                        if (parametersFromProvidedParametersFile is null || !parametersFromProvidedParametersFile.ContainsKey(parameterName))
+                        {
+                            if (IsOfTypeArrayOrObject(parameterType))
+                            {
+                                missingArrayOrObjectTypes.Add(parameterName);
+                                continue;
+                            }
+
+                            var updatedDeploymentParameter = new BicepDeploymentParameter(
+                                name: parameterName,
+                                value: null,
+                                isMissingParam: true,
+                                isExpression: false,
+                                isSecure: parameterSymbol.IsSecure(),
+                                parameterType: parameterType);
+                            updatedDeploymentParameters.Add(updatedDeploymentParameter);
+                        }
+                    }
+                    else
+                    {
+                        // If param is of type array or object, we don't want to provide an option to override.
+                        // We'll simply ignore and continue
+                        if (IsOfTypeArrayOrObject(parameterType))
+                        {
+                            continue;
+                        }
+
+                        // If the parameter:
+                        // - contains default value in bicep file
+                        // - is also mentioned in parameters file
+                        // then the value specified in the parameters file will take precedence.
+                        // We will not provide an option to override in the UI
+                        if (parametersFromProvidedParametersFile is not null && parametersFromProvidedParametersFile.ContainsKey(parameterName))
+                        {
+                            continue;
+                        }
+
+                        if (defaultParametersFromTemplate?[parameterName]?["defaultValue"] is JToken defaultValueObject &&
+                            defaultValueObject is not null &&
+                            defaultValueObject.ToString() is string defaultValue)
+                        {
+                            bool isExpression = IsExpression(modifier);
+
+                            if (isExpression)
+                            {
+                                defaultValue = defaultValue.TrimStart('[').TrimEnd(']');
+                            }
+                            var updatedDeploymentParameter = new BicepDeploymentParameter(
+                                name: parameterName,
+                                value: defaultValue.ToString(),
+                                isMissingParam: false,
+                                isExpression: isExpression,
+                                isSecure: parameterSymbol.IsSecure(),
+                                parameterType: parameterType);
+                            updatedDeploymentParameters.Add(updatedDeploymentParameter);
+                        }
+                    }
+                }
+
+                return new BicepDeploymentParametersResponse(
+                    updatedDeploymentParameters,
+                    parametersFileExists,
+                    parametersFileName,
+                    GetErrorMessageForMissingArrayOrObjectTypes(missingArrayOrObjectTypes));
+
+            }
+            catch (Exception e)
+            {
+                return new BicepDeploymentParametersResponse(new List<BicepDeploymentParameter>(), parametersFileExists, parametersFileName, e.Message);
+            }
+        }
+
+        private bool IsExpression(SyntaxBase modifier)
+        {
+            return modifier is ParameterDefaultValueSyntax parameterDefaultValueSyntax &&
+                parameterDefaultValueSyntax.DefaultValue is ExpressionSyntax expressionSyntax &&
+                expressionSyntax is not null &&
+                expressionSyntax is not StringSyntax &&
+                expressionSyntax is not IntegerLiteralSyntax &&
+                expressionSyntax is not BooleanLiteralSyntax;
+        }
+
+        private string GetParameterFileName(string documentPath, bool parametersFileExists, string parametersFilePath)
+        {
+            if (parametersFileExists)
+            {
+                return Path.GetFileName(parametersFilePath);
+            }
+
+            return Path.GetFileNameWithoutExtension(documentPath) + ".parameters.json";
+        }
+
+        private string? GetErrorMessageForMissingArrayOrObjectTypes(List<string> missingArrayOrObjectTypes)
+        {
+            if (!missingArrayOrObjectTypes.Any())
+            {
+                return null;
+            }
+
+            return string.Format(LangServerResources.MissingParamValueForArrayOrObjectType, string.Join(",", missingArrayOrObjectTypes));
+        }
+
+        public Dictionary<string, dynamic>? GetParametersInfoFromProvidedFile(string parametersFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(parametersFilePath) || !File.Exists(parametersFilePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                var parametersFileContents = File.ReadAllText(parametersFilePath);
+                var jObject = JObject.Parse(parametersFileContents);
+
+                if (jObject.ContainsKey("$schema") && jObject.ContainsKey("contentVersion") && jObject.ContainsKey("parameters"))
+                {
+                    var parametersObject = jObject["parameters"];
+
+                    if (parametersObject is not null)
+                    {
+                        parametersFileContents = parametersObject.ToString();
+                    }
+                }
+
+                return JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(parametersFileContents);
+            }
+            catch(Exception e)
+            {
+                throw new Exception(string.Format(LangServerResources.InvalidParameterFile, parametersFilePath, e.Message));
+            }
+        }
+
+        private IEnumerable<ParameterSymbol> GetParameterSymbols(string documentPath)
+        {
+            var documentUri = DocumentUri.FromFileSystemPath(documentPath);
+            var compilationContext = compilationManager.GetCompilation(documentUri);
+
+            if (compilationContext is null)
+            {
+                return Enumerable.Empty<ParameterSymbol>();
+            }
+
+            var semanticModel = compilationContext.Compilation.GetEntrypointSemanticModel();
+            return semanticModel.Root.ParameterDeclarations
+                .Where(sym => semanticModel.FindReferences(sym).OfType<VariableAccessSyntax>().Any());
+        }
+
+        private bool IsOfTypeArrayOrObject(ParameterType? parameterType)
+        {
+            return parameterType is not null &&
+                (parameterType == ParameterType.Array || parameterType == ParameterType.Object);
+        }
+
+        public ParameterType? GetParameterType(ParameterDeclarationSyntax parameterDeclarationSyntax)
+        {
+            if (parameterDeclarationSyntax.ParameterType is SimpleTypeSyntax simpleTypeSyntax &&
+                simpleTypeSyntax is not null)
+            {
+                return simpleTypeSyntax.TypeName switch
+                {
+                    "array" => ParameterType.Array,
+                    "bool" => ParameterType.Bool,
+                    "int" => ParameterType.Int,
+                    "object" => ParameterType.Object,
+                    "string" => ParameterType.String,
+                    _ => null,
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.ResourceManager;
@@ -13,7 +14,23 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public record BicepDeploymentStartParams(string documentPath, string parameterFilePath, string id, string deploymentScope, string location, string template, string token, string expiresOnTimestamp, string deployId, string portalUrl) : IRequest<string>;
+    public record BicepUpdatedDeploymentParameter(string name, string value, bool isSecure, ParameterType? parameterType);
+
+    public record BicepDeploymentStartParams(
+        string documentPath,
+        string parametersFilePath,
+        string id,
+        string deploymentScope,
+        string location,
+        string template,
+        string token,
+        string expiresOnTimestamp,
+        string deployId,
+        string portalUrl,
+        bool parametersFileExists,
+        string parametersFileName,
+        ParametersFileUpdateOption parametersFileUpdateOption,
+        List<BicepUpdatedDeploymentParameter> updatedDeploymentParameters) : IRequest<string>;
 
     public record BicepDeploymentStartResponse(bool isSuccess, string outputMessage, string? viewDeploymentInPortalMessage);
 
@@ -45,11 +62,14 @@ namespace Bicep.LanguageServer.Handlers
                 armClient,
                 request.documentPath,
                 request.template,
-                request.parameterFilePath,
+                request.parametersFilePath,
                 request.id,
                 request.deploymentScope,
                 request.location,
                 request.deployId,
+                request.parametersFileName,
+                request.parametersFileUpdateOption,
+                request.updatedDeploymentParameters,
                 request.portalUrl,
                 deploymentName,
                 deploymentOperationsCache);

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentWaitForCompletionCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentWaitForCompletionCommandHandler.cs
@@ -27,6 +27,9 @@ namespace Bicep.LanguageServer.Handlers
         /// This handler waits for the deployment to complete and sends a "deploymentComplete" notification to the client.
         /// This notification can be used on the client side to write success/failure messsage to the output channel without
         /// blocking other commands.
+        /// Note: Base handler - ExecuteTypedResponseCommandHandlerBase is serial. This blocks other commands on the client side.
+        /// To avoid the above issue, we changed the RequestProcessType to parallel in <see cref="Server"/>
+        /// We need to make sure changes to this handler are thread safe.
         /// </summary>
         public BicepDeploymentWaitForCompletionCommandHandler(IDeploymentOperationsCache deploymentOperationsCache, ILanguageServerFacade server, ISerializer serializer, ITelemetryProvider telemetryProvider)
             : base(LangServerConstants.DeployWaitForCompletionCommand, serializer)

--- a/src/Bicep.LangServer/LangServerConstants.cs
+++ b/src/Bicep.LangServer/LangServerConstants.cs
@@ -6,6 +6,7 @@ namespace Bicep.LanguageServer
     public static class LangServerConstants
     {
         public const string BuildCommand = "build";
+        public const string DeployCompleteMethod = "deploymentComplete";
         public const string DeployStartCommand = "deploy/start";
         public const string DeployWaitForCompletionCommand = "deploy/waitForCompletion";
         public const string GetDeploymentParametersCommand = "getDeploymentParameters";

--- a/src/Bicep.LangServer/LangServerConstants.cs
+++ b/src/Bicep.LangServer/LangServerConstants.cs
@@ -8,6 +8,7 @@ namespace Bicep.LanguageServer
         public const string BuildCommand = "build";
         public const string DeployStartCommand = "deploy/start";
         public const string DeployWaitForCompletionCommand = "deploy/waitForCompletion";
+        public const string GetDeploymentParametersCommand = "getDeploymentParameters";
         public const string GetDeploymentScopeCommand = "getDeploymentScope";
         public const string ForceModulesRestoreCommand = "forceModulesRestore";
     }

--- a/src/Bicep.LangServer/LangServerResources.Designer.cs
+++ b/src/Bicep.LangServer/LangServerResources.Designer.cs
@@ -151,7 +151,7 @@ namespace Bicep.LanguageServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameters of type array or object should either contain a default value or must be specified in parameters.json file. Please update the value for following parameters: {0}.
+        ///   Looks up a localized string similar to Parameters of type array or object should either contain a default value or must be specified in parameters.json file. Please update the value for the following parameters: {0}.
         /// </summary>
         public static string MissingParamValueForArrayOrObjectType {
             get {

--- a/src/Bicep.LangServer/LangServerResources.Designer.cs
+++ b/src/Bicep.LangServer/LangServerResources.Designer.cs
@@ -115,11 +115,29 @@ namespace Bicep.LanguageServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deployment failed for {0}. Please fix the following issues in the parameter file: {1}.
+        ///   Looks up a localized string similar to Encountered error while reading parameters file: {0}. Please fix the following issue: {1}.
+        /// </summary>
+        public static string InvalidParameterFile {
+            get {
+                return ResourceManager.GetString("InvalidParameterFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deployment failed for {0}. Please fix following issues in the parameter file {1}: {2}.
         /// </summary>
         public static string InvalidParameterFileDeploymentFailedMessage {
             get {
                 return ResourceManager.GetString("InvalidParameterFileDeploymentFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deployment failed for {0}. Please provide a valid value for parameter: {1}.
+        /// </summary>
+        public static string InvalidParameterValueDeploymentFailedMessage {
+            get {
+                return ResourceManager.GetString("InvalidParameterValueDeploymentFailedMessage", resourceCulture);
             }
         }
         
@@ -129,6 +147,15 @@ namespace Bicep.LanguageServer {
         public static string MissingLocationDeploymentFailedMessage {
             get {
                 return ResourceManager.GetString("MissingLocationDeploymentFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameters of type array or object should either contain a default value or must be specified in parameters.json file. Please update the value for following parameters: {0}.
+        /// </summary>
+        public static string MissingParamValueForArrayOrObjectType {
+            get {
+                return ResourceManager.GetString("MissingParamValueForArrayOrObjectType", resourceCulture);
             }
         }
         

--- a/src/Bicep.LangServer/LangServerResources.resx
+++ b/src/Bicep.LangServer/LangServerResources.resx
@@ -149,7 +149,7 @@
     <value>Deployment failed for {0}. Please provide a valid location.</value>
   </data>
   <data name="MissingParamValueForArrayOrObjectType" xml:space="preserve">
-    <value>Parameters of type array or object should either contain a default value or must be specified in parameters.json file. Please update the value for following parameters: {0}</value>
+    <value>Parameters of type array or object should either contain a default value or must be specified in parameters.json file. Please update the value for the following parameters: {0}</value>
   </data>
   <data name="UnsupportedTargetScopeMessage" xml:space="preserve">
     <value>Unsupported target scope: {0}.</value>

--- a/src/Bicep.LangServer/LangServerResources.resx
+++ b/src/Bicep.LangServer/LangServerResources.resx
@@ -136,11 +136,20 @@
     <value>Edit {0} in bicepconfig.json</value>
     <comment>{0} = programmatic name of a linter rule</comment>
   </data>
+  <data name="InvalidParameterFile" xml:space="preserve">
+    <value>Encountered error while reading parameters file: {0}. Please fix the following issue: {1}</value>
+  </data>
   <data name="InvalidParameterFileDeploymentFailedMessage" xml:space="preserve">
-    <value>Deployment failed for {0}. Please fix the following issues in the parameter file: {1}</value>
+    <value>Deployment failed for {0}. Please fix following issues in the parameter file {1}: {2}</value>
+  </data>
+  <data name="InvalidParameterValueDeploymentFailedMessage" xml:space="preserve">
+    <value>Deployment failed for {0}. Please provide a valid value for parameter: {1}</value>
   </data>
   <data name="MissingLocationDeploymentFailedMessage" xml:space="preserve">
     <value>Deployment failed for {0}. Please provide a valid location.</value>
+  </data>
+  <data name="MissingParamValueForArrayOrObjectType" xml:space="preserve">
+    <value>Parameters of type array or object should either contain a default value or must be specified in parameters.json file. Please update the value for following parameters: {0}</value>
   </data>
   <data name="UnsupportedTargetScopeMessage" xml:space="preserve">
     <value>Unsupported target scope: {0}.</value>

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -24,6 +24,7 @@ using Bicep.LanguageServer.Snippets;
 using Bicep.LanguageServer.Telemetry;
 using Bicep.LanguageServer.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 using OmniSharp.Extensions.LanguageServer.Server;
 using System;
@@ -73,7 +74,9 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepTelemetryHandler>()
                     .WithHandler<BicepBuildCommandHandler>()
                     .WithHandler<BicepDeploymentStartCommandHandler>()
-                    .WithHandler<BicepDeploymentWaitForCompletionCommandHandler>()
+                    // Base handler - ExecuteTypedResponseCommandHandlerBase is serial. This blocks other commands on the client side.
+                    // To avoid the above issue, we'll change the RequestProcessType to parallel
+                    .WithHandler<BicepDeploymentWaitForCompletionCommandHandler>(new JsonRpcHandlerOptions() { RequestProcessType = RequestProcessType.Parallel })
                     .WithHandler<BicepDeploymentScopeRequestHandler>()
                     .WithHandler<BicepDeploymentParametersHandler>()
                     .WithHandler<BicepForceModulesRestoreCommandHandler>()

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -75,6 +75,7 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepDeploymentStartCommandHandler>()
                     .WithHandler<BicepDeploymentWaitForCompletionCommandHandler>()
                     .WithHandler<BicepDeploymentScopeRequestHandler>()
+                    .WithHandler<BicepDeploymentParametersHandler>()
                     .WithHandler<BicepForceModulesRestoreCommandHandler>()
                     .WithHandler<BicepRegistryCacheRequestHandler>()
                     .WithHandler<InsertResourceHandler>()

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -602,10 +602,7 @@ export class DeployCommand implements Command {
     const quickPickItems: IAzureQuickPickItem[] = [];
     if (paramValue) {
       const useExpressionValue: IAzureQuickPickItem = {
-        label: localize(
-          "useExpressionValue",
-          `Use value of expression "${paramValue}"`
-        ),
+        label: localize("useExpressionValue", `Use value of "${paramValue}"`),
         data: undefined,
       };
       quickPickItems.push(useExpressionValue);

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -668,7 +668,7 @@ export class DeployCommand implements Command {
       await vscode.workspace.findFiles("**/*.{json,jsonc}", undefined)
     ).filter((f) => !!f.fsPath);
 
-    workspaceJsonFiles.sort((a, b) => a.path.localeCompare(b.path));
+    workspaceJsonFiles.sort((a, b) => compareStrings(a.path, b.path));
 
     for (const uri of workspaceJsonFiles) {
       const workspaceRoot: string | undefined =

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -54,6 +54,7 @@ export class DeployCommand implements Command {
   private _no: IAzureQuickPickItem = {
     label: localize("no", "No"),
     data: undefined,
+    priority: "highest",
   };
   private _yesNoQuickPickItems: IAzureQuickPickItem[] = [this._yes, this._no];
 

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -33,10 +33,7 @@ import {
   LanguageClient,
   TextDocumentIdentifier,
 } from "vscode-languageclient/node";
-import {
-  compareStrings,
-  findOrCreateActiveBicepFile,
-} from "./findOrCreateActiveBicepFile";
+import { findOrCreateActiveBicepFile } from "./findOrCreateActiveBicepFile";
 
 export class DeployCommand implements Command {
   private _none: IAzureQuickPickItem<string> = {
@@ -456,7 +453,7 @@ export class DeployCommand implements Command {
       {
         canPickMany: false,
         placeHolder: `Select a parameter file`,
-        suppressPersistence: true,
+        id: sourceUri.toString(),
       }
     );
 
@@ -679,7 +676,7 @@ export class DeployCommand implements Command {
       const quickPickItem: IAzureQuickPickItem<string> = {
         label: `${"$(json) "} ${relativePath}`,
         data: uri.fsPath,
-        id: uri.path,
+        id: uri.toString(),
       };
       quickPickItems.push(quickPickItem);
     }

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -618,11 +618,6 @@ export class DeployCommand implements Command {
       data: undefined,
     };
     quickPickItems.push(enterNewValue);
-    const leaveBlank: IAzureQuickPickItem = {
-      label: localize("leaveBlank", `"" (leave blank)`),
-      data: undefined,
-    };
-    quickPickItems.push(leaveBlank);
 
     const result: IAzureQuickPickItem = await _context.ui.showQuickPick(
       quickPickItems,
@@ -633,9 +628,7 @@ export class DeployCommand implements Command {
       }
     );
 
-    if (result == leaveBlank) {
-      return "";
-    } else if (result == enterNewValue) {
+    if (result == enterNewValue) {
       const paramValue = await vscode.window.showInputBox({
         placeHolder: `Please enter value for parameter "${paramName}"`,
       });

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -33,7 +33,10 @@ import {
   LanguageClient,
   TextDocumentIdentifier,
 } from "vscode-languageclient/node";
-import { findOrCreateActiveBicepFile } from "./findOrCreateActiveBicepFile";
+import {
+  compareStrings,
+  findOrCreateActiveBicepFile,
+} from "./findOrCreateActiveBicepFile";
 
 export class DeployCommand implements Command {
   private _none: IAzureQuickPickItem<string> = {

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -33,11 +33,9 @@ import {
   LanguageClient,
   TextDocumentIdentifier,
 } from "vscode-languageclient/node";
-import {
-  compareStrings,
-  findOrCreateActiveBicepFile,
-} from "./findOrCreateActiveBicepFile";
+import { findOrCreateActiveBicepFile } from "./findOrCreateActiveBicepFile";
 import { setOutputChannelManagerAtTheStartOfDeployment } from "./deployHelper";
+import { compareStringsOrdinal } from "../utils/compareStringsOrdinal";
 
 export class DeployCommand implements Command {
   private _none: IAzureQuickPickItem<string> = {
@@ -660,7 +658,7 @@ export class DeployCommand implements Command {
       await vscode.workspace.findFiles("**/*.{json,jsonc}", undefined)
     ).filter((f) => !!f.fsPath);
 
-    workspaceJsonFiles.sort((a, b) => compareStrings(a.path, b.path));
+    workspaceJsonFiles.sort((a, b) => compareStringsOrdinal(a.path, b.path));
 
     for (const uri of workspaceJsonFiles) {
       const workspaceRoot: string | undefined =

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -37,7 +37,7 @@ import {
   compareStrings,
   findOrCreateActiveBicepFile,
 } from "./findOrCreateActiveBicepFile";
-import { setOutputChannelManager } from "./deployHelper";
+import { setOutputChannelManagerAtTheStartOfDeployment } from "./deployHelper";
 
 export class DeployCommand implements Command {
   private _none: IAzureQuickPickItem<string> = {
@@ -74,7 +74,7 @@ export class DeployCommand implements Command {
     const deployId = Math.random().toString();
     context.telemetry.properties.deployId = deployId;
 
-    setOutputChannelManager(this.outputChannelManager);
+    setOutputChannelManagerAtTheStartOfDeployment(this.outputChannelManager);
 
     documentUri = await findOrCreateActiveBicepFile(
       context,

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -395,7 +395,7 @@ export class DeployCommand implements Command {
         });
 
       // If user chose to create a parameters file at the end of deployment flow, we'll
-      // create one and open it in vscode.
+      // open it in vscode.
       if (parametersFileUpdateOption == ParametersFileUpdateOption.Create) {
         parametersFilePath = path.join(
           path.dirname(documentPath),

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -365,7 +365,7 @@ export class DeployCommand implements Command {
         updatedDeploymentParameters.length > 0 &&
         !updatedDeploymentParameters.every((x) => x.isSecure)
       ) {
-        parametersFileUpdateOption = await this.updateParametersFile(
+        parametersFileUpdateOption = await this.askToUpdateParametersFile(
           context,
           documentPath,
           await fse.pathExists(parametersFilePath),
@@ -546,7 +546,7 @@ export class DeployCommand implements Command {
     ];
   }
 
-  private async updateParametersFile(
+  private async askToUpdateParametersFile(
     _context: IActionContext,
     documentPath: string,
     parametersFileExists: boolean,

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -394,20 +394,24 @@ export class DeployCommand implements Command {
           arguments: [deploymentStartParams],
         });
 
-      // If user chose to create a parameters file at the end of deployment flow, we'll
+      // If user chose to create/update/overwrite a parameters file at the end of deployment flow, we'll
       // open it in vscode.
-      if (parametersFileUpdateOption == ParametersFileUpdateOption.Create) {
-        parametersFilePath = path.join(
-          path.dirname(documentPath),
-          parametersFileName
-        );
+      if (parametersFileUpdateOption != ParametersFileUpdateOption.None) {
+        if (
+          parametersFileUpdateOption == ParametersFileUpdateOption.Create ||
+          parametersFileUpdateOption == ParametersFileUpdateOption.Overwrite
+        ) {
+          parametersFilePath = path.join(
+            path.dirname(documentPath),
+            parametersFileName
+          );
+        }
         const parametersFileTextDocument =
           await vscode.workspace.openTextDocument(parametersFilePath);
         await vscode.window.showTextDocument(parametersFileTextDocument);
       }
       return deploymentStartResponse;
     }
-
     return undefined;
   }
 

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -37,6 +37,7 @@ import {
   compareStrings,
   findOrCreateActiveBicepFile,
 } from "./findOrCreateActiveBicepFile";
+import { setOutputChannelManager } from "./deployHelper";
 
 export class DeployCommand implements Command {
   private _none: IAzureQuickPickItem<string> = {
@@ -72,6 +73,8 @@ export class DeployCommand implements Command {
   ): Promise<void> {
     const deployId = Math.random().toString();
     context.telemetry.properties.deployId = deployId;
+
+    setOutputChannelManager(this.outputChannelManager);
 
     documentUri = await findOrCreateActiveBicepFile(
       context,
@@ -171,7 +174,7 @@ export class DeployCommand implements Command {
         }
       }
 
-      await this.sendDeployWaitForCompletionCommand(
+      this.sendDeployWaitForCompletionCommand(
         deployId,
         deploymentStartResponse,
         documentPath
@@ -432,15 +435,10 @@ export class DeployCommand implements Command {
             deployId,
             documentPath,
           };
-        const outputMessage: string = await this.client.sendRequest(
-          "workspace/executeCommand",
-          {
-            command: "deploy/waitForCompletion",
-            arguments: [bicepDeploymentWaitForCompletionParams],
-          }
-        );
-
-        this.outputChannelManager.appendToOutputChannel(outputMessage);
+        await this.client.sendRequest("workspace/executeCommand", {
+          command: "deploy/waitForCompletion",
+          arguments: [bicepDeploymentWaitForCompletionParams],
+        });
       }
     }
   }

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -668,7 +668,7 @@ export class DeployCommand implements Command {
       await vscode.workspace.findFiles("**/*.{json,jsonc}", undefined)
     ).filter((f) => !!f.fsPath);
 
-    workspaceJsonFiles.sort((a, b) => compareStrings(a.path, b.path));
+    workspaceJsonFiles.sort((a, b) => a.path.localeCompare(b.path));
 
     for (const uri of workspaceJsonFiles) {
       const workspaceRoot: string | undefined =

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -605,7 +605,7 @@ export class DeployCommand implements Command {
     }
 
     _context.telemetry.properties.parametersFileUpdateOption =
-    parametersFileUpdateOptionString;
+      parametersFileUpdateOptionString;
     return parametersFileUpdateOption;
   }
 

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -554,11 +554,14 @@ export class DeployCommand implements Command {
     parametersFileName: string
   ) {
     let placeholder: string;
+    let parametersFileUpdateOptionString = "None";
     let parametersFileUpdateOption: ParametersFileUpdateOption;
     if (parametersFileExists) {
+      parametersFileUpdateOptionString = "Update";
       parametersFileUpdateOption = ParametersFileUpdateOption.Update;
       placeholder = `Update ${parametersFileName} with values used in this deployment?`;
     } else {
+      parametersFileUpdateOptionString = "Create";
       parametersFileUpdateOption = ParametersFileUpdateOption.Create;
       placeholder = `Create parameters file from values used in this deployment?`;
     }
@@ -591,8 +594,10 @@ export class DeployCommand implements Command {
           );
 
           if (result == this._yes) {
+            parametersFileUpdateOptionString = "Overwrite";
             parametersFileUpdateOption = ParametersFileUpdateOption.Overwrite;
           } else {
+            parametersFileUpdateOptionString = "None";
             parametersFileUpdateOption = ParametersFileUpdateOption.None;
           }
         }
@@ -600,7 +605,7 @@ export class DeployCommand implements Command {
     }
 
     _context.telemetry.properties.parametersFileUpdateOption =
-      parametersFileUpdateOption.toString();
+    parametersFileUpdateOptionString;
     return parametersFileUpdateOption;
   }
 

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -435,7 +435,7 @@ export class DeployCommand implements Command {
             deployId,
             documentPath,
           };
-        await this.client.sendRequest("workspace/executeCommand", {
+        this.client.sendRequest("workspace/executeCommand", {
           command: "deploy/waitForCompletion",
           arguments: [bicepDeploymentWaitForCompletionParams],
         });

--- a/src/vscode-bicep/src/commands/deployHelper.ts
+++ b/src/vscode-bicep/src/commands/deployHelper.ts
@@ -5,13 +5,15 @@ import { OutputChannelManager } from "../utils/OutputChannelManager";
 
 let _outputChannelManager: OutputChannelManager;
 
-export async function writeToOutputChannel(outputMessage: string) {
+export async function writeDeploymentOutputMessageToBicepOperationsOutputChannel(
+  outputMessage: string
+) {
   if (_outputChannelManager) {
     _outputChannelManager.appendToOutputChannel(outputMessage);
   }
 }
 
-export function setOutputChannelManager(
+export function setOutputChannelManagerAtTheStartOfDeployment(
   outputChannelManager: OutputChannelManager
 ) {
   _outputChannelManager = outputChannelManager;

--- a/src/vscode-bicep/src/commands/deployHelper.ts
+++ b/src/vscode-bicep/src/commands/deployHelper.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { OutputChannelManager } from "../utils/OutputChannelManager";
+
+let _outputChannelManager: OutputChannelManager;
+
+export async function writeToOutputChannel(outputMessage: string) {
+  if (_outputChannelManager) {
+    _outputChannelManager.appendToOutputChannel(outputMessage);
+  }
+}
+
+export function setOutputChannelManager(
+  outputChannelManager: OutputChannelManager
+) {
+  _outputChannelManager = outputChannelManager;
+}

--- a/src/vscode-bicep/src/commands/findOrCreateActiveBicepFile.ts
+++ b/src/vscode-bicep/src/commands/findOrCreateActiveBicepFile.ts
@@ -12,6 +12,7 @@ import {
 import * as path from "path";
 import * as os from "os";
 import * as fse from "fs-extra";
+import { compareStringsOrdinal } from "../utils/compareStringsOrdinal";
 import { TextDocument, Uri, window, workspace } from "vscode";
 
 type TargetFile =
@@ -60,7 +61,7 @@ export async function findOrCreateActiveBicepFile(
     .concat(visibleBicepFiles)
     .forEach((bf) => map.set(bf.fsPath, bf));
   const bicepFilesSorted = Array.from(map.values());
-  bicepFilesSorted.sort((a, b) => compareStrings(a.path, b.path));
+  bicepFilesSorted.sort((a, b) => compareStringsOrdinal(a.path, b.path));
 
   if (bicepFilesSorted.length === 1) {
     // Only a single Bicep file in the workspace/visible editors - choose it
@@ -160,14 +161,4 @@ async function queryCreateBicepFile(
   await window.showTextDocument(document);
 
   return uri;
-}
-
-export function compareStrings(a: string, b: string): number {
-  if (a > b) {
-    return 1;
-  } else if (b > a) {
-    return -1;
-  } else {
-    return 0;
-  }
 }

--- a/src/vscode-bicep/src/commands/findOrCreateActiveBicepFile.ts
+++ b/src/vscode-bicep/src/commands/findOrCreateActiveBicepFile.ts
@@ -162,7 +162,7 @@ async function queryCreateBicepFile(
   return uri;
 }
 
-function compareStrings(a: string, b: string): number {
+export function compareStrings(a: string, b: string): number {
   if (a > b) {
     return 1;
   } else if (b > a) {

--- a/src/vscode-bicep/src/commands/findOrCreateActiveBicepFile.ts
+++ b/src/vscode-bicep/src/commands/findOrCreateActiveBicepFile.ts
@@ -60,7 +60,7 @@ export async function findOrCreateActiveBicepFile(
     .concat(visibleBicepFiles)
     .forEach((bf) => map.set(bf.fsPath, bf));
   const bicepFilesSorted = Array.from(map.values());
-  bicepFilesSorted.sort((a, b) => compareStrings(a.path, b.path));
+  bicepFilesSorted.sort((a, b) => a.path.localeCompare(b.path));
 
   if (bicepFilesSorted.length === 1) {
     // Only a single Bicep file in the workspace/visible editors - choose it
@@ -160,14 +160,4 @@ async function queryCreateBicepFile(
   await window.showTextDocument(document);
 
   return uri;
-}
-
-export function compareStrings(a: string, b: string): number {
-  if (a > b) {
-    return 1;
-  } else if (b > a) {
-    return -1;
-  } else {
-    return 0;
-  }
 }

--- a/src/vscode-bicep/src/commands/findOrCreateActiveBicepFile.ts
+++ b/src/vscode-bicep/src/commands/findOrCreateActiveBicepFile.ts
@@ -60,7 +60,7 @@ export async function findOrCreateActiveBicepFile(
     .concat(visibleBicepFiles)
     .forEach((bf) => map.set(bf.fsPath, bf));
   const bicepFilesSorted = Array.from(map.values());
-  bicepFilesSorted.sort((a, b) => a.path.localeCompare(b.path));
+  bicepFilesSorted.sort((a, b) => compareStrings(a.path, b.path));
 
   if (bicepFilesSorted.length === 1) {
     // Only a single Bicep file in the workspace/visible editors - choose it
@@ -160,4 +160,14 @@ async function queryCreateBicepFile(
   await window.showTextDocument(document);
 
   return uri;
+}
+
+export function compareStrings(a: string, b: string): number {
+  if (a > b) {
+    return 1;
+  } else if (b > a) {
+    return -1;
+  } else {
+    return 0;
+  }
 }

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -16,7 +16,7 @@ import {
   CloseAction,
   TransportKind,
 } from "vscode-languageclient/node";
-import { writeToOutputChannel } from "../commands/deployHelper";
+import { writeDeploymentOutputMessageToBicepOperationsOutputChannel } from "../commands/deployHelper";
 
 const dotnetRuntimeVersion = "6.0";
 const packagedServerPath = "bicepLanguageServer/Bicep.LangServer.dll";
@@ -157,7 +157,10 @@ async function launchLanguageService(
 
   await client.onReady();
 
-  client.onNotification("deploymentComplete", writeToOutputChannel);
+  client.onNotification(
+    "deploymentComplete",
+    writeDeploymentOutputMessageToBicepOperationsOutputChannel
+  );
 
   getLogger().info("Bicep language service ready.");
 

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -16,6 +16,7 @@ import {
   CloseAction,
   TransportKind,
 } from "vscode-languageclient/node";
+import { writeToOutputChannel } from "../commands/deployHelper";
 
 const dotnetRuntimeVersion = "6.0";
 const packagedServerPath = "bicepLanguageServer/Bicep.LangServer.dll";
@@ -155,6 +156,8 @@ async function launchLanguageService(
   getLogger().info("Bicep language service started.");
 
   await client.onReady();
+
+  client.onNotification("deploymentComplete", writeToOutputChannel);
 
   getLogger().info("Bicep language service ready.");
 

--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -58,7 +58,7 @@ export interface BicepDeploymentScopeResponse {
 
 export interface BicepDeploymentStartParams {
   documentPath: string;
-  parameterFilePath: string;
+  parametersFilePath: string;
   id: string;
   deploymentScope: string;
   location: string;
@@ -67,6 +67,9 @@ export interface BicepDeploymentStartParams {
   expiresOnTimestamp: string;
   deployId: string;
   portalUrl: string;
+  parametersFileName: string;
+  parametersFileUpdateOption: ParametersFileUpdateOption;
+  updatedDeploymentParameters: BicepUpdatedDeploymentParameter[];
 }
 
 export interface BicepDeploymentStartResponse {
@@ -78,6 +81,43 @@ export interface BicepDeploymentStartResponse {
 export interface BicepDeploymentWaitForCompletionParams {
   deployId: string;
   documentPath: string;
+}
+
+export interface BicepDeploymentParameter {
+  name: string;
+  value?: string | undefined;
+  isMissingParam: boolean;
+  isExpression: boolean;
+  isSecure: boolean;
+  parameterType: ParameterType | undefined;
+}
+
+export interface BicepDeploymentParametersResponse {
+  deploymentParameters: BicepDeploymentParameter[];
+  parametersFileName: string;
+  errorMessage?: string;
+}
+
+export interface BicepUpdatedDeploymentParameter {
+  name: string;
+  value: string;
+  isSecure: boolean;
+  parameterType: ParameterType | undefined;
+}
+
+export enum ParametersFileUpdateOption {
+  Create = 1,
+  None = 2,
+  Overwrite = 3,
+  Update = 4,
+}
+
+export enum ParameterType {
+  Array = 1,
+  Bool = 2,
+  Int = 3,
+  Object = 4,
+  String = 5,
 }
 
 export interface BicepCacheResponse {

--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -106,9 +106,15 @@ export interface BicepUpdatedDeploymentParameter {
 }
 
 export enum ParametersFileUpdateOption {
+  // If the user did not provide a parameters file to be used during deployment and chose to create one at the end of deployment flow
   Create = 1,
+  // User select "No" to create/update parameters file at the end of deployment flow
   None = 2,
+  // If the user did not provide a parameters file to be used in deployment, but chose to create one at the end of the flow and
+  // file with name <bicep_file_name>.parameters.json already exists in the same folder as bicep file
   Overwrite = 3,
+  // If the user provided a file to be used during deployment and chose to update it with values from current deployment at the
+  // end of deployment flow
   Update = 4,
 }
 

--- a/src/vscode-bicep/src/utils/compareStringsOrdinal.ts
+++ b/src/vscode-bicep/src/utils/compareStringsOrdinal.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function compareStringsOrdinal(a: string, b: string): number {
+  if (a > b) {
+    return 1;
+  } else if (b > a) {
+    return -1;
+  } else {
+    return 0;
+  }
+}


### PR DESCRIPTION
**Fixes:**
#6159
#7005
#7019 
 #7024
#6773

**Changes in the PR include:**
-	Support for additional/missing parameters. Note: we only support parameters of type int, bool and string. Arrays and objects are ignored for now because of the complexity involved
-	Missing params – these are parameters that are not specified in parameters file and don’t have a default value in bicep file. We will show an input box that will let the user input value for missing params
-	Params with default values – these are parameters that are specified in bicep file with default value. We will provide an input box, prefilled with default value from bicep file. User can either press enter to use the default or provide a new value. Note: Expression strings are handled differently. We will provide three options here: 1. Use the expression as is 2. Provide a new value 3. Leave blank. Note: In case of (1), value will not be written to parameters file
-	After iterating through all the parameters, the user can either choose to create a new parameters file, if it doesn’t exist or update an existing file. Note: secure parameters will be sent across to the azure sdk and used in deployment, but will not be written to parameters file
-	UI changes to show all the .json/.jsonc files from the workspace along with current – None and Browse options
-	Added telemetry
-	Added unit tests


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7030)