### PR TITLE
Update visual studio vsix version to match vscode

### DIFF
--- a/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/Bicep.VSLanguageServerClient.Vsix.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/Bicep.VSLanguageServerClient.Vsix.csproj
@@ -58,6 +58,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.107" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bicep.VSLanguageServerClient\Bicep.VSLanguageServerClient.csproj">

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/Bicep.VSLanguageServerClient.Vsix.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/Bicep.VSLanguageServerClient.Vsix.csproj
@@ -58,7 +58,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.107" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bicep.VSLanguageServerClient\Bicep.VSLanguageServerClient.csproj">

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/source.extension.vsixmanifest
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="Bicep.VSLanguageServerClient.Vsix.e3e48977-4eba-4835-9f1d-c0b9310b6ee7" Version="1.0" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="Bicep.VSLanguageServerClient.Vsix.e3e48977-4eba-4835-9f1d-c0b9310b6ee7" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Bicep</DisplayName>
     <Description xml:space="preserve">Bicep Visual Studio Extension.</Description>
     <Icon>Icons\bicep-logo-256.png</Icon>


### PR DESCRIPTION
Includes changes to update visual studio vsix version to match vscode.

Screenshot from my machine after installing vsix:
![image](https://user-images.githubusercontent.com/30270536/182042293-7d520247-44f8-43b0-8042-577c79e1650c.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7773)