### PR TITLE
Fix for issue 7455

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -3748,5 +3748,28 @@ resource storageAccountName_resource 'Microsoft.Storage/storageAccounts@2021-04-
             result.Template.Should().HaveValueAtPath("$.resources[1].type", "Microsoft.Storage/storageAccounts");
             result.Template.Should().NotHaveValueAtPath("$.resources[1].dependsOn");
         }
+
+        /// <summary>
+        /// https://github.com/Azure/bicep/issues/7455
+        /// </summary>
+        [TestMethod]
+        public void Test_Issue7455()
+        {
+            var result = CompilationHelper.Compile(@"
+var test1  = {
+  'tata':'loco'
+}
+
+var test2 = {
+  'tata':'cola'
+}
+
+param useFirst bool = true
+
+var value = (useFirst ? test1 : test2).tata
+").ExcludingLinterDiagnostics();
+
+            result.Should().NotHaveAnyDiagnostics();
+       }
     }
 }

--- a/src/Bicep.Core.Samples/Files/InvalidLambdas_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidLambdas_LF/main.symbols.bicep
@@ -56,8 +56,8 @@ var reduce5 = reduce(range(0, 10), 0, i => i)
 //@[04:11) Variable reduce5. Type: error. Declaration start char: 0, length: 45
 
 var ternary = map([123], true ? i => '${i}' : i => 'hello!')
-//@[32:33) Local i. Type: int. Declaration start char: 32, length: 1
-//@[46:47) Local i. Type: int. Declaration start char: 46, length: 1
+//@[32:33) Local i. Type: any. Declaration start char: 32, length: 1
+//@[46:47) Local i. Type: any. Declaration start char: 46, length: 1
 //@[04:11) Variable ternary. Type: any. Declaration start char: 0, length: 60
 
 var outsideArgs = i => 123

--- a/src/Bicep.Core.Samples/Files/Lambdas_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Lambdas_LF/main.symbols.bicep
@@ -159,6 +159,6 @@ var modLoopNames = map(range(0, 5), i => modLoop[i].name)
 //@[004:016) Variable modLoopNames. Type: string[]. Declaration start char: 0, length: 57
 
 var parentheses = map([123], (i => '${i}'))
-//@[030:031) Local i. Type: int. Declaration start char: 30, length: 1
+//@[030:031) Local i. Type: any. Declaration start char: 30, length: 1
 //@[004:015) Variable parentheses. Type: string[]. Declaration start char: 0, length: 43
 

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -36,16 +36,6 @@ namespace Bicep.Core.TypeSystem
 
         public TypeSymbol? GetDeclaredType(SyntaxBase syntax) => this.GetDeclaredTypeAssignment(syntax)?.Reference.Type;
 
-        private DeclaredTypeAssignment? GetParentTypeAssignment(SyntaxBase syntax)
-        {
-            if (binder.GetParent(syntax) is {} parent)
-            {
-                return GetTypeAssignment(parent);
-            }
-
-            return null;
-        }
-
         private DeclaredTypeAssignment? GetTypeAssignment(SyntaxBase syntax)
         {
             RuntimeHelpers.EnsureSufficientExecutionStack();
@@ -114,20 +104,6 @@ namespace Bicep.Core.TypeSystem
 
                 case FunctionArgumentSyntax functionArgument:
                     return GetFunctionArgumentType(functionArgument);
-
-                case ParenthesizedExpressionSyntax:
-                case TernaryOperationSyntax:
-                    return GetParentTypeAssignment(syntax);
-            }
-
-            var parent = binder.GetParent(syntax);
-            switch (parent)
-            {
-                // These expressions do not modify the declared type - we can get more accurate validation by checking the parent declared type
-                case ParenthesizedExpressionSyntax parenthesizedExpression:
-                    return GetTypeAssignment(parent);
-                case TernaryOperationSyntax ternary when (syntax == ternary.TrueExpression || syntax == ternary.FalseExpression):
-                    return GetTypeAssignment(parent);
             }
 
             return null;

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -104,6 +104,9 @@ namespace Bicep.Core.TypeSystem
 
                 case FunctionArgumentSyntax functionArgument:
                     return GetFunctionArgumentType(functionArgument);
+
+                case ParenthesizedExpressionSyntax parenthesizedExpression:
+                    return GetTypeAssignment(parenthesizedExpression.Expression);
             }
 
             return null;


### PR DESCRIPTION
This was a bug I introduced with #7083.

In order to support better type validation for a lambda inside a parenthesized expression, I added logic to calculate the child declared type based on the parent declared type (e.g. so the declared type of the lambda in `map([123], (i => i))` can be evaluated). Elsewhere the parent declared type is calculated based on child declared type - so in the place where these two pieces of logic meet, we get a cycle.  To fix I've removed the logic I put in so that declared type is always calculated in a consistent direction.

Closes #7455 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7483)