### PR TITLE
Add indenting calculation to single- and multi-line code actions

### DIFF
--- a/src/Bicep.Core.UnitTests/Assertions/BicepFileAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/BicepFileAssertions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Navigation;
+using Bicep.Core.Syntax;
 using Bicep.Core.Workspaces;
 using FluentAssertions;
 using FluentAssertions.Primitives;
@@ -27,6 +29,23 @@ namespace Bicep.Core.UnitTests.Assertions
         public AndConstraint<BicepFileAssertions> HaveSourceText(string expected, string because = "", params object[] becauseArgs)
         {
             Subject.ProgramSyntax.ToTextPreserveFormatting().Should().EqualIgnoringNewlines(expected, because, becauseArgs);
+
+            return new AndConstraint<BicepFileAssertions>(this);
+        }
+
+        public AndConstraint<BicepFileAssertions> HaveEquivalentSourceText(BicepFile other, string because = "", params object[] becauseArgs)
+        {
+            var expectedText = Subject.ProgramSyntax.ToTextPreserveFormatting();
+            var actualText = other.ProgramSyntax.ToTextPreserveFormatting();
+
+            expectedText.Should().EqualIgnoringNewlines(actualText, because, becauseArgs);
+
+            return new AndConstraint<BicepFileAssertions>(this);
+        }
+
+        public AndConstraint<BicepFileAssertions> NotHaveParseErrors(string because = "", params object[] becauseArgs)
+        {
+            Subject.ProgramSyntax.GetParseDiagnostics().Should().NotContain(d => d.Level == DiagnosticLevel.Error, because, becauseArgs);
 
             return new AndConstraint<BicepFileAssertions>(this);
         }

--- a/src/Bicep.Core/CodeAction/Fixes/MultilineObjectsAndArraysCodeFixProvider.cs
+++ b/src/Bicep.Core/CodeAction/Fixes/MultilineObjectsAndArraysCodeFixProvider.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
-using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
+using Bicep.Core.PrettyPrint;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 
@@ -15,6 +16,21 @@ namespace Bicep.Core.CodeAction.Fixes
     {
         public const string ConvertToMultiLineDescription = "Convert to multi line";
         public const string ConvertToSingleLineDescription = "Convert to single line";
+        private const int IndentSpaces = 2;
+
+        private static ImmutableArray<SyntaxBase> GetChildren(SyntaxBase syntax)
+            => syntax switch {
+                ObjectSyntax x => x.Children,
+                ArraySyntax x => x.Children,
+                _ => throw new NotImplementedException($"{nameof(syntax)} is unexpected type {syntax?.GetType()}"),
+            };
+
+        private static SyntaxBase ReplaceChildren(SyntaxBase syntax, IEnumerable<SyntaxBase> children)
+            => syntax switch {
+                ObjectSyntax x => new ObjectSyntax(x.OpenBrace, children, x.CloseBrace),
+                ArraySyntax x => new ArraySyntax(x.OpenBracket, children, x.CloseBracket),
+                _ => throw new NotImplementedException($"{nameof(syntax)} is unexpected type {syntax?.GetType()}"),
+            };
 
         public IEnumerable<CodeFix> GetFixes(SemanticModel semanticModel, IReadOnlyList<SyntaxBase> matchingNodes)
         {
@@ -24,45 +40,37 @@ namespace Bicep.Core.CodeAction.Fixes
                 yield break;
             }
 
-            var children = objectOrArray switch {
-                ObjectSyntax x => x.Children,
-                ArraySyntax x => x.Children,
-                _ => throw new NotImplementedException($"{nameof(objectOrArray)} is unexpected type {objectOrArray?.GetType()}"),
-            };
+            var children = GetChildren(objectOrArray);
 
             if (children.Any(x => x is Token { Type: TokenType.Comma }) ||
                 !children.Any(x => x is Token { Type: TokenType.NewLine }))
             {
-                // expression has multiple or all items on one line
+                // Array/object has some items on a single line. Let's offer to convert to a multi-line array/object
                 var updatedChildren = children
                     .Where(x => x is not Token { Type: TokenType.Comma } and not Token { Type: TokenType.NewLine })
                     .SelectMany(x => new [] { SyntaxFactory.NewlineToken, x })
                     .Concat(new [] { SyntaxFactory.NewlineToken });
 
-                SyntaxBase newItem = objectOrArray switch {
-                    ObjectSyntax x => new ObjectSyntax(x.OpenBrace, updatedChildren, x.CloseBrace),
-                    ArraySyntax x => new ArraySyntax(x.OpenBracket, updatedChildren, x.CloseBracket),
-                    _ => throw new NotImplementedException($"{nameof(objectOrArray)} is unexpected type {objectOrArray?.GetType()}"),
-                };
+                var newItem = ReplaceChildren(objectOrArray, updatedChildren);
 
-                var codeReplacement = new CodeReplacement(objectOrArray.Span, newItem.ToText(indent: "  "));
+                var replacementText = FormatHelper.ToFormattedTextWithNewIndentation(semanticModel, objectOrArray, newItem, IndentSpaces);
+
+                var codeReplacement = new CodeReplacement(objectOrArray.Span, replacementText);
                 yield return new CodeFix(ConvertToMultiLineDescription, false, CodeFixKind.Refactor, codeReplacement);
             }
 
             if (children.Any(x => x is Token { Type: TokenType.NewLine }))
             {
-                // expression has items across multiple lines
+                // Array/object has some items on multiple lines. Let's offer to convert to a single-line array/object
                 var updatedChildren = children
                     .Where(x => x is not Token { Type: TokenType.Comma } and not Token { Type: TokenType.NewLine })
                     .SelectMany((x, i) => i == 0 ? new [] { x } : new[] { SyntaxFactory.CommaToken, x });
 
-                SyntaxBase newItem = objectOrArray switch {
-                    ObjectSyntax x => new ObjectSyntax(x.OpenBrace, updatedChildren, x.CloseBrace),
-                    ArraySyntax x => new ArraySyntax(x.OpenBracket, updatedChildren, x.CloseBracket),
-                    _ => throw new NotImplementedException($"{nameof(objectOrArray)} is unexpected type {objectOrArray?.GetType()}"),
-                };
+                var newItem = ReplaceChildren(objectOrArray, updatedChildren);
 
-                var codeReplacement = new CodeReplacement(objectOrArray.Span, newItem.ToText(indent: "  "));
+                var replacementText = FormatHelper.ToFormattedTextWithNewIndentation(semanticModel, objectOrArray, newItem, IndentSpaces);
+
+                var codeReplacement = new CodeReplacement(objectOrArray.Span, replacementText);
                 yield return new CodeFix(ConvertToSingleLineDescription, false, CodeFixKind.Refactor, codeReplacement);
             }
         }

--- a/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
@@ -69,15 +69,12 @@ namespace Bicep.Core.Navigation
         /// <summary>
         /// Generate a string that represents this Syntax element
         /// </summary>
-        /// <param name="syntax"></param>
-        /// <param name="indent"></param>
-        /// <returns></returns>
-        public static string ToText(this SyntaxBase syntax, string indent = "")
+        public static string ToText(this SyntaxBase syntax, string indent = "", string? newLineSequence = null)
         {
             var sb = new StringBuilder();
             var documentBuildVisitor = new DocumentBuildVisitor();
             var document = documentBuildVisitor.BuildDocument(syntax);
-            document.Layout(sb, indent, System.Environment.NewLine);
+            document.Layout(sb, indent, newLineSequence ?? System.Environment.NewLine);
             return sb.ToString();
         }
 

--- a/src/Bicep.Core/PrettyPrint/FormatHelper.cs
+++ b/src/Bicep.Core/PrettyPrint/FormatHelper.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using Bicep.Core.Navigation;
+using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
+using Bicep.Core.Text;
+
+namespace Bicep.Core.PrettyPrint
+{
+    public static class FormatHelper
+    {
+        /// <summary>
+        /// Calculates the number of spaces that a particular piece of syntax is indented by.
+        /// </summary>
+        /// <param name="semanticModel">The semantic model.</param>
+        /// <param name="syntax">The piece of syntax to calculate indenting for.</param>
+        public static int GetIndentLevel(SemanticModel semanticModel, SyntaxBase syntax)
+        {
+            var ancestors = semanticModel.Binder.GetAllAncestors<SyntaxBase>(syntax);
+
+            var indentLevel = 0;
+            for (var i = ancestors.Length - 1; i >= 0; i--)
+            {
+                if (ancestors[i] is ObjectPropertySyntax objectProperty &&
+                    i > 0 && ancestors[i - 1] is ObjectSyntax @object)
+                {
+                    i--;
+
+                    // Try and search upwards to find the first place where the object and property are on different lines
+                    var propPosition = TextCoordinateConverter.GetPosition(semanticModel.SourceFile.LineStarts, objectProperty.Span.Position);
+                    var objPosition = TextCoordinateConverter.GetPosition(semanticModel.SourceFile.LineStarts, @object.Span.Position);
+
+                    if (propPosition.line != objPosition.line)
+                    {
+                        indentLevel = propPosition.character;
+                        break;
+                    }
+
+                    continue;
+                }
+
+                if (ancestors[i] is ArrayItemSyntax arrayItem &&
+                    i > 0 && ancestors[i - 1] is ArraySyntax array)
+                {
+                    i--;
+
+                    // Try and search upwards to find the first place where the array and property are on different lines
+                    var propPosition = TextCoordinateConverter.GetPosition(semanticModel.SourceFile.LineStarts, arrayItem.Span.Position);
+                    var objPosition = TextCoordinateConverter.GetPosition(semanticModel.SourceFile.LineStarts, array.Span.Position);
+
+                    if (propPosition.line != objPosition.line)
+                    {
+                        indentLevel = propPosition.character;
+                        break;
+                    }
+
+                    continue;
+                }
+            }
+
+            return indentLevel;
+        }
+
+        /// <summary>
+        /// Prints a new piece of syntax to string, using the position of an existing piece of syntax on the syntax tree to correctly calculate indenting.
+        /// Useful if you intend to replace the old syntax with the new syntax (e.g. in a code action) and have the indenting fit correctly with the document.
+        /// </summary>
+        /// <param name="semanticModel">The semantic model.</param>
+        /// <param name="oldSyntax">The piece of existing syntax to use for indenting calculations.</param>
+        /// <param name="newSyntax">The piece syntax to print with correct indenting.</param>
+        /// <param name="tabSize">The assumed tab size of the document (number of spaces for each level of indenting).</param>
+        public static string ToFormattedTextWithNewIndentation(SemanticModel semanticModel, SyntaxBase oldSyntax, SyntaxBase newSyntax, int tabSize)
+        {
+            var indentLevel = GetIndentLevel(semanticModel, oldSyntax);
+
+            return newSyntax.ToText(
+                indent: new String(' ', tabSize),
+                newLineSequence: $"{Environment.NewLine}{new String(' ', indentLevel)}");
+        }
+    }
+}


### PR DESCRIPTION
This logic should also be useful for other future code actions inserting/modifying syntax, and for #853

This fixes a big limitation of the code actions I added under #5830 where updated code would be improperly nested.

Previously, the following would be generated for one of the actions run on a deeply nested object/array:
```bicep
var foo = {
  bar: {
baz: {
  hello: 'bicep'
}
  }
}
```

Now we should instead  generate:
```bicep
var foo = {
  bar: {
    baz: {
      hello: 'bicep'
    }
  }
}
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7172)