### PR TITLE
Update LangServer CodeAction test to account for spans that have multiple proposed code fixes

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -111,17 +111,7 @@ namespace Bicep.LangServer.IntegrationTests
                     // Assert.
                     quickFixes.Should().NotBeNull();
 
-                    var spansOverlap = (IFixable f) =>
-                    {
-                        if (span.Position <= f.Span.Position)
-                        {
-                            return span.GetEndPosition() >= f.Span.Position;
-                        }
-
-                        return f.Span.GetEndPosition() >= span.Position;
-                    };
-
-                    var bicepFixes = fixables.Where(spansOverlap).SelectMany(f => f.Fixes).ToHashSet();
+                    var bicepFixes = fixables.Where(f => TextSpan.AreOverlapping(span, f.Span) || TextSpan.AreNeighbors(span, f.Span) || TextSpan.AreNeighbors(f.Span, span)).SelectMany(f => f.Fixes).ToHashSet();
                     var quickFixList = quickFixes.Where(x => x.CodeAction?.Kind == CodeActionKind.QuickFix).ToList();
 
                     quickFixList.Should().HaveSameCount(bicepFixes);

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -95,48 +95,65 @@ namespace Bicep.LangServer.IntegrationTests
 
             // construct a parallel compilation
             var lineStarts = compilation.SourceFileGrouping.EntryPoint.LineStarts;
-            var fixables = compilation.GetEntrypointSemanticModel().GetAllDiagnostics().OfType<IFixable>();
+            var fixables = compilation.GetEntrypointSemanticModel().GetAllDiagnostics().OfType<IFixable>().ToList();
 
             foreach (var fixable in fixables)
             {
                 foreach (var span in GetOverlappingSpans(fixable.Span))
                 {
+                    var range = span.ToRange(lineStarts);
                     var quickFixes = await client.RequestCodeAction(new CodeActionParams
                     {
                         TextDocument = new TextDocumentIdentifier(uri),
-                        Range = span.ToRange(lineStarts),
+                        Range = range,
                     });
 
                     // Assert.
                     quickFixes.Should().NotBeNull();
 
-                    var quickFixList = quickFixes.Where(x => x.CodeAction?.Kind == CodeActionKind.QuickFix).ToList();
-                    var bicepFixList = fixable.Fixes.ToList();
+                    var spansOverlap = (IFixable f) =>
+                    {
+                        if (span.Position <= f.Span.Position)
+                        {
+                            return span.GetEndPosition() >= f.Span.Position;
+                        }
 
-                    quickFixList.Should().HaveSameCount(bicepFixList);
+                        return f.Span.GetEndPosition() >= span.Position;
+                    };
+
+                    var bicepFixes = fixables.Where(spansOverlap).SelectMany(f => f.Fixes).ToHashSet();
+                    var quickFixList = quickFixes.Where(x => x.CodeAction?.Kind == CodeActionKind.QuickFix).ToList();
+
+                    quickFixList.Should().HaveSameCount(bicepFixes);
 
                     for (int i = 0; i < quickFixList.Count; i++)
                     {
                         var quickFix = quickFixList[i];
-                        var bicepFix = bicepFixList[i];
 
                         quickFix.IsCodeAction.Should().BeTrue();
                         quickFix.CodeAction!.Kind.Should().Be(CodeActionKind.QuickFix);
-                        quickFix.CodeAction.Title.Should().Be(bicepFix.Description);
                         quickFix.CodeAction.Edit!.Changes.Should().ContainKey(uri);
 
                         var textEditList = quickFix.CodeAction.Edit.Changes![uri].ToList();
-                        var replacementList = bicepFix.Replacements.ToList();
 
-                        for (int j = 0; j < textEditList.Count; j++)
+                        bicepFixes.RemoveWhere(fix =>
                         {
-                            var textEdit = textEditList[j];
-                            var replacement = replacementList[j];
+                            if (fix.Description != quickFix.CodeAction.Title)
+                            {
+                                return false;
+                            }
 
-                            textEdit.Range.Should().Be(replacement.ToRange(lineStarts));
-                            textEdit.NewText.Should().Be(replacement.Text);
-                        }
+                            var replacementSet = fix.Replacements.ToHashSet();
+                            foreach (var edit in textEditList)
+                            {
+                                replacementSet.RemoveWhere(replacement => edit.Range == replacement.ToRange(lineStarts) && edit.NewText == replacement.Text);
+                            }
+
+                            return replacementSet.Count == 0;
+                        }).Should().Be(1, "No matching fix found.");
                     }
+
+                    bicepFixes.Count.Should().Be(0);
                 }
             }
         }


### PR DESCRIPTION
The `Bicep.LangServer.IntegrationTests.CodeActionTests::RequestingCodeActionWithFixableDiagnosticsShouldProduceQuickFixes` test method currently does not support lines for which multiple code fixes are proposed. This PR updates the test to be aware of when one code fix region overlaps with another and to expect multiple fixes in that case.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7369)