### PR TITLE
Fixed type checking exception with overloaded binary operators and operands of `any` type

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -3599,5 +3599,20 @@ resource container_ActorColdStorage 'Microsoft.DocumentDB/databaseAccounts/sqlDa
                 ("BCP240", DiagnosticLevel.Error, "The \"parent\" property only permits direct references to resources. Expressions are not supported.")
             });
         }
+
+        /// <summary>
+        /// https://github.com/Azure/bicep/issues/7271
+        /// </summary>
+        [TestMethod]
+        public void Test_Issue7271()
+        {
+            var result = CompilationHelper.Compile(@"
+var less           = any(1) < any(2)
+var lessOrEqual    = any(1) <= any(2)
+var greater        = any(1) > any(2)
+var greaterOrEqual = any(1) >= any(2)");
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        }
     }
 }

--- a/src/Bicep.Core.UnitTests/Semantics/BinaryOperationResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/BinaryOperationResolverTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Bicep.Core.UnitTests.Semantics
+{
+    [TestClass]
+    public class BinaryOperationResolverTests
+    {
+        [DynamicData(nameof(GetAllBinaryOperators), DynamicDataSourceType.Method)]
+        [DataTestMethod]
+        public void OverloadedOperatorsShouldHaveSameReturnType(BinaryOperator @operator)
+        {
+            var matches = BinaryOperationResolver.GetMatches(@operator).ToImmutableArray();
+            matches.Should().HaveCountGreaterThanOrEqualTo(1);
+
+            var first = matches.First();
+
+            matches.Should().AllSatisfy(match => match.ReturnType.Should().Be(first.ReturnType), "because the type checker depends on overloaded operators having the same return type");
+        }
+
+        private static IEnumerable<object[]> GetAllBinaryOperators() => Enum.GetValues<BinaryOperator>().Select(value => new object[] { value });
+    }
+}

--- a/src/Bicep.Core/TypeSystem/BinaryOperationResolver.cs
+++ b/src/Bicep.Core/TypeSystem/BinaryOperationResolver.cs
@@ -48,20 +48,10 @@ namespace Bicep.Core.TypeSystem
             new BinaryOperatorInfo(BinaryOperator.Coalesce, LanguageConstants.Any, LanguageConstants.Any)
         }.ToLookup(info => info.Operator);
 
-        public static BinaryOperatorInfo? TryMatchExact(BinaryOperator @operator, TypeSymbol operandType1, TypeSymbol operandType2)
-        {
-            return OperatorLookup[@operator]
-                .SingleOrDefault(info => TypeValidator.AreTypesAssignable(operandType1, info.OperandType) == true &&
-                                         TypeValidator.AreTypesAssignable(operandType2, info.OperandType) == true);
-        }
-
-        public static IEnumerable<BinaryOperatorInfo> GetMatches(BinaryOperator @operator, TypeSymbol operandType1, TypeSymbol operandType2)
-        {
-            // error types will cause this to return multiple operator matches in some cases
-            return OperatorLookup[@operator]
-                .Where(info => TypeValidator.AreTypesAssignable(operandType1, info.OperandType) != false &&
-                               TypeValidator.AreTypesAssignable(operandType2, info.OperandType) != false);
-        }
+        public static IEnumerable<BinaryOperatorInfo> GetMatches(BinaryOperator @operator, TypeSymbol operandType1, TypeSymbol operandType2) =>
+            OperatorLookup[@operator]
+                .Where(info => TypeValidator.AreTypesAssignable(operandType1, info.OperandType) &&
+                               TypeValidator.AreTypesAssignable(operandType2, info.OperandType));
 
         public static IEnumerable<BinaryOperatorInfo> GetMatches(BinaryOperator @operator) => OperatorLookup[@operator];
     }

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -766,8 +766,13 @@ namespace Bicep.Core.TypeSystem
 
                 // operands don't appear to have errors
                 // let's match the operator now
-                var operatorInfo = BinaryOperationResolver.TryMatchExact(syntax.Operator, operandType1, operandType2);
-                if (operatorInfo != null)
+                // we may receive multiple matches when an overloaded operator (such as <, <=, >, or >=) is used with operands of "any" type
+                // however, overloaded operators MUST have the same return type, so we can use the first match
+                // (the return type constraint on overloaded operators has a corresponding test assertion to prevent future regressions)
+                var operatorInfo = BinaryOperationResolver
+                    .GetMatches(syntax.Operator, operandType1, operandType2)
+                    .FirstOrDefault();
+                if (operatorInfo is not null)
                 {
                     // we found a match - use its return type
                     return operatorInfo.ReturnType;


### PR DESCRIPTION
This fixes #7271.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7337)