### PR TITLE
Add ability to generate .bicep file from a Kubernetes manifest

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -850,6 +850,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "KgdpJtAHf119JmlXU2P+HTo5vht8dKTrb8bP1vQeEV2jnkQNuVGg+tSea7T/eZe5xaStRZaRXyGQobUMJgb44w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2080,7 +2085,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
           "CommandLineParser": "2.9.1",
-          "OmniSharp.Extensions.LanguageServer": "0.19.5"
+          "OmniSharp.Extensions.LanguageServer": "0.19.5",
+          "SharpYaml": "2.0.0"
         }
       }
     },

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -850,6 +850,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "KgdpJtAHf119JmlXU2P+HTo5vht8dKTrb8bP1vQeEV2jnkQNuVGg+tSea7T/eZe5xaStRZaRXyGQobUMJgb44w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2070,7 +2075,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
           "CommandLineParser": "2.9.1",
-          "OmniSharp.Extensions.LanguageServer": "0.19.5"
+          "OmniSharp.Extensions.LanguageServer": "0.19.5",
+          "SharpYaml": "2.0.0"
         }
       }
     },

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -850,6 +850,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "KgdpJtAHf119JmlXU2P+HTo5vht8dKTrb8bP1vQeEV2jnkQNuVGg+tSea7T/eZe5xaStRZaRXyGQobUMJgb44w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2058,7 +2063,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
           "CommandLineParser": "2.9.1",
-          "OmniSharp.Extensions.LanguageServer": "0.19.5"
+          "OmniSharp.Extensions.LanguageServer": "0.19.5",
+          "SharpYaml": "2.0.0"
         }
       }
     },

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -860,6 +860,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "KgdpJtAHf119JmlXU2P+HTo5vht8dKTrb8bP1vQeEV2jnkQNuVGg+tSea7T/eZe5xaStRZaRXyGQobUMJgb44w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2024,7 +2029,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
           "CommandLineParser": "2.9.1",
-          "OmniSharp.Extensions.LanguageServer": "0.19.5"
+          "OmniSharp.Extensions.LanguageServer": "0.19.5",
+          "SharpYaml": "2.0.0"
         }
       }
     },

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -847,6 +847,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "KgdpJtAHf119JmlXU2P+HTo5vht8dKTrb8bP1vQeEV2jnkQNuVGg+tSea7T/eZe5xaStRZaRXyGQobUMJgb44w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2043,7 +2048,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
           "CommandLineParser": "2.9.1",
-          "OmniSharp.Extensions.LanguageServer": "0.19.5"
+          "OmniSharp.Extensions.LanguageServer": "0.19.5",
+          "SharpYaml": "2.0.0"
         }
       }
     },

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -847,6 +847,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "KgdpJtAHf119JmlXU2P+HTo5vht8dKTrb8bP1vQeEV2jnkQNuVGg+tSea7T/eZe5xaStRZaRXyGQobUMJgb44w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2043,7 +2048,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
           "CommandLineParser": "2.9.1",
-          "OmniSharp.Extensions.LanguageServer": "0.19.5"
+          "OmniSharp.Extensions.LanguageServer": "0.19.5",
+          "SharpYaml": "2.0.0"
         }
       }
     },

--- a/src/Bicep.LangServer.IntegrationTests/Assertions/TelemetryEventParamsAssertions.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Assertions/TelemetryEventParamsAssertions.cs
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using FluentAssertions;
 using FluentAssertions.Primitives;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Bicep.Core.UnitTests.Assertions;
+using FluentAssertions.Collections;
+using System.Collections.Generic;
 
 namespace Bicep.LangServer.IntegrationTests.Assertions
 {
@@ -10,6 +15,11 @@ namespace Bicep.LangServer.IntegrationTests.Assertions
         public static TelemetryEventParamsAssertions Should(this TelemetryEventParams instance)
         {
             return new TelemetryEventParamsAssertions(instance);
+        }
+
+        public static TelemetryEventParamsCollectionAssertions Should(this IEnumerable<TelemetryEventParams> instance)
+        {
+            return new TelemetryEventParamsCollectionAssertions(instance);
         }
     }
 
@@ -21,5 +31,30 @@ namespace Bicep.LangServer.IntegrationTests.Assertions
         }
 
         protected override string Identifier => "telemetry event";
+
+        public AndConstraint<TelemetryEventParamsAssertions> HaveProperties(JObject properties, string because = "", params object[] becauseArgs)
+        {
+            (Subject.ExtensionData["properties"] as JToken)!.Should().DeepEqual(properties, because, becauseArgs);
+
+            return new(this);
+        }
+    }
+
+    public class TelemetryEventParamsCollectionAssertions : GenericCollectionAssertions<IEnumerable<TelemetryEventParams>, TelemetryEventParams>
+    {
+        public TelemetryEventParamsCollectionAssertions(IEnumerable<TelemetryEventParams> instance)
+            : base(instance)
+        {
+        }
+
+        protected override string Identifier => "telemetry";
+
+        public AndConstraint<TelemetryEventParamsCollectionAssertions> ContainEvent(string eventName, JObject properties, string because = "", params object[] becauseArgs)
+        {
+            Subject.Should().ContainSingle(x => x.ExtensionData["eventName"] as string == eventName)
+                .Which.Should().HaveProperties(properties);
+
+            return new(this);
+        }
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/Files/ImportKubernetesManifest/azure-vote-all-in-one-redis/manifest.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Files/ImportKubernetesManifest/azure-vote-all-in-one-redis/manifest.bicep
@@ -1,0 +1,142 @@
+@secure()
+param kubeConfig string
+
+import kubernetes as k8s {
+  namespace: 'default'
+  kubeConfig: kubeConfig
+}
+
+resource appsDeployment_azureVoteBack 'apps/Deployment@v1' = {
+  metadata: {
+    name: 'azure-vote-back'
+  }
+  spec: {
+    replicas: 1
+    selector: {
+      matchLabels: {
+        app: 'azure-vote-back'
+      }
+    }
+    template: {
+      metadata: {
+        labels: {
+          app: 'azure-vote-back'
+        }
+      }
+      spec: {
+        nodeSelector: {
+          'beta.kubernetes.io/os': 'linux'
+        }
+        containers: [
+          {
+            name: 'azure-vote-back'
+            image: 'mcr.microsoft.com/oss/bitnami/redis:6.0.8'
+            env: [
+              {
+                name: 'ALLOW_EMPTY_PASSWORD'
+                value: 'yes'
+              }
+            ]
+            ports: [
+              {
+                containerPort: 6379
+                name: 'redis'
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+
+resource coreService_azureVoteBack 'core/Service@v1' = {
+  metadata: {
+    name: 'azure-vote-back'
+  }
+  spec: {
+    ports: [
+      {
+        port: 6379
+      }
+    ]
+    selector: {
+      app: 'azure-vote-back'
+    }
+  }
+}
+
+resource appsDeployment_azureVoteFront 'apps/Deployment@v1' = {
+  metadata: {
+    name: 'azure-vote-front'
+  }
+  spec: {
+    replicas: 1
+    selector: {
+      matchLabels: {
+        app: 'azure-vote-front'
+      }
+    }
+    strategy: {
+      rollingUpdate: {
+        maxSurge: 1
+        maxUnavailable: 1
+      }
+    }
+    minReadySeconds: 5
+    template: {
+      metadata: {
+        labels: {
+          app: 'azure-vote-front'
+        }
+      }
+      spec: {
+        nodeSelector: {
+          'beta.kubernetes.io/os': 'linux'
+        }
+        containers: [
+          {
+            name: 'azure-vote-front'
+            image: 'mcr.microsoft.com/azuredocs/azure-vote-front:v1'
+            ports: [
+              {
+                containerPort: 80
+              }
+            ]
+            resources: {
+              requests: {
+                cpu: '250m'
+              }
+              limits: {
+                cpu: '500m'
+              }
+            }
+            env: [
+              {
+                name: 'REDIS'
+                value: 'azure-vote-back'
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+
+resource coreService_azureVoteFront 'core/Service@v1' = {
+  metadata: {
+    name: 'azure-vote-front'
+  }
+  spec: {
+    type: 'LoadBalancer'
+    ports: [
+      {
+        port: 80
+      }
+    ]
+    selector: {
+      app: 'azure-vote-front'
+    }
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Files/ImportKubernetesManifest/azure-vote-all-in-one-redis/manifest.yml
+++ b/src/Bicep.LangServer.IntegrationTests/Files/ImportKubernetesManifest/azure-vote-all-in-one-redis/manifest.yml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: azure-vote-back
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: azure-vote-back
+  template:
+    metadata:
+      labels:
+        app: azure-vote-back
+    spec:
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
+      containers:
+      - name: azure-vote-back
+        image: mcr.microsoft.com/oss/bitnami/redis:6.0.8
+        env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        ports:
+        - containerPort: 6379
+          name: redis
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: azure-vote-back
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: azure-vote-back
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: azure-vote-front
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: azure-vote-front
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  minReadySeconds: 5 
+  template:
+    metadata:
+      labels:
+        app: azure-vote-front
+    spec:
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
+      containers:
+      - name: azure-vote-front
+        image: mcr.microsoft.com/azuredocs/azure-vote-front:v1
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 250m
+          limits:
+            cpu: 500m
+        env:
+        - name: REDIS
+          value: "azure-vote-back"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: azure-vote-front
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: azure-vote-front

--- a/src/Bicep.LangServer.IntegrationTests/Files/ImportKubernetesManifest/wordpress/manifest.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Files/ImportKubernetesManifest/wordpress/manifest.bicep
@@ -1,0 +1,306 @@
+@secure()
+param kubeConfig string
+
+import kubernetes as k8s {
+  namespace: 'default'
+  kubeConfig: kubeConfig
+}
+
+resource corePersistentVolume_wordpressPv1 'core/PersistentVolume@v1' = {
+  metadata: {
+    name: 'wordpress-pv-1'
+  }
+  spec: {
+    capacity: {
+      storage: '20Gi'
+    }
+    accessModes: [
+      'ReadWriteOnce'
+    ]
+    gcePersistentDisk: {
+      pdName: 'wordpress-1'
+      fsType: 'ext4'
+    }
+  }
+}
+
+resource corePersistentVolume_wordpressPv2 'core/PersistentVolume@v1' = {
+  metadata: {
+    name: 'wordpress-pv-2'
+  }
+  spec: {
+    capacity: {
+      storage: '20Gi'
+    }
+    accessModes: [
+      'ReadWriteOnce'
+    ]
+    gcePersistentDisk: {
+      pdName: 'wordpress-2'
+      fsType: 'ext4'
+    }
+  }
+}
+
+resource corePersistentVolume_localPv1 'core/PersistentVolume@v1' = {
+  metadata: {
+    name: 'local-pv-1'
+    labels: {
+      type: 'local'
+    }
+  }
+  spec: {
+    capacity: {
+      storage: '20Gi'
+    }
+    accessModes: [
+      'ReadWriteOnce'
+    ]
+    hostPath: {
+      path: '/tmp/data/pv-1'
+    }
+  }
+}
+
+resource corePersistentVolume_localPv2 'core/PersistentVolume@v1' = {
+  metadata: {
+    name: 'local-pv-2'
+    labels: {
+      type: 'local'
+    }
+  }
+  spec: {
+    capacity: {
+      storage: '20Gi'
+    }
+    accessModes: [
+      'ReadWriteOnce'
+    ]
+    hostPath: {
+      path: '/tmp/data/pv-2'
+    }
+  }
+}
+
+resource coreService_wordpressMysql 'core/Service@v1' = {
+  metadata: {
+    name: 'wordpress-mysql'
+    labels: {
+      app: 'wordpress'
+    }
+  }
+  spec: {
+    ports: [
+      {
+        port: 3306
+      }
+    ]
+    selector: {
+      app: 'wordpress'
+      tier: 'mysql'
+    }
+    clusterIP: 'None'
+  }
+}
+
+resource corePersistentVolumeClaim_mysqlPvClaim 'core/PersistentVolumeClaim@v1' = {
+  metadata: {
+    name: 'mysql-pv-claim'
+    labels: {
+      app: 'wordpress'
+    }
+  }
+  spec: {
+    accessModes: [
+      'ReadWriteOnce'
+    ]
+    resources: {
+      requests: {
+        storage: '20Gi'
+      }
+    }
+  }
+}
+
+resource appsDeployment_wordpressMysql 'apps/Deployment@v1' = {
+  metadata: {
+    name: 'wordpress-mysql'
+    labels: {
+      app: 'wordpress'
+    }
+  }
+  spec: {
+    selector: {
+      matchLabels: {
+        app: 'wordpress'
+        tier: 'mysql'
+      }
+    }
+    strategy: {
+      type: 'Recreate'
+    }
+    template: {
+      metadata: {
+        labels: {
+          app: 'wordpress'
+          tier: 'mysql'
+        }
+      }
+      spec: {
+        containers: [
+          {
+            image: 'mysql:5.6'
+            name: 'mysql'
+            env: [
+              {
+                name: 'MYSQL_ROOT_PASSWORD'
+                valueFrom: {
+                  secretKeyRef: {
+                    name: 'mysql-pass'
+                    key: 'password'
+                  }
+                }
+              }
+            ]
+            livenessProbe: {
+              tcpSocket: {
+                port: 3306
+              }
+            }
+            ports: [
+              {
+                containerPort: 3306
+                name: 'mysql'
+              }
+            ]
+            volumeMounts: [
+              {
+                name: 'mysql-persistent-storage'
+                mountPath: '/var/lib/mysql'
+              }
+            ]
+          }
+        ]
+        volumes: [
+          {
+            name: 'mysql-persistent-storage'
+            persistentVolumeClaim: {
+              claimName: 'mysql-pv-claim'
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+resource coreService_wordpress 'core/Service@v1' = {
+  metadata: {
+    name: 'wordpress'
+    labels: {
+      app: 'wordpress'
+    }
+  }
+  spec: {
+    ports: [
+      {
+        port: 80
+      }
+    ]
+    selector: {
+      app: 'wordpress'
+      tier: 'frontend'
+    }
+    type: 'LoadBalancer'
+  }
+}
+
+resource corePersistentVolumeClaim_wpPvClaim 'core/PersistentVolumeClaim@v1' = {
+  metadata: {
+    name: 'wp-pv-claim'
+    labels: {
+      app: 'wordpress'
+    }
+  }
+  spec: {
+    accessModes: [
+      'ReadWriteOnce'
+    ]
+    resources: {
+      requests: {
+        storage: '20Gi'
+      }
+    }
+  }
+}
+
+resource appsDeployment_wordpress 'apps/Deployment@v1' = {
+  metadata: {
+    name: 'wordpress'
+    labels: {
+      app: 'wordpress'
+    }
+  }
+  spec: {
+    selector: {
+      matchLabels: {
+        app: 'wordpress'
+        tier: 'frontend'
+      }
+    }
+    strategy: {
+      type: 'Recreate'
+    }
+    template: {
+      metadata: {
+        labels: {
+          app: 'wordpress'
+          tier: 'frontend'
+        }
+      }
+      spec: {
+        containers: [
+          {
+            image: 'wordpress:4.8-apache'
+            name: 'wordpress'
+            env: [
+              {
+                name: 'WORDPRESS_DB_HOST'
+                value: 'wordpress-mysql'
+              }
+              {
+                name: 'WORDPRESS_DB_PASSWORD'
+                valueFrom: {
+                  secretKeyRef: {
+                    name: 'mysql-pass'
+                    key: 'password'
+                  }
+                }
+              }
+            ]
+            ports: [
+              {
+                containerPort: 80
+                name: 'wordpress'
+              }
+            ]
+            volumeMounts: [
+              {
+                name: 'wordpress-persistent-storage'
+                mountPath: '/var/www/html'
+              }
+            ]
+          }
+        ]
+        volumes: [
+          {
+            name: 'wordpress-persistent-storage'
+            persistentVolumeClaim: {
+              claimName: 'wp-pv-claim'
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Files/ImportKubernetesManifest/wordpress/manifest.yml
+++ b/src/Bicep.LangServer.IntegrationTests/Files/ImportKubernetesManifest/wordpress/manifest.yml
@@ -1,0 +1,190 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: wordpress-pv-1
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  gcePersistentDisk:
+    pdName: wordpress-1
+    fsType: ext4
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: wordpress-pv-2
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  gcePersistentDisk:
+    pdName: wordpress-2
+    fsType: ext4
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv-1
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/data/pv-1
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv-2
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/data/pv-2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress-mysql
+  labels:
+    app: wordpress
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: wordpress
+    tier: mysql
+  clusterIP: None
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+  labels:
+    app: wordpress
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1 # for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+kind: Deployment
+metadata:
+  name: wordpress-mysql
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: mysql
+    spec:
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        livenessProbe:
+          tcpSocket:
+            port: 3306
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pv-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: wordpress
+    tier: frontend
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-pv-claim
+  labels:
+    app: wordpress
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1 #  for k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+kind: Deployment
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: frontend
+    spec:
+      containers:
+      - image: wordpress:4.8-apache
+        name: wordpress
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: wordpress-mysql
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-pass
+              key: password
+        ports:
+        - containerPort: 80
+          name: wordpress
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wordpress-persistent-storage
+        persistentVolumeClaim:
+          claimName: wp-pv-claim

--- a/src/Bicep.LangServer.IntegrationTests/ImportKubernetesManifestTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ImportKubernetesManifestTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Bicep.Core.UnitTests.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.LanguageServer.Handlers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Bicep.Core.UnitTests;
+using System.Linq;
+using FluentAssertions;
+using Bicep.Core.Extensions;
+using Bicep.Core.UnitTests.Baselines;
+
+namespace Bicep.LangServer.IntegrationTests
+{
+    [TestClass]
+    public class ImportKubernetesManifestTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        private static IEnumerable<object[]> GetWorkingExampleData()
+            => EmbeddedFile.LoadAll(
+                typeof(ImportKubernetesManifestTests).Assembly,
+                "ImportKubernetesManifest",
+                streamName => Path.GetExtension(streamName) == ".yml")
+            .Select(x => new object[] { x });
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetWorkingExampleData), DynamicDataSourceType.Method)]
+        [TestCategory(BaselineHelper.BaselineTestCategory)]
+        public async Task ImportKubernetesManifest_generates_valid_bicep_files_from_kubernetes_manifests(EmbeddedFile embeddedYml)
+        {
+            var baselineFolder = BaselineFolder.BuildOutputFolder(TestContext, embeddedYml);
+            var yamlFile = baselineFolder.EntryFile;
+            var bicepFile = baselineFolder.GetFileOrEnsureCheckedIn(Path.ChangeExtension(embeddedYml.FileName, ".bicep"));
+
+            var features = BicepTestConstants.Features with { ImportsEnabled = true, };
+
+            using var helper = await LanguageServerHelper.StartServerWithClientConnectionAsync(
+                this.TestContext,
+                options => {},
+                new LanguageServer.Server.CreationOptions(Features: features));
+            var client = helper.Client;
+
+            var response = await client.SendRequest(new ImportKubernetesManifestRequest(yamlFile.OutputFilePath), default);
+
+            bicepFile.ShouldHaveExpectedValue();
+
+            var context = new CompilationHelper.CompilationHelperContext(Features: features);
+            CompilationHelper.Compile(context, bicepFile.ReadFromOutputFolder()).Should().GenerateATemplate();
+        }
+    }
+}

--- a/src/Bicep.LangServer.IntegrationTests/ImportKubernetesManifestTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ImportKubernetesManifestTests.cs
@@ -96,7 +96,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var message = await messageListener.WaitNext();
             message.Should().HaveMessageAndType(
-                "Failed to deserialize kubernetes resource YAML.",
+                "Failed to deserialize kubernetes manifest YAML.",
                 MessageType.Error);
         }
     }

--- a/src/Bicep.LangServer.IntegrationTests/ImportKubernetesManifestTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ImportKubernetesManifestTests.cs
@@ -56,11 +56,11 @@ namespace Bicep.LangServer.IntegrationTests
 
             var response = await client.SendRequest(new ImportKubernetesManifestRequest(yamlFile.OutputFilePath), default);
 
-            var telemetry = await telemetryEventsListener.WaitNext();
-            telemetry.Should().HaveEventNameAndProperties("ImportKubernetesManifest/success", new JObject
-            {
-                ["success"] = "true",
-            });
+            var telemetry = await telemetryEventsListener.WaitForAll();
+            telemetry.Should().ContainEvent("ImportKubernetesManifest/success", new JObject
+                {
+                    ["success"] = "true",
+                });
 
             bicepFile.ShouldHaveExpectedValue();
 
@@ -88,11 +88,11 @@ namespace Bicep.LangServer.IntegrationTests
             var response = await client.SendRequest(new ImportKubernetesManifestRequest(manifestFile), default);
             response.BicepFilePath.Should().BeNull();
 
-            var telemetry = await telemetryEventsListener.WaitNext();
-            telemetry.Should().HaveEventNameAndProperties("ImportKubernetesManifest/failure", new JObject
-            {
-                ["failureType"] = "DeserializeYamlFailed",
-            });
+            var telemetry = await telemetryEventsListener.WaitForAll();
+            telemetry.Should().ContainEvent("ImportKubernetesManifest/failure", new JObject
+                {
+                    ["failureType"] = "DeserializeYamlFailed",
+                });
 
             var message = await messageListener.WaitNext();
             message.Should().HaveMessageAndType(

--- a/src/Bicep.LangServer.IntegrationTests/InsertResourceCommandTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/InsertResourceCommandTests.cs
@@ -32,7 +32,6 @@ using System.Linq;
 using System;
 using Bicep.LangServer.IntegrationTests.Assertions;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
-using Bicep.LanguageServer.Telemetry;
 
 namespace Bicep.LangServer.IntegrationTests
 {
@@ -46,7 +45,7 @@ namespace Bicep.LangServer.IntegrationTests
             MultipleMessageListener<PublishDiagnosticsParams> Diagnostics,
             MultipleMessageListener<ShowMessageParams> ShowMessage,
             MultipleMessageListener<ApplyWorkspaceEditParams> ApplyWorkspaceEdit,
-            MultipleMessageListener<BicepTelemetryEvent> Telemetry);
+            MultipleMessageListener<TelemetryEventParams> Telemetry);
 
         private Listeners CreateListeners()
             => new(new(), new(), new(), new());
@@ -58,25 +57,21 @@ namespace Bicep.LangServer.IntegrationTests
         {
             return await LanguageServerHelper.StartServerWithClientConnectionAsync(
                 this.TestContext,
-                options =>
-                {
-                    options.OnPublishDiagnostics(x => listeners.Diagnostics.AddMessage(x));
-                    options.OnShowMessage(x => listeners.ShowMessage.AddMessage(x));
-                    options.OnApplyWorkspaceEdit(async p =>
+                options => options
+                    .OnPublishDiagnostics(listeners.Diagnostics.AddMessage)
+                    .OnShowMessage(listeners.ShowMessage.AddMessage)
+                    .OnApplyWorkspaceEdit(async p =>
                     {
                         listeners.ApplyWorkspaceEdit.AddMessage(p);
 
                         await Task.Yield();
                         return new();
-                    });
-                    options.OnTelemetryEvent<BicepTelemetryEvent>(x => listeners.Telemetry.AddMessage(x));
-                },
+                    })
+                    .OnTelemetryEvent(listeners.Telemetry.AddMessage),
                 new LanguageServer.Server.CreationOptions(
-                    onRegisterServices: services =>
-                    {
-                        services.AddSingleton<IAzResourceProvider>(azResourceProvider);
-                        services.AddSingleton<IAzResourceTypeLoader>(azResourceTypeLoader);
-                    }));
+                    onRegisterServices: services => services
+                        .AddSingleton<IAzResourceProvider>(azResourceProvider)
+                        .AddSingleton<IAzResourceTypeLoader>(azResourceTypeLoader)));
         }
 
         [TestMethod]
@@ -165,12 +160,12 @@ module myMod './module.bicep' = {
 output myOutput string = 'myOutput'
 ");
 
-            var telemetryEvents = await listeners.Telemetry.WaitForAll();
-
-            telemetryEvents.Should().Contain(
-                x => x.EventName == "InsertResource/success" &&
-                x.Properties["resourceType"] == "My.Rp/myTypes" &&
-                x.Properties["apiVersion"] == "2020-01-01");
+            var telemetry = await listeners.Telemetry.WaitForAll();
+            telemetry.Should().ContainEvent("InsertResource/success", new JObject
+                {
+                    ["resourceType"] = "My.Rp/myTypes",
+                    ["apiVersion"] = "2020-01-01",
+                });
         }
 
         [TestMethod]
@@ -264,12 +259,12 @@ module myMod './module.bicep' = {
 output myOutput string = 'myOutput'
 ");
 
-            var telemetryEvents = await listeners.Telemetry.WaitForAll();
-
-            telemetryEvents.Should().Contain(
-                x => x.EventName == "InsertResource/success" &&
-                x.Properties["resourceType"] == "Microsoft.Resources/resourceGroups" &&
-                x.Properties["apiVersion"] == "2020-01-01");
+            var telemetry = await listeners.Telemetry.WaitForAll();
+            telemetry.Should().ContainEvent("InsertResource/success", new JObject
+                {
+                    ["resourceType"] = "Microsoft.Resources/resourceGroups",
+                    ["apiVersion"] = "2020-01-01",
+                });
         }
 
         [TestMethod]
@@ -358,12 +353,12 @@ module myMod './module.bicep' = {
 output myOutput string = 'myOutput'
 ");
 
-            var telemetryEvents = await listeners.Telemetry.WaitForAll();
-
-            telemetryEvents.Should().Contain(
-                x => x.EventName == "InsertResource/success" &&
-                x.Properties["resourceType"] == "My.Rp/myTypes/childType" &&
-                x.Properties["apiVersion"] == "2020-01-01");
+            var telemetry = await listeners.Telemetry.WaitForAll();
+            telemetry.Should().ContainEvent("InsertResource/success", new JObject
+                {
+                    ["resourceType"] = "My.Rp/myTypes/childType",
+                    ["apiVersion"] = "2020-01-01",
+                });
         }
 
         [TestMethod]
@@ -410,11 +405,11 @@ output myOutput string = 'myOutput'
                 "Failed to parse supplied resourceId \"this isn't a resource id!\".",
                 MessageType.Error);
 
-            var telemetryEvents = await listeners.Telemetry.WaitForAll();
-
-            telemetryEvents.Should().Contain(
-                x => x.EventName == "InsertResource/failure" &&
-                x.Properties["failureType"] == "ParseResourceIdFailed");
+            var telemetry = await listeners.Telemetry.WaitForAll();
+            telemetry.Should().ContainEvent("InsertResource/failure", new JObject
+                {
+                    ["failureType"] = "ParseResourceIdFailed"
+                });
         }
 
         [TestMethod]
@@ -459,11 +454,11 @@ output myOutput string = 'myOutput'
                 "Failed to find a Bicep type definition for resource of type \"MadeUp.Rp/madeUpTypes\".",
                 MessageType.Error);
 
-            var telemetryEvents = await listeners.Telemetry.WaitForAll();
-
-            telemetryEvents.Should().Contain(
-                x => x.EventName == "InsertResource/failure" &&
-                x.Properties["failureType"] == "MissingType(MadeUp.Rp/madeUpTypes)");
+            var telemetry = await listeners.Telemetry.WaitForAll();
+            telemetry.Should().ContainEvent("InsertResource/failure", new JObject
+                {
+                    ["failureType"] = "MissingType(MadeUp.Rp/madeUpTypes)",
+                });
         }
 
         [TestMethod]
@@ -556,12 +551,12 @@ module myMod './module.bicep' = {
 output myOutput string = 'myOutput'
 ");
 
-            var telemetryEvents = await listeners.Telemetry.WaitForAll();
-
-            telemetryEvents.Should().Contain(
-                x => x.EventName == "InsertResource/success" &&
-                x.Properties["resourceType"] == "My.Rp/myTypes" &&
-                x.Properties["apiVersion"] == "2020-01-01");
+            var telemetry = await listeners.Telemetry.WaitForAll();
+            telemetry.Should().ContainEvent("InsertResource/success", new JObject
+                {
+                    ["resourceType"] = "My.Rp/myTypes",
+                    ["apiVersion"] = "2020-01-01",
+                });
         }
 
         [TestMethod]
@@ -616,11 +611,11 @@ output myOutput string = 'myOutput'
                 "Caught exception fetching resource: And something went wrong again!.",
                 MessageType.Error);
 
-            var telemetryEvents = await listeners.Telemetry.WaitForAll();
-
-            telemetryEvents.Should().Contain(
-                x => x.EventName == "InsertResource/failure" &&
-                x.Properties["failureType"] == "FetchResourceFailure");
+            var telemetry = await listeners.Telemetry.WaitForAll();
+            telemetry.Should().ContainEvent("InsertResource/failure", new JObject
+                {
+                    ["failureType"] = "FetchResourceFailure",
+                });
         }
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -864,6 +864,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "KgdpJtAHf119JmlXU2P+HTo5vht8dKTrb8bP1vQeEV2jnkQNuVGg+tSea7T/eZe5xaStRZaRXyGQobUMJgb44w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2084,7 +2089,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
           "CommandLineParser": "2.9.1",
-          "OmniSharp.Extensions.LanguageServer": "0.19.5"
+          "OmniSharp.Extensions.LanguageServer": "0.19.5",
+          "SharpYaml": "2.0.0"
         }
       }
     },

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -863,6 +863,11 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "SharpYaml": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "KgdpJtAHf119JmlXU2P+HTo5vht8dKTrb8bP1vQeEV2jnkQNuVGg+tSea7T/eZe5xaStRZaRXyGQobUMJgb44w=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2083,7 +2088,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "1.0.0",
           "CommandLineParser": "2.9.1",
-          "OmniSharp.Extensions.LanguageServer": "0.19.5"
+          "OmniSharp.Extensions.LanguageServer": "0.19.5",
+          "SharpYaml": "2.0.0"
         }
       },
       "bicep.langserver.integrationtests": {

--- a/src/Bicep.LangServer/Bicep.LangServer.csproj
+++ b/src/Bicep.LangServer/Bicep.LangServer.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="SharpYaml" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using Bicep.Core.PrettyPrint;
+using Bicep.Core.PrettyPrint.Options;
+using Bicep.Core.Syntax;
+using MediatR;
+using OmniSharp.Extensions.JsonRpc;
+using SharpYaml.Serialization;
+
+namespace Bicep.LanguageServer.Handlers
+{
+    [Method("bicep/importKubernetesManifest", Direction.ClientToServer)]
+    public record ImportKubernetesManifestRequest(string ManifestFilePath)
+        : IRequest<ImportKubernetesManifestResponse>;
+
+    public record ImportKubernetesManifestResponse(string BicepFilePath);
+
+    public class ImportKubernetesManifestHandler : IJsonRpcRequestHandler<ImportKubernetesManifestRequest, ImportKubernetesManifestResponse>
+    {
+        public async Task<ImportKubernetesManifestResponse> Handle(ImportKubernetesManifestRequest request, CancellationToken cancellationToken)
+        {
+            var bicepFilePath = Path.ChangeExtension(request.ManifestFilePath, ".bicep");
+            var manifestContents = await File.ReadAllTextAsync(request.ManifestFilePath);
+
+            var bicepContents = Decompile(manifestContents);
+
+            await File.WriteAllTextAsync(bicepFilePath, bicepContents, cancellationToken);
+
+            return new(bicepFilePath);
+        }
+
+        public static string Decompile(string manifestContents)
+        {
+            manifestContents = StringUtils.ReplaceNewlines(manifestContents, "\n");
+
+            var resources = manifestContents.Split("\n---\n");
+
+            var declarations = new List<SyntaxBase>();
+
+            declarations.Add(new ParameterDeclarationSyntax(
+                new SyntaxBase[] {
+                    SyntaxFactory.CreateDecorator("secure"),
+                    SyntaxFactory.NewlineToken,
+                },
+                SyntaxFactory.CreateToken(Core.Parsing.TokenType.Identifier, "param"),
+                SyntaxFactory.CreateIdentifier("kubeConfig"),
+                new SimpleTypeSyntax(SyntaxFactory.CreateToken(TokenType.Identifier, "string")),
+                null));
+
+            declarations.Add(new ImportDeclarationSyntax(
+                Enumerable.Empty<SyntaxBase>(),
+                SyntaxFactory.CreateToken(Core.Parsing.TokenType.Identifier, "import"),
+                SyntaxFactory.CreateIdentifier("kubernetes"),
+                SyntaxFactory.CreateToken(Core.Parsing.TokenType.Identifier, "as"),
+                SyntaxFactory.CreateIdentifier("k8s"),
+                SyntaxFactory.CreateObject(new [] {
+                    SyntaxFactory.CreateObjectProperty("namespace", SyntaxFactory.CreateStringLiteral("default")),
+                    SyntaxFactory.CreateObjectProperty("kubeConfig", SyntaxFactory.CreateIdentifier("kubeConfig")),
+                })
+            ));
+
+            foreach (var resource in resources)
+            {
+                var yamlValue = new Serializer().Deserialize(resource);
+
+                var syntax = ProcessResource(yamlValue);
+
+                declarations.Add(syntax);
+            }
+
+            var program = new ProgramSyntax(
+                declarations.SelectMany(x => new SyntaxBase[] { x, SyntaxFactory.DoubleNewlineToken }),
+                SyntaxFactory.CreateToken(TokenType.EndOfFile, ""),
+                Enumerable.Empty<IDiagnostic>());
+
+            return PrettyPrinter.PrintProgram(program, new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false));
+        }
+
+        private static ResourceDeclarationSyntax ProcessResource(object? resource)
+        {
+            if (resource is not Dictionary<object, object> dictValue)
+            {
+                throw new NotImplementedException($"Unsupported type {resource?.GetType()}");
+            }
+
+            if (!(dictValue.TryGetValue("kind", out var kindObj) && kindObj is string type &&
+                dictValue.TryGetValue("apiVersion", out var apiVersionObj) && apiVersionObj is string apiVersion))
+            {
+                throw new NotImplementedException($"Expected properties 'type' & 'kind'");
+            }
+
+            (type, apiVersion) = apiVersion.LastIndexOf('/') switch {
+                -1 => ($"core/{type}", apiVersion),
+                int x => ($"{apiVersion.Substring(0, x)}/{type}", apiVersion.Substring(x + 1)),
+            };
+
+            var filteredResource = dictValue
+                .Where(x => x.Key as string != "kind" && x.Key as string != "apiVersion")
+                .ToDictionary(x => x.Key, x => x.Value);
+
+            var resourceBody = ProcessValue(filteredResource);
+
+            var identifier = type;
+            if ((resourceBody as ObjectSyntax)?.TryGetPropertyByNameRecursive("metadata", "name") is {} nameProperty &&
+                (nameProperty.Value as StringSyntax)?.TryGetLiteralValue() is {} nameString)
+            {
+                identifier = $"{type}_{nameString}";
+            }
+
+            var identifierBuilder = new StringBuilder();
+            var capitalizeNext = false;
+            for (var i = 0; i < identifier.Length; i++)
+            {
+                var c = identifier[i];
+                var isValidChar =
+                    (c >= 'a' && c <= 'z') ||
+                    (c >= 'A' && c <= 'Z') ||
+                    (i > 0 && c >= '0' && c <= '9') ||
+                    (i > 0 && c == '_');
+
+                if (capitalizeNext && (c >= 'a' && c <= 'z'))
+                {
+                    // 32 equals 'a' - 'A'
+                    c -= (char)32;
+                }
+
+                if (isValidChar)
+                {
+                    identifierBuilder.Append(c);
+                }
+                capitalizeNext = !isValidChar;
+            }
+
+            var sanitizedIdentifier = identifierBuilder.ToString();
+
+            return new ResourceDeclarationSyntax(
+                Enumerable.Empty<SyntaxBase>(),
+                SyntaxFactory.CreateToken(Core.Parsing.TokenType.Identifier, "resource"),
+                SyntaxFactory.CreateIdentifier(sanitizedIdentifier),
+                SyntaxFactory.CreateStringLiteral($"{type}@{apiVersion}"),
+                null,
+                SyntaxFactory.AssignmentToken,
+                resourceBody);
+        }
+
+        private static SyntaxBase ProcessValue(object value)
+        {
+            switch (value)
+            {
+                case Dictionary<object, object> dictValue:
+                    var objectProperties = new List<ObjectPropertySyntax>();
+                    foreach (var kvp in dictValue)
+                    {
+                        if (kvp.Key is not string keyName)
+                        {
+                            throw new NotImplementedException($"Unsupported object key {kvp.Key.GetType()}");
+                        }
+
+                        var objectProperty = SyntaxFactory.CreateObjectProperty(keyName, ProcessValue(kvp.Value));
+                        objectProperties.Add(objectProperty);
+                    }
+                    return SyntaxFactory.CreateObject(objectProperties);
+                case List<object> listValue:
+                    var arrayProperties = new List<SyntaxBase>();
+                    foreach (var prop in listValue)
+                    {
+                        arrayProperties.Add(ProcessValue(prop));
+                    }
+                    return SyntaxFactory.CreateArray(arrayProperties);
+                case string stringValue:
+                    return SyntaxFactory.CreateStringLiteral(stringValue);
+                case bool boolValue:
+                    return SyntaxFactory.CreateBooleanLiteral(boolValue);
+                case int intValue:
+                    return SyntaxFactory.CreatePositiveOrNegativeInteger(intValue);
+                default:
+                    throw new NotImplementedException($"Unsupported type {value.GetType()}");
+            }
+        }
+    }
+}

--- a/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
+++ b/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
@@ -33,7 +33,6 @@ using OmniSharp.Extensions.LanguageServer.Protocol;
 using Bicep.Core.Navigation;
 using Bicep.Core.Rewriters;
 using System.Text.RegularExpressions;
-using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Telemetry;
 using System.Diagnostics;
@@ -52,7 +51,7 @@ namespace Bicep.LanguageServer.Handlers
         private readonly ICompilationManager compilationManager;
         private readonly IAzResourceProvider azResourceProvider;
         private readonly IAzResourceTypeLoader azResourceTypeLoader;
-        private readonly ITelemetryProvider telemetryProvider;
+        private readonly TelemetryAndErrorHandlingHelper<Unit> helper;
 
         public InsertResourceHandler(ILanguageServerFacade server, ICompilationManager compilationManager, IAzResourceProvider azResourceProvider, IAzResourceTypeLoader azResourceTypeLoader, ITelemetryProvider telemetryProvider)
         {
@@ -60,102 +59,97 @@ namespace Bicep.LanguageServer.Handlers
             this.compilationManager = compilationManager;
             this.azResourceProvider = azResourceProvider;
             this.azResourceTypeLoader = azResourceTypeLoader;
-            this.telemetryProvider = telemetryProvider;
+            this.helper = new TelemetryAndErrorHandlingHelper<Unit>(server.Window, telemetryProvider, Unit.Value);
         }
 
-        public async Task<Unit> Handle(InsertResourceParams request, CancellationToken cancellationToken)
-        {
-            var context = compilationManager.GetCompilation(request.TextDocument.Uri);
-            if (context is null)
-            {
-                return Unit.Value;
-            }
-
-            if (TryParseResourceId(request.ResourceId) is not { } resourceId)
-            {
-                server.Window.ShowError($"Failed to parse supplied resourceId \"{request.ResourceId}\".");
-                telemetryProvider.PostEvent(BicepTelemetryEvent.InsertResourceFailure("ParseResourceIdFailed"));
-                return Unit.Value;
-            }
-
-            var matchedType = azResourceTypeLoader.GetAvailableTypes()
-                .Where(x => StringComparer.OrdinalIgnoreCase.Equals(resourceId.FullyQualifiedType, x.FormatType()))
-                .OrderByDescending(x => x.ApiVersion, ApiVersionComparer.Instance)
-                .FirstOrDefault();
-
-            if (matchedType is null || matchedType.ApiVersion is null)
-            {
-                server.Window.ShowError($"Failed to find a Bicep type definition for resource of type \"{resourceId.FullyQualifiedType}\".");
-                telemetryProvider.PostEvent(BicepTelemetryEvent.InsertResourceFailure($"MissingType({resourceId.FullyQualifiedType})"));
-                return Unit.Value;
-            }
-
-            JsonElement? resource = null;
-            try
-            {
-                // First attempt a direct GET on the resource using the Bicep type API version.
-                resource = await azResourceProvider.GetGenericResource(
-                    context.Compilation.Configuration,
-                    resourceId,
-                    apiVersion: matchedType.ApiVersion,
-                    cancellationToken);
-            }
-            catch (Exception exception)
-            {
-                // We want to keep going here - we'll try again without the API version.
-                Trace.WriteLine($"Failed to fetch resource '{resourceId}' with API version {matchedType.ApiVersion}: {exception}");
-            }
-
-            try
-            {
-                // If the direct GET fails, attempt to look it up without the API version.
-                // This will use the latest version from the /providers/<provider> API.
-                if (resource is null)
+        public Task<Unit> Handle(InsertResourceParams request, CancellationToken cancellationToken)
+            => helper.ExecuteWithTelemetryAndErrorHandling(async () => {
+                var context = compilationManager.GetCompilation(request.TextDocument.Uri);
+                if (context is null)
                 {
+                    return (Unit.Value, null);
+                }
+
+                if (TryParseResourceId(request.ResourceId) is not { } resourceId)
+                {
+                    throw new TelemetryAndErrorHandlingException(
+                        $"Failed to parse supplied resourceId \"{request.ResourceId}\".",
+                        BicepTelemetryEvent.InsertResourceFailure("ParseResourceIdFailed"));
+                }
+
+                var matchedType = azResourceTypeLoader.GetAvailableTypes()
+                    .Where(x => StringComparer.OrdinalIgnoreCase.Equals(resourceId.FullyQualifiedType, x.FormatType()))
+                    .OrderByDescending(x => x.ApiVersion, ApiVersionComparer.Instance)
+                    .FirstOrDefault();
+
+                if (matchedType is null || matchedType.ApiVersion is null)
+                {
+                    throw new TelemetryAndErrorHandlingException(
+                        $"Failed to find a Bicep type definition for resource of type \"{resourceId.FullyQualifiedType}\".",
+                        BicepTelemetryEvent.InsertResourceFailure($"MissingType({resourceId.FullyQualifiedType})"));
+                }
+
+                JsonElement? resource = null;
+                try
+                {
+                    // First attempt a direct GET on the resource using the Bicep type API version.
                     resource = await azResourceProvider.GetGenericResource(
                         context.Compilation.Configuration,
                         resourceId,
-                        apiVersion: null,
+                        apiVersion: matchedType.ApiVersion,
                         cancellationToken);
                 }
-            }
-            catch (Exception exception)
-            {
-                Trace.WriteLine($"Failed to fetch resource '{resourceId}' without API version: {exception}");
-
-                server.Window.ShowError($"Caught exception fetching resource: {exception.Message}.");
-                telemetryProvider.PostEvent(BicepTelemetryEvent.InsertResourceFailure($"FetchResourceFailure"));
-            }
-
-            if (!resource.HasValue)
-            {
-                return Unit.Value;
-            }
-
-            var resourceDeclaration = CreateResourceSyntax(resource.Value, resourceId, matchedType);
-            var insertContext = GetInsertContext(context, request.Position);
-            var replacement = GenerateCodeReplacement(context.Compilation, resourceDeclaration, insertContext);
-
-            await server.Workspace.ApplyWorkspaceEdit(new ApplyWorkspaceEditParams
-            {
-                Edit = new()
+                catch (Exception exception)
                 {
-                    Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                    // We want to keep going here - we'll try again without the API version.
+                    Trace.WriteLine($"Failed to fetch resource '{resourceId}' with API version {matchedType.ApiVersion}: {exception}");
+                }
+
+                try
+                {
+                    // If the direct GET fails, attempt to look it up without the API version.
+                    // This will use the latest version from the /providers/<provider> API.
+                    if (resource is null)
                     {
-                        [request.TextDocument.Uri] = new[] {
-                            new TextEdit
-                            {
-                                Range = replacement.ToRange(context.LineStarts),
-                                NewText = replacement.Text,
+                        resource = await azResourceProvider.GetGenericResource(
+                            context.Compilation.Configuration,
+                            resourceId,
+                            apiVersion: null,
+                            cancellationToken);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Trace.WriteLine($"Failed to fetch resource '{resourceId}' without API version: {exception}");
+
+                    throw new TelemetryAndErrorHandlingException(
+                        $"Caught exception fetching resource: {exception.Message}.",
+                        BicepTelemetryEvent.InsertResourceFailure($"FetchResourceFailure"));
+                }
+
+                var resourceDeclaration = CreateResourceSyntax(resource.Value, resourceId, matchedType);
+                var insertContext = GetInsertContext(context, request.Position);
+                var replacement = GenerateCodeReplacement(context.Compilation, resourceDeclaration, insertContext);
+
+                await server.Workspace.ApplyWorkspaceEdit(new ApplyWorkspaceEditParams
+                {
+                    Edit = new()
+                    {
+                        Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                        {
+                            [request.TextDocument.Uri] = new[] {
+                                new TextEdit
+                                {
+                                    Range = replacement.ToRange(context.LineStarts),
+                                    NewText = replacement.Text,
+                                },
                             },
                         },
                     },
-                },
-            }, cancellationToken);
+                }, cancellationToken);
 
-            telemetryProvider.PostEvent(BicepTelemetryEvent.InsertResourceSuccess(resourceId.FullyQualifiedType, matchedType.ApiVersion));
-            return Unit.Value;
-        }
+                return (Unit.Value, BicepTelemetryEvent.InsertResourceSuccess(resourceId.FullyQualifiedType, matchedType.ApiVersion));
+            });
 
         private record InsertContext(
             bool StartWithNewline,

--- a/src/Bicep.LangServer/Handlers/TelemetryAndErrorHandlingHelper.cs
+++ b/src/Bicep.LangServer/Handlers/TelemetryAndErrorHandlingHelper.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Threading.Tasks;
+using Bicep.LanguageServer.Telemetry;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+
+namespace Bicep.LanguageServer.Handlers
+{
+    public class TelemetryAndErrorHandlingException : Exception
+    {
+        public BicepTelemetryEvent TelemetryEvent { get; }
+
+        public TelemetryAndErrorHandlingException(string message, BicepTelemetryEvent telemetryEvent)
+            : base(message)
+        {
+            TelemetryEvent = telemetryEvent;
+        }
+    }
+
+    public class TelemetryAndErrorHandlingHelper<T>
+    {
+        private readonly IWindowLanguageServer window;
+        private readonly ITelemetryProvider telemetryProvider;
+        private readonly T errorResponse;
+
+        public TelemetryAndErrorHandlingHelper(
+            IWindowLanguageServer window,
+            ITelemetryProvider telemetryProvider,
+            T errorResponse)
+        {
+            this.window = window;
+            this.telemetryProvider = telemetryProvider;
+            this.errorResponse = errorResponse;
+        }
+
+        public async Task<T> ExecuteWithTelemetryAndErrorHandling(Func<Task<(T result, BicepTelemetryEvent? successTelemetry)>> executeFunc)
+        {
+            try
+            {
+                var (result, successTelemetry) = await executeFunc();
+                if (successTelemetry is not null)
+                {
+                    telemetryProvider.PostEvent(successTelemetry);
+                }
+
+                return result;
+            }
+            catch (TelemetryAndErrorHandlingException ex)
+            {
+                window.ShowError(ex.Message);
+                telemetryProvider.PostEvent(ex.TelemetryEvent);
+
+                return errorResponse;
+            }
+            catch (Exception ex)
+            {
+                telemetryProvider.PostEvent(BicepTelemetryEvent.UnhandledException(ex));
+                throw;
+            }
+        }
+    }
+}

--- a/src/Bicep.LangServer/LangServerConstants.cs
+++ b/src/Bicep.LangServer/LangServerConstants.cs
@@ -13,6 +13,7 @@ namespace Bicep.LanguageServer
         public const string GetDeploymentParametersCommand = "getDeploymentParameters";
         public const string GetDeploymentScopeCommand = "getDeploymentScope";
         public const string ForceModulesRestoreCommand = "forceModulesRestore";
+        public const string ImportKubernetesManifestCommand = "importKubernetesManifest";
         public const string CreateConfigFile = "createConfigFile";
         // An internal-only command used in code actions to edit a particular rule in the bicepconfig.json file
         public const string EditLinterRuleCommandName = "bicep.EditLinterRule";

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -81,6 +81,7 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepDeploymentWaitForCompletionCommandHandler>(new JsonRpcHandlerOptions() { RequestProcessType = RequestProcessType.Parallel })
                     .WithHandler<BicepDeploymentScopeRequestHandler>()
                     .WithHandler<BicepDeploymentParametersHandler>()
+                    .WithHandler<ImportKubernetesManifestHandler>()
                     .WithHandler<BicepForceModulesRestoreCommandHandler>()
                     .WithHandler<BicepRegistryCacheRequestHandler>()
                     .WithHandler<InsertResourceHandler>()

--- a/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
+++ b/src/Bicep.LangServer/Telemetry/BicepTelemetryEvent.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -101,6 +102,27 @@ namespace Bicep.LanguageServer.Telemetry
                 }
             );
 
+        public static BicepTelemetryEvent ImportKubernetesManifestSuccess()
+            => new BicepTelemetryEvent
+            (
+                eventName:  "ImportKubernetesManifest/success",
+                properties: new()
+                {
+                    // Properties has to contain some data
+                    ["success"] = ToTrueFalse(true),
+                }
+            );
+
+        public static BicepTelemetryEvent ImportKubernetesManifestFailure(string failureType)
+            => new BicepTelemetryEvent
+            (
+                eventName:  "ImportKubernetesManifest/failure",
+                properties: new()
+                {
+                    ["failureType"] = failureType,
+                }
+            );
+
         public static BicepTelemetryEvent CreateDisableNextLineDiagnostics(string code)
             => new BicepTelemetryEvent
             (
@@ -180,6 +202,16 @@ namespace Bicep.LanguageServer.Telemetry
                 {
                     ["deployId"] = deployId,
                     ["result"] = isSuccess ? Result.Succeeded : Result.Failed
+                }
+            );
+
+        public static BicepTelemetryEvent UnhandledException(Exception exception)
+            => new BicepTelemetryEvent
+            (
+                eventName: TelemetryConstants.EventNames.UnhandledException,
+                properties: new()
+                {
+                    ["exception"] = exception.ToString(),
                 }
             );
     }

--- a/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
+++ b/src/Bicep.LangServer/Telemetry/TelemetryConstants.cs
@@ -28,6 +28,7 @@ namespace Bicep.LanguageServer.Telemetry
             public const string LinterCoreEnabledStateChange = "linter/coreenabledstatechange";
             public const string LinterRuleStateChange = "linter/rulestatechange";
             public const string LinterRuleStateOnBicepFileOpen = "linter/rulestateonopen";
+            public const string UnhandledException = "unhandledException";
         }
     }
 }

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -42,6 +42,12 @@
           "OmniSharp.Extensions.LanguageServer.Shared": "0.19.5"
         }
       },
+      "SharpYaml": {
+        "type": "Direct",
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "KgdpJtAHf119JmlXU2P+HTo5vht8dKTrb8bP1vQeEV2jnkQNuVGg+tSea7T/eZe5xaStRZaRXyGQobUMJgb44w=="
+      },
       "Azure.Bicep.Types": {
         "type": "Transitive",
         "resolved": "0.2.34",

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -42,6 +42,7 @@
     "onCommand:bicep.deploy",
     "onCommand:bicep.forceModulesRestore",
     "onCommand:bicep.insertResource",
+    "onCommand:bicep.importKubernetesManifest",
     "onCommand:bicep.showSource",
     "onCommand:bicep.showVisualizer",
     "onCommand:bicep.showVisualizerToSide",
@@ -83,6 +84,11 @@
           "description": "Prepend each line displayed in the Bicep Operations output channel with a timestamp.",
           "default": true,
           "$comment": "This is used by vscode-azuretools package and has to be in the following format: <extensionPrefix>.enableOutputTimestamps"
+        },
+        "bicep.importsEnabledExperimental": {
+          "type": "boolean",
+          "description": "Enable Bicep import statements (experimental!)",
+          "default": false
         }
       }
     },
@@ -173,6 +179,12 @@
       {
         "command": "bicep.insertResource",
         "title": "Insert Resource...",
+        "category": "Bicep",
+        "icon": "$(cloud-download)"
+      },
+      {
+        "command": "bicep.importKubernetesManifest",
+        "title": "Import Kubernetes Manifest",
         "category": "Bicep",
         "icon": "$(cloud-download)"
       },
@@ -382,6 +394,10 @@
         {
           "command": "bicep.showVisualizerToSide",
           "group": "0_bicep"
+        },
+        {
+          "command": "bicep.importKubernetesManifest",
+          "when": "config.bicep.importsEnabledExperimental"
         },
         {
           "command": "bicep.showSource",

--- a/src/vscode-bicep/src/commands/importKubernetesManifest.ts
+++ b/src/vscode-bicep/src/commands/importKubernetesManifest.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import vscode, { ViewColumn } from "vscode";
+import { importKubernetesManifestRequestType } from "../language/protocol";
+import { Command } from "./types";
+import { IActionContext, parseError } from "@microsoft/vscode-azext-utils";
+import { LanguageClient } from "vscode-languageclient/node";
+
+export class ImportKubernetesManifestCommand implements Command {
+  public readonly id = "bicep.importKubernetesManifest";
+  public constructor(private readonly client: LanguageClient) {}
+
+  public async execute(
+    context: IActionContext,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    documentUri?: vscode.Uri | undefined,
+  ): Promise<void> {
+    const manifestPath = await context.ui.showOpenDialog({
+      canSelectMany: false,
+      openLabel: "Select Kubernetes Manifest File",
+      filters: { "YAML files": ["yml", "yaml"] },
+    });
+
+    try {
+      const response = await this.client.sendRequest(
+        importKubernetesManifestRequestType,
+        {
+          manifestFilePath: manifestPath[0].fsPath,
+        }
+      );
+
+      const document = await vscode.workspace.openTextDocument(
+        response.bicepFilePath
+      );
+
+      await vscode.window.showTextDocument(document, ViewColumn.Active);
+    } catch (err) {
+      this.client.error("Build failed", parseError(err).message, true);
+    }
+  }
+}

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -33,6 +33,7 @@ import {
   resetLogger,
 } from "./utils";
 import { CreateBicepConfigurationFile } from "./commands/createConfigurationFile";
+import { ImportKubernetesManifestCommand } from "./commands/importKubernetesManifest";
 
 class BicepExtension extends Disposable {
   private constructor(public readonly extensionUri: vscode.Uri) {
@@ -107,7 +108,8 @@ export async function activate(
         new ShowSourceCommand(viewManager),
         new WalkthroughCopyToClipboardCommand(),
         new WalkthroughCreateBicepFileCommand(),
-        new WalkthroughOpenBicepFileCommand()
+        new WalkthroughOpenBicepFileCommand(),
+        new ImportKubernetesManifestCommand(languageClient)
       );
   });
 }

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -48,6 +48,10 @@ function getServerStartupOptions(
     // pause language server startup until a dotnet debugger has been attached
     args.push(`--wait-for-debugger`);
   }
+  const envVars = {
+    ...process.env,
+    ...getFeatureEnvVars(),
+  };
 
   switch (transportKind) {
     case TransportKind.stdio: {
@@ -55,7 +59,7 @@ function getServerStartupOptions(
         command: dotnetCommandPath,
         args: [languageServerPath, ...args],
         options: {
-          env: process.env,
+          env: envVars,
         },
       };
       return {
@@ -70,7 +74,7 @@ function getServerStartupOptions(
         transport: transportKind,
         args,
         options: {
-          env: process.env,
+          env: envVars,
         },
       };
       return {
@@ -263,5 +267,15 @@ function configureTelemetry(client: lsp.LanguageClient) {
       );
       return defaultErrorHandler.closed();
     },
+  };
+}
+
+function getFeatureEnvVars() {
+  const importsEnabledExperimental = vscode.workspace
+    .getConfiguration("bicep")
+    .get<boolean>("importsEnabledExperimental");
+
+  return {
+    BICEP_IMPORTS_ENABLED_EXPERIMENTAL: importsEnabledExperimental,
   };
 }

--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -149,6 +149,22 @@ export const insertResourceRequestType = new ProtocolNotificationType<
   void
 >("textDocument/insertResource");
 
+export interface ImportKubernetesManifestRequest {
+  manifestFilePath: string;
+}
+
+export interface ImportKubernetesManifestResponse {
+  bicepFilePath: string;
+}
+
+export const importKubernetesManifestRequestType = new ProtocolRequestType<
+  ImportKubernetesManifestRequest,
+  ImportKubernetesManifestResponse,
+  never,
+  void,
+  void
+>("bicep/importKubernetesManifest");
+
 export interface CreateBicepConfigParams {
   destinationPath: string;
 }


### PR DESCRIPTION
* Add setting `importsEnabledExperimental` to VSIX package to enable/disable extensibility.
* Add action `importKubernetesManifest` which takes a path to a kubernetes manifest, and generates a bicep file from it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7812)