### PR TITLE
Handle race condition in visualizer

### DIFF
--- a/src/vscode-bicep/src/test/e2e/completion.test.ts
+++ b/src/vscode-bicep/src/test/e2e/completion.test.ts
@@ -34,7 +34,7 @@ describe("completion", (): void => {
     await executeCloseAllEditors();
   });
 
-  it("should provide completion while typing an indentifier", async () => {
+  it("should provide completion while typing an identifier", async () => {
     await editor.edit((editBuilder) =>
       editBuilder.insert(new Position(17, 0), "var foo = data")
     );

--- a/src/vscode-bicep/src/test/e2e/visualizer.test.ts
+++ b/src/vscode-bicep/src/test/e2e/visualizer.test.ts
@@ -64,10 +64,21 @@ describe("visualizer", (): void => {
   it("should open source", async () => {
     expect(vscode.window.activeTextEditor).toBeUndefined();
 
-    const examplePath = resolveExamplePath("201", "sql");
-    const textDocument = await vscode.workspace.openTextDocument(examplePath);
+    const examplePath = resolveExamplePath("000", "empty");
+    const document = await vscode.workspace.openTextDocument(examplePath);
 
-    await executeShowVisualizerToSideCommand(textDocument.uri);
+    await executeShowVisualizerToSideCommand(document.uri);
+
+    await until(() => visualizerIsReady(document.uri), {
+      interval: 100,
+    });
+
+    if (!visualizerIsReady(document.uri)) {
+      throw new Error(
+        `Expected visualizer to be ready for ${document.uri.toString()}`
+      );
+    }
+
     const sourceEditor = await executeShowSourceCommand();
 
     expectDefined(sourceEditor);

--- a/src/vscode-bicep/src/visualizer/view.ts
+++ b/src/vscode-bicep/src/visualizer/view.ts
@@ -144,9 +144,15 @@ export class BicepVisualizerView extends Disposable {
       return;
     }
 
-    this.webviewPanel.webview.postMessage(
-      createDeploymentGraphMessage(this.documentUri.fsPath, deploymentGraph)
-    );
+    try {
+      await this.webviewPanel.webview.postMessage(
+        createDeploymentGraphMessage(this.documentUri.fsPath, deploymentGraph)
+      );
+    } catch (error) {
+      // Race condition: the webview was closed before receiving the message,
+      // which causes "Unknown webview handle" error.
+      getLogger().debug((error as Error).message ?? error);
+    }
   }
 
   private handleDidReceiveMessage(message: Message): void {


### PR DESCRIPTION
This fixes the flaky e2e test on macOS.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7514)