### PR TITLE
Add a linter to warn on nondeterministic resource names

### DIFF
--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.diagnostics.bicep
@@ -120,6 +120,7 @@ module moduleWithCalculatedName './child/optionalParams.bicep'= {
 resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
 //@[43:076) [BCP081 (Warning)] Resource type "Mock.Rp/mockResource@2020-01-01" does not have types available. (CodeDescription: none) |'Mock.Rp/mockResource@2020-01-01'|
   name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+//@[08:077) [use-stable-resource-identifiers (Warning)] Resource identifiers should be reproducible outside of their initial deployment context. Resource resWithCalculatedNameDependencies's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (resWithCalculatedNameDependencies.name -> deployTimeSuffix (default value) -> newGuid()). (CodeDescription: bicep core(https://aka.ms/bicep/linter/use-stable-resource-identifiers)) |'${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'|
   properties: {
     modADep: moduleWithCalculatedName.outputs.outputObj
   }

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseStableResourceIdentifiersRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseStableResourceIdentifiersRuleTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using Bicep.Core.Analyzers.Linter.Rules;
+using Bicep.Core.UnitTests.Assertions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
+{
+    [TestClass]
+    public class UseStableResourceIdentifiersRuleTests : LinterRuleTestsBase
+    {
+        private void CompileAndTest(string text, params string[] expectedMessages)
+        {
+            AssertLinterRuleDiagnostics(UseStableResourceIdentifiersRule.Code, text, diags =>
+            {
+                if (expectedMessages.Any())
+                {
+                    diags.Where(e => e.Code == UseStableResourceIdentifiersRule.Code).Select(e => e.Message).Should().Contain(expectedMessages);
+                }
+                else
+                {
+                    diags.Where(e => e.Code == UseStableResourceIdentifiersRule.Code).Count().Should().Be(0);
+                }
+            });
+        }
+
+        [DataRow(@"
+            param location string = resourceGroup().location
+
+            resource storage 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+              name: 'literalName'
+              location: location
+              kind: 'StorageV2'
+              sku: {
+                name: 'Standard_LRS'
+              }
+            }"
+        )]
+        [DataRow(@"
+            param location string = resourceGroup().location
+            param snap string
+
+            var crackle = 'crackle'
+            var pop = '${snap}${crackle}'
+
+            resource storage 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+              name: pop
+              location: location
+              kind: 'StorageV2'
+              sku: {
+                name: 'Standard_LRS'
+              }
+            }"
+        )]
+        [DataRow(@"
+            param location string = resourceGroup().location
+            param snap string = newGuid()
+
+            var crackle = snap
+            var pop = '${snap}${crackle}'
+
+            resource storage 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+              name: pop
+              location: location
+              kind: 'StorageV2'
+              sku: {
+                name: 'Standard_LRS'
+              }
+            }",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> snap (default value) -> newGuid()).",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> crackle -> snap (default value) -> newGuid())."
+        )]
+        [DataRow(@"
+            param location string = resourceGroup().location
+            param snap string = utcNow('F')
+
+            var crackle = snap
+            var pop = '${snap}${crackle}'
+
+            resource storage 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+              name: pop
+              location: location
+              kind: 'StorageV2'
+              sku: {
+                name: 'Standard_LRS'
+              }
+            }",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> snap (default value) -> utcNow('F')).",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> crackle -> snap (default value) -> utcNow('F'))."
+        )]
+        [DataTestMethod]
+        public void TestRule(string text, params string[] expectedMessages)
+        {
+            CompileAndTest(text, expectedMessages);
+        }
+    }
+}

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Navigation;
+using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Bicep.Core.Analyzers.Linter.Rules
+{
+    public sealed class UseStableResourceIdentifiersRule : LinterRuleBase
+    {
+        public new const string Code = "use-stable-resource-identifiers";
+
+        public UseStableResourceIdentifiersRule() : base(
+            code: Code,
+            description: CoreResources.UseStableResourceIdentifiersMessage,
+            docUri: new Uri($"https://aka.ms/bicep/linter/{Code}"))
+        { }
+
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        {
+            foreach (var resource in model.DeclaredResources)
+            {
+                foreach (var identifier in resource.Type.UniqueIdentifierProperties)
+                {
+                    if (resource.Symbol.TryGetBodyPropertyValue(identifier) is { } identifierSyntax)
+                    {
+                        var visitor = new Visitor(model);
+                        identifierSyntax.Accept(visitor);
+                        foreach (var (path, functionName) in visitor.PathsToNonDeterministicFunctionsUsed)
+                        {
+                            yield return CreateDiagnosticForSpan(identifierSyntax.Span, resource.Symbol.Name, identifier, functionName, $"{resource.Symbol.Name}.{identifier} -> {path}");
+                        }
+                    }
+                }
+            }
+        }
+
+        public override string FormatMessage(params object[] values)
+            => string.Format(CoreResources.UseStableResourceIdentifiersMessageFormat, values);
+
+        private class Visitor : SyntaxVisitor
+        {
+            private static IReadOnlySet<string> NonDeterministicFunctionNames = new HashSet<string>
+            {
+                "newGuid",
+                "utcNow",
+            };
+            private readonly SemanticModel model;
+            private readonly Dictionary<string, string> pathsToNonDeterministicFunctionsUsed = new();
+            private readonly LinkedList<Symbol> pathSegments = new();
+
+            internal Visitor(SemanticModel model)
+            {
+                this.model = model;
+            }
+
+            internal IEnumerable<KeyValuePair<string, string>> PathsToNonDeterministicFunctionsUsed => pathsToNonDeterministicFunctionsUsed;
+
+            public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
+            {
+                if (NonDeterministicFunctionNames.Contains(syntax.Name.IdentifierName))
+                {
+                    pathsToNonDeterministicFunctionsUsed.Add(FormatPath(syntax.ToText()), syntax.Name.IdentifierName);
+                }
+                base.VisitFunctionCallSyntax(syntax);
+            }
+
+            public override void VisitVariableAccessSyntax(VariableAccessSyntax syntax)
+            {
+                switch (model.GetSymbolInfo(syntax))
+                {
+                    case ParameterSymbol @parameter:
+                        if (@parameter.DeclaringParameter.Modifier is ParameterDefaultValueSyntax defaultValueSyntax)
+                        {
+                            pathSegments.AddLast(@parameter);
+                            defaultValueSyntax.Accept(this);
+                            pathSegments.RemoveLast();
+                        }
+                        break;
+                    case VariableSymbol @variable:
+                        // Variable cycles are reported on elsewhere. As far as this visitor is concerned, a cycle does not introduce nondeterminism.
+                        if (pathSegments.Contains(@variable))
+                        {
+                            return;
+                        }
+
+                        pathSegments.AddLast(@variable);
+                        @variable.DeclaringVariable.Value.Accept(this);
+                        pathSegments.RemoveLast();
+                        break;
+                }
+
+                base.VisitVariableAccessSyntax(syntax);
+            }
+
+            private string FormatPath(string functionCall)
+            {
+                var path = new StringBuilder();
+                foreach (var segment in pathSegments)
+                {
+                    if (segment is ParameterSymbol @parameter)
+                    {
+                        path.Append(@parameter.Name);
+                        path.Append(" (default value) -> ");
+                    }
+                    else if (segment is VariableSymbol @variable)
+                    {
+                        path.Append(@variable.Name);
+                        path.Append(" -> ");
+                    }
+                }
+
+                path.Append(functionCall);
+
+                return path.ToString();
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Bicep.Core {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace Bicep.Core {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CoreResources {
-
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal CoreResources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Bicep.Core {
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Bicep.Core {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Property &apos;adminUserName&apos; should not use a literal value. Use a param instead..
         /// </summary>
@@ -68,7 +68,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("AdminUsernameShouldNotBeLiteralRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Custom bicepconfig.json file found ({0})..
         /// </summary>
@@ -77,7 +77,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("BicepConfigCustomSettingsFoundFormatMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No bicepconfig.json found for configuration override..
         /// </summary>
@@ -86,7 +86,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("BicepConfigNoCustomSettingsMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Environment URLs should not be hardcoded. Use the environment() function to ensure compatibility across clouds..
         /// </summary>
@@ -95,7 +95,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("EnvironmentUrlHardcodedRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use string interpolation: {0}..
         /// </summary>
@@ -104,7 +104,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("InterpolateNotConcatFixTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use string interpolation instead of the concat function..
         /// </summary>
@@ -113,7 +113,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("InterpolateNotConcatRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Linter is disabled in settings file located at {0} .
         /// </summary>
@@ -122,7 +122,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("LinterDisabledFormatMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Analyzer &apos;{0}&apos; encountered an unexpected exception. {1}.
         /// </summary>
@@ -131,7 +131,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("LinterRuleExceptionMessageFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource location should be specified by a parameter without a default value or one that defaults to &apos;global&apos; or resourceGroup().location..
         /// </summary>
@@ -140,7 +140,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("LocationSetByParameterRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Maximum number of outputs used..
         /// </summary>
@@ -149,7 +149,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("MaxNumberOutputsRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Too many outputs. Number of outputs is limited to {0}..
         /// </summary>
@@ -158,7 +158,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("MaxNumberOutputsRuleMessageFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Maximum number of parameters used..
         /// </summary>
@@ -167,7 +167,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("MaxNumberParametersRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Too many parameters. Number of parameters is limited to {0}..
         /// </summary>
@@ -176,7 +176,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("MaxNumberParametersRuleMessageFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Maximum number of resources used..
         /// </summary>
@@ -185,7 +185,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("MaxNumberResourcesRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Too many resources. Number of resources is limited to {0}..
         /// </summary>
@@ -194,7 +194,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("MaxNumberResourcesRuleMessageFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Maximum number of variables used..
         /// </summary>
@@ -203,7 +203,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("MaxNumberVariablesRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Too many variables. Number of variables is limited to {0}..
         /// </summary>
@@ -212,7 +212,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("MaxNumberVariablesRuleMessageFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A resource location should not use a hard-coded string or variable value. Change variable &apos;{0}&apos; into a parameter instead..
         /// </summary>
@@ -221,7 +221,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoHardcodedLocation_ErrorChangeVarToParam", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; may be used as a resource location in the module and should not be assigned a hard-coded string or variable value..
         /// </summary>
@@ -230,7 +230,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoHardcodedLocation_ErrorForModuleParam", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A resource location should not use a hard-coded string or variable value..
         /// </summary>
@@ -239,7 +239,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoHardcodedLocation_ErrorForResourceLocation", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Please use a parameter value, an expression, or the string &apos;{0}&apos;. Found: &apos;{1}&apos;.
         /// </summary>
@@ -248,7 +248,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoHardcodedLocation_ErrorSolution", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Change variable &apos;{0}&apos; into a parameter instead.
         /// </summary>
@@ -257,7 +257,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoHardcodedLocation_FixChangeVarToParam", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Create new parameter &apos;{0}&apos; with default value {1}.
         /// </summary>
@@ -266,7 +266,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoHardcodedLocation_FixNewParam", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; of module &apos;{1}&apos; isn&apos;t assigned an explicit value, and its default value may not give the intended behavior for a location-related parameter. You should assign an explicit value to the parameter..
         /// </summary>
@@ -275,7 +275,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoHardcodedLocation_ModuleLocationNeedsExplicitValue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A resource location should be either an expression or the string &apos;{0}&apos;. Found &apos;{1}&apos;.
         /// </summary>
@@ -284,7 +284,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoHardcodedLocation_ResourceLocationShouldBeExpressionOrGlobal", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A resource&apos;s location should not use a hard-coded string or variable value. It should use a parameter, an expression, or the string &apos;global&apos;..
         /// </summary>
@@ -293,7 +293,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoHardcodedLocationRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Functions resourceGroup().location and deployment().location should only be used as the default value of a parameter..
         /// </summary>
@@ -302,7 +302,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoLocExprOutsideParamsRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use a parameter here instead of &apos;{0}&apos;. &apos;resourceGroup().location&apos; and &apos;deployment().location&apos; should only be used as a default value for parameters..
         /// </summary>
@@ -311,7 +311,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoLocExprOutsideParamsRuleError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No unnecessary dependsOn..
         /// </summary>
@@ -320,7 +320,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoUnnecessaryDependsOnRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remove unnecessary dependsOn entry &apos;{0}&apos;..
         /// </summary>
@@ -329,7 +329,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("NoUnnecessaryDependsOnRuleMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to function &apos;{0}&apos;.
         /// </summary>
@@ -338,7 +338,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("OutputsShouldNotContainSecretsFunction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} Found possible secret: {1}.
         /// </summary>
@@ -347,7 +347,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("OutputsShouldNotContainSecretsMessageFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to output name &apos;{0}&apos; suggests a secret.
         /// </summary>
@@ -356,7 +356,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("OutputsShouldNotContainSecretsOutputName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Outputs should not contain secrets..
         /// </summary>
@@ -365,7 +365,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("OutputsShouldNotContainSecretsRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to secure parameter &apos;{0}&apos;.
         /// </summary>
@@ -374,7 +374,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("OutputsShouldNotContainSecretsSecureParam", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to All parameters must be used..
         /// </summary>
@@ -383,7 +383,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("ParameterMustBeUsedRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Parameter &quot;{0}&quot; is declared but never used..
         /// </summary>
@@ -392,7 +392,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("ParameterMustBeUsedRuleMessageFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to function &apos;{0}&apos;.
         /// </summary>
@@ -401,7 +401,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("PossibleSecretMessageFunction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to secure parameter &apos;{0}&apos;.
         /// </summary>
@@ -410,7 +410,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("PossibleSecretMessageSecureParam", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remove quotes from property name &apos;{0}&apos;..
         /// </summary>
@@ -419,7 +419,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("PreferUnquotedPropertyNamesDeclarationFixTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Replace array syntax with &apos;{0}&apos;..
         /// </summary>
@@ -428,7 +428,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("PreferUnquotedPropertyNamesDereferenceFixTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation..
         /// </summary>
@@ -437,7 +437,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("PreferUnquotedPropertyNamesRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use protectedSettings for commandToExecute secrets.
         /// </summary>
@@ -446,7 +446,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("ProtectCommandToExecuteSecretsRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use protectedSettings for commandToExecute secrets. Found possible secret: {0}.
         /// </summary>
@@ -455,7 +455,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("ProtectCommandToExecuteSecretsRuleMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remove insecure default value..
         /// </summary>
@@ -464,7 +464,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("SecureParameterDefaultFixTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Secure parameters should not have hardcoded defaults (except for empty or newGuid())..
         /// </summary>
@@ -473,7 +473,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("SecureParameterDefaultRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remove unnecessary string interpolation..
         /// </summary>
@@ -482,7 +482,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("SimplifyInterpolationFixTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remove unnecessary string interpolation..
         /// </summary>
@@ -491,7 +491,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("SimplifyInterpolationRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to All variables must be used..
         /// </summary>
@@ -500,7 +500,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("UnusedVariableRuleDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Variable &quot;{0}&quot; is declared but never used..
         /// </summary>
@@ -509,7 +509,25 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("UnusedVariableRuleMessageFormat", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resource identifiers should be reproducible outside of their initial deployment context. .
+        /// </summary>
+        internal static string UseStableResourceIdentifiersMessage {
+            get {
+                return ResourceManager.GetString("UseStableResourceIdentifiersMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resource identifiers should be reproducible outside of their initial deployment context. Resource {0}&apos;s &apos;{1}&apos; identifier is potentially nondeterministic due to its use of the &apos;{2}&apos; function ({3})..
+        /// </summary>
+        internal static string UseStableResourceIdentifiersMessageFormat {
+            get {
+                return ResourceManager.GetString("UseStableResourceIdentifiersMessageFormat", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Virtual machines shouldn&apos;t use preview images..
         /// </summary>
@@ -518,7 +536,7 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("UseStableVMImage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Virtual machines shouldn&apos;t use preview images. Use stable version in imageReference property &quot;{0}&quot;..
         /// </summary>

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -296,5 +296,12 @@
   </data>
   <data name="PreferUnquotedPropertyNamesRuleDescription" xml:space="preserve">
     <value>Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation.</value>
+  </data>
+  <data name="UseStableResourceIdentifiersMessage" xml:space="preserve">
+    <value>Resource identifiers should be reproducible outside of their initial deployment context. </value>
+  </data>
+  <data name="UseStableResourceIdentifiersMessageFormat" xml:space="preserve">
+    <value>Resource identifiers should be reproducible outside of their initial deployment context. Resource {0}'s '{1}' identifier is potentially nondeterministic due to its use of the '{2}' function ({3}).</value>
+    <comment>{0} is the symbolic name of the resource. {1} is the name of the identifier property. {2} is the name of the nondeterministic function used. {3} is the symbol dereference path by which the nondeterministic function call is included.</comment>
   </data>
 </root>

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -461,6 +461,16 @@
                       "$ref": "#/definitions/rule-def-error-level"
                     }
                   ]
+                },
+                "use-stable-resource-identifiers": {
+                  "allOf": [
+                    {
+                      "description": "Resources identifiers should be reproducible outside of their initial deployment context. See https://aka.ms/bicep/linter/use-stable-resource-identifiers"
+                    },
+                    {
+                      "$ref": "#/definitions/rule"
+                    }
+                  ]
                 }
               }
             }

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -465,7 +465,7 @@
                 "use-stable-resource-identifiers": {
                   "allOf": [
                     {
-                      "description": "Resources identifiers should be reproducible outside of their initial deployment context. See https://aka.ms/bicep/linter/use-stable-resource-identifiers"
+                      "description": "Resource identifiers should be reproducible outside of their initial deployment context. See https://aka.ms/bicep/linter/use-stable-resource-identifiers"
                     },
                     {
                       "$ref": "#/definitions/rule"


### PR DESCRIPTION
Resolves #7562 

One theme that came up during discussion around #6065 was that while you certainly *can* create a resource that can't be addressed outside of its initial deployment context, doing so nerfs WhatIf, makes deployments non-repeatable, and is generally not a great idea. 

This PR adds a linter that will emit a warning if any of a resource's unique identifiers rely on a non-deterministic value (i.e., a parameter whose default value uses the `newGuid` or `utcNow` functions). This does not address the core issue of #6065 but should help with one of the concerns around the "outlining" solution proposed in that issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7491)