### PR TITLE
Fix up some CI issues

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Extensibility/AadNamespaceType.cs
+++ b/src/Bicep.Core.IntegrationTests/Extensibility/AadNamespaceType.cs
@@ -65,8 +65,6 @@ namespace Bicep.Core.IntegrationTests.Extensibility
 
             public IEnumerable<ResourceTypeReference> GetAvailableTypes()
                 => resourceTypes.Keys;
-
-            public void ClearCaches() { }
         }
 
         public static NamespaceType Create(string aliasName)

--- a/src/Bicep.Core.IntegrationTests/Extensibility/StorageNamespaceType.cs
+++ b/src/Bicep.Core.IntegrationTests/Extensibility/StorageNamespaceType.cs
@@ -94,8 +94,6 @@ namespace Bicep.Core.IntegrationTests.Extensibility
 
             public IEnumerable<ResourceTypeReference> GetAvailableTypes()
                 => resourceTypes.Keys;
-
-            public void ClearCaches() { }
         }
 
         public static NamespaceType Create(string aliasName)

--- a/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
@@ -16,6 +16,8 @@ using Bicep.Core.Extensions;
 using Moq;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Semantics.Namespaces;
+using System.Reflection;
+using Bicep.Core.Resources;
 
 namespace Bicep.Core.UnitTests.TypeSystem.Az
 {
@@ -29,31 +31,54 @@ namespace Bicep.Core.UnitTests.TypeSystem.Az
             LanguageConstants.ResourceParentPropertyName
         }.ToImmutableHashSet(LanguageConstants.IdentifierComparer);
 
-        [DataTestMethod]
-        [DataRow(ResourceTypeGenerationFlags.None)]
-        [DataRow(ResourceTypeGenerationFlags.ExistingResource)]
-        [DataRow(ResourceTypeGenerationFlags.HasParentDefined)]
-        [DataRow(ResourceTypeGenerationFlags.NestedResource)]
-        [DataRow(ResourceTypeGenerationFlags.ExistingResource | ResourceTypeGenerationFlags.HasParentDefined)]
-        public void AzResourceTypeProvider_can_deserialize_all_types_without_throwing(ResourceTypeGenerationFlags flags)
+        private static NamespaceType GetAzNamespaceType()
         {
-            var typeProvider = TestTypeHelper.CreateWithAzTypes();
-            var namespaceType = typeProvider.TryGetNamespace("az", "az", ResourceScope.ResourceGroup)!;
+            var nsProvider = new DefaultNamespaceProvider(new AzResourceTypeLoader(), BicepTestConstants.Features);
 
-            var resourceTypeProvider = namespaceType.ResourceTypeProvider;
-            var availableTypes = resourceTypeProvider.GetAvailableTypes();
+            return nsProvider.TryGetNamespace("az", "az", ResourceScope.ResourceGroup)!;
+        }
 
-            // sanity check - we know there should be a lot of types available
-            var expectedTypeCount = 3000;
-            availableTypes.Should().HaveCountGreaterThan(expectedTypeCount);
+        private static IEnumerable<object[]> GetDeserializeTestData()
+        {
+            var flagPermutationsToTest = new [] {
+                ResourceTypeGenerationFlags.None,
+                ResourceTypeGenerationFlags.ExistingResource,
+                ResourceTypeGenerationFlags.HasParentDefined,
+                ResourceTypeGenerationFlags.NestedResource,
+                ResourceTypeGenerationFlags.ExistingResource | ResourceTypeGenerationFlags.HasParentDefined,
+            };
 
-            foreach (var availableType in availableTypes)
+            foreach (var providerGrouping in GetAzNamespaceType().ResourceTypeProvider.GetAvailableTypes().GroupBy(x => x.TypeSegments[0])) {
+                foreach (var apiVersionGrouping in providerGrouping.GroupBy(x => x.ApiVersion)) {
+                    foreach (var flags in flagPermutationsToTest) {
+                        var providerName = providerGrouping.Key;
+                        var apiVersion = apiVersionGrouping.Key!;
+                        var resourceTypes = apiVersionGrouping.Select(x => x.FormatName()).ToList();
+
+                        yield return new object[] { providerName, apiVersion, flags, resourceTypes };
+                    }
+                }
+            }
+        }
+
+        public static string GetDeserializeTestDisplayName(MethodInfo info, object[] values)
+            => $"{info.Name} ({string.Join(',', new[] { values[0], values[1], values[2] }.Select(x => x.ToString()))})";
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetDeserializeTestData), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetDeserializeTestDisplayName))]
+        public void AzResourceTypeProvider_can_deserialize_all_types_without_throwing(string providerName, string apiVersion, ResourceTypeGenerationFlags flags, IReadOnlyList<string> resourceTypes)
+        {
+            // We deliberately load a new instance here for each test iteration rather than re-using an instance.
+            // This is becase there are various internal caches which will consume too much memory and crash in CI if allowed to grow unrestricted.
+            var azNamespaceType = GetAzNamespaceType();
+            var resourceTypeProvider = azNamespaceType.ResourceTypeProvider;
+
+            foreach (var availableType in resourceTypes)
             {
-                // Clear the resource type cache - each time we load a new one, the memory footprint will increase.
-                resourceTypeProvider.ClearCaches();
+                var typeReference = ResourceTypeReference.Parse(availableType);
 
-                resourceTypeProvider.HasDefinedType(availableType).Should().BeTrue();
-                var resourceType = resourceTypeProvider.TryGetDefinedType(namespaceType, availableType, flags)!;
+                resourceTypeProvider.HasDefinedType(typeReference).Should().BeTrue();
+                var resourceType = resourceTypeProvider.TryGetDefinedType(azNamespaceType, typeReference, flags)!;
 
                 try
                 {
@@ -100,14 +125,13 @@ namespace Bicep.Core.UnitTests.TypeSystem.Az
 
         [TestMethod]
         public void AzResourceTypeProvider_can_list_all_types_without_throwing()
-
         {
-            var resourceTypeProvider = new AzResourceTypeProvider(new AzResourceTypeLoader());
+            var resourceTypeProvider = GetAzNamespaceType().ResourceTypeProvider;
             var availableTypes = resourceTypeProvider.GetAvailableTypes();
 
             // sanity check - we know there should be a lot of types available
-            var expectedTypeCount = 3000;
-            availableTypes.Should().HaveCountGreaterThan(expectedTypeCount);
+            var minExpectedTypes = 3000;
+            availableTypes.Should().HaveCountGreaterThan(minExpectedTypes);
         }
 
         [TestMethod]

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
@@ -471,11 +471,5 @@ namespace Bicep.Core.TypeSystem.Az
 
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => availableResourceTypes;
-
-        public void ClearCaches()
-        {
-            definedTypeCache.Clear();
-            generatedTypeCache.Clear();
-        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/EmptyResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/EmptyResourceTypeProvider.cs
@@ -19,7 +19,5 @@ namespace Bicep.Core.TypeSystem
 
         public bool HasDefinedType(ResourceTypeReference typeReference)
             => false;
-
-        public void ClearCaches() { }
     }
 }

--- a/src/Bicep.Core/TypeSystem/IResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/IResourceTypeProvider.cs
@@ -26,7 +26,5 @@ namespace Bicep.Core.TypeSystem
         /// Returns the full list of available types defined by this provider.
         /// </summary>
         IEnumerable<ResourceTypeReference> GetAvailableTypes();
-
-        void ClearCaches();
     }
 }

--- a/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeProvider.cs
@@ -125,7 +125,7 @@ namespace Bicep.Core.TypeSystem.K8s
                             updatedProperties.Add(new TypeProperty(metadataProperty.Name, metadataProperty.TypeReference, ConvertToReadOnly(metadataProperty.Flags), metadataProperty.Description));
                         }
                     }
-        
+
                     var updatedMetadataType = new ObjectType(
                         metadataType.Name,
                         metadataType.ValidationFlags,
@@ -179,11 +179,5 @@ namespace Bicep.Core.TypeSystem.K8s
 
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => availableResourceTypes;
-
-        public void ClearCaches()
-        {
-            definedTypeCache.Clear();
-            generatedTypeCache.Clear();
-        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/ResourceTypeCache.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceTypeCache.cs
@@ -32,8 +32,5 @@ namespace Bicep.Core.TypeSystem
 
             return cache.GetOrAdd(cacheKey, cacheKey => buildFunc());
         }
-
-        public void Clear()
-            => cache.Clear();
     }
 }

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepGetRecommendedConfigLocationHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepGetRecommendedConfigLocationHandlerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Bicep.Core.UnitTests.Assertions;
@@ -34,7 +35,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             var actual = BicepGetRecommendedConfigLocationHandler.GetRecommendedConfigFileLocation((string[]?)null, bicepFilePath);
             var expected = Environment.CurrentDirectory;
 
-            actual.Should().Be(expected); 
+            actual.Should().Be(expected);
         }
 
         [TestMethod]
@@ -90,67 +91,60 @@ namespace Bicep.LangServer.UnitTests.Handlers
             actual.Should().Be(expected);
         }
 
-        // Bicep file is in a workspace folder - return the first one that matches, or else the bicep file's folder
-        [DataRow(new string[] { "c:\\workspace1" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1")]
-        [DataRow(new string[] { "c:\\workspace1" }, "c:\\workspace1\\two\\bicepconfig.json", "c:\\workspace1")]
-        [DataRow(new string[] { "c:\\workspace1" }, "c:\\workspace1\\two\\three\\bicepconfig.json", "c:\\workspace1")]
-        [DataRow(new string[] { "c:\\workspace1\\two" }, "c:\\workspace1\\two\\three\\bicepconfig.json", "c:\\workspace1\\two")]
-        [DataRow(new string[] { "c:\\workspace1\\two\\three" }, "c:\\workspace1\\two\\three\\bicepconfig.json", "c:\\workspace1\\two\\three")]
-        [DataRow(new string[] { "c:\\workspace1", "c:\\workspace2" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1")]
-        [DataRow(new string[] { "c:\\workspace2", "c:\\workspace1" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1")]
-        [DataRow(
-            new string[] { "c:\\workspace1\\two\\three\four", "c:\\workspace1\\two\\three", "c:\\workspace1\\two", "c:\\workspace1" },
-            "c:\\workspace1\\two\\three\\five\\bicepconfig.json",
-            "c:\\workspace1\\two\\three")]
-        // Bicep file not in any workspace folder - return bicep file's folder
-        [DataRow(new string[] { "c:\\workspace1" }, "c:\\workspace2\\bicepconfig.json", "c:\\workspace2")]
-        [DataRow(new string[] { "c:\\workspace1\\two\\three" }, "c:\\workspace1\\two\\bicepconfig.json", "c:\\workspace1\\two")]
-        // Case insensitive
-        [DataRow(new string[] { "c:\\Workspace1" }, "c:\\workspace1\\bicepconfig.json", "c:\\Workspace1")]
-        [DataRow(new string[] { "C:\\workspace1" }, "c:\\workspace1\\bicepconfig.json", "C:\\workspace1")]
-        // Folders partially match
-        [DataRow(new string[] { "c:\\workspace" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1")]
-        [DataRow(new string[] { "c:\\workspace1" }, "c:\\workspace\\bicepconfig.json", "c:\\workspace")]
-#if !WINDOWS_BUILD
-        [Ignore]
-#endif
-        [DataTestMethod]
-        public void WorkspaceFolders_Windows(string[] workspaceFolders, string bicepFilePath, string expected)
+        private static IEnumerable<object[]> GetWorkspaceFoldersTestData()
         {
-            var actual = BicepGetRecommendedConfigLocationHandler.GetRecommendedConfigFileLocation(workspaceFolders, bicepFilePath);
-
-            actual.Should().Be(expected);
-        }
-
-        // Bicep file is in a workspace folder - return the first one that matches, or else the bicep file's folder
-        [DataRow(new string[] { "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1")]
-        [DataRow(new string[] { "/workspace1" }, "/workspace1/two/bicepconfig.json", "/workspace1")]
-        [DataRow(new string[] { "/workspace1" }, "/workspace1/two/three/bicepconfig.json", "/workspace1")]
-        [DataRow(new string[] { "/workspace1/two" }, "/workspace1/two/three/bicepconfig.json", "/workspace1/two")]
-        [DataRow(new string[] { "/workspace1/two/three" }, "/workspace1/two/three/bicepconfig.json", "/workspace1/two/three")]
-        [DataRow(new string[] { "/workspace1/two/three" }, "/workspace1/two/three/four/bicepconfig.json", "/workspace1/two/three")]
-        [DataRow(new string[] { "/workspace1", "/workspace2" }, "/workspace1/bicepconfig.json", "/workspace1")]
-        [DataRow(new string[] { "/workspace2", "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1")]
-        [DataRow(new string[] { "/workspace1/two/three\four", "/workspace1/two/three", "/workspace1/two", "/workspace1" }, "/workspace1/two/three/five/bicepconfig.json", "/workspace1/two/three")]
-        // Bicep file not in any workspace folder - return bicep file's folder
-        [DataRow(new string[] { "/workspace1" }, "/workspace2/bicepconfig.json", "/workspace2")]
-        [DataRow(new string[] { "/workspace1/two/three" }, "/workspace1/two/bicepconfig.json", "/workspace1/two")]
-        // Case sensitive - no match, return bicep file's folder
-        [DataRow(new string[] { "/Workspace1" }, "/workspace1/bicepconfig.json", "/workspace1")]
-        [DataRow(new string[] { "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1")]
-        // Folders partially match
-        [DataRow(new string[] { "/workspace" }, "/workspace1/bicepconfig.json", "/workspace1")]
-        [DataRow(new string[] { "/workspace1" }, "/workspace/bicepconfig.json", "/workspace")]
 #if WINDOWS_BUILD
-        [Ignore]
+            // Bicep file is in a workspace folder - return the first one that matches, or else the bicep file's folder
+            yield return new object[] { new string[] { "c:\\workspace1" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1" };
+            yield return new object[] { new string[] { "c:\\workspace1" }, "c:\\workspace1\\two\\bicepconfig.json", "c:\\workspace1" };
+            yield return new object[] { new string[] { "c:\\workspace1" }, "c:\\workspace1\\two\\three\\bicepconfig.json", "c:\\workspace1" };
+            yield return new object[] { new string[] { "c:\\workspace1\\two" }, "c:\\workspace1\\two\\three\\bicepconfig.json", "c:\\workspace1\\two" };
+            yield return new object[] { new string[] { "c:\\workspace1\\two\\three" }, "c:\\workspace1\\two\\three\\bicepconfig.json", "c:\\workspace1\\two\\three" };
+            yield return new object[] { new string[] { "c:\\workspace1", "c:\\workspace2" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1" };
+            yield return new object[] { new string[] { "c:\\workspace2", "c:\\workspace1" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1" };
+            yield return new object[] {
+                new string[] { "c:\\workspace1\\two\\three\four", "c:\\workspace1\\two\\three", "c:\\workspace1\\two", "c:\\workspace1" },
+                "c:\\workspace1\\two\\three\\five\\bicepconfig.json",
+                "c:\\workspace1\\two\\three" };
+            // Bicep file not in any workspace folder - return bicep file's folder
+            yield return new object[] { new string[] { "c:\\workspace1" }, "c:\\workspace2\\bicepconfig.json", "c:\\workspace2" };
+            yield return new object[] { new string[] { "c:\\workspace1\\two\\three" }, "c:\\workspace1\\two\\bicepconfig.json", "c:\\workspace1\\two" };
+            // Case insensitive
+            yield return new object[] { new string[] { "c:\\Workspace1" }, "c:\\workspace1\\bicepconfig.json", "c:\\Workspace1" };
+            yield return new object[] { new string[] { "C:\\workspace1" }, "c:\\workspace1\\bicepconfig.json", "C:\\workspace1" };
+            // Folders partially match
+            yield return new object[] { new string[] { "c:\\workspace" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1" };
+            yield return new object[] { new string[] { "c:\\workspace1" }, "c:\\workspace\\bicepconfig.json", "c:\\workspace" };
+#else
+            // Bicep file is in a workspace folder - return the first one that matches, or else the bicep file's folder
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/two/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/two/three/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1/two" }, "/workspace1/two/three/bicepconfig.json", "/workspace1/two" };
+            yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/three/bicepconfig.json", "/workspace1/two/three" };
+            yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/three/four/bicepconfig.json", "/workspace1/two/three" };
+            yield return new object[] { new string[] { "/workspace1", "/workspace2" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace2", "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1/two/three\four", "/workspace1/two/three", "/workspace1/two", "/workspace1" }, "/workspace1/two/three/five/bicepconfig.json", "/workspace1/two/three" };
+            // Bicep file not in any workspace folder - return bicep file's folder
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace2/bicepconfig.json", "/workspace2" };
+            yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/bicepconfig.json", "/workspace1/two" };
+            // Case sensitive - no match, return bicep file's folder
+            yield return new object[] { new string[] { "/Workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            // Folders partially match
+            yield return new object[] { new string[] { "/workspace" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace/bicepconfig.json", "/workspace" };
 #endif
+        }
+
         [DataTestMethod]
-        public void WorkspaceFolders_MacLinux(string[] workspaceFolders, string bicepFilePath, string expected)
+        [DynamicData(nameof(GetWorkspaceFoldersTestData), DynamicDataSourceType.Method)]
+        public void WorkspaceFolders(string[] workspaceFolders, string bicepFilePath, string expected)
         {
             var actual = BicepGetRecommendedConfigLocationHandler.GetRecommendedConfigFileLocation(workspaceFolders, bicepFilePath);
 
             actual.Should().Be(expected);
         }
-
     }
 }

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepTextDocumentSyncHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepTextDocumentSyncHandlerTests.cs
@@ -123,6 +123,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         }
 
         [TestMethod]
+        [Ignore("Disabled due to flakiness - https://github.com/Azure/bicep/issues/7370")]
         public async Task ChangingLinterRuleDiagnosticLevel_ToDefaultValue_ShouldNotFireTelemetryEvent()
         {
             var prevBicepConfigFileContents = @"{
@@ -161,6 +162,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         }
 
         [TestMethod]
+        [Ignore("Disabled due to flakiness - https://github.com/Azure/bicep/issues/7370")]
         public async Task ChangingLinterRuleDiagnosticLevel_WithOverallStateSetToFalse_ShouldNotFireTelemetryEvent()
         {
             var prevBicepConfigFileContents = @"{


### PR DESCRIPTION
* I realized after #7725 was merged that there's another cache [here](https://github.com/Azure/bicep/blob/a9ff1f54ca773c16eb4b4471ce452fca795d2b68/src/Bicep.Core/TypeSystem/Az/AzResourceTypeFactory.cs#L14) which has the same issue. I've simplified the solution to just re-instantiate the classes to empty the cache. I've had 10 green builds out of the 10 I tested with this approach, and can confirm using `top` that memory usage stays low while the suite is running (without the fix, it increases until the test process crashes).
* I've added `[Ignore]` to the flaky test from #7370 as it's also contributing to a fair number of red builds.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7730)