### PR TITLE
fixed exception due to loop-invariant index expression

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -3872,5 +3872,68 @@ var value = (useFirst ? test1 : test2).tata
 
             result.Should().NotHaveAnyDiagnostics();
        }
+
+        /// <summary>
+        /// https://github.com/Azure/bicep/issues/6863
+        /// </summary>
+        [TestMethod]
+        public void Test_Issue6863()
+        {
+            var result = CompilationHelper.Compile(@"
+@description('Region to deploy to')
+param Location string = resourceGroup().location
+
+var Names = [
+  'fruit-primary'
+  'fruit-secondary'
+]
+
+var Service_Bus_Queues = [
+  'apples'
+  'oranges'
+]
+
+resource serviceBuses 'Microsoft.ServiceBus/namespaces@2021-11-01' = [for name in Names: {
+  name: name
+  location: Location
+  sku: {
+    name: 'Premium'
+    tier: 'Premium'
+  }
+  properties: {
+    zoneRedundant: false
+  }
+}]
+
+resource queues 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' = [for item in Service_Bus_Queues: {
+  parent: serviceBuses[0]
+  name: item
+}]
+
+resource queueAuthorizationRules 'Microsoft.ServiceBus/namespaces/queues/authorizationRules@2021-11-01' = [for (item, index) in Service_Bus_Queues: {
+  parent: queues[index]
+  name: 'Listen'
+  properties: {
+    rights: [
+      'Listen'
+    ]
+  }
+}]
+");
+
+            result.Should().NotHaveAnyDiagnostics();
+
+            result.Template.Should().HaveValueAtPath("$.resources[0].copy.name", "serviceBuses");
+            result.Template.Should().HaveValueAtPath("$.resources[0].name", "[variables('Names')[copyIndex()]]");
+            result.Template.Should().NotHaveValueAtPath("$.resources[0].dependsOn");
+
+            result.Template.Should().HaveValueAtPath("$.resources[1].copy.name", "queues");
+            result.Template.Should().HaveValueAtPath("$.resources[1].name", "[format('{0}/{1}', variables('Names')[0], variables('Service_Bus_Queues')[copyIndex()])]");
+            result.Template.Should().HaveValueAtPath("$.resources[1].dependsOn", new JArray("[resourceId('Microsoft.ServiceBus/namespaces', variables('Names')[0])]"));
+
+            result.Template.Should().HaveValueAtPath("$.resources[2].copy.name", "queueAuthorizationRules");
+            result.Template.Should().HaveValueAtPath("$.resources[2].name", "[format('{0}/{1}/{2}', variables('Names')[0], variables('Service_Bus_Queues')[copyIndex()], 'Listen')]");
+            result.Template.Should().HaveValueAtPath("$.resources[2].dependsOn", new JArray("[resourceId('Microsoft.ServiceBus/namespaces/queues', variables('Names')[0], variables('Service_Bus_Queues')[copyIndex()])]"));
+        }
     }
 }

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -628,17 +628,12 @@ namespace Bicep.Core.Emit
 
                 switch (inaccessibleLocalLoops.Count)
                 {
-                    case 0 when i == startingAncestorIndex:
+                    case 0:
                         /*
-                         * There are no local vars to replace. It is impossible for a local var to be introduced at the next level
-                         * so we can just bail out with the result.
-                         *
-                         * This path is followed by non-loop resources.
-                         *
-                         * Case 0 is not possible for non-starting ancestor index because
-                         * once we have a local variable replacement, it will propagate to the next levels
+                         * Hardcoded index expression resulted in no more local vars to replace.
+                         * We can just bail out with the result.
                          */
-                        return ancestor.Resource.NameSyntax;
+                        return rewritten;
 
                     case 1 when ancestor.IndexExpression is not null:
                         if (LocalSymbolDependencyVisitor.GetLocalSymbolDependencies(this.context.SemanticModel, rewritten).SingleOrDefault(s => s.LocalKind == LocalKind.ForExpressionItemVariable) is { } loopItemSymbol)


### PR DESCRIPTION
We should no longer throw an exception when generating resource loops with loop-invariant parent index expressions in the middle of an ancestor chain. This fixes #6863.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7754)