### PR TITLE
Bicep deploy - update BicepDeploymentParametersHandler to handle requests from unopened file 

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
@@ -27,6 +27,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         public TestContext? TestContext { get; set; }
 
         private readonly ISerializer Serializer = StrictMock.Of<ISerializer>().Object;
+        private readonly IDeploymentFileCompilationCache DeploymentFileCompilationCache = new DeploymentFileCompilationCache();
 
         [TestMethod]
         public async Task Handle_WithNoParamsInSourceFile_ShouldReturnEmptyListOfUpdatedDeploymentParameters()
@@ -48,9 +49,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
   ""resources"": []
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, string.Empty);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
@@ -81,9 +80,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
   ""resources"": []
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, bicepFileContents);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
@@ -138,9 +135,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   ]
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, bicepFileContents);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
@@ -204,10 +199,8 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
     }
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
             var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, bicepFileContents);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, parametersFilePath, template, CancellationToken.None);
 
@@ -258,9 +251,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   ]
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, bicepFileContents);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
@@ -324,10 +315,8 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
     }
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
             var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, bicepFileContents);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, parametersFilePath, template, CancellationToken.None);
 
@@ -385,9 +374,7 @@ param testProperties object = {
   ]
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, string.Empty);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
@@ -437,9 +424,7 @@ param allowedOrigins array = [
   ]
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, string.Empty);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
@@ -486,9 +471,7 @@ param testProperties object";
   ]
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, bicepFileContents);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
@@ -543,9 +526,7 @@ resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@
   ]
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, bicepFileContents);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
@@ -608,10 +589,8 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
       ""value"": ""westus""
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
             var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, string.Empty);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, parametersFilePath, template, CancellationToken.None);
 
@@ -670,9 +649,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   ]
 }";
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, bicepFileContents);
 
             var result = await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
 
@@ -704,6 +681,56 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
             result.errorMessage.Should().BeNull();
         }
 
+        [TestMethod]
+        public async Task Handle_WithValidInput_VerifyNoEntryInDeploymentFileCompilationCache()
+        {
+            var bicepFileContents = @"param name string = 'test'
+param location string = 'global
+resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: name
+  location: location
+}";
+            var template = @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""metadata"": {
+    ""_generator"": {
+      ""name"": ""bicep"",
+      ""version"": ""0.6.18.56646"",
+      ""templateHash"": ""3422964353444461889""
+    }
+  },
+  ""parameters"": {
+    ""name"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""test""
+    },
+    ""location"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""global""
+    }
+  },
+  ""resources"": [
+    {
+      ""type"": ""Microsoft.Network/dnsZones"",
+      ""apiVersion"": ""2018-05-01"",
+      ""name"": ""[parameters('name')]"",
+      ""location"": ""[parameters('location')]""
+    }
+  ]
+}";
+            var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var compilation = bicepCompilationManager.GetCompilation(documentUri)!.Compilation;
+            DeploymentFileCompilationCache.CacheCompilation(documentUri, compilation);
+            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(DeploymentFileCompilationCache, Serializer);
+
+            await bicepDeploymentParametersHandler.Handle(bicepFilePath, string.Empty, template, CancellationToken.None);
+
+            Assert.IsNull(DeploymentFileCompilationCache.FindAndRemoveCompilation(documentUri));
+        }
+
         [DataTestMethod]
         [DataRow("param test string = 'test'", ParameterType.String)]
         [DataRow("param test int = 1", ParameterType.Int)]
@@ -726,9 +753,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
             parameterDeclarationSyntax.Should().NotBeNull();
 
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, string.Empty);
 
             var result = bicepDeploymentParametersHandler.GetParameterType(parameterDeclarationSyntax!);
 
@@ -743,9 +768,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
         public void GetParametersInfoFromProvidedFile_WithInvalidInput_ShouldReturnNull(string parametersFilePath)
         {
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, string.Empty, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, string.Empty);
 
             var result = bicepDeploymentParametersHandler.GetParametersInfoFromProvidedFile(parametersFilePath);
 
@@ -765,9 +788,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
 }";
             var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, string.Empty, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, string.Empty);
 
             var result = bicepDeploymentParametersHandler.GetParametersInfoFromProvidedFile(parametersFilePath);
 
@@ -819,9 +840,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
 }";
             var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", parametersFileContents);
             var bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", string.Empty);
-            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, string.Empty, true);
-            var bicepDeploymentParametersHandler = new BicepDeploymentParametersHandler(bicepCompilationManager, Serializer);
+            var bicepDeploymentParametersHandler = GetBicepDeploymentParametersHandler(bicepFilePath, string.Empty);
 
             var result = bicepDeploymentParametersHandler.GetParametersInfoFromProvidedFile(parametersFilePath);
 
@@ -860,6 +879,16 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
     ""property2"": ""value2""
   }
 }");
+        }
+
+        private BicepDeploymentParametersHandler GetBicepDeploymentParametersHandler(string bicepFilePath, string bicepFileContents)
+        {
+            var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, true);
+            var compilation = bicepCompilationManager.GetCompilation(documentUri)!.Compilation;
+            DeploymentFileCompilationCache.CacheCompilation(documentUri, compilation);
+
+            return new BicepDeploymentParametersHandler(DeploymentFileCompilationCache, Serializer);
         }
     }
 }

--- a/src/Bicep.LangServer/Deploy/DeploymentFileCompilationCache.cs
+++ b/src/Bicep.LangServer/Deploy/DeploymentFileCompilationCache.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using Bicep.Core.Semantics;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+
+namespace Bicep.LanguageServer.Deploy
+{
+    public class DeploymentFileCompilationCache: IDeploymentFileCompilationCache
+    {
+        private readonly ConcurrentDictionary<DocumentUri, Compilation> compilationCache = new ConcurrentDictionary<DocumentUri, Compilation>();
+
+        public void CacheCompilation(DocumentUri documentUri, Compilation compilation)
+        {
+            compilationCache.TryAdd(documentUri, compilation);
+        }
+
+        public Compilation? FindAndRemoveCompilation(DocumentUri documentUri)
+        {
+            if (compilationCache.TryRemove(documentUri, out Compilation? compilation) && compilation is not null)
+            {
+                return compilation;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Bicep.LangServer/Deploy/IDeploymentFileCompilationCache.cs
+++ b/src/Bicep.LangServer/Deploy/IDeploymentFileCompilationCache.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Semantics;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+
+namespace Bicep.LanguageServer.Deploy
+{
+    public interface IDeploymentFileCompilationCache
+    {
+        public void CacheCompilation(DocumentUri documentUri, Compilation compilation);
+
+        public Compilation? FindAndRemoveCompilation(DocumentUri documentUri);
+    }
+}

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -31,7 +31,7 @@ namespace Bicep.LanguageServer.Handlers
     /// </summary>
     public class BicepDeploymentParametersHandler : ExecuteTypedResponseCommandHandlerBase<string, string, string, BicepDeploymentParametersResponse>
     {
-        IDeploymentFileCompilationCache deploymentFileCompilationCache;
+        private readonly IDeploymentFileCompilationCache deploymentFileCompilationCache;
 
         public BicepDeploymentParametersHandler(
             IDeploymentFileCompilationCache deploymentFileCompilationCache,

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
@@ -21,6 +21,7 @@ using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
+using Bicep.LanguageServer.Deploy;
 using Bicep.LanguageServer.Utils;
 using MediatR;
 using OmniSharp.Extensions.JsonRpc;
@@ -44,6 +45,7 @@ namespace Bicep.LanguageServer.Handlers
         private readonly EmitterSettings emitterSettings;
         private readonly ICompilationManager compilationManager;
         private readonly IConfigurationManager configurationManager;
+        IDeploymentFileCompilationCache deploymentFileCompilationCache;
         private readonly IFeatureProvider features;
         private readonly IFileResolver fileResolver;
         private readonly IModuleDispatcher moduleDispatcher;
@@ -53,6 +55,7 @@ namespace Bicep.LanguageServer.Handlers
             EmitterSettings emitterSettings,
             ICompilationManager compilationManager,
             IConfigurationManager configurationManager,
+            IDeploymentFileCompilationCache deploymentFileCompilationCache,
             IFeatureProvider features,
             IFileResolver fileResolver,
             IModuleDispatcher moduleDispatcher,
@@ -62,6 +65,7 @@ namespace Bicep.LanguageServer.Handlers
         {
             this.compilationManager = compilationManager;
             this.configurationManager = configurationManager;
+            this.deploymentFileCompilationCache = deploymentFileCompilationCache;
             this.emitterSettings = emitterSettings;
             this.features = features;
             this.fileResolver = fileResolver;
@@ -78,6 +82,10 @@ namespace Bicep.LanguageServer.Handlers
             try
             {
                 compilation = GetCompilation(documentUri);
+
+                // Cache the compilation so that it can be reused by BicepDeploymentParametersHandler
+                deploymentFileCompilationCache.CacheCompilation(documentUri, compilation);
+
                 var deploymentScope = GetDeploymentScope(compilation.GetEntrypointSemanticModel().TargetScope);
 
                 return Task.FromResult(new BicepDeploymentScopeResponse(deploymentScope, GetCompiledFile(compilation, documentUri), null));

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
@@ -45,7 +45,7 @@ namespace Bicep.LanguageServer.Handlers
         private readonly EmitterSettings emitterSettings;
         private readonly ICompilationManager compilationManager;
         private readonly IConfigurationManager configurationManager;
-        IDeploymentFileCompilationCache deploymentFileCompilationCache;
+        private readonly IDeploymentFileCompilationCache deploymentFileCompilationCache;
         private readonly IFeatureProvider features;
         private readonly IFileResolver fileResolver;
         private readonly IModuleDispatcher moduleDispatcher;

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -140,6 +140,7 @@ namespace Bicep.LanguageServer
             services.AddSingleton<IBicepConfigChangeHandler, BicepConfigChangeHandler>();
             services.AddSingleton<IDeploymentCollectionProvider, DeploymentCollectionProvider>();
             services.AddSingleton<IDeploymentOperationsCache, DeploymentOperationsCache>();
+            services.AddSingleton<IDeploymentFileCompilationCache, DeploymentFileCompilationCache>();
         }
 
         public void Dispose()


### PR DESCRIPTION
BicepDeploymentParametersHandler doesn't handle requests from unopened file. CompilationContext would be null here: https://github.com/Azure/bicep/blob/44bc2d0f95c231fa44d2900e1de2882f5b9b653a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs#L210 as ICompilationManager will not have an entry for unopened files. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7151)