### PR TITLE
Add custom message target to handle telmetry events in visual studio

### DIFF
--- a/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/Telemetry/TelemetryCustomMessageTargetTests.cs
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/Telemetry/TelemetryCustomMessageTargetTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.VSLanguageServerClient.Telemetry;
+using FluentAssertions;
+using Microsoft.VisualStudio.Telemetry;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.VSLanguageServerClient.UnitTests.MiddleLayerProviders
+{
+    [TestClass]
+    public class TelemetryCustomMessageTargetTests
+    {
+        [DataRow("{}")]
+        [DataRow(@"{ ""a"": ""b""}")]
+        [DataRow(@"{ ""a"": 1 }")]
+        [DataRow(@"{ ""eventName"": """" }")]
+        [DataRow(@"{ ""eventName"": ""   "" }")]
+        [DataTestMethod]
+        public void GetTelemetryEvent_WithInvalidInput_ShouldReturnNull(string input)
+        {
+            var jObject = JObject.Parse(input);
+            var telemetryCustomMessageTarget = new TelemetryCustomMessageTarget(TelemetryService.DefaultSession);
+            var result = telemetryCustomMessageTarget.GetTelemetryEvent(jObject);
+
+            result.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetTelemetryEvent_WithEventNameAndProperties_ShouldReturnTelemetryEvent()
+        {
+            var input = JObject.Parse(@"{
+  ""eventName"": ""diagnostics/editlinterrule"",
+  ""properties"": {
+    ""code"": ""adminusername-should-not-be-literal"",
+    ""newConfigFile"": ""false"",
+    ""newRuleAdded"": ""false"",
+    ""error"": """",
+    ""result"": ""succeeded""
+  }
+}");
+            var telemetryCustomMessageTarget = new TelemetryCustomMessageTarget(TelemetryService.DefaultSession);
+            var result = telemetryCustomMessageTarget.GetTelemetryEvent(input);
+
+            result.Should().NotBeNull();
+            result!.Name.Should().Be("vs/bicep/diagnostics/editlinterrule");
+            result.Properties.Count.Should().Be(5);
+            result.Properties["code"].Should().Be("adminusername-should-not-be-literal");
+            result.Properties["newConfigFile"].Should().Be("false");
+            result.Properties["newRuleAdded"].Should().Be("false");
+            result.Properties["error"].Should().Be(string.Empty);
+            result.Properties["result"].Should().Be("succeeded");
+        }
+
+        [TestMethod]
+        public void GetTelemetryEvent_WithoutProperties_ShouldReturnTelemetryEvent()
+        {
+            var input = JObject.Parse(@"{
+  ""eventName"": ""diagnostics/editlinterrule""
+}");
+            var telemetryCustomMessageTarget = new TelemetryCustomMessageTarget(TelemetryService.DefaultSession);
+            var result = telemetryCustomMessageTarget.GetTelemetryEvent(input);
+
+            result.Should().NotBeNull();
+            result!.Name.Should().Be("vs/bicep/diagnostics/editlinterrule");
+            result.Properties.Should().BeEmpty();
+        }
+    }
+}

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/packages.lock.json
@@ -402,8 +402,8 @@
       },
       "Microsoft.VisualStudio.Telemetry": {
         "type": "Transitive",
-        "resolved": "16.4.22",
-        "contentHash": "5iqH3R6pLGNG/6HM+FyvQPwgluHpFk2QW7pB2FVjBHZEqz43h/j9RcxlDqvtTmvP/NTNKI7OYvgQrtgtS0JOmQ==",
+        "resolved": "16.4.78",
+        "contentHash": "weAZihzUsO3JVeFw39UzB2lY7/SryHHSuqeCOlqBarnXeW0C9scZugEgFVT0Y+nNuJf8LjrlRzUI9xpOaf8UEQ==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.VisualStudio.RemoteControl": "16.3.44",
@@ -717,13 +717,14 @@
       "bicep.vslanguageserverclient": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.VisualStudio.LanguageServer.Client": "[17.1.68, )",
-          "Microsoft.VisualStudio.LanguageServer.Protocol": "[17.1.8, )",
-          "Microsoft.VisualStudio.Setup.Configuration.Interop": "[3.2.2146, )",
-          "Microsoft.VisualStudio.Shell.Interop": "[17.1.32210.191, )",
-          "Microsoft.VisualStudio.Threading": "[17.1.46, )",
-          "Microsoft.VisualStudio.Utilities": "[17.1.32210.191, )",
-          "OmniSharp.Extensions.LanguageServer": "[0.19.5, )"
+          "Microsoft.VisualStudio.LanguageServer.Client": "17.1.68",
+          "Microsoft.VisualStudio.LanguageServer.Protocol": "17.1.8",
+          "Microsoft.VisualStudio.Setup.Configuration.Interop": "3.2.2146",
+          "Microsoft.VisualStudio.Shell.Interop": "17.1.32210.191",
+          "Microsoft.VisualStudio.Threading": "17.1.46",
+          "Microsoft.VisualStudio.Utilities": "17.1.32210.191",
+          "Microsoft.Visualstudio.Telemetry": "16.4.78",
+          "OmniSharp.Extensions.LanguageServer": "0.19.5"
         }
       }
     },

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/packages.lock.json
@@ -697,8 +697,8 @@
       },
       "Microsoft.VisualStudio.Telemetry": {
         "type": "Transitive",
-        "resolved": "16.4.22",
-        "contentHash": "5iqH3R6pLGNG/6HM+FyvQPwgluHpFk2QW7pB2FVjBHZEqz43h/j9RcxlDqvtTmvP/NTNKI7OYvgQrtgtS0JOmQ==",
+        "resolved": "16.4.78",
+        "contentHash": "weAZihzUsO3JVeFw39UzB2lY7/SryHHSuqeCOlqBarnXeW0C9scZugEgFVT0Y+nNuJf8LjrlRzUI9xpOaf8UEQ==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.VisualStudio.RemoteControl": "16.3.44",
@@ -1305,13 +1305,14 @@
       "bicep.vslanguageserverclient": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.VisualStudio.LanguageServer.Client": "[17.1.68, )",
-          "Microsoft.VisualStudio.LanguageServer.Protocol": "[17.1.8, )",
-          "Microsoft.VisualStudio.Setup.Configuration.Interop": "[3.2.2146, )",
-          "Microsoft.VisualStudio.Shell.Interop": "[17.1.32210.191, )",
-          "Microsoft.VisualStudio.Threading": "[17.1.46, )",
-          "Microsoft.VisualStudio.Utilities": "[17.1.32210.191, )",
-          "OmniSharp.Extensions.LanguageServer": "[0.19.5, )"
+          "Microsoft.VisualStudio.LanguageServer.Client": "17.1.68",
+          "Microsoft.VisualStudio.LanguageServer.Protocol": "17.1.8",
+          "Microsoft.VisualStudio.Setup.Configuration.Interop": "3.2.2146",
+          "Microsoft.VisualStudio.Shell.Interop": "17.1.32210.191",
+          "Microsoft.VisualStudio.Threading": "17.1.46",
+          "Microsoft.VisualStudio.Utilities": "17.1.32210.191",
+          "Microsoft.Visualstudio.Telemetry": "16.4.78",
+          "OmniSharp.Extensions.LanguageServer": "0.19.5"
         }
       }
     },

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/Bicep.VSLanguageServerClient.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/Bicep.VSLanguageServerClient.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.1.8" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="17.1.32210.191" />
-	<PackageReference Include="Microsoft.Visualstudio.Telemetry" Version="16.4.78" />
+    <PackageReference Include="Microsoft.Visualstudio.Telemetry" Version="16.4.78" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.1.46" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="17.1.32210.191" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/Bicep.VSLanguageServerClient.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/Bicep.VSLanguageServerClient.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.1.8" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="17.1.32210.191" />
+	<PackageReference Include="Microsoft.Visualstudio.Telemetry" Version="16.4.78" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.1.46" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="17.1.32210.191" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/BicepLanguageServerClient.cs
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/BicepLanguageServerClient.cs
@@ -79,15 +79,7 @@ namespace Bicep.VSLanguageServerClient
 
             var connection = new Connection(process.StandardOutput.BaseStream, process.StandardInput.BaseStream);
             var telemetryEvent = new TelemetryEvent("vs/bicep/clientInitialization");
-
-            if (connection is not null)
-            {
-                telemetryEvent.Properties["status"] = "succeeded";
-            }
-            else
-            {
-                telemetryEvent.Properties["status"] = "failed";
-            }
+            telemetryEvent.Properties["status"] = connection is null ? "failed" : "succeeded";
 
             TelemetrySession.PostEvent(telemetryEvent);
 

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/Telemetry/TelemetryCustomMessageTarget.cs
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/Telemetry/TelemetryCustomMessageTarget.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Telemetry;
+using Newtonsoft.Json.Linq;
+using StreamJsonRpc;
+
+namespace Bicep.VSLanguageServerClient.Telemetry
+{
+    /// <summary>
+    /// VS lsp doesn't handle 'telemetry/event' and that's by design. This class receives 'telemetry/event' messages
+    /// from bicep language server and posts the telemetry event using <see cref="TelemetrySession"/>
+    /// </summary>
+    public class TelemetryCustomMessageTarget
+    {
+        private readonly TelemetrySession TelemetrySession;
+
+        public TelemetryCustomMessageTarget(TelemetrySession telemetrySession)
+        {
+            this.TelemetrySession = telemetrySession;
+        }
+
+        [JsonRpcMethod(Methods.TelemetryEventName)]
+        public Task HandleTelemetryEventAsync(JToken jToken)
+        {
+            if (jToken is JObject jObject)
+            {
+                var telemetryEvent = GetTelemetryEvent(jObject);
+
+                if (telemetryEvent is not null)
+                {
+                    TelemetrySession.PostEvent(telemetryEvent);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public TelemetryEvent? GetTelemetryEvent(JObject jObject)
+        {
+            var eventName = jObject.Property("eventName", StringComparison.OrdinalIgnoreCase)?.Value.ToString();
+
+            if (!string.IsNullOrWhiteSpace(eventName))
+            {
+                eventName = "vs/bicep/" + eventName;
+
+                var telemetryEvent = new TelemetryEvent(eventName);
+
+                var properties = jObject.Property("properties", StringComparison.OrdinalIgnoreCase);
+
+                if (properties is not null &&
+                    properties.HasValues &&
+                    properties.Value.ToObject<IDictionary<string, string>>() is IDictionary<string, string> bicepTelemetryProperties)
+                {
+                    foreach (var kvp in bicepTelemetryProperties)
+                    {
+                        telemetryEvent.Properties[kvp.Key] = kvp.Value;
+                    }
+                }
+
+                return telemetryEvent;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/packages.lock.json
@@ -55,6 +55,19 @@
           "Microsoft.VisualStudio.Interop": "17.1.32210.191"
         }
       },
+      "Microsoft.VisualStudio.Telemetry": {
+        "type": "Direct",
+        "requested": "[16.4.78, )",
+        "resolved": "16.4.78",
+        "contentHash": "weAZihzUsO3JVeFw39UzB2lY7/SryHHSuqeCOlqBarnXeW0C9scZugEgFVT0Y+nNuJf8LjrlRzUI9xpOaf8UEQ==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.7.0",
+          "Microsoft.VisualStudio.RemoteControl": "16.3.44",
+          "Microsoft.VisualStudio.Utilities.Internal": "16.3.36",
+          "Newtonsoft.Json": "13.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+        }
+      },
       "Microsoft.VisualStudio.Threading": {
         "type": "Direct",
         "requested": "[17.1.46, )",
@@ -391,18 +404,6 @@
           "System.ComponentModel.Composition": "4.5.0",
           "System.Threading.Tasks.Dataflow": "5.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "Microsoft.VisualStudio.Telemetry": {
-        "type": "Transitive",
-        "resolved": "16.4.22",
-        "contentHash": "5iqH3R6pLGNG/6HM+FyvQPwgluHpFk2QW7pB2FVjBHZEqz43h/j9RcxlDqvtTmvP/NTNKI7OYvgQrtgtS0JOmQ==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.VisualStudio.RemoteControl": "16.3.44",
-          "Microsoft.VisualStudio.Utilities.Internal": "16.3.36",
-          "Newtonsoft.Json": "13.0.1",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
         }
       },
       "Microsoft.VisualStudio.Text.Data": {


### PR DESCRIPTION
 VS lsp doesn't handle 'telemetry/event' and that's by design. This class receives 'telemetry/event' messages from bicep language server and posts the telemetry event using VS TelemetrySession.

![image](https://user-images.githubusercontent.com/30270536/180950512-62da04aa-9802-4ad7-b9e6-cfb008afaa77.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7702)