### PR TITLE
Turn off cs1591 xml comments

### DIFF
--- a/src/.globalconfig
+++ b/src/.globalconfig
@@ -215,7 +215,7 @@ dotnet_diagnostic.CA5403.severity = warning
 # Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
 dotnet_diagnostic.CS1573.severity = suggestion
 # Missing XML comment for publicly visible type or member 'Type_or_Member'
-dotnet_diagnostic.CS1591.severity = suggestion
+dotnet_diagnostic.CS1591.severity = none
 
 # VSTHRD200: Use "Async" suffix for async methods
 dotnet_diagnostic.VSTHRD200.severity = none

--- a/src/Bicep.Core/FileSystem/IFileResolver.cs
+++ b/src/Bicep.Core/FileSystem/IFileResolver.cs
@@ -33,6 +33,7 @@ namespace Bicep.Core.FileSystem
         /// <param name="failureBuilder">Builder for the failure to return, if unsuccessful.</param>
         /// <param name="fileEncoding">Encoding to use when reading file. Auto if set to null</param>
         /// <param name="maxCharacters">Maximum number of text characters to read. if negative - read all.</param>
+        /// <param name="detectedEncoding">The encoding that was detected (if no failure occurred)</param>
         bool TryRead(Uri fileUri, [NotNullWhen(true)] out string? fileContents, [NotNullWhen(false)] out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder, Encoding fileEncoding, int maxCharacters, [NotNullWhen(true)] out Encoding? detectedEncoding);
 
         bool TryReadAtMostNCharaters(Uri fileUri, Encoding fileEncoding, int n, [NotNullWhen(true)] out string? fileContents);

--- a/src/Bicep.Core/Registry/IModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/IModuleRegistry.cs
@@ -30,6 +30,8 @@ namespace Bicep.Core.Registry
         /// <summary>
         /// Attempts to parse the specified unqualified reference or returns a failure builder.
         /// </summary>
+        /// <param name="aliasName">The alias name</param>
+        /// <param name="configuration">The root configuration</param>
         /// <param name="reference">The unqualified module reference</param>
         /// <param name="failureBuilder">set to an error builder if parsing fails when null is returned</param>
         ModuleReference? TryParseModuleReference(string? aliasName, string reference, RootConfiguration configuration, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder);

--- a/src/Bicep.Core/Semantics/SymbolHelper.cs
+++ b/src/Bicep.Core/Semantics/SymbolHelper.cs
@@ -12,6 +12,8 @@ namespace Bicep.Core.Semantics
         /// Returns the symbol that was bound to the specified syntax node. Will return null for syntax nodes that never get bound to symbols. Otherwise,
         /// a symbol will always be returned. Binding failures are represented with a non-null error symbol.
         /// </summary>
+        /// <param name="binder">the binder </param>
+        /// <param name="getDeclaredTypeFunc">lambda to retrieve declared type from syntax base (to avoid cyclic dependencies)</param>
         /// <param name="syntax">the syntax node</param>
         public static Symbol? TryGetSymbolInfo(IBinder binder, Func<SyntaxBase, TypeSymbol?> getDeclaredTypeFunc, SyntaxBase syntax)
         {

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -797,7 +797,6 @@ namespace Bicep.LanguageServer.Completions
         /// <summary>
         /// Determines if we are inside an expression. Will not produce a correct result if context kind is set is already set to something.
         /// </summary>
-        /// <param name="matchingNodes">The matching nodes</param>
         private static bool IsInnerExpressionContext(List<SyntaxBase> matchingNodes, int offset)
         {
             if (!matchingNodes.OfType<ExpressionSyntax>().Any())

--- a/src/Bicep.LangServer/Handlers/BicepEditLinterRuleCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepEditLinterRuleCommandHandler.cs
@@ -127,8 +127,6 @@ namespace Bicep.LanguageServer.Handlers
         /// If the given rule has an entry for its error level in the configuration file, show that file and select the current
         /// level value (so that the end user can immediatey edit it).
         /// </summary>
-        /// <param name="ruleCode"></param>
-        /// <param name="configFilePath"></param>
         /// <returns>True if the rule exists and displaying/highlighting succeeds, otherwise false.</returns>
         private static async Task<bool> SelectRuleLevelIfExists(ILanguageServerFacade server, string ruleCode, string configFilePath)
         {


### PR DESCRIPTION
This is currently set to "suggestion" which in VS is supposed to show an "information" item.  At least on VS Mac, though, it doesn't show up at all.  But in VsCode, they do show up, so I have 5K+ "information" items aways in the task list and underlined in the code editor:
<img width="1441" alt="image" src="https://user-images.githubusercontent.com/6913354/176961941-928984b9-ac4d-498a-9079-a6b80eb3c144.png">
Since hardly anyone ever writes xml comments in this project, this is completely useless, so turning them completely off.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7437)