### PR TITLE
Update SemanticTokenType to support colorization for ObjectPropertySyntax key in Visual Studio

### DIFF
--- a/src/Bicep.LangServer/SemanticTokenVisitor.cs
+++ b/src/Bicep.LangServer/SemanticTokenVisitor.cs
@@ -114,7 +114,7 @@ namespace Bicep.LanguageServer
             }
             else
             {
-                AddTokenType(syntax.Key, SemanticTokenType.Method);
+                AddTokenType(syntax.Key, SemanticTokenType.TypeParameter);
             }
             Visit(syntax.Colon);
             Visit(syntax.Value);

--- a/src/Bicep.Wasm/LanguageHelpers/SemanticTokenVisitor.cs
+++ b/src/Bicep.Wasm/LanguageHelpers/SemanticTokenVisitor.cs
@@ -103,7 +103,7 @@ namespace Bicep.Wasm.LanguageHelpers
             }
             else
             {
-                AddTokenType(syntax.Key, SemanticTokenType.Member);
+                AddTokenType(syntax.Key, SemanticTokenType.TypeParameter);
             }
             Visit(syntax.Colon);
             Visit(syntax.Value);


### PR DESCRIPTION
SemanticTokenType.Method is not supported in Visual Studio. Also, "Method" is not really accurate. So updating it to "TypeParameter" so that colorization works in both vs and vscode. I picked "TypeParameter" as it's not used anywhere

**Without changes in vscode:**
![image](https://user-images.githubusercontent.com/30270536/179581577-1d0aefa2-831f-4d97-82dc-7b0cb95bc670.png)

**With changes in vscode:**
![image](https://user-images.githubusercontent.com/30270536/179581654-27ad59a6-f4c3-4c67-8e64-509a6e29eb24.png)

**Without changes in visual studio:**
![image](https://user-images.githubusercontent.com/30270536/179581899-b5233acf-14f9-490c-b4b9-df168085dd30.png)

**With changes in visual studio:**
![image](https://user-images.githubusercontent.com/30270536/179582116-08528b5f-7134-4b90-80b7-796076fd695b.png)
