### PR TITLE
Port linter rule: secure-secrets-in-params

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/Linter/Common/FindPossibleSecretsVisitorTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/Linter/Common/FindPossibleSecretsVisitorTests.cs
@@ -29,7 +29,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.Linter.Common
                     .Should().HaveCount(1, "Each testcase should contain a single output with an expression to test")
                     .And.Subject.First();
 
-                var secrets = FindPossibleSecretsVisitor.FindPossibleSecrets(semanticModel, output.Value);
+                var secrets = FindPossibleSecretsVisitor.FindPossibleSecretsInExpression(semanticModel, output.Value);
                 secrets.Select(s => s.FoundMessage).Should().BeEquivalentTo(expectedFoundMessages);
             }
         }

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
@@ -33,14 +33,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         {
             AssertLinterRuleDiagnostics(ruleCode, bicepText, onCompileErrors, diags =>
             {
-                if (diags.Count() > 0)
-                {
-                    diags.Should().HaveCount(expectedDiagnosticCountForCode);
-                }
-                else
-                {
-                    diags.Should().HaveCount(expectedDiagnosticCountForCode);
-                }
+                diags.Should().HaveCount(expectedDiagnosticCountForCode);
             });
         }
 

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
@@ -33,7 +33,14 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         {
             AssertLinterRuleDiagnostics(ruleCode, bicepText, onCompileErrors, diags =>
             {
-                diags.Should().HaveCount(expectedDiagnosticCountForCode);
+                if (diags.Count() > 0)
+                {
+                    diags.Should().HaveCount(expectedDiagnosticCountForCode);
+                }
+                else
+                {
+                    diags.Should().HaveCount(expectedDiagnosticCountForCode);
+                }
             });
         }
 
@@ -74,7 +81,5 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     assertAction);
             }
         }
-
-
     }
 }

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/MaxNumberOutputsRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/MaxNumberOutputsRuleTests.cs
@@ -13,10 +13,10 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
     public class MaxNumberOutputsRuleTests : LinterRuleTestsBase
     {
         [TestMethod]
-        public void ParameterNameInFormattedMessage()
+        public void MaxNumberOfParamsInFormattedMessage()
         {
             var ruleToTest = new MaxNumberOutputsRule();
-            ruleToTest.GetMessage(1).Should().Be("Too many outputs. Number of outputs is limited to 1.");
+            ruleToTest.GetMessage(123).Should().Be("Too many outputs. Number of outputs is limited to 123.");
         }
 
         private void CompileAndTest(string text, params string[] unusedParams)

--- a/src/Bicep.Core/Analyzers/Linter/Common/FindPossibleSecretsVisitor.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Common/FindPossibleSecretsVisitor.cs
@@ -29,10 +29,10 @@ namespace Bicep.Core.Analyzers.Linter.Common
         private readonly List<PossibleSecret> possibleSecrets = new();
 
         /// <summary>
-        /// Searches in an expression for possible references to sensitive data, such as secure parameters or list* functions (may but
+        /// Searches in an expression for possible references to sensitive data, such as secure parameters or list* functions (many but
         /// not all of which return sensitive information)
         /// </summary>
-        public static IImmutableList<PossibleSecret> FindPossibleSecrets(SemanticModel semanticModel, SyntaxBase syntax)
+        public static IImmutableList<PossibleSecret> FindPossibleSecretsInExpression(SemanticModel semanticModel, SyntaxBase syntax)
         {
             FindPossibleSecretsVisitor visitor = new(semanticModel);
             visitor.Visit(syntax);

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Bicep.Core.Analyzers.Linter.Rules
+{
+    public sealed class SecretsInParamsMustBeSecureRule : LinterRuleBase
+    {
+        public new const string Code = "secure-secrets-in-params";
+        public const int MaxNumber = 256;
+
+        private static readonly Regex HasSecretRegex = new("password|pwd|secret|accountkey|acctkey", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Allow certain patterns we know about in ARM
+        private static readonly Regex AllowedRegex = new(
+            // secret + Permissions (keyVault secret perms is an accessPolicy property)
+            "secretpermissions"
+            // secret + version (url or simply the version property of a secret)
+            + "|secretversion"
+            // secret + url/uri
+            + "|secretur[il]"
+            // secret + name
+            + "|secretname",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public SecretsInParamsMustBeSecureRule() : base(
+            code: Code,
+            description: CoreResources.SecretsInParamsRule_Description,
+            docUri: new Uri($"https://aka.ms/bicep/linter/{Code}"),
+            diagnosticLevel: DiagnosticLevel.Warning)
+        { }
+
+        public override string FormatMessage(params object[] values)
+        {
+            string paramName = (string)values[0];
+            return string.Format(CoreResources.SecretsInParamsRule_MessageFormat, paramName);
+        }
+
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        {
+            foreach (var param in model.Root.ParameterDeclarations)
+            {
+                if (!param.IsSecure())
+                {
+                    if (AnalyzeUnsecuredParameter(param) is IDiagnostic diag)
+                    {
+                        yield return diag;
+                    }
+                }
+            }
+        }
+
+        //asdfg fix
+        private IDiagnostic? AnalyzeUnsecuredParameter(ParameterSymbol parameterSymbol)
+        {
+            string name = parameterSymbol.Name;
+            if (HasSecretRegex.IsMatch(name))
+            {
+                if (!AllowedRegex.IsMatch(name))
+                {
+                    return CreateDiagnosticForSpan(parameterSymbol.NameSyntax.Span, name);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseProtectedSettingsForCommandToExecuteSecretsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseProtectedSettingsForCommandToExecuteSecretsRule.cs
@@ -81,7 +81,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                                 if (matches)
                                 {
                                     // Does it contain any possible secrets?
-                                    var secrets = FindPossibleSecretsVisitor.FindPossibleSecrets(semanticModel, commandToExecuteSyntax.Value);
+                                    var secrets = FindPossibleSecretsVisitor.FindPossibleSecretsInExpression(semanticModel, commandToExecuteSyntax.Value);
                                     if (secrets.Any())
                                     {
                                         diagnostics.Add(CreateDiagnosticForSpan(commandToExecuteSyntax.Key.Span, secrets[0].FoundMessage));

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -499,6 +499,24 @@ namespace Bicep.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Parameters that represent secrets must be secure..
+        /// </summary>
+        internal static string SecretsInParamsRule_Description {
+            get {
+                return ResourceManager.GetString("SecretsInParamsRule_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; may represent a secret (according to its name) and must be declared with the &apos;@secure()&apos; attribute..
+        /// </summary>
+        internal static string SecretsInParamsRule_MessageFormat {
+            get {
+                return ResourceManager.GetString("SecretsInParamsRule_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove insecure default value..
         /// </summary>
         internal static string SecureParameterDefaultFixTitle {

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -324,6 +324,12 @@
   <data name="PreferUnquotedPropertyNamesRuleDescription" xml:space="preserve">
     <value>Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation.</value>
   </data>
+  <data name="SecretsInParamsRule_Description" xml:space="preserve">
+    <value>Parameters that represent secrets must be secure.</value>
+  </data>
+  <data name="SecretsInParamsRule_MessageFormat" xml:space="preserve">
+    <value>Parameter '{0}' may represent a secret (according to its name) and must be declared with the '@secure()' attribute.</value>
+  </data>
   <data name="UseStableResourceIdentifiersMessage" xml:space="preserve">
     <value>Resource identifiers should be reproducible outside of their initial deployment context. </value>
   </data>

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -402,6 +402,16 @@
                     }
                   ]
                 },
+                "secure-secrets-in-params": {
+                  "allOf": [
+                    {
+                      "description": "Parameters that represent secrets must be secure. See https://aka.ms/bicep/linter/secure-secrets-in-params"
+                    },
+                    {
+                      "$ref": "#/definitions/rule"
+                    }
+                  ]
+                },
                 "secure-parameter-default": {
                   "allOf": [
                     {


### PR DESCRIPTION
Fixes #7224 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7641)