### PR TITLE
LoadJsonContent fix selecting multiple tokens and handling copy object property

### DIFF
--- a/Bicep.sln.DotSettings
+++ b/Bicep.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002Etxt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -13,6 +13,8 @@ using Bicep.Core.TypeSystem;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 
@@ -21,8 +23,7 @@ namespace Bicep.Core.IntegrationTests
     [TestClass]
     public class ScenarioTests
     {
-        [NotNull]
-        public TestContext? TestContext { get; set; }
+        [NotNull] public TestContext? TestContext { get; set; }
 
         [TestMethod]
         // https://github.com/azure/bicep/issues/3636
@@ -43,7 +44,7 @@ namespace Bicep.Core.IntegrationTests
             {
                 const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
                 return new string(Enumerable.Repeat(chars, generateRandomInt())
-                  .Select(s => s[generateRandomInt(0, s.Length - 1)]).ToArray());
+                    .Select(s => s[generateRandomInt(0, s.Length - 1)]).ToArray());
             }
 
             var file = "param adminuser string\nvar adminstring = 'xyx ${adminuser} 123'\n";
@@ -53,6 +54,7 @@ namespace Bicep.Core.IntegrationTests
                 file += $"  testa{i}: '{randomString()} ${{adminuser}} {randomString()}'\n";
                 file += $"  testb{i}: '{randomString()} ${{adminstring}} {randomString()}'\n";
             }
+
             file += "}\n";
 
             // not a true test for existing diagnostics
@@ -72,7 +74,8 @@ param l
 ");
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP028", DiagnosticLevel.Error, "Identifier \"l\" is declared multiple times. Remove or rename the duplicates."),
                 ("BCP079", DiagnosticLevel.Error, "This expression is referencing its own declaration, which is not allowed."),
                 ("BCP028", DiagnosticLevel.Error, "Identifier \"l\" is declared multiple times. Remove or rename the duplicates."),
@@ -566,7 +569,8 @@ resource redis 'Microsoft.Cache/Redis@2019-07-01' = {
 "));
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP120", DiagnosticLevel.Error, "This expression is being used in an assignment to the \"scope\" property of the \"module\" type, which requires a value that can be calculated at the start of the deployment. You are referencing a variable which cannot be calculated at the start (\"appResGrp\" -> \"rg\"). Properties of rg which can be calculated at the start include \"name\"."),
             });
         }
@@ -699,7 +703,8 @@ resource rgReader 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' =
 ");
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP139", DiagnosticLevel.Error, "A resource's scope must match the scope of the Bicep file for it to be deployable. You must use modules to deploy resources to a different scope."),
                 ("BCP139", DiagnosticLevel.Error, "A resource's scope must match the scope of the Bicep file for it to be deployable. You must use modules to deploy resources to a different scope."),
                 ("BCP139", DiagnosticLevel.Error, "A resource's scope must match the scope of the Bicep file for it to be deployable. You must use modules to deploy resources to a different scope."),
@@ -715,7 +720,8 @@ targetScope = 'blablah'
 ");
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP033", DiagnosticLevel.Error, "Expected a value of type \"'managementGroup' | 'resourceGroup' | 'subscription' | 'tenant'\" but the provided value is of type \"'blablah'\"."),
             });
         }
@@ -747,7 +753,8 @@ output duplicate string = 'hello'
 ");
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP145", DiagnosticLevel.Error, "Output \"duplicate\" is declared multiple times. Remove or rename the duplicates."),
                 ("BCP145", DiagnosticLevel.Error, "Output \"duplicate\" is declared multiple times. Remove or rename the duplicates."),
             });
@@ -763,7 +770,8 @@ output output2 string = output1
 ");
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP058", DiagnosticLevel.Error, "The name \"output1\" is an output. Outputs cannot be referenced in expressions."),
             });
         }
@@ -778,7 +786,8 @@ output xx = x
 ");
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP146", DiagnosticLevel.Error, "Expected an output type at this location. Please specify one of the following types: \"array\", \"bool\", \"int\", \"object\", \"string\"."),
             });
         }
@@ -877,14 +886,14 @@ module stamp_1_secrets './kevault-secrets.bicep' = [for secret in secrets: {
         public void Test_Issue1592()
         {
             var result = CompilationHelper.Compile(
-              ("main.bicep", @"
+                ("main.bicep", @"
 module foo 'test.bicep' = {
   name: 'foo'
 }
 
 output fooName string = foo.name
     "),
-              ("test.bicep", @""));
+                ("test.bicep", @""));
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
             result.Template.Should().HaveValueAtPath("$.outputs['fooName'].value", "foo");
@@ -895,7 +904,7 @@ output fooName string = foo.name
         public void Test_Issue1592_special_cases()
         {
             var result = CompilationHelper.Compile(
-              ("main.bicep", @"
+                ("main.bicep", @"
 param someParam string
 
 module foo 'test.bicep' = {
@@ -905,7 +914,7 @@ module foo 'test.bicep' = {
 output fooName string = foo.name
 output fooOutput string = foo.outputs.test
     "),
-              ("test.bicep", @"
+                ("test.bicep", @"
 output test string = 'hello'
 "));
 
@@ -926,7 +935,8 @@ resource foo 'Microsoft.Compute/virtualMachines@2020-06-01' = {
 ");
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP025", DiagnosticLevel.Error, "The property \"name\" is declared multiple times in this object. Remove or rename the duplicate properties."),
                 ("BCP025", DiagnosticLevel.Error, "The property \"name\" is declared multiple times in this object. Remove or rename the duplicate properties."),
             });
@@ -943,7 +953,8 @@ var foo = 42
 ");
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP032", DiagnosticLevel.Error, "The value must be a compile-time constant."),
                 ("BCP057", DiagnosticLevel.Error, "The name \"w\" does not exist in the current context."),
             });
@@ -998,7 +1009,8 @@ output bar bool = true
 output bar int = 42
 "));
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP104", DiagnosticLevel.Error, "The referenced module has errors."),
             });
         }
@@ -1024,7 +1036,8 @@ resource eventGridSubscription 'Microsoft.EventGrid/topics/providers/eventSubscr
 
             // verify the template still compiles
             result.Template.Should().NotBeNull();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP174", DiagnosticLevel.Warning, "Type validation is not available for resource types declared containing a \"/providers/\" segment. Please instead use the \"scope\" property."),
             });
 
@@ -1041,7 +1054,8 @@ resource resC 'Rp.A/a/b/providers@2020-06-01' = {
 ");
 
             result.Template.Should().NotBeNull();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP081", DiagnosticLevel.Warning, "Resource type \"Rp.A/providers@2020-06-01\" does not have types available."),
                 ("BCP081", DiagnosticLevel.Warning, "Resource type \"Rp.A/providers/a/b@2020-06-01\" does not have types available."),
                 ("BCP081", DiagnosticLevel.Warning, "Resource type \"Rp.A/a/b/providers@2020-06-01\" does not have types available."),
@@ -1093,7 +1107,8 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-prev
 ");
 
             result.Should().NotGenerateATemplate();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP029", DiagnosticLevel.Error, "The resource type is not valid. Specify a valid resource type of format \"<types>@<apiVersion>\"."),
                 ("BCP062", DiagnosticLevel.Error, "The referenced declaration with name \"aksDefaultPoolSubnet\" is not valid."),
                 ("BCP062", DiagnosticLevel.Error, "The referenced declaration with name \"aksDefaultPoolSubnet\" is not valid."),
@@ -1138,7 +1153,8 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-prev
 ");
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
-            result.Template.Should().HaveValueAtPath("$.resources[?(@.type == 'Microsoft.Authorization/roleAssignments')].dependsOn", new JArray {
+            result.Template.Should().HaveValueAtPath("$.resources[?(@.type == 'Microsoft.Authorization/roleAssignments')].dependsOn", new JArray
+            {
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'asdfsdf')]",
                 "[resourceId('Microsoft.Network/virtualNetworks', 'asdfasdf')]", // dependsOn should include the virtualNetwork parent resource
             });
@@ -1178,7 +1194,8 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-prev
 ");
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
-            result.Template.Should().HaveValueAtPath("$.resources[?(@.type == 'Microsoft.Authorization/roleAssignments')].dependsOn", new JArray {
+            result.Template.Should().HaveValueAtPath("$.resources[?(@.type == 'Microsoft.Authorization/roleAssignments')].dependsOn", new JArray
+            {
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'asdfsdf')]",
                 "[resourceId('Microsoft.Network/virtualNetworks', 'asdfasdf')]", // dependsOn should include the virtualNetwork parent resource
             });
@@ -1223,7 +1240,8 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-prev
 ");
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
-            result.Template.Should().HaveValueAtPath("$.resources[?(@.type == 'Microsoft.Authorization/roleAssignments')].dependsOn", new JArray {
+            result.Template.Should().HaveValueAtPath("$.resources[?(@.type == 'Microsoft.Authorization/roleAssignments')].dependsOn", new JArray
+            {
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'asdfsdf')]",
                 "[resourceId('Microsoft.Network/virtualNetworks', variables('vnets')[copyIndex()])]", // dependsOn should include the virtualNetwork parent resource
             });
@@ -1272,10 +1290,11 @@ output badArray array = [for (name, i) in jsonArrayBad : {
 
 
             var evaluated = TemplateEvaluator.Evaluate(result.Template);
-            var expectedOutput = new JArray {
-                new JObject { ["element"] = "one" },
-                new JObject { ["element"] = "two" },
-                new JObject { ["element"] = "three" },
+            var expectedOutput = new JArray
+            {
+                new JObject {["element"] = "one"},
+                new JObject {["element"] = "two"},
+                new JObject {["element"] = "three"},
             };
             evaluated.Should().HaveValueAtPath("$.outputs['flatArray'].value", expectedOutput);
             evaluated.Should().HaveValueAtPath("$.outputs['goodArray'].value", expectedOutput);
@@ -1298,14 +1317,18 @@ output providerOutput object = {
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
 
-            var providersMetadata = new[] {
-                new {
+            var providersMetadata = new[]
+            {
+                new
+                {
                     @namespace = "Microsoft.Web",
-                    resourceTypes = new[] {
-                        new {
+                    resourceTypes = new[]
+                    {
+                        new
+                        {
                             resourceType = "sites",
-                            locations = new[] { "West US", "East US", },
-                            apiVersions = new[] { "2019-01-01", "2020-01-01", },
+                            locations = new[] {"West US", "East US",},
+                            apiVersions = new[] {"2019-01-01", "2020-01-01",},
                         }
                     }
                 }
@@ -1322,11 +1345,13 @@ output providerOutput object = {
             evaluated.Should().HaveValueAtPath("$.outputs['providerOutput'].value.thing", new JObject
             {
                 ["namespace"] = "Microsoft.Web",
-                ["resourceTypes"] = new JArray {
-                    new JObject {
+                ["resourceTypes"] = new JArray
+                {
+                    new JObject
+                    {
                         ["resourceType"] = "sites",
-                        ["locations"] = new JArray { "West US", "East US" },
-                        ["apiVersions"] = new JArray { "2019-01-01", "2020-01-01" },
+                        ["locations"] = new JArray {"West US", "East US"},
+                        ["apiVersions"] = new JArray {"2019-01-01", "2020-01-01"},
                     }
                 }
             });
@@ -1354,14 +1379,18 @@ output providersLocationFirst string = providers('Test.Rp', 'fakeResource').loca
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
 
-            var providersMetadata = new[] {
-                new {
+            var providersMetadata = new[]
+            {
+                new
+                {
                     @namespace = "Test.Rp",
-                    resourceTypes = new[] {
-                        new {
+                    resourceTypes = new[]
+                    {
+                        new
+                        {
                             resourceType = "fakeResource",
-                            locations = new[] { "Earth", "Mars" },
-                            apiVersions = new[] { "3024-01-01", "4100-01-01", },
+                            locations = new[] {"Earth", "Mars"},
+                            apiVersions = new[] {"3024-01-01", "4100-01-01",},
                         }
                     }
                 }
@@ -1376,11 +1405,13 @@ output providersLocationFirst string = providers('Test.Rp', 'fakeResource').loca
             });
 
             evaluated.Should().HaveValueAtPath("$.outputs['providersNamespace'].value", "Test.Rp");
-            evaluated.Should().HaveValueAtPath("$.outputs['providersResources'].value", new JArray {
-                new JObject {
+            evaluated.Should().HaveValueAtPath("$.outputs['providersResources'].value", new JArray
+            {
+                new JObject
+                {
                     ["resourceType"] = "fakeResource",
-                    ["locations"] = new JArray { "Earth", "Mars" },
-                    ["apiVersions"] = new JArray { "3024-01-01", "4100-01-01" },
+                    ["locations"] = new JArray {"Earth", "Mars"},
+                    ["apiVersions"] = new JArray {"3024-01-01", "4100-01-01"},
                 }
             });
 
@@ -1450,7 +1481,8 @@ resource vmNotWorking 'Microsoft.Compute/virtualMachines@2020-06-01' = {
 ");
 
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP037", DiagnosticLevel.Warning, "The property \"valThatDoesNotExist\" from source declaration \"vmNotWorkingProps\" is not allowed on objects of type \"VirtualMachineProperties\". Permissible properties include \"additionalCapabilities\", \"availabilitySet\", \"billingProfile\", \"diagnosticsProfile\", \"evictionPolicy\", \"extensionsTimeBudget\", \"hardwareProfile\", \"host\", \"hostGroup\", \"licenseType\", \"networkProfile\", \"osProfile\", \"priority\", \"proximityPlacementGroup\", \"securityProfile\", \"storageProfile\", \"virtualMachineScaleSet\". If this is an inaccuracy in the documentation, please report it to the Bicep Team."),
             });
         }
@@ -1518,7 +1550,8 @@ resource my_interface 'Microsoft.Network/networkInterfaces@2015-05-01-preview' =
 }
 ");
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP120", DiagnosticLevel.Error, "This expression is being used in an assignment to the \"location\" property of the \"Microsoft.Network/networkInterfaces\" type, which requires a value that can be calculated at the start of the deployment. Properties of vnet which can be calculated at the start include \"apiVersion\", \"id\", \"name\", \"type\"."),
             });
         }
@@ -1669,7 +1702,8 @@ output tagsoutput object = {
 }
 "));
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP120", DiagnosticLevel.Error, "This expression is being used in an assignment to the \"tags\" property of the \"Microsoft.Network/virtualWans\" type, which requires a value that can be calculated at the start of the deployment. Properties of tags which can be calculated at the start include \"name\"."),
                 ("BCP120", DiagnosticLevel.Error, "This expression is being used in an assignment to the \"tags\" property of the \"Microsoft.Network/virtualWans\" type, which requires a value that can be calculated at the start of the deployment. Properties of tags which can be calculated at the start include \"name\"."),
                 ("BCP120", DiagnosticLevel.Error, "This expression is being used in an assignment to the \"tags\" property of the \"Microsoft.Network/networkSecurityGroups\" type, which requires a value that can be calculated at the start of the deployment. Properties of tags which can be calculated at the start include \"name\"."),
@@ -1698,7 +1732,8 @@ output vmExtNames array = [for vmExtName in vm::vmExts: {
 }]
 ");
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP144", DiagnosticLevel.Error, "Directly referencing a resource or module collection is not currently supported. Apply an array indexer to the expression.")
             });
         }
@@ -1718,7 +1753,8 @@ output snetIds array = [for subnet in vnet.properties.subnets: {
 }]
 ");
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP178", DiagnosticLevel.Error, "This expression is being used in the for-expression, which requires a value that can be calculated at the start of the deployment. Properties of vnet which can be calculated at the start include \"apiVersion\", \"id\", \"name\", \"type\".")
             });
         }
@@ -1753,7 +1789,8 @@ resource rg3 'Microsoft.Resources/resourceGroups@2020-10-01' = if (rg2[0].tags.f
 }
 ");
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP179", DiagnosticLevel.Warning, "Unique resource or deployment name is required when looping. The loop item variable \"item\" must be referenced in at least one of the value expressions of the following properties: \"name\""),
                 ("BCP178", DiagnosticLevel.Error, "This expression is being used in the for-expression, which requires a value that can be calculated at the start of the deployment. You are referencing a variable which cannot be calculated at the start (\"test\" -> \"rg\"). Properties of rg which can be calculated at the start include \"apiVersion\", \"id\", \"name\", \"type\"."),
                 ("BCP177", DiagnosticLevel.Error, "This expression is being used in the if-condition expression, which requires a value that can be calculated at the start of the deployment. Properties of rg2 which can be calculated at the start include \"apiVersion\", \"id\", \"name\", \"type\".")
@@ -1772,7 +1809,8 @@ resource rg3 'Microsoft.Resources/resourceGroups@2020-10-01' = if (rg2[0].tags.f
 param foo string = 'peach'
 ");
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP027", DiagnosticLevel.Error, "The parameter expects a default value of type \"'apple' | 'banana'\" but provided value is of type \"'peach'\"."),
             });
         }
@@ -1814,7 +1852,8 @@ output storageAccount object = {
 }
 "));
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP181", DiagnosticLevel.Error, "This expression is being used in an argument of the function \"listSecrets\", which requires a value that can be calculated at the start of the deployment. Properties of stgModule which can be calculated at the start include \"name\"."),
                 ("BCP181", DiagnosticLevel.Error, "This expression is being used in an argument of the function \"listSecrets\", which requires a value that can be calculated at the start of the deployment. Properties of stgModule which can be calculated at the start include \"name\"."),
                 ("BCP181", DiagnosticLevel.Error, "This expression is being used in an argument of the function \"listKeys\", which requires a value that can be calculated at the start of the deployment. Properties of stgModule which can be calculated at the start include \"name\"."),
@@ -1840,7 +1879,8 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
 }
 ");
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP080", DiagnosticLevel.Error, "The expression is involved in a cycle (\"nameCopy\" -> \"name\")."),
                 ("BCP080", DiagnosticLevel.Error, "The expression is involved in a cycle (\"name\" -> \"nameCopy\")."),
                 ("BCP080", DiagnosticLevel.Error, "The expression is involved in a cycle (\"name\" -> \"nameCopy\").")
@@ -1901,7 +1941,8 @@ resource cname 'Microsoft.Network/dnsZones/CNAME@2018-05-01' = {
   parent: null
 }
 ");
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP036", DiagnosticLevel.Error, "The property \"name\" expected a value of type \"string\" but the provided value is of type \"null\"."),
                 ("BCP036", DiagnosticLevel.Error, "The property \"scope\" expected a value of type \"resource | tenant\" but the provided value is of type \"null\"."),
                 ("BCP036", DiagnosticLevel.Error, "The property \"name\" expected a value of type \"string\" but the provided value is of type \"null\"."),
@@ -1939,7 +1980,7 @@ var primaryFoo = foos[0]
 ");
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
             {
-                ("BCP076",DiagnosticLevel.Error,"Cannot index over expression of type \"array | bool\". Arrays or objects are required.")
+                ("BCP076", DiagnosticLevel.Error, "Cannot index over expression of type \"array | bool\". Arrays or objects are required.")
             });
         }
 
@@ -2013,7 +2054,7 @@ resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2019-11-01' = {
 ");
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
             {
-                ("BCP120",DiagnosticLevel.Error,"This expression is being used in an assignment to the \"name\" property of the \"Microsoft.Network/publicIPAddresses\" type, which requires a value that can be calculated at the start of the deployment.")
+                ("BCP120", DiagnosticLevel.Error, "This expression is being used in an assignment to the \"name\" property of the \"Microsoft.Network/publicIPAddresses\" type, which requires a value that can be calculated at the start of the deployment.")
             });
         }
 
@@ -2048,7 +2089,7 @@ resource pipelineRun 'Microsoft.ContainerRegistry/registries/pipelineRuns@2019-1
 ");
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
             {
-                ("BCP177",DiagnosticLevel.Error,"This expression is being used in the if-condition expression, which requires a value that can be calculated at the start of the deployment. Properties of importPipeline which can be calculated at the start include \"apiVersion\", \"id\", \"name\", \"type\".")
+                ("BCP177", DiagnosticLevel.Error, "This expression is being used in the if-condition expression, which requires a value that can be calculated at the start of the deployment. Properties of importPipeline which can be calculated at the start include \"apiVersion\", \"id\", \"name\", \"type\".")
             });
         }
 
@@ -2118,7 +2159,8 @@ resource subnetRef 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' existi
   scope: resourceGroup(vnetResourceGroupName)
 }
 ");
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP169", DiagnosticLevel.Error, "Expected resource name to contain 1 \"/\" character(s). The number of name segments must match the number of segments in the resource type."),
             });
         }
@@ -2471,7 +2513,8 @@ resource kv 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
 ");
 
             result.Template.Should().NotHaveValue();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP080", DiagnosticLevel.Error, "The expression is involved in a cycle (\"secret\" -> \"ap\" -> \"importPipeline\")."),
                 ("BCP080", DiagnosticLevel.Error, "The expression is involved in a cycle (\"importPipeline\" -> \"secret\" -> \"ap\")."),
                 ("BCP080", DiagnosticLevel.Error, "The expression is involved in a cycle (\"importPipeline\" -> \"secret\" -> \"ap\")."),
@@ -2602,7 +2645,8 @@ output out3 string = paramString + paramString
 output out4 string = 'hello' + 'world'
 ");
 
-            result.Should().HaveDiagnostics(new[] {
+            result.Should().HaveDiagnostics(new[]
+            {
                 ("BCP045", DiagnosticLevel.Error, "Cannot apply operator \"+\" to operands of type \"string\" and \"string\". Use string interpolation instead."),
                 ("BCP045", DiagnosticLevel.Error, "Cannot apply operator \"+\" to operands of type \"string\" and \"'world'\". Use string interpolation instead."),
                 ("BCP045", DiagnosticLevel.Error, "Cannot apply operator \"+\" to operands of type \"string\" and \"string\". Use string interpolation instead."),
@@ -2724,7 +2768,8 @@ var myValue = 2147483647
         {
             var result = CompilationHelper.Compile(fileContents);
 
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP010", DiagnosticLevel.Error, "Expected a valid 64-bit signed integer.")
             });
         }
@@ -2736,14 +2781,16 @@ var myValue = 2147483647
         public void Test_Issue5456_1()
         {
             var typeReference = ResourceTypeReference.Parse("My.Rp/myResource@2020-01-01");
-            var typeLoader = TestTypeHelper.CreateAzResourceTypeLoaderWithTypes(new[] {
-                new ResourceTypeComponents(typeReference, ResourceScope.ResourceGroup, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new [] {
+            var typeLoader = TestTypeHelper.CreateAzResourceTypeLoaderWithTypes(new[]
+            {
+                new ResourceTypeComponents(typeReference, ResourceScope.ResourceGroup, new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, new[]
+                {
                     new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.DeployTimeConstant, "name property"),
                     new TypeProperty("tags", LanguageConstants.Array, TypePropertyFlags.ReadOnly, "tags property"),
-                    new TypeProperty("properties", new ObjectType("properties",TypeSymbolValidationFlags.Default, new []
+                    new TypeProperty("properties", new ObjectType("properties", TypeSymbolValidationFlags.Default, new[]
                     {
                         new TypeProperty("prop1", LanguageConstants.String, TypePropertyFlags.ReadOnly, "prop1")
-                    },null), TypePropertyFlags.ReadOnly, "properties property"),
+                    }, null), TypePropertyFlags.ReadOnly, "properties property"),
                 }, null))
             });
 
@@ -2911,7 +2958,8 @@ resource foo 'Microsoft.AAD/domainServices@2021-05-01' existing = {
 
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01'
 ");
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP018", DiagnosticLevel.Error, "Expected the \"=\" character at this location.")
             });
         }
@@ -2932,7 +2980,8 @@ resource foo 'Microsoft.Authorization/policyAssignments@2021-06-01' existing = {
 
 resource managementGroup 'Microsoft.Management/managementGroups@2021-04-01'
 ");
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP018", DiagnosticLevel.Error, "Expected the \"=\" character at this location.")
             });
         }
@@ -3016,7 +3065,8 @@ resource foo 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   }
 }
 ");
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP120", DiagnosticLevel.Error, "This expression is being used in an assignment to the \"name\" property of the \"Microsoft.Storage/storageAccounts\" type, which requires a value that can be calculated at the start of the deployment. Properties of existingStg which can be calculated at the start include \"apiVersion\", \"id\", \"type\".")
             });
         }
@@ -3152,12 +3202,14 @@ resource auth 'Microsoft.Web/sites/config@2021-03-01' = [for (c, i) in configs: 
 ");
 
             // verify we have diagnostics for 'properties'
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP037", DiagnosticLevel.Warning, "The property \"madeUpProperty\" is not allowed on objects of type \"SiteAuthSettingsV2Properties\". Permissible properties include \"globalValidation\", \"httpSettings\", \"identityProviders\", \"login\", \"platform\". If this is an inaccuracy in the documentation, please report it to the Bicep Team.")
             });
 
             result.Template.Should().HaveValueAtPath("$.resources[1].name", "[format('{0}/{1}', variables('configs')[copyIndex()].name, 'authsettingsV2')]");
-            result.Template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray {
+            result.Template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray
+            {
                 "[resourceId('Microsoft.Web/sites', variables('configs')[copyIndex()].name)]",
             });
         }
@@ -3230,7 +3282,8 @@ resource foo 'Microsoft.Storage/storageAccounts@2021-09-00' = {
   }
 }
 ");
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP081", DiagnosticLevel.Warning, "Resource type \"Microsoft.Storage/storageAccounts@2021-09-00\" does not have types available."),
                 ("BCP036", DiagnosticLevel.Warning, "The property \"name\" expected a value of type \"string\" but the provided value is of type \"int\". If this is an inaccuracy in the documentation, please report it to the Bicep Team."),
                 ("BCP036", DiagnosticLevel.Warning, "The property \"capacity\" expected a value of type \"int\" but the provided value is of type \"'1'\". If this is an inaccuracy in the documentation, please report it to the Bicep Team."),
@@ -3278,7 +3331,8 @@ resource vaultAssignments 'Microsoft.Authorization/roleAssignments@2020-10-01-pr
   }
 }]
 ");
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP179", DiagnosticLevel.Warning, "Unique resource or deployment name is required when looping. The loop item variable \"roleId\" must be referenced in at least one of the value expressions of the following properties: \"name\", \"scope\"")
             });
         }
@@ -3320,9 +3374,71 @@ resource vaultAssignments 'Microsoft.Authorization/roleAssignments@2020-10-01-pr
   }
 }]
 ");
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
                 ("BCP179", DiagnosticLevel.Warning, "Unique resource or deployment name is required when looping. The loop item variable \"roleId\" or the index variable \"index\" must be referenced in at least one of the value expressions of the following properties in the loop body: \"name\", \"scope\"")
             });
+        }
+
+        /// <summary>
+        /// https://github.com/Azure/bicep/issues/7241
+        /// </summary>
+        [TestMethod]
+        public void Test_Issue_7241_1()
+        {
+            var result = CompilationHelper.Compile(@"
+var foo = {
+  copy: [
+    {
+      name: 'blah'
+      count: '[notAFunction()]'
+      input: {}
+    }
+  ]
+}
+var bar = {
+  'copy': 'copy'
+}
+");
+
+            // verify we have diagnostics for 'properties'
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+            result.Template.Should().NotBeNull();
+
+            using (new AssertionScope())
+            {
+                result.Template!.SelectToken("$.variables.foo").Should().NotBeNull()
+                    .And.Subject.As<JObject>().Properties().ElementAt(0).Name.Should().Be("[string('copy')]");
+                result.Template!.SelectToken("$.variables.bar").Should().NotBeNull()
+                    .And.Subject.As<JObject>().Properties().ElementAt(0).Name.Should().Be("[string('copy')]");
+                result.Template!.SelectToken("$.variables.bar").Should().NotBeNull()
+                    .And.Subject.As<JObject>().Properties().ElementAt(0).Value.Should().DeepEqual("copy");
+            }
+        }
+
+        /// <summary>
+        /// https://github.com/Azure/bicep/issues/7241
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("copy")]
+        [DataRow("COPY")]
+        [DataRow("Copy")]
+        [DataRow("CoPy")]
+        public void Test_Issue_7241_2(string copy)
+        {
+            var result = CompilationHelper.Compile(@"
+var "+copy+@" = {}
+");
+
+
+            using (new AssertionScope())
+            {
+                result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new []
+                {
+                    ("BCP239", DiagnosticLevel.Error, "Identifier \"copy\" is a reserved Bicep symbol name and cannot be used in this context.")
+                });
+                result.Template.Should().BeNull();
+            }
         }
     }
 }

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -312,6 +312,20 @@
     }
   },
   {
+    "label": "copy",
+    "kind": "variable",
+    "detail": "copy",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_copy",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "copy"
+    }
+  },
+  {
     "label": "dataUri",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
@@ -312,6 +312,20 @@
     }
   },
   {
+    "label": "copy",
+    "kind": "variable",
+    "detail": "copy",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_copy",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "copy"
+    }
+  },
+  {
     "label": "dataUri",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -330,6 +330,20 @@
     }
   },
   {
+    "label": "copy",
+    "kind": "variable",
+    "detail": "copy",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_copy",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "copy"
+    }
+  },
+  {
     "label": "dataUri",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
@@ -240,3 +240,11 @@ var keyVaultSecretArrayVar = [
 var keyVaultSecretArrayInterpolatedVar = [
   '${kv.getSecret('mySecret')}'
 ]
+
+var copy = [
+  {
+    name: 'one'
+    count: '[notAFunction()]'
+    input: {}
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -406,3 +406,12 @@ var keyVaultSecretArrayInterpolatedVar = [
 //@[05:29) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (CodeDescription: none) |kv.getSecret('mySecret')|
 ]
 
+var copy = [
+//@[04:08) [BCP239 (Error)] Identifier "copy" is a reserved Bicep symbol name and cannot be used in this context. (CodeDescription: none) |copy|
+//@[04:08) [no-unused-vars (Warning)] Variable "copy" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |copy|
+  {
+    name: 'one'
+    count: '[notAFunction()]'
+    input: {}
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.formatted.bicep
@@ -238,3 +238,11 @@ var keyVaultSecretArrayVar = [
 var keyVaultSecretArrayInterpolatedVar = [
   '${kv.getSecret('mySecret')}'
 ]
+
+var copy = [
+  {
+    name: 'one'
+    count: '[notAFunction()]'
+    input: {}
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
@@ -338,3 +338,11 @@ var keyVaultSecretArrayInterpolatedVar = [
   '${kv.getSecret('mySecret')}'
 ]
 
+var copy = [
+//@[04:08) Variable copy. Type: object[]. Declaration start char: 0, length: 82
+  {
+    name: 'one'
+    count: '[notAFunction()]'
+    input: {}
+  }
+]

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 
-//@[00:5341) ProgramSyntax
+//@[00:5424) ProgramSyntax
 //@[00:0001) ├─Token(NewLine) |\n|
 // unknown declaration
 //@[22:0023) ├─Token(NewLine) |\n|
@@ -1839,6 +1839,50 @@ var keyVaultSecretArrayInterpolatedVar = [
 //@[31:0032) | | ├─Token(NewLine) |\n|
 ]
 //@[00:0001) | | └─Token(RightSquare) |]|
-//@[01:0002) ├─Token(NewLine) |\n|
+//@[01:0003) ├─Token(NewLine) |\n\n|
 
-//@[00:0000) └─Token(EndOfFile) ||
+var copy = [
+//@[00:0082) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0008) | ├─IdentifierSyntax
+//@[04:0008) | | └─Token(Identifier) |copy|
+//@[09:0010) | ├─Token(Assignment) |=|
+//@[11:0082) | └─ArraySyntax
+//@[11:0012) | | ├─Token(LeftSquare) |[|
+//@[12:0013) | | ├─Token(NewLine) |\n|
+  {
+//@[02:0067) | | ├─ArrayItemSyntax
+//@[02:0067) | | | └─ObjectSyntax
+//@[02:0003) | | | | ├─Token(LeftBrace) |{|
+//@[03:0004) | | | | ├─Token(NewLine) |\n|
+    name: 'one'
+//@[04:0015) | | | | ├─ObjectPropertySyntax
+//@[04:0008) | | | | | ├─IdentifierSyntax
+//@[04:0008) | | | | | | └─Token(Identifier) |name|
+//@[08:0009) | | | | | ├─Token(Colon) |:|
+//@[10:0015) | | | | | └─StringSyntax
+//@[10:0015) | | | | | | └─Token(StringComplete) |'one'|
+//@[15:0016) | | | | ├─Token(NewLine) |\n|
+    count: '[notAFunction()]'
+//@[04:0029) | | | | ├─ObjectPropertySyntax
+//@[04:0009) | | | | | ├─IdentifierSyntax
+//@[04:0009) | | | | | | └─Token(Identifier) |count|
+//@[09:0010) | | | | | ├─Token(Colon) |:|
+//@[11:0029) | | | | | └─StringSyntax
+//@[11:0029) | | | | | | └─Token(StringComplete) |'[notAFunction()]'|
+//@[29:0030) | | | | ├─Token(NewLine) |\n|
+    input: {}
+//@[04:0013) | | | | ├─ObjectPropertySyntax
+//@[04:0009) | | | | | ├─IdentifierSyntax
+//@[04:0009) | | | | | | └─Token(Identifier) |input|
+//@[09:0010) | | | | | ├─Token(Colon) |:|
+//@[11:0013) | | | | | └─ObjectSyntax
+//@[11:0012) | | | | | | ├─Token(LeftBrace) |{|
+//@[12:0013) | | | | | | └─Token(RightBrace) |}|
+//@[13:0014) | | | | ├─Token(NewLine) |\n|
+  }
+//@[02:0003) | | | | └─Token(RightBrace) |}|
+//@[03:0004) | | ├─Token(NewLine) |\n|
+]
+//@[00:0001) | | └─Token(RightSquare) |]|
+//@[01:0001) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
@@ -1181,6 +1181,36 @@ var keyVaultSecretArrayInterpolatedVar = [
 //@[31:32) NewLine |\n|
 ]
 //@[00:01) RightSquare |]|
-//@[01:02) NewLine |\n|
+//@[01:03) NewLine |\n\n|
 
-//@[00:00) EndOfFile ||
+var copy = [
+//@[00:03) Identifier |var|
+//@[04:08) Identifier |copy|
+//@[09:10) Assignment |=|
+//@[11:12) LeftSquare |[|
+//@[12:13) NewLine |\n|
+  {
+//@[02:03) LeftBrace |{|
+//@[03:04) NewLine |\n|
+    name: 'one'
+//@[04:08) Identifier |name|
+//@[08:09) Colon |:|
+//@[10:15) StringComplete |'one'|
+//@[15:16) NewLine |\n|
+    count: '[notAFunction()]'
+//@[04:09) Identifier |count|
+//@[09:10) Colon |:|
+//@[11:29) StringComplete |'[notAFunction()]'|
+//@[29:30) NewLine |\n|
+    input: {}
+//@[04:09) Identifier |input|
+//@[09:10) Colon |:|
+//@[11:12) LeftBrace |{|
+//@[12:13) RightBrace |}|
+//@[13:14) NewLine |\n|
+  }
+//@[02:03) RightBrace |}|
+//@[03:04) NewLine |\n|
+]
+//@[00:01) RightSquare |]|
+//@[01:01) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/Assets/test2.json.txt
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/Assets/test2.json.txt
@@ -1,0 +1,16 @@
+{
+  "products": [
+    {
+      "name": "pizza",
+      "price": 5.00
+    },
+    {
+      "name": "salad",
+      "price": 3.99
+    },
+    {
+      "name": "bread",
+      "price": 2.00
+    }
+  ]
+}

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.bicep
@@ -87,3 +87,5 @@ var testJsonObject2_1 = loadJsonContent('./Assets/test.json.txt', '.object')
 var testJsonNestedString2 = testJson.object.nestedString
 var testJsonNestedString2_1 = testJsonObject2_1.nestedString
 var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object.nestedString')
+
+var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.diagnostics.bicep
@@ -129,3 +129,6 @@ var testJsonNestedString2_1 = testJsonObject2_1.nestedString
 var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object.nestedString')
 //@[4:27) [no-unused-vars (Warning)] Variable "testJsonNestedString2_2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |testJsonNestedString2_2|
 
+var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
+//@[4:25) [no-unused-vars (Warning)] Variable "testJsonTokensAsArray" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |testJsonTokensAsArray|
+

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.formatted.bicep
@@ -86,3 +86,5 @@ var testJsonObject2_1 = loadJsonContent('./Assets/test.json.txt', '.object')
 var testJsonNestedString2 = testJson.object.nestedString
 var testJsonNestedString2_1 = testJsonObject2_1.nestedString
 var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object.nestedString')
+
+var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2915170562570431876"
+      "templateHash": "2040438214449056164"
     }
   },
   "variables": {
@@ -36,6 +36,10 @@
       "nestedString": "someVal"
     },
     "$fxv#21": "someVal",
+    "$fxv#22": [
+      "pizza",
+      "salad"
+    ],
     "$fxv#3": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
     "$fxv#4": "g8fCjQHuFUfnHlTUHxe3qmjeM3HlYSToV7qTGrcJ6vgFNjvgpmxnexFbzjJV/Ejx8jXKa8L32YUn1f/HUnPY6u5c1SaGaP8OiVyRK4ef52hOtc3Yd29c9ubDsLohwLlmuiQDCvVduNMejR6eZy50ti3eYaLu3e04IKC7kTFO0Ph/vSIhlfkS6lUB9e7EJuHAa+3yJFn0uIVFs/BF67fNV9zwx92XyhFL8tmv3IZNd1+0cAby99+zif6iBPXcJ5XTUUz4UHaPmZLPT75hd4iGZzOk/I+FAsUTxRDra76D+sSXay7qBv5TyVLlhs7kqSVAecki6vQG0Siku64tl3PKKEy9JV1lHItgg/IFDYNd8/DKMUpEi90wunW/CfTpQcctzHzZFjl5euswaXgTDvVt2KRHPpi3likE8b1GuyKFVfKNT47VFGSabuUZlhDzbzx7qECnIpA1M7kH+TUHhGTe3ezmmPq+EO6jybYNMpMs+7gcfYAEtzE4gfpubKHLQI8ZYFKFxPCo0ypOwh4Z1nStJkcrNX2UlSDFfPb+LlCaGRxRKPN9md+2sr4x6qm0TptmI9o8wJF7FvqJUS2obFz2KhnfdKg7seuknpisasENchzEO2hoMtpCf5Lt3ZwsLCnFrllFaNmV2BWfA0k74f5MykjIioppM8ajdzORDtjTv/WcNyxdVlTV6nr2Oe43WFKZT0DFMDGHVgTZRBxVH5JtfT1akurR+IyvTegR6kSMHXSWlE1iEoPK8gdNpFLHdAJ8VwPnMGRC8CoCGzDeAakmwiHuecPOzcg9cOQe2Rlo68kJSr6q2hEcTmm9kPj7vfAeocqlosDd2Ci7xcBAJNb/rC4IVllhZPyqt2C8L1VbN5wZfBNgwpA73oOX0kxIKoCqH+Ni167WvC1ZwTqlVAWeAa1RiSplisinKBwDXahu2qDhVJyOt/RwV8Y+W3ynFGXYOW9BDwXVwKUm2zrKl6j0Y1AUTH5HArfCwwThXW2ZFslbr/fM9nJPAbbxpDY2FQBAlt8ST3PyLrFBfXlsV0JqVhidnw94NAbTiPqck15pTGbncg8VunYUAMw/JAOLf2SIJ8cA75IdJMp0UJXoMcOfVKkVdgMbGi7BHtJ3ZFwIajbNdWoNQV0k/LlwwmqGYGkh71wBX4WEdW6MqvvT8Mt/xyA6xzflqnMzgvQPIe6v29FETR9wxSKG52oCOY/DtPXEo+DgZvQwQn3F4BwX+GZawHbbMjWCIDxoSmph5TfZMzF0EkhEi47Uk93FPgiBQPjKSYMxnJ9Lo9UwZjsxdtk7ONKe1GIxfHdx3no4uuRp8WKqjpz017VBOWubdXPxO8Q8QOv6nT9faVVCMUQApehFlg==",
     "$fxv#5": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
@@ -106,7 +110,8 @@
     "testJsonObject2_1": "[variables('$fxv#20')]",
     "testJsonNestedString2": "[variables('testJson').object.nestedString]",
     "testJsonNestedString2_1": "[variables('testJsonObject2_1').nestedString]",
-    "testJsonNestedString2_2": "[variables('$fxv#21')]"
+    "testJsonNestedString2_2": "[variables('$fxv#21')]",
+    "testJsonTokensAsArray": "[variables('$fxv#22')]"
   },
   "resources": [
     {

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15452192655718038021"
+      "templateHash": "8040030251324118678"
     }
   },
   "variables": {
@@ -38,6 +38,10 @@
       "nestedString": "someVal"
     },
     "$fxv#21": "someVal",
+    "$fxv#22": [
+      "pizza",
+      "salad"
+    ],
     "$fxv#3": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
     "$fxv#4": "g8fCjQHuFUfnHlTUHxe3qmjeM3HlYSToV7qTGrcJ6vgFNjvgpmxnexFbzjJV/Ejx8jXKa8L32YUn1f/HUnPY6u5c1SaGaP8OiVyRK4ef52hOtc3Yd29c9ubDsLohwLlmuiQDCvVduNMejR6eZy50ti3eYaLu3e04IKC7kTFO0Ph/vSIhlfkS6lUB9e7EJuHAa+3yJFn0uIVFs/BF67fNV9zwx92XyhFL8tmv3IZNd1+0cAby99+zif6iBPXcJ5XTUUz4UHaPmZLPT75hd4iGZzOk/I+FAsUTxRDra76D+sSXay7qBv5TyVLlhs7kqSVAecki6vQG0Siku64tl3PKKEy9JV1lHItgg/IFDYNd8/DKMUpEi90wunW/CfTpQcctzHzZFjl5euswaXgTDvVt2KRHPpi3likE8b1GuyKFVfKNT47VFGSabuUZlhDzbzx7qECnIpA1M7kH+TUHhGTe3ezmmPq+EO6jybYNMpMs+7gcfYAEtzE4gfpubKHLQI8ZYFKFxPCo0ypOwh4Z1nStJkcrNX2UlSDFfPb+LlCaGRxRKPN9md+2sr4x6qm0TptmI9o8wJF7FvqJUS2obFz2KhnfdKg7seuknpisasENchzEO2hoMtpCf5Lt3ZwsLCnFrllFaNmV2BWfA0k74f5MykjIioppM8ajdzORDtjTv/WcNyxdVlTV6nr2Oe43WFKZT0DFMDGHVgTZRBxVH5JtfT1akurR+IyvTegR6kSMHXSWlE1iEoPK8gdNpFLHdAJ8VwPnMGRC8CoCGzDeAakmwiHuecPOzcg9cOQe2Rlo68kJSr6q2hEcTmm9kPj7vfAeocqlosDd2Ci7xcBAJNb/rC4IVllhZPyqt2C8L1VbN5wZfBNgwpA73oOX0kxIKoCqH+Ni167WvC1ZwTqlVAWeAa1RiSplisinKBwDXahu2qDhVJyOt/RwV8Y+W3ynFGXYOW9BDwXVwKUm2zrKl6j0Y1AUTH5HArfCwwThXW2ZFslbr/fM9nJPAbbxpDY2FQBAlt8ST3PyLrFBfXlsV0JqVhidnw94NAbTiPqck15pTGbncg8VunYUAMw/JAOLf2SIJ8cA75IdJMp0UJXoMcOfVKkVdgMbGi7BHtJ3ZFwIajbNdWoNQV0k/LlwwmqGYGkh71wBX4WEdW6MqvvT8Mt/xyA6xzflqnMzgvQPIe6v29FETR9wxSKG52oCOY/DtPXEo+DgZvQwQn3F4BwX+GZawHbbMjWCIDxoSmph5TfZMzF0EkhEi47Uk93FPgiBQPjKSYMxnJ9Lo9UwZjsxdtk7ONKe1GIxfHdx3no4uuRp8WKqjpz017VBOWubdXPxO8Q8QOv6nT9faVVCMUQApehFlg==",
     "$fxv#5": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n Donec laoreet sem tortor, ut dignissim ipsum ornare vel.\n  Duis ac ipsum turpis.\n\tMaecenas at condimentum dui.\n Suspendisse aliquet efficitur iaculis.\nIn hac habitasse platea dictumst.\nEtiam consectetur ut libero ac lobortis.\n\tNullam vitae auctor massa.\nFusce tincidunt urna purus, sit amet.\n",
@@ -108,7 +112,8 @@
     "testJsonObject2_1": "[variables('$fxv#20')]",
     "testJsonNestedString2": "[variables('testJson').object.nestedString]",
     "testJsonNestedString2_1": "[variables('testJsonObject2_1').nestedString]",
-    "testJsonNestedString2_2": "[variables('$fxv#21')]"
+    "testJsonNestedString2_2": "[variables('$fxv#21')]",
+    "testJsonTokensAsArray": "[variables('$fxv#22')]"
   },
   "resources": {
     "module1": {

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbols.bicep
@@ -133,3 +133,6 @@ var testJsonNestedString2_1 = testJsonObject2_1.nestedString
 var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object.nestedString')
 //@[4:27) Variable testJsonNestedString2_2. Type: 'someVal'. Declaration start char: 0, length: 95
 
+var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
+//@[4:25) Variable testJsonTokensAsArray. Type: ('pizza' | 'salad')[]. Declaration start char: 0, length: 104
+

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.syntax.bicep
@@ -1,5 +1,5 @@
 var loadedText1 = loadTextContent('Assets/TextFile.CRLF.txt')
-//@[000:3682) ProgramSyntax
+//@[000:3790) ProgramSyntax
 //@[000:0061) ├─VariableDeclarationSyntax
 //@[000:0003) | ├─Token(Identifier) |var|
 //@[004:0015) | ├─IdentifierSyntax
@@ -1007,6 +1007,26 @@ var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object
 //@[072:0094) | | | └─StringSyntax
 //@[072:0094) | | | | └─Token(StringComplete) |'.object.nestedString'|
 //@[094:0095) | | └─Token(RightParen) |)|
-//@[095:0097) ├─Token(NewLine) |\r\n|
+//@[095:0099) ├─Token(NewLine) |\r\n\r\n|
+
+var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
+//@[000:0104) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0025) | ├─IdentifierSyntax
+//@[004:0025) | | └─Token(Identifier) |testJsonTokensAsArray|
+//@[026:0027) | ├─Token(Assignment) |=|
+//@[028:0104) | └─FunctionCallSyntax
+//@[028:0043) | | ├─IdentifierSyntax
+//@[028:0043) | | | └─Token(Identifier) |loadJsonContent|
+//@[043:0044) | | ├─Token(LeftParen) |(|
+//@[044:0069) | | ├─FunctionArgumentSyntax
+//@[044:0069) | | | └─StringSyntax
+//@[044:0069) | | | | └─Token(StringComplete) |'./Assets/test2.json.txt'|
+//@[069:0070) | | ├─Token(Comma) |,|
+//@[071:0103) | | ├─FunctionArgumentSyntax
+//@[071:0103) | | | └─StringSyntax
+//@[071:0103) | | | | └─Token(StringComplete) |'.products[?(@.price > 3)].name'|
+//@[103:0104) | | └─Token(RightParen) |)|
+//@[104:0106) ├─Token(NewLine) |\r\n|
 
 //@[000:0000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.tokens.bicep
@@ -605,6 +605,18 @@ var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object
 //@[070:071) Comma |,|
 //@[072:094) StringComplete |'.object.nestedString'|
 //@[094:095) RightParen |)|
-//@[095:097) NewLine |\r\n|
+//@[095:099) NewLine |\r\n\r\n|
+
+var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
+//@[000:003) Identifier |var|
+//@[004:025) Identifier |testJsonTokensAsArray|
+//@[026:027) Assignment |=|
+//@[028:043) Identifier |loadJsonContent|
+//@[043:044) LeftParen |(|
+//@[044:069) StringComplete |'./Assets/test2.json.txt'|
+//@[069:070) Comma |,|
+//@[071:103) StringComplete |'.products[?(@.price > 3)].name'|
+//@[103:104) RightParen |)|
+//@[104:106) NewLine |\r\n|
 
 //@[000:000) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
@@ -494,6 +494,20 @@
     }
   },
   {
+    "label": "copyBlockInObject",
+    "kind": "variable",
+    "detail": "copyBlockInObject",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_copyBlockInObject",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "copyBlockInObject"
+    }
+  },
+  {
     "label": "createArray",
     "kind": "variable",
     "detail": "createArray",

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.bicep
@@ -323,3 +323,13 @@ module.exports = function (context) {
     context.done();
 }
 '''
+
+var copyBlockInObject = {
+  copy: [
+    {
+      name: 'blah'
+      count: '[notAFunction()]'
+      input: {}
+    }
+  ]
+}

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.diagnostics.bicep
@@ -405,3 +405,13 @@ module.exports = function (context) {
 }
 '''
 
+var copyBlockInObject = {
+//@[04:21) [no-unused-vars (Warning)] Variable "copyBlockInObject" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |copyBlockInObject|
+  copy: [
+    {
+      name: 'blah'
+      count: '[notAFunction()]'
+      input: {}
+    }
+  ]
+}

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.formatted.bicep
@@ -322,3 +322,13 @@ module.exports = function (context) {
     context.done();
 }
 '''
+
+var copyBlockInObject = {
+  copy: [
+    {
+      name: 'blah'
+      count: '[notAFunction()]'
+      input: {}
+    }
+  ]
+}

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5474777074424075084"
+      "templateHash": "1821257246828594867"
     }
   },
   "parameters": {
@@ -243,7 +243,16 @@
     "multilineExtraQuotesNewlines": "'\nabc\n'",
     "multilineSingleLine": "hello!",
     "multilineFormatted": "[format('Hello,\nmy\nname is\n{0}\n', 'Anthony')]",
-    "multilineJavaScript": "// NOT RECOMMENDED PATTERN\nconst fs = require('fs');\n\nmodule.exports = function (context) {\n    fs.readFile('./hello.txt', (err, data) => {\n        if (err) {\n            context.log.error('ERROR', err);\n            // BUG #1: This will result in an uncaught exception that crashes the entire process\n            throw err;\n        }\n        context.log(`Data from file: ${data}`);\n        // context.done() should be called here\n    });\n    // BUG #2: Data is not guaranteed to be read before the Azure Function's invocation ends\n    context.done();\n}\n"
+    "multilineJavaScript": "// NOT RECOMMENDED PATTERN\nconst fs = require('fs');\n\nmodule.exports = function (context) {\n    fs.readFile('./hello.txt', (err, data) => {\n        if (err) {\n            context.log.error('ERROR', err);\n            // BUG #1: This will result in an uncaught exception that crashes the entire process\n            throw err;\n        }\n        context.log(`Data from file: ${data}`);\n        // context.done() should be called here\n    });\n    // BUG #2: Data is not guaranteed to be read before the Azure Function's invocation ends\n    context.done();\n}\n",
+    "copyBlockInObject": {
+      "[string('copy')]": [
+        {
+          "name": "blah",
+          "count": "[[notAFunction()]",
+          "input": {}
+        }
+      ]
+    }
   },
   "resources": []
 }

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12480395712152468332"
+      "templateHash": "3331544128513028707"
     }
   },
   "parameters": {
@@ -245,7 +245,16 @@
     "multilineExtraQuotesNewlines": "'\nabc\n'",
     "multilineSingleLine": "hello!",
     "multilineFormatted": "[format('Hello,\nmy\nname is\n{0}\n', 'Anthony')]",
-    "multilineJavaScript": "// NOT RECOMMENDED PATTERN\nconst fs = require('fs');\n\nmodule.exports = function (context) {\n    fs.readFile('./hello.txt', (err, data) => {\n        if (err) {\n            context.log.error('ERROR', err);\n            // BUG #1: This will result in an uncaught exception that crashes the entire process\n            throw err;\n        }\n        context.log(`Data from file: ${data}`);\n        // context.done() should be called here\n    });\n    // BUG #2: Data is not guaranteed to be read before the Azure Function's invocation ends\n    context.done();\n}\n"
+    "multilineJavaScript": "// NOT RECOMMENDED PATTERN\nconst fs = require('fs');\n\nmodule.exports = function (context) {\n    fs.readFile('./hello.txt', (err, data) => {\n        if (err) {\n            context.log.error('ERROR', err);\n            // BUG #1: This will result in an uncaught exception that crashes the entire process\n            throw err;\n        }\n        context.log(`Data from file: ${data}`);\n        // context.done() should be called here\n    });\n    // BUG #2: Data is not guaranteed to be read before the Azure Function's invocation ends\n    context.done();\n}\n",
+    "copyBlockInObject": {
+      "[string('copy')]": [
+        {
+          "name": "blah",
+          "count": "[[notAFunction()]",
+          "input": {}
+        }
+      ]
+    }
   },
   "resources": {}
 }

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.symbols.bicep
@@ -442,3 +442,13 @@ module.exports = function (context) {
 }
 '''
 
+var copyBlockInObject = {
+//@[04:21) Variable copyBlockInObject. Type: object. Declaration start char: 0, length: 120
+  copy: [
+    {
+      name: 'blah'
+      count: '[notAFunction()]'
+      input: {}
+    }
+  ]
+}

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 
-//@[000:7120) ProgramSyntax
+//@[000:7241) ProgramSyntax
 //@[000:0001) ├─Token(NewLine) |\n|
 // int
 //@[006:0007) ├─Token(NewLine) |\n|
@@ -2836,6 +2836,61 @@ module.exports = function (context) {
     context.done();
 }
 '''
-//@[003:0004) ├─Token(NewLine) |\n|
+//@[003:0005) ├─Token(NewLine) |\n\n|
 
-//@[000:0000) └─Token(EndOfFile) ||
+var copyBlockInObject = {
+//@[000:0120) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0021) | ├─IdentifierSyntax
+//@[004:0021) | | └─Token(Identifier) |copyBlockInObject|
+//@[022:0023) | ├─Token(Assignment) |=|
+//@[024:0120) | └─ObjectSyntax
+//@[024:0025) | | ├─Token(LeftBrace) |{|
+//@[025:0026) | | ├─Token(NewLine) |\n|
+  copy: [
+//@[002:0092) | | ├─ObjectPropertySyntax
+//@[002:0006) | | | ├─IdentifierSyntax
+//@[002:0006) | | | | └─Token(Identifier) |copy|
+//@[006:0007) | | | ├─Token(Colon) |:|
+//@[008:0092) | | | └─ArraySyntax
+//@[008:0009) | | | | ├─Token(LeftSquare) |[|
+//@[009:0010) | | | | ├─Token(NewLine) |\n|
+    {
+//@[004:0078) | | | | ├─ArrayItemSyntax
+//@[004:0078) | | | | | └─ObjectSyntax
+//@[004:0005) | | | | | | ├─Token(LeftBrace) |{|
+//@[005:0006) | | | | | | ├─Token(NewLine) |\n|
+      name: 'blah'
+//@[006:0018) | | | | | | ├─ObjectPropertySyntax
+//@[006:0010) | | | | | | | ├─IdentifierSyntax
+//@[006:0010) | | | | | | | | └─Token(Identifier) |name|
+//@[010:0011) | | | | | | | ├─Token(Colon) |:|
+//@[012:0018) | | | | | | | └─StringSyntax
+//@[012:0018) | | | | | | | | └─Token(StringComplete) |'blah'|
+//@[018:0019) | | | | | | ├─Token(NewLine) |\n|
+      count: '[notAFunction()]'
+//@[006:0031) | | | | | | ├─ObjectPropertySyntax
+//@[006:0011) | | | | | | | ├─IdentifierSyntax
+//@[006:0011) | | | | | | | | └─Token(Identifier) |count|
+//@[011:0012) | | | | | | | ├─Token(Colon) |:|
+//@[013:0031) | | | | | | | └─StringSyntax
+//@[013:0031) | | | | | | | | └─Token(StringComplete) |'[notAFunction()]'|
+//@[031:0032) | | | | | | ├─Token(NewLine) |\n|
+      input: {}
+//@[006:0015) | | | | | | ├─ObjectPropertySyntax
+//@[006:0011) | | | | | | | ├─IdentifierSyntax
+//@[006:0011) | | | | | | | | └─Token(Identifier) |input|
+//@[011:0012) | | | | | | | ├─Token(Colon) |:|
+//@[013:0015) | | | | | | | └─ObjectSyntax
+//@[013:0014) | | | | | | | | ├─Token(LeftBrace) |{|
+//@[014:0015) | | | | | | | | └─Token(RightBrace) |}|
+//@[015:0016) | | | | | | ├─Token(NewLine) |\n|
+    }
+//@[004:0005) | | | | | | └─Token(RightBrace) |}|
+//@[005:0006) | | | | ├─Token(NewLine) |\n|
+  ]
+//@[002:0003) | | | | └─Token(RightSquare) |]|
+//@[003:0004) | | ├─Token(NewLine) |\n|
+}
+//@[000:0001) | | └─Token(RightBrace) |}|
+//@[001:0001) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.tokens.bicep
@@ -1784,6 +1784,44 @@ module.exports = function (context) {
     context.done();
 }
 '''
-//@[003:004) NewLine |\n|
+//@[003:005) NewLine |\n\n|
 
-//@[000:000) EndOfFile ||
+var copyBlockInObject = {
+//@[000:003) Identifier |var|
+//@[004:021) Identifier |copyBlockInObject|
+//@[022:023) Assignment |=|
+//@[024:025) LeftBrace |{|
+//@[025:026) NewLine |\n|
+  copy: [
+//@[002:006) Identifier |copy|
+//@[006:007) Colon |:|
+//@[008:009) LeftSquare |[|
+//@[009:010) NewLine |\n|
+    {
+//@[004:005) LeftBrace |{|
+//@[005:006) NewLine |\n|
+      name: 'blah'
+//@[006:010) Identifier |name|
+//@[010:011) Colon |:|
+//@[012:018) StringComplete |'blah'|
+//@[018:019) NewLine |\n|
+      count: '[notAFunction()]'
+//@[006:011) Identifier |count|
+//@[011:012) Colon |:|
+//@[013:031) StringComplete |'[notAFunction()]'|
+//@[031:032) NewLine |\n|
+      input: {}
+//@[006:011) Identifier |input|
+//@[011:012) Colon |:|
+//@[013:014) LeftBrace |{|
+//@[014:015) RightBrace |}|
+//@[015:016) NewLine |\n|
+    }
+//@[004:005) RightBrace |}|
+//@[005:006) NewLine |\n|
+  ]
+//@[002:003) RightSquare |]|
+//@[003:004) NewLine |\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:001) EndOfFile ||

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1406,6 +1406,11 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP238",
                 "Unexpected new line character after a comma.");
+
+            public ErrorDiagnostic ReservedIdentifier(string name) => new(
+                TextSpan,
+                "BCP239",
+                $"Identifier \"{name}\" is a reserved Bicep symbol name and cannot be used in this context.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -319,7 +321,7 @@ namespace Bicep.Core.Emit
 
         private static void DetectCopyVariableName(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
-            var copyVariableSymbol = semanticModel.Root.VariableDeclarations.FirstOrDefault(x => x.Name.Equals(LanguageConstants.CopyLoopIdentifier, LanguageConstants.IdentifierComparison));
+            var copyVariableSymbol = semanticModel.Root.VariableDeclarations.FirstOrDefault(x => x.Name.Equals(LanguageConstants.CopyLoopIdentifier, StringComparison.OrdinalIgnoreCase));
             if (copyVariableSymbol is not null)
             {
                 diagnosticWriter.Write(DiagnosticBuilder.ForPosition(copyVariableSymbol.NameSyntax).ReservedIdentifier(LanguageConstants.CopyLoopIdentifier));

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -33,8 +33,9 @@ namespace Bicep.Core.Emit
             DetectUnexpectedResourceLoopInvariantProperties(model, diagnosticWriter);
             DetectUnexpectedModuleLoopInvariantProperties(model, diagnosticWriter);
             DetectUnsupportedModuleParameterAssignments(model, diagnosticWriter);
+            DetectCopyVariableName(model, diagnosticWriter);
 
-            return new EmitLimitationInfo(diagnosticWriter.GetDiagnostics(), moduleScopeData, resourceScopeData);
+            return new(diagnosticWriter.GetDiagnostics(), moduleScopeData, resourceScopeData);
         }
 
         private static void DetectDuplicateNames(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter, ImmutableDictionary<DeclaredResourceMetadata, ScopeHelper.ScopeData> resourceScopeData, ImmutableDictionary<ModuleSymbol, ScopeHelper.ScopeData> moduleScopeData)
@@ -130,7 +131,7 @@ namespace Bicep.Core.Emit
             }
         }
 
-        public static void DetectIncorrectlyFormattedNames(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
+        private static void DetectIncorrectlyFormattedNames(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
             // TODO move into Az extension
             foreach (var resource in semanticModel.DeclaredResources)
@@ -188,7 +189,7 @@ namespace Bicep.Core.Emit
             }
         }
 
-        public static void DetectUnexpectedResourceLoopInvariantProperties(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
+        private static void DetectUnexpectedResourceLoopInvariantProperties(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
             foreach (var resource in semanticModel.DeclaredResources)
             {
@@ -241,7 +242,7 @@ namespace Bicep.Core.Emit
             }
         }
 
-        public static void DetectUnexpectedModuleLoopInvariantProperties(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
+        private static void DetectUnexpectedModuleLoopInvariantProperties(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
             foreach (var module in semanticModel.Root.ModuleDeclarations)
             {
@@ -286,7 +287,7 @@ namespace Bicep.Core.Emit
             }
         }
 
-        public static void DetectUnsupportedModuleParameterAssignments(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
+        private static void DetectUnsupportedModuleParameterAssignments(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
         {
             foreach (var moduleSymbol in semanticModel.Root.ModuleDeclarations)
             {
@@ -313,6 +314,15 @@ namespace Bicep.Core.Emit
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(paramsValue).ModuleParametersPropertyRequiresObjectLiteral());
                         break;
                 }
+            }
+        }
+
+        private static void DetectCopyVariableName(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
+        {
+            var copyVariableSymbol = semanticModel.Root.VariableDeclarations.FirstOrDefault(x => x.Name.Equals(LanguageConstants.CopyLoopIdentifier, LanguageConstants.IdentifierComparison));
+            if (copyVariableSymbol is not null)
+            {
+                diagnosticWriter.Write(DiagnosticBuilder.ForPosition(copyVariableSymbol.NameSyntax).ReservedIdentifier(LanguageConstants.CopyLoopIdentifier));
             }
         }
 

--- a/src/Bicep.Core/Emit/ExpressionEmitter.cs
+++ b/src/Bicep.Core/Emit/ExpressionEmitter.cs
@@ -128,7 +128,7 @@ namespace Bicep.Core.Emit
         }
 
         public string GetSymbolicName(DeclaredResourceMetadata resource)
-            =>  converter.GetSymbolicName(resource);
+            => converter.GetSymbolicName(resource);
 
         public void EmitIndexedSymbolReference(ModuleSymbol moduleSymbol, SyntaxBase indexExpression, SyntaxBase newContext)
         {
@@ -315,7 +315,7 @@ namespace Bicep.Core.Emit
             if (propertyLookup.Contains(true))
             {
                 // we have properties whose value is a for-expression
-                this.EmitProperty("copy", () =>
+                this.EmitCopyProperty(() =>
                 {
                     this.writer.WriteStartArray();
 
@@ -427,6 +427,9 @@ namespace Bicep.Core.Emit
         public void EmitProperty(string name, Action valueFunc)
             => EmitPropertyInternal(new JTokenExpression(name), valueFunc);
 
+        public void EmitCopyProperty(Action valueFunc)
+            => EmitPropertyInternal(new JTokenExpression(LanguageConstants.CopyLoopIdentifier), valueFunc, skipCopyCheck: true);
+
         public void EmitProperty(string name, string value)
             => EmitPropertyInternal(new JTokenExpression(name), value);
 
@@ -436,9 +439,14 @@ namespace Bicep.Core.Emit
         public void EmitProperty(SyntaxBase syntaxKey, SyntaxBase syntaxValue)
             => EmitPropertyInternal(converter.ConvertExpression(syntaxKey), syntaxValue);
 
-        private void EmitPropertyInternal(LanguageExpression expressionKey, Action valueFunc)
+        private void EmitPropertyInternal(LanguageExpression expressionKey, Action valueFunc, bool skipCopyCheck = false)
         {
             var serializedName = ExpressionSerializer.SerializeExpression(expressionKey);
+            if (!skipCopyCheck && serializedName.Equals(LanguageConstants.CopyLoopIdentifier, StringComparison.OrdinalIgnoreCase))
+            {
+                // we escape "copy" property name with a ARM expression to avoid it being interpreted by ARM as a copy instruction
+                serializedName = $"[string('{serializedName}')]";
+            }
             writer.WritePropertyName(serializedName);
 
             valueFunc();

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -269,7 +269,7 @@ namespace Bicep.Core.Emit
             if (GetNonInlinedVariables(valueIsLoop: true).Any())
             {
                 // we have variables whose values are loops
-                emitter.EmitProperty("copy", () =>
+                emitter.EmitCopyProperty(() =>
                 {
                     jsonWriter.WriteStartArray();
 
@@ -466,7 +466,7 @@ namespace Bicep.Core.Emit
             if (loops.Count == 1)
             {
                 var batchSize = GetBatchSize(resource.Symbol.DeclaringResource);
-                emitter.EmitProperty("copy", () => emitter.EmitCopyObject(loops[0].name, loops[0].@for, loops[0].input, batchSize: batchSize));
+                emitter.EmitCopyProperty(() => emitter.EmitCopyObject(loops[0].name, loops[0].@for, loops[0].input, batchSize: batchSize));
             }
             else if (loops.Count > 1)
             {
@@ -563,7 +563,7 @@ namespace Bicep.Core.Emit
                 {
                     // the value is a for-expression
                     // write a single property copy loop
-                    emitter.EmitProperty("copy", () =>
+                    emitter.EmitCopyProperty(() =>
                     {
                         jsonWriter.WriteStartArray();
                         emitter.EmitCopyObject("value", @for, @for.Body, "value");
@@ -615,7 +615,7 @@ namespace Bicep.Core.Emit
                     }
 
                     var batchSize = GetBatchSize(moduleSymbol.DeclaringModule);
-                    emitter.EmitProperty("copy", () => emitter.EmitCopyObject(moduleSymbol.Name, @for, input: null, batchSize: batchSize));
+                    emitter.EmitCopyProperty(() => emitter.EmitCopyObject(moduleSymbol.Name, @for, input: null, batchSize: batchSize));
                     break;
             }
 
@@ -862,7 +862,7 @@ namespace Bicep.Core.Emit
 
             if (outputSymbol.Value is ForSyntax @for)
             {
-                emitter.EmitProperty("copy", () => emitter.EmitCopyObject(name: null, @for, @for.Body));
+                emitter.EmitCopyProperty(() => emitter.EmitCopyObject(name: null, @for, @for.Body));
             }
             else
             {

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -59,6 +59,8 @@ namespace Bicep.Core
         public const string TargetScopeTypeSubscription = "subscription";
         public const string TargetScopeTypeResourceGroup = "resourceGroup";
 
+        public const string CopyLoopIdentifier = "copy";
+
         public const string BicepConfigurationFileName = "bicepconfig.json";
 
         // An internal-only command used in code actions to edit a particular rule in the bicepconfig.json file
@@ -168,7 +170,7 @@ namespace Bicep.Core
 
         // types allowed to use in output and parameter declarations
         public static readonly ImmutableSortedDictionary<string, TypeSymbol> DeclarationTypes = new[] { String, Object, Int, Bool, Array }.ToImmutableSortedDictionary(type => type.Name, type => type, StringComparer.Ordinal);
-
+        
         public static TypeSymbol? TryGetDeclarationType(string? typeName)
         {
             if (typeName != null && DeclarationTypes.TryGetValue(typeName, out var primitiveType))

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -599,10 +599,21 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 try
                 {
-                    token = token.SelectToken(tokenSelectorPath, false);
-                    if (token is null)
+                    var selectTokens = token.SelectTokens(tokenSelectorPath, false).ToList();
+                    switch (selectTokens.Count)
                     {
-                        return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+                        case 0:
+                            return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[1]).NoJsonTokenOnPathOrPathInvalid()));
+                        case 1:
+                            token = selectTokens.First();
+                            break;
+                        default:
+                            token = new JArray();
+                            foreach (var selectToken in selectTokens)
+                            {
+                                ((JArray)token).Add(selectToken);
+                            }
+                            break;
                     }
                 }
                 catch (JsonException)

--- a/src/Bicep.Decompiler/ArmHelpers/TemplateHelpers.cs
+++ b/src/Bicep.Decompiler/ArmHelpers/TemplateHelpers.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Azure.Deployments.Expression.Engines;
 using Azure.Deployments.Expression.Expressions;
+using Bicep.Core;
 using Bicep.Decompiler.Exceptions;
 using Newtonsoft.Json.Linq;
 
@@ -100,9 +101,9 @@ namespace Bicep.Decompiler.ArmHelpers
 
                 var (childType, childName, _) = ParseResource(childResourceObject);
 
-                if (GetProperty(resource, "copy") is { } copyProperty)
+                if (GetProperty(resource, LanguageConstants.CopyLoopIdentifier) is { } copyProperty)
                 {
-                    childResourceObject["copy"] = copyProperty.Value;
+                    childResourceObject[LanguageConstants.CopyLoopIdentifier] = copyProperty.Value;
                 }
                 if (GetProperty(resource, "condition") is { } conditionProperty)
                 {

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -63,7 +63,6 @@ namespace Bicep.LanguageServer.Snippets
             "scale",
             "plan",
             "identity",
-            "copy",
             "dependsOn",
             "tags",
             "properties"


### PR DESCRIPTION
- LoadJsonContent with selecting multiple tokens
- Handling objects' 'copy' property name

Fixes #7208
Fixes #7241 

# Contributing a Pull Request

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7293)