### PR TITLE
removal of unnecessary parameter from ParamBinder constructor

### DIFF
--- a/src/Bicep.Core/Semantics/ParamBinder.cs
+++ b/src/Bicep.Core/Semantics/ParamBinder.cs
@@ -16,7 +16,7 @@ namespace Bicep.Core.Semantics
         private readonly ImmutableDictionary<SyntaxBase, Symbol> bindings;
         private readonly ImmutableDictionary<BindableSymbol, ImmutableArray<BindableSymbol>> cyclesBySymbol;
 
-        public ParamBinder(BicepParamFile bicepParamFile, ISymbolContext symbolContext)
+        public ParamBinder(BicepParamFile bicepParamFile)
         {
             this.bicepParamFile = bicepParamFile;
             var symbols = ParamAssignmentSymbolCollectVisitor.GetSymbols(bicepParamFile);


### PR DESCRIPTION
removal of unnecessary parameter from ParamBinder constructor

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7526)