### PR TITLE
Cache diagnostics on the SemanticModel

### DIFF
--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -114,7 +114,7 @@ namespace Bicep.Cli.Services
             return decompilation;
         }
 
-        private static IReadOnlyDictionary<BicepFile, IEnumerable<IDiagnostic>> GetModuleRestoreDiagnosticsByBicepFile(SourceFileGrouping sourceFileGrouping, ImmutableHashSet<ModuleDeclarationSyntax> originalModulesToRestore, bool forceModulesRestore)
+        private static ImmutableDictionary<BicepFile, ImmutableArray<IDiagnostic>> GetModuleRestoreDiagnosticsByBicepFile(SourceFileGrouping sourceFileGrouping, ImmutableHashSet<ModuleDeclarationSyntax> originalModulesToRestore, bool forceModulesRestore)
         {
             static IEnumerable<IDiagnostic> GetModuleDiagnosticsPerFile(SourceFileGrouping grouping, BicepFile bicepFile, ImmutableHashSet<ModuleDeclarationSyntax> originalModulesToRestore, bool forceModulesRestore)
             {
@@ -134,7 +134,7 @@ namespace Bicep.Cli.Services
 
             return sourceFileGrouping.SourceFiles
                 .OfType<BicepFile>()
-                .ToDictionary(bicepFile => bicepFile, bicepFile => GetModuleDiagnosticsPerFile(sourceFileGrouping, bicepFile, originalModulesToRestore, forceModulesRestore));
+                .ToImmutableDictionary(bicepFile => bicepFile, bicepFile => GetModuleDiagnosticsPerFile(sourceFileGrouping, bicepFile, originalModulesToRestore, forceModulesRestore).ToImmutableArray());
         }
 
         private void LogDiagnostics(Compilation compilation)
@@ -147,7 +147,7 @@ namespace Bicep.Cli.Services
             LogDiagnostics(compilation.GetAllDiagnosticsByBicepFile());
         }
 
-        private void LogDiagnostics(IReadOnlyDictionary<BicepFile, IEnumerable<IDiagnostic>> diagnosticsByBicepFile)
+        private void LogDiagnostics(ImmutableDictionary<BicepFile, ImmutableArray<IDiagnostic>> diagnosticsByBicepFile)
         {
             foreach (var (bicepFile, diagnostics) in diagnosticsByBicepFile)
             {

--- a/src/Bicep.Core.IntegrationTests/ModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -753,7 +754,7 @@ output out string = p.properties.minimalTlsVersion
             return stringBuilder.ToString();
         }
 
-        private static (bool success, IDictionary<Uri, IEnumerable<IDiagnostic>> diagnosticsByFile) GetSuccessAndDiagnosticsByFile(Compilation compilation)
+        private static (bool success, IDictionary<Uri, ImmutableArray<IDiagnostic>> diagnosticsByFile) GetSuccessAndDiagnosticsByFile(Compilation compilation)
         {
             var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.FileUri, kvp => kvp.Value);
             var success = diagnosticsByFile.Values.SelectMany(x => x).All(d => d.Level != DiagnosticLevel.Error);

--- a/src/Bicep.Core.IntegrationTests/Scenarios/LocalJsonModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/LocalJsonModuleTests.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
 using Bicep.Core.UnitTests.Assertions;
@@ -125,7 +124,7 @@ module mod 'module.json' = {
             }
         }
 
-        private static IReadOnlyDictionary<string, IEnumerable<IDiagnostic>> GetDiagnosticsByFileName(Compilation compilation) =>
-            compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => Path.GetFileName(kvp.Key.FileUri.LocalPath), kvp => kvp.Value);
+        private static ImmutableDictionary<string, ImmutableArray<IDiagnostic>> GetDiagnosticsByFileName(Compilation compilation) =>
+            compilation.GetAllDiagnosticsByBicepFile().ToImmutableDictionary(kvp => Path.GetFileName(kvp.Key.FileUri.LocalPath), kvp => kvp.Value);
     }
 }

--- a/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
@@ -58,7 +58,8 @@ namespace Bicep.Core.IntegrationTests.Semantics
         public void EndOfFileFollowingSpaceAfterParameterKeyWordShouldNotThrow()
         {
             var compilation = new Compilation(BicepTestConstants.Features, TestTypeHelper.CreateEmptyProvider(), SourceFileGroupingFactory.CreateFromText("parameter ", BicepTestConstants.FileResolver), BicepTestConstants.BuiltInConfiguration, BicepTestConstants.LinterAnalyzer);
-            compilation.GetEntrypointSemanticModel().GetParseDiagnostics();
+
+            FluentActions.Invoking(() => compilation.GetEntrypointSemanticModel().GetAllDiagnostics()).Should().NotThrow();
         }
 
         [DataTestMethod]

--- a/src/Bicep.Core/Semantics/Compilation.cs
+++ b/src/Bicep.Core/Semantics/Compilation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Bicep.Core.Analyzers.Interfaces;
@@ -60,8 +59,8 @@ namespace Bicep.Core.Semantics
         public ISemanticModel GetSemanticModel(ISourceFile sourceFile)
             => this.lazySemanticModelLookup[sourceFile].Value;
 
-        public IReadOnlyDictionary<BicepFile, IEnumerable<IDiagnostic>> GetAllDiagnosticsByBicepFile()
-            => SourceFileGrouping.SourceFiles.OfType<BicepFile>().ToDictionary(
+        public ImmutableDictionary<BicepFile, ImmutableArray<IDiagnostic>> GetAllDiagnosticsByBicepFile()
+            => SourceFileGrouping.SourceFiles.OfType<BicepFile>().ToImmutableDictionary(
                 bicepFile => bicepFile,
                 bicepFile => this.GetSemanticModel(bicepFile).GetAllDiagnostics());
 

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -28,7 +28,7 @@ namespace Bicep.Core.Semantics
 
         private readonly Lazy<ImmutableArray<ResourceMetadata>> allResourcesLazy;
         private readonly Lazy<ImmutableArray<DeclaredResourceMetadata>> declaredResourcesLazy;
-        private readonly Lazy<IEnumerable<IDiagnostic>> allDiagnostics;
+        private readonly Lazy<ImmutableArray<IDiagnostic>> allDiagnostics;
 
         public SemanticModel(Compilation compilation, BicepFile sourceFile, IFileResolver fileResolver, IBicepAnalyzer linterAnalyzer)
         {
@@ -68,7 +68,7 @@ namespace Bicep.Core.Semantics
             this.declaredResourcesLazy = new Lazy<ImmutableArray<DeclaredResourceMetadata>>(() => this.AllResources.OfType<DeclaredResourceMetadata>().ToImmutableArray());
 
             // lazy load single use diagnostic set
-            this.allDiagnostics = new Lazy<IEnumerable<IDiagnostic>>(() => AssembleDiagnostics());
+            this.allDiagnostics = new Lazy<ImmutableArray<IDiagnostic>>(() => AssembleDiagnostics());
 
             this.parametersLazy = new Lazy<ImmutableArray<ParameterMetadata>>(() =>
             {
@@ -156,13 +156,13 @@ namespace Bicep.Core.Semantics
         /// <summary>
         /// Gets all the parser and lexer diagnostics unsorted. Does not include diagnostics from the semantic model.
         /// </summary>
-        public IEnumerable<IDiagnostic> GetParseDiagnostics() => this.Root.Syntax.GetParseDiagnostics();
+        private IEnumerable<IDiagnostic> GetParseDiagnostics() => this.Root.Syntax.GetParseDiagnostics();
 
         /// <summary>
         /// Gets all the semantic diagnostics unsorted. Does not include parser and lexer diagnostics.
         /// </summary>
         /// <returns></returns>
-        public IReadOnlyList<IDiagnostic> GetSemanticDiagnostics()
+        private IReadOnlyList<IDiagnostic> GetSemanticDiagnostics()
         {
             var diagnosticWriter = ToListDiagnosticWriter.Create();
 
@@ -186,7 +186,7 @@ namespace Bicep.Core.Semantics
         /// Gets all the analyzer diagnostics unsorted.
         /// </summary>
         /// <returns></returns>
-        public IReadOnlyList<IDiagnostic> GetAnalyzerDiagnostics()
+        private IReadOnlyList<IDiagnostic> GetAnalyzerDiagnostics()
         {
             var diagnostics = LinterAnalyzer.Analyze(this);
 
@@ -199,12 +199,9 @@ namespace Bicep.Core.Semantics
         /// <summary>
         /// Cached diagnostics from compilation
         /// </summary>
-        public IEnumerable<IDiagnostic> GetAllDiagnostics()
-        {
-            return AssembleDiagnostics();
-        }
+        public ImmutableArray<IDiagnostic> GetAllDiagnostics() => allDiagnostics.Value;
 
-        private IReadOnlyList<IDiagnostic> AssembleDiagnostics()
+        private ImmutableArray<IDiagnostic> AssembleDiagnostics()
         {
             var diagnostics = GetParseDiagnostics()
                 .Concat(GetSemanticDiagnostics())
@@ -232,7 +229,7 @@ namespace Bicep.Core.Semantics
                 filteredDiagnostics.Add(diagnostic);
             }
 
-            return filteredDiagnostics;
+            return filteredDiagnostics.ToImmutableArray();
         }
 
         /// <summary>

--- a/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -104,7 +103,7 @@ namespace Bicep.LanguageServer.Handlers
                 compilation = context.Compilation;
             }
 
-            KeyValuePair<BicepFile, IEnumerable<IDiagnostic>> diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
+            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
                 .FirstOrDefault(x => x.Key.FileUri == fileUri);
 
             if (diagnosticsByFile.Value.Any(x => x.Level == DiagnosticLevel.Error))

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -109,7 +108,7 @@ namespace Bicep.LanguageServer.Handlers
         {
             var fileUri = documentUri.ToUri();
 
-            KeyValuePair<BicepFile, IEnumerable<IDiagnostic>> diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
+            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
                 .FirstOrDefault(x => x.Key.FileUri == fileUri);
 
             if (diagnosticsByFile.Value.Any(x => x.Level == DiagnosticLevel.Error))

--- a/src/Bicep.LangServer/Handlers/BicepGenerateParamsCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepGenerateParamsCommandHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -103,7 +102,7 @@ namespace Bicep.LanguageServer.Handlers
                 compilation = context.Compilation;
             }
 
-            KeyValuePair<BicepFile, IEnumerable<IDiagnostic>> diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
+            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
                 .FirstOrDefault(x => x.Key.FileUri == fileUri);
 
             if (diagnosticsByFile.Value.Any(x => x.Level == DiagnosticLevel.Error))

--- a/src/Bicep.LangServer/Utils/DiagnosticsHelper.cs
+++ b/src/Bicep.LangServer/Utils/DiagnosticsHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Text;
@@ -11,7 +12,7 @@ namespace Bicep.LanguageServer.Utils
 {
     public static class DiagnosticsHelper
     {
-        public static string GetDiagnosticsMessage(KeyValuePair<BicepFile, IEnumerable<IDiagnostic>> diagnosticsByFile)
+        public static string GetDiagnosticsMessage(KeyValuePair<BicepFile, ImmutableArray<IDiagnostic>> diagnosticsByFile)
         {
             StringBuilder sb = new StringBuilder();
             IReadOnlyList<int> lineStarts = diagnosticsByFile.Key.LineStarts;


### PR DESCRIPTION
Implementing @StephenWeatherford's suggestion in #7406

This took the execution time for `RequestingCodeActionWithFixableDiagnosticsShouldProduceQuickFixes` on my Codespaces VM from 11m34s down to 22s.

Closes #7406 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7432)