### PR TITLE
Refactor logic that sends out telemetry on file open

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/Assertions/TelemetryEventParamsAssertions.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Assertions/TelemetryEventParamsAssertions.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using FluentAssertions;
 using FluentAssertions.Primitives;
-using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using Bicep.Core.UnitTests.Assertions;
 
 namespace Bicep.LangServer.IntegrationTests.Assertions
 {
@@ -24,13 +21,5 @@ namespace Bicep.LangServer.IntegrationTests.Assertions
         }
 
         protected override string Identifier => "telemetry event";
-
-        public AndConstraint<TelemetryEventParamsAssertions> HaveEventNameAndProperties(string eventName, JObject properties, string because = "", params object[] becauseArgs)
-        {
-            (Subject.ExtensionData["eventName"] as string)!.Should().Be(eventName, because, becauseArgs);
-            (Subject.ExtensionData["properties"] as JToken)!.Should().DeepEqual(properties, because, becauseArgs);
-
-            return new(this);
-        }
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/MultipleMessageListener.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/MultipleMessageListener.cs
@@ -17,7 +17,7 @@ namespace Bicep.LangServer.IntegrationTests
         private readonly List<TaskCompletionSource<T>> completionSources = new();
 
         private int listenPosition = 0;
-        private int writePosition = 0;        
+        private int writePosition = 0;
 
         public async Task<T> WaitNext(int timeout = DefaultTimeout)
         {
@@ -34,6 +34,20 @@ namespace Bicep.LangServer.IntegrationTests
             }
 
             return await IntegrationTestHelper.WithTimeoutAsync(onMessageTask, timeout);
+        }
+
+        public async Task<List<T>> WaitForAll(int timeout = DefaultTimeout)
+        {
+            List<T> onMessageTasks = new List<T>();
+
+            foreach (var completionSource in completionSources)
+            {
+                var onMessageTask = completionSource.Task;
+                var response = await IntegrationTestHelper.WithTimeoutAsync(onMessageTask, timeout);
+                onMessageTasks.Add(response);
+            }
+
+            return onMessageTasks;
         }
 
         public async Task EnsureNoMessageSent(int timeout = DefaultTimeout)

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -97,16 +97,16 @@ namespace Bicep.LanguageServer
             UpsertCompilationInternal(documentUri, null, shallowCopy, reloadBicepConfig);
         }
 
-        public void UpsertCompilation(DocumentUri documentUri, int? version, string fileContents, string? languageId = null, bool isFileOpen = false)
+        public void UpsertCompilation(DocumentUri documentUri, int? version, string fileContents, string? languageId = null, bool wasTriggeredByFileOpenEvent = false)
         {
             if (this.ShouldUpsertCompilation(documentUri, languageId))
             {
                 var newFile = SourceFileFactory.CreateSourceFile(documentUri.ToUri(), fileContents);
-                UpsertCompilationInternal(documentUri, version, newFile, isFileOpen: isFileOpen);
+                UpsertCompilationInternal(documentUri, version, newFile, wasTriggeredByFileOpenEvent: wasTriggeredByFileOpenEvent);
             }
         }
 
-        private void UpsertCompilationInternal(DocumentUri documentUri, int? version, ISourceFile newFile, bool reloadBicepConfig = false, bool isFileOpen = false)
+        private void UpsertCompilationInternal(DocumentUri documentUri, int? version, ISourceFile newFile, bool reloadBicepConfig = false, bool wasTriggeredByFileOpenEvent = false)
         {
             var (_, removedFiles) = workspace.UpsertSourceFile(newFile);
 
@@ -114,14 +114,14 @@ namespace Bicep.LanguageServer
             if (newFile is BicepFile)
             {
                 // Do not update compilation if it is an ARM template file, since it cannot be an entrypoint.
-                UpdateCompilationInternal(documentUri, version, modelLookup, removedFiles, reloadBicepConfig, isFileOpen);
+                UpdateCompilationInternal(documentUri, version, modelLookup, removedFiles, reloadBicepConfig, wasTriggeredByFileOpenEvent);
             }
 
             foreach (var (entrypointUri, context) in activeContexts)
             {
                 if (removedFiles.Any(x => context.Compilation.SourceFileGrouping.SourceFiles.Contains(x)))
                 {
-                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig, isFileOpen);
+                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig, wasTriggeredByFileOpenEvent);
                 }
             }
         }
@@ -209,7 +209,7 @@ namespace Bicep.LanguageServer
             return closedFiles.ToImmutableArray();
         }
 
-        private (ImmutableArray<ISourceFile> added, ImmutableArray<ISourceFile> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version, IDictionary<ISourceFile, ISemanticModel> modelLookup, IEnumerable<ISourceFile> removedFiles, bool reloadBicepConfig = false, bool isFileOpen = false)
+        private (ImmutableArray<ISourceFile> added, ImmutableArray<ISourceFile> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version, IDictionary<ISourceFile, ISemanticModel> modelLookup, IEnumerable<ISourceFile> removedFiles, bool reloadBicepConfig = false, bool wasTriggeredByFileOpenEvent = false)
         {
             var configuration = this.GetConfigurationSafely(documentUri, out var configurationDiagnostic);
 
@@ -269,7 +269,7 @@ namespace Bicep.LanguageServer
                     diagnostics = diagnostics.Append(configurationDiagnostic);
                 }
 
-                if (isFileOpen)
+                if (wasTriggeredByFileOpenEvent)
                 {
                     SendTelemetryOnBicepFileOpen(context.Compilation.GetEntrypointSemanticModel(), documentUri.ToUri(), configuration, sourceFiles, diagnostics);
                 }

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -97,16 +97,16 @@ namespace Bicep.LanguageServer
             UpsertCompilationInternal(documentUri, null, shallowCopy, reloadBicepConfig);
         }
 
-        public void UpsertCompilation(DocumentUri documentUri, int? version, string fileContents, string? languageId = null, bool wasTriggeredByFileOpenEvent = false)
+        public void UpsertCompilation(DocumentUri documentUri, int? version, string fileContents, string? languageId = null, bool triggeredByFileOpenEvent = false)
         {
             if (this.ShouldUpsertCompilation(documentUri, languageId))
             {
                 var newFile = SourceFileFactory.CreateSourceFile(documentUri.ToUri(), fileContents);
-                UpsertCompilationInternal(documentUri, version, newFile, wasTriggeredByFileOpenEvent: wasTriggeredByFileOpenEvent);
+                UpsertCompilationInternal(documentUri, version, newFile, triggeredByFileOpenEvent: triggeredByFileOpenEvent);
             }
         }
 
-        private void UpsertCompilationInternal(DocumentUri documentUri, int? version, ISourceFile newFile, bool reloadBicepConfig = false, bool wasTriggeredByFileOpenEvent = false)
+        private void UpsertCompilationInternal(DocumentUri documentUri, int? version, ISourceFile newFile, bool reloadBicepConfig = false, bool triggeredByFileOpenEvent = false)
         {
             var (_, removedFiles) = workspace.UpsertSourceFile(newFile);
 
@@ -114,14 +114,14 @@ namespace Bicep.LanguageServer
             if (newFile is BicepFile)
             {
                 // Do not update compilation if it is an ARM template file, since it cannot be an entrypoint.
-                UpdateCompilationInternal(documentUri, version, modelLookup, removedFiles, reloadBicepConfig, wasTriggeredByFileOpenEvent);
+                UpdateCompilationInternal(documentUri, version, modelLookup, removedFiles, reloadBicepConfig, triggeredByFileOpenEvent);
             }
 
             foreach (var (entrypointUri, context) in activeContexts)
             {
                 if (removedFiles.Any(x => context.Compilation.SourceFileGrouping.SourceFiles.Contains(x)))
                 {
-                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig, wasTriggeredByFileOpenEvent);
+                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig, triggeredByFileOpenEvent);
                 }
             }
         }
@@ -209,7 +209,7 @@ namespace Bicep.LanguageServer
             return closedFiles.ToImmutableArray();
         }
 
-        private (ImmutableArray<ISourceFile> added, ImmutableArray<ISourceFile> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version, IDictionary<ISourceFile, ISemanticModel> modelLookup, IEnumerable<ISourceFile> removedFiles, bool reloadBicepConfig = false, bool wasTriggeredByFileOpenEvent = false)
+        private (ImmutableArray<ISourceFile> added, ImmutableArray<ISourceFile> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version, IDictionary<ISourceFile, ISemanticModel> modelLookup, IEnumerable<ISourceFile> removedFiles, bool reloadBicepConfig = false, bool triggeredByFileOpenEvent = false)
         {
             var configuration = this.GetConfigurationSafely(documentUri, out var configurationDiagnostic);
 
@@ -269,7 +269,7 @@ namespace Bicep.LanguageServer
                     diagnostics = diagnostics.Append(configurationDiagnostic);
                 }
 
-                if (wasTriggeredByFileOpenEvent)
+                if (triggeredByFileOpenEvent)
                 {
                     SendTelemetryOnBicepFileOpen(context.Compilation.GetEntrypointSemanticModel(), documentUri.ToUri(), configuration, sourceFiles, diagnostics);
                 }

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -97,16 +97,16 @@ namespace Bicep.LanguageServer
             UpsertCompilationInternal(documentUri, null, shallowCopy, reloadBicepConfig);
         }
 
-        public void UpsertCompilation(DocumentUri documentUri, int? version, string fileContents, string? languageId = null)
+        public void UpsertCompilation(DocumentUri documentUri, int? version, string fileContents, string? languageId = null, bool isFileOpen = false)
         {
             if (this.ShouldUpsertCompilation(documentUri, languageId))
             {
                 var newFile = SourceFileFactory.CreateSourceFile(documentUri.ToUri(), fileContents);
-                UpsertCompilationInternal(documentUri, version, newFile);
+                UpsertCompilationInternal(documentUri, version, newFile, isFileOpen);
             }
         }
 
-        private void UpsertCompilationInternal(DocumentUri documentUri, int? version, ISourceFile newFile, bool reloadBicepConfig = false)
+        private void UpsertCompilationInternal(DocumentUri documentUri, int? version, ISourceFile newFile, bool reloadBicepConfig = false, bool isFileOpen = false)
         {
             var (_, removedFiles) = workspace.UpsertSourceFile(newFile);
 
@@ -114,14 +114,14 @@ namespace Bicep.LanguageServer
             if (newFile is BicepFile)
             {
                 // Do not update compilation if it is an ARM template file, since it cannot be an entrypoint.
-                UpdateCompilationInternal(documentUri, version, modelLookup, removedFiles, reloadBicepConfig);
+                UpdateCompilationInternal(documentUri, version, modelLookup, removedFiles, reloadBicepConfig, isFileOpen);
             }
 
             foreach (var (entrypointUri, context) in activeContexts)
             {
                 if (removedFiles.Any(x => context.Compilation.SourceFileGrouping.SourceFiles.Contains(x)))
                 {
-                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig);
+                    UpdateCompilationInternal(entrypointUri, null, modelLookup, removedFiles, reloadBicepConfig, isFileOpen);
                 }
             }
         }
@@ -209,7 +209,7 @@ namespace Bicep.LanguageServer
             return closedFiles.ToImmutableArray();
         }
 
-        private (ImmutableArray<ISourceFile> added, ImmutableArray<ISourceFile> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version, IDictionary<ISourceFile, ISemanticModel> modelLookup, IEnumerable<ISourceFile> removedFiles, bool reloadBicepConfig = false)
+        private (ImmutableArray<ISourceFile> added, ImmutableArray<ISourceFile> removed) UpdateCompilationInternal(DocumentUri documentUri, int? version, IDictionary<ISourceFile, ISemanticModel> modelLookup, IEnumerable<ISourceFile> removedFiles, bool reloadBicepConfig = false, bool isFileOpen = false)
         {
             var configuration = this.GetConfigurationSafely(documentUri, out var configurationDiagnostic);
 
@@ -269,7 +269,7 @@ namespace Bicep.LanguageServer
                     diagnostics = diagnostics.Append(configurationDiagnostic);
                 }
 
-                if (version == 1)
+                if (isFileOpen)
                 {
                     SendTelemetryOnBicepFileOpen(context.Compilation.GetEntrypointSemanticModel(), documentUri.ToUri(), configuration, sourceFiles, diagnostics);
                 }

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -102,7 +102,7 @@ namespace Bicep.LanguageServer
             if (this.ShouldUpsertCompilation(documentUri, languageId))
             {
                 var newFile = SourceFileFactory.CreateSourceFile(documentUri.ToUri(), fileContents);
-                UpsertCompilationInternal(documentUri, version, newFile, isFileOpen);
+                UpsertCompilationInternal(documentUri, version, newFile, isFileOpen: isFileOpen);
             }
         }
 

--- a/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
+++ b/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
@@ -12,7 +12,7 @@ namespace Bicep.LanguageServer.CompilationManager
 
         void RefreshCompilation(DocumentUri uri, bool reloadBicepConfig = false);
 
-        void UpsertCompilation(DocumentUri uri, int? version, string text, string? languageId = null, bool isFileOpen = false);
+        void UpsertCompilation(DocumentUri uri, int? version, string text, string? languageId = null, bool wasTriggeredByFileOpenEvent = false);
 
         void CloseCompilation(DocumentUri uri);
 

--- a/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
+++ b/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
@@ -12,7 +12,7 @@ namespace Bicep.LanguageServer.CompilationManager
 
         void RefreshCompilation(DocumentUri uri, bool reloadBicepConfig = false);
 
-        void UpsertCompilation(DocumentUri uri, int? version, string text, string? languageId = null, bool wasTriggeredByFileOpenEvent = false);
+        void UpsertCompilation(DocumentUri uri, int? version, string text, string? languageId = null, bool triggeredByFileOpenEvent = false);
 
         void CloseCompilation(DocumentUri uri);
 

--- a/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
+++ b/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
@@ -12,7 +12,7 @@ namespace Bicep.LanguageServer.CompilationManager
 
         void RefreshCompilation(DocumentUri uri, bool reloadBicepConfig = false);
 
-        void UpsertCompilation(DocumentUri uri, int? version, string text, string? languageId = null);
+        void UpsertCompilation(DocumentUri uri, int? version, string text, string? languageId = null, bool isFileOpen = false);
 
         void CloseCompilation(DocumentUri uri);
 

--- a/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
@@ -63,7 +63,7 @@ namespace Bicep.LanguageServer.Handlers
                 bicepConfigChangeHandler.HandleBicepConfigOpenEvent(documentUri);
             }
 
-            this.compilationManager.UpsertCompilation(documentUri, request.TextDocument.Version, request.TextDocument.Text, request.TextDocument.LanguageId, wasTriggeredByFileOpenEvent: true);
+            this.compilationManager.UpsertCompilation(documentUri, request.TextDocument.Version, request.TextDocument.Text, request.TextDocument.LanguageId, triggeredByFileOpenEvent: true);
 
             return Unit.Task;
         }

--- a/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
@@ -63,7 +63,7 @@ namespace Bicep.LanguageServer.Handlers
                 bicepConfigChangeHandler.HandleBicepConfigOpenEvent(documentUri);
             }
 
-            this.compilationManager.UpsertCompilation(documentUri, request.TextDocument.Version, request.TextDocument.Text, request.TextDocument.LanguageId, isFileOpen: true);
+            this.compilationManager.UpsertCompilation(documentUri, request.TextDocument.Version, request.TextDocument.Text, request.TextDocument.LanguageId, wasTriggeredByFileOpenEvent: true);
 
             return Unit.Task;
         }

--- a/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepTextDocumentSyncHandler.cs
@@ -63,7 +63,7 @@ namespace Bicep.LanguageServer.Handlers
                 bicepConfigChangeHandler.HandleBicepConfigOpenEvent(documentUri);
             }
 
-            this.compilationManager.UpsertCompilation(documentUri, request.TextDocument.Version, request.TextDocument.Text, request.TextDocument.LanguageId);
+            this.compilationManager.UpsertCompilation(documentUri, request.TextDocument.Version, request.TextDocument.Text, request.TextDocument.LanguageId, isFileOpen: true);
 
             return Unit.Task;
         }


### PR DESCRIPTION
Noticed this issue while testing telemetry events in VS. VS lsp sends back version number 2 on file open.  Per my conversation with VS platform team, this is expected. This causes us to not send out telemetry events on file open in VS. I refactored our code to handle this scenario better so that telemetry events get sent out for both vs and vscode.

VS telemetry:
![image](https://user-images.githubusercontent.com/30270536/182906856-00353092-f413-48ea-a639-14d7d9a160b7.png)

VScode telemetry:
![image](https://user-images.githubusercontent.com/30270536/182907442-4af685d4-b4b9-4046-adc9-222b4f81919e.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7715)