### PR TITLE
Fix a flaky vscode e2e test on macOS

### DIFF
--- a/src/vscode-bicep/src/test/e2e/visualizer.test.ts
+++ b/src/vscode-bicep/src/test/e2e/visualizer.test.ts
@@ -69,7 +69,7 @@ describe("visualizer", (): void => {
     const examplePath = resolveExamplePath("201", "sql");
     const textDocument = await vscode.workspace.openTextDocument(examplePath);
 
-    await executeShowVisualizerCommand(textDocument.uri);
+    await executeShowVisualizerToSideCommand(textDocument.uri);
     const sourceEditor = await executeShowSourceCommand();
 
     expectDefined(sourceEditor);

--- a/src/vscode-bicep/src/test/e2e/visualizer.test.ts
+++ b/src/vscode-bicep/src/test/e2e/visualizer.test.ts
@@ -18,9 +18,7 @@ import { expectDefined } from "../utils/assert";
 const extensionLogPath = path.join(__dirname, "../../../bicep.log");
 
 describe("visualizer", (): void => {
-  afterEach(async () => {
-    await executeCloseAllEditors();
-  });
+  afterEach(executeCloseAllEditors);
 
   it("should open visualizer webview", async () => {
     const examplePath = resolveExamplePath("101", "vm-simple-linux");


### PR DESCRIPTION
The `visualizer should open source` test fails on macOS with `Error: Unknown webview handle:` randomly when the visualizer webview become invisible after executing the `show source` command. The PR changes to test to open the visualizer to side so the webview is always visible. To verify to fix, I queued [6 successive builds](https://github.com/Azure/bicep/runs/6925654990) for the branch, and the test all passed on macOS.