### PR TITLE
Remove setting for bicep deploy and make it available by default

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -83,11 +83,6 @@
           "description": "Prepend each line displayed in the Bicep Operations output channel with a timestamp.",
           "default": true,
           "$comment": "This is used by vscode-azuretools package and has to be in the following format: <extensionPrefix>.enableOutputTimestamps"
-        },
-        "bicep.enableDeploy": {
-          "type": "boolean",
-          "description": "(Preview) Enable/disable Bicep Deploy feature",
-          "default": false
         }
       }
     },
@@ -271,7 +266,7 @@
         },
         {
           "command": "bicep.deploy",
-          "when": "resourceLangId == bicep && config.bicep.enableDeploy",
+          "when": "resourceLangId == bicep",
           "group": "0_bicep"
         },
         {
@@ -308,7 +303,7 @@
         },
         {
           "command": "bicep.deploy",
-          "when": "resourceLangId == bicep && config.bicep.enableDeploy",
+          "when": "resourceLangId == bicep",
           "group": "0_bicep"
         },
         {
@@ -335,7 +330,7 @@
         },
         {
           "command": "bicep.deploy",
-          "when": "resourceLangId == bicep && config.bicep.enableDeploy",
+          "when": "resourceLangId == bicep",
           "group": "0_bicep"
         },
         {
@@ -370,7 +365,6 @@
         },
         {
           "command": "bicep.deploy",
-          "when": "config.bicep.enableDeploy",
           "group": "0_bicep"
         },
         {
@@ -483,7 +477,7 @@
           {
             "id": "deployToAzure",
             "title": "Deploy to Azure",
-            "description": "Bicep right-click deploy is in preview! To enable this feature, navigate to settings (``Ctrl/CMD + ,``) and select Bicep: Enable Deploy. If you don't have the [Azure Account Extension](command:extension.open?%5B%22ms-vscode.azure-account%22%5D) installed, you will need it to complete this step.\n[Deploy](command:bicep.deploy?%7B%22walkthrough%22%3A%22true%22%7D)",
+            "description": "It's time to get these resources into Azure. If you don't have the [Azure Account Extension](command:extension.open?%5B%22ms-vscode.azure-account%22%5D) installed, you will need it to complete this step.\n[Deploy](command:bicep.deploy?%7B%22walkthrough%22%3A%22true%22%7D)",
             "media": {
               "image": "media/walkthroughs/gettingStarted/5_Deploy.gif",
               "altText": "Example of deploying Bicep file to Azure"


### PR DESCRIPTION
As a part of this PR:
Removed setting for bicep deploy feature:
![image](https://user-images.githubusercontent.com/30270536/175394259-93991635-5ba4-40a9-b319-957ebf02b456.png)

Updated walkthrough:
![image](https://user-images.githubusercontent.com/30270536/175394351-55e00a3f-e69b-41d9-aae1-54c44a02b05e.png)

Made deploy command show up by default:
![image](https://user-images.githubusercontent.com/30270536/175394448-cb71b2d4-afb5-4ca9-9bc8-930377e52c4e.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7349)