### PR TITLE
Added license to the VS code extension

### DIFF
--- a/src/vscode-bicep/LICENSE
+++ b/src/vscode-bicep/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Azure/bicep.git"
+    "url": "https://github.com/Azure/bicep"
   },
   "galleryBanner": {
     "color": "E7F1FA",


### PR DESCRIPTION
We were missing the license link in the VS code extension. `vsce` picks up the LICENSE file from the root of the extension project. I just copied the license from the repo root and confirmed that the generated .vsixmanifest file inside the VSIX contains a link to the file. The link should appear when we upload the VSIX to the VS gallery during the next release.

Also fixed the repo URL, which unnecessarily included a ".git" suffix. The link was working but it was just weird.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7767)