### PR TITLE
Insert Resource: Attempt API-version based lookup with generic fallback

### DIFF
--- a/src/Bicep.Core/Tracing/DiagnosticOptionsExtensions.cs
+++ b/src/Bicep.Core/Tracing/DiagnosticOptionsExtensions.cs
@@ -44,9 +44,11 @@ namespace Bicep.Core.Tracing
             // ensure User-Agent mentions us
             options.ApplicationId = $"{LanguageConstants.LanguageId}/{ThisAssembly.AssemblyFileVersion}";
 
+            // This option just controls whether the User-Agent header is sent
+            options.IsTelemetryEnabled = false;
+
             options.IsLoggingContentEnabled = false;
             options.IsDistributedTracingEnabled = false;
-            options.IsTelemetryEnabled = false;
 
             foreach (var header in additionalHeaders)
             {

--- a/src/Bicep.Core/Tracing/DiagnosticOptionsExtensions.cs
+++ b/src/Bicep.Core/Tracing/DiagnosticOptionsExtensions.cs
@@ -45,7 +45,7 @@ namespace Bicep.Core.Tracing
             options.ApplicationId = $"{LanguageConstants.LanguageId}/{ThisAssembly.AssemblyFileVersion}";
 
             // This option just controls whether the User-Agent header is sent
-            options.IsTelemetryEnabled = false;
+            options.IsTelemetryEnabled = true;
 
             options.IsLoggingContentEnabled = false;
             options.IsDistributedTracingEnabled = false;

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.ResourceManager;
+using Bicep.Core.Tracing;
 using Bicep.LanguageServer.Deploy;
 using Bicep.LanguageServer.Telemetry;
 using MediatR;
@@ -52,8 +53,11 @@ namespace Bicep.LanguageServer.Handlers
         {
             PostDeployStartTelemetryEvent(request.deployId);
 
+            var options = new ArmClientOptions();
+            options.Diagnostics.ApplySharedResourceManagerSettings();
+
             var credential = new CredentialFromTokenAndTimeStamp(request.token, request.expiresOnTimestamp);
-            var armClient = new ArmClient(credential);
+            var armClient = new ArmClient(credential, default, options);
 
             string deploymentName = "bicep_deployment_" + DateTime.UtcNow.ToString("yyyyMMddHHmmss");
 

--- a/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
+++ b/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
@@ -36,6 +36,7 @@ using System.Text.RegularExpressions;
 using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Telemetry;
+using System.Diagnostics;
 
 namespace Bicep.LanguageServer.Handlers
 {
@@ -89,23 +90,49 @@ namespace Bicep.LanguageServer.Handlers
                 return Unit.Value;
             }
 
-            JsonElement resource;
+            JsonElement? resource = null;
             try
             {
+                // First attempt a direct GET on the resource using the Bicep type API version.
                 resource = await azResourceProvider.GetGenericResource(
                     context.Compilation.Configuration,
                     resourceId,
-                    matchedType.ApiVersion,
+                    apiVersion: matchedType.ApiVersion,
                     cancellationToken);
             }
             catch (Exception exception)
             {
+                // We want to keep going here - we'll try again without the API version.
+                Trace.WriteLine($"Failed to fetch resource '{resourceId}' with API version {matchedType.ApiVersion}: {exception}");
+            }
+
+            try
+            {
+                // If the direct GET fails, attempt to look it up without the API version.
+                // This will use the latest version from the /providers/<provider> API.
+                if (resource is null)
+                {
+                    resource = await azResourceProvider.GetGenericResource(
+                        context.Compilation.Configuration,
+                        resourceId,
+                        apiVersion: null,
+                        cancellationToken);
+                }
+            }
+            catch (Exception exception)
+            {
+                Trace.WriteLine($"Failed to fetch resource '{resourceId}' without API version: {exception}");
+
                 server.Window.ShowError($"Caught exception fetching resource: {exception.Message}.");
                 telemetryProvider.PostEvent(BicepTelemetryEvent.InsertResourceFailure($"FetchResourceFailure"));
+            }
+
+            if (!resource.HasValue)
+            {
                 return Unit.Value;
             }
 
-            var resourceDeclaration = CreateResourceSyntax(resource, resourceId, matchedType);
+            var resourceDeclaration = CreateResourceSyntax(resource.Value, resourceId, matchedType);
             var insertContext = GetInsertContext(context, request.Position);
             var replacement = GenerateCodeReplacement(context.Compilation, resourceDeclaration, insertContext);
 

--- a/src/Bicep.LangServer/Providers/AzResourceProvider.cs
+++ b/src/Bicep.LangServer/Providers/AzResourceProvider.cs
@@ -9,6 +9,7 @@ using Bicep.Core.Registry.Auth;
 using Bicep.Core.Configuration;
 using System.Threading;
 using Azure.Core;
+using System.Collections.Generic;
 
 namespace Bicep.LanguageServer.Providers
 {
@@ -21,20 +22,35 @@ namespace Bicep.LanguageServer.Providers
             this.credentialFactory = credentialFactory;
         }
 
-        private ArmClient CreateArmClient(RootConfiguration configuration, string subscriptionId)
+        private ArmClient CreateArmClient(RootConfiguration configuration, string subscriptionId, IEnumerable<(string resourceType, string apiVersion)> resourceTypeApiVersionMapping)
         {
             var options = new ArmClientOptions();
             options.Diagnostics.ApplySharedResourceManagerSettings();
-            options.Environment = new ArmEnvironment(configuration.Cloud.ResourceManagerEndpointUri, configuration.Cloud.AuthenticationScope); ;
+            options.Environment = new ArmEnvironment(configuration.Cloud.ResourceManagerEndpointUri, configuration.Cloud.AuthenticationScope);
+            foreach (var (resourceType, apiVersion) in resourceTypeApiVersionMapping)
+            {
+                options.SetApiVersion(new ResourceType(resourceType), apiVersion);
+            }
 
             var credential = this.credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.ActiveDirectoryAuthorityUri);
 
             return new ArmClient(credential, subscriptionId, options);
         }
 
-        public async Task<JsonElement> GetGenericResource(RootConfiguration configuration, IAzResourceProvider.AzResourceIdentifier resourceId, string apiVersion, CancellationToken cancellationToken)
+        public async Task<JsonElement> GetGenericResource(RootConfiguration configuration, IAzResourceProvider.AzResourceIdentifier resourceId, string? apiVersion, CancellationToken cancellationToken)
         {
-            var armClient = CreateArmClient(configuration, resourceId.subscriptionId);
+            var resourceTypeApiVersionMapping = new List<(string resourceType, string apiVersion)>();
+            if (apiVersion is not null)
+            {
+                // If we have an API version from the Bicep type, use it.
+                // Otherwise, the SDK client will attempt to fetch the latest version from the /providers/<provider> API.
+                // This is not always guaranteed to work, as child resources are not necessarily declared.
+                resourceTypeApiVersionMapping.Add((
+                    resourceType: resourceId.FullyQualifiedType,
+                    apiVersion: apiVersion));
+            }
+
+            var armClient = CreateArmClient(configuration, resourceId.subscriptionId, resourceTypeApiVersionMapping);
             var resourceIdentifier = new ResourceIdentifier(resourceId.FullyQualifiedId);
             var response = await armClient.GetGenericResource(resourceIdentifier).GetAsync(cancellationToken);
             if (response is null ||

--- a/src/Bicep.LangServer/Providers/IAzResourceProvider.cs
+++ b/src/Bicep.LangServer/Providers/IAzResourceProvider.cs
@@ -16,6 +16,6 @@ namespace Bicep.LanguageServer.Providers
             string UnqualifiedName,
             string subscriptionId);
 
-        Task<JsonElement> GetGenericResource(RootConfiguration configuration, AzResourceIdentifier resourceId, string apiVersion, CancellationToken cancellationToken);
+        Task<JsonElement> GetGenericResource(RootConfiguration configuration, AzResourceIdentifier resourceId, string? apiVersion, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
* Insert Resource: Fetch the resource using the Bicep type API version first, and fall back to the current logic (finding the API version dynamically) if that fails. See my investigation in #6980 for more info about the fix.
* Ensure the User-Agent header is being sent to ARM.
* I also notice we're not setting shared settings in the Deploy handler - I've fixed that.

Closes #6980
Closes #7162

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7163)