### PR TITLE
Extensibility - fix namespace completions, make kubernetes a singleton namespace

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Extensibility/AadNamespaceType.cs
+++ b/src/Bicep.Core.IntegrationTests/Extensibility/AadNamespaceType.cs
@@ -19,7 +19,7 @@ namespace Bicep.Core.IntegrationTests.Extensibility
         }.ToImmutableHashSet();
 
         public static NamespaceSettings Settings { get; } = new(
-            IsSingleton: false,
+            IsSingleton: true,
             BicepProviderName: BuiltInName,
             ConfigurationType: null,
             ArmTemplateProviderName: "AAD",

--- a/src/Bicep.Core.IntegrationTests/Extensibility/TestExtensibilityNamespaceProvider.cs
+++ b/src/Bicep.Core.IntegrationTests/Extensibility/TestExtensibilityNamespaceProvider.cs
@@ -4,19 +4,26 @@ using Bicep.Core.TypeSystem;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Features;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Bicep.Core.IntegrationTests.Extensibility
 {
-    public class ExtensibilityNamespaceProvider : INamespaceProvider
+    public class TestExtensibilityNamespaceProvider : INamespaceProvider
     {
         private readonly INamespaceProvider defaultNamespaceProvider;
 
-        public ExtensibilityNamespaceProvider(IAzResourceTypeLoader azResourceTypeLoader, IFeatureProvider featureProvider)
+        public TestExtensibilityNamespaceProvider(IAzResourceTypeLoader azResourceTypeLoader, IFeatureProvider featureProvider)
         {
             defaultNamespaceProvider = new DefaultNamespaceProvider(azResourceTypeLoader, featureProvider);
         }
 
         public bool AllowImportStatements => defaultNamespaceProvider.AllowImportStatements;
+
+        public IEnumerable<string> AvailableNamespaces => defaultNamespaceProvider.AvailableNamespaces.Concat(new [] {
+            StorageNamespaceType.BuiltInName,
+            AadNamespaceType.BuiltInName,
+        });
 
         public NamespaceType? TryGetNamespace(string providerName, string aliasName, ResourceScope resourceScope)
         {

--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -22,7 +22,7 @@ namespace Bicep.Core.IntegrationTests
         {
             var features = BicepTestConstants.CreateFeaturesProvider(TestContext, importsEnabled: true);
             var resourceTypeLoader = BicepTestConstants.AzResourceTypeLoader;
-            var namespaceProvider = new ExtensibilityNamespaceProvider(resourceTypeLoader, features);
+            var namespaceProvider = new TestExtensibilityNamespaceProvider(resourceTypeLoader, features);
 
             return new(
                 AzResourceTypeLoader: resourceTypeLoader,
@@ -464,7 +464,7 @@ Hello from Bicep!"));
             }
           },
           ""variables"": {
-            ""$fxv#0"": ""\nHello from Bicep!""            
+            ""$fxv#0"": ""\nHello from Bicep!""
           },
           ""imports"": {
             ""stg"": {

--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -18,7 +18,7 @@ namespace Bicep.Core.IntegrationTests
         [NotNull]
         public TestContext? TestContext { get; set; }
 
-        private CompilationHelper.CompilationHelperContext GetCompilationContext()
+        private CompilationHelper.CompilationHelperContext GetCompilationContextWithTestExtensibilityProvider()
         {
             var features = BicepTestConstants.CreateFeaturesProvider(TestContext, importsEnabled: true);
             var resourceTypeLoader = BicepTestConstants.AzResourceTypeLoader;
@@ -30,10 +30,13 @@ namespace Bicep.Core.IntegrationTests
                 NamespaceProvider: namespaceProvider);
         }
 
+        private CompilationHelper.CompilationHelperContext GetCompilationContext() =>
+            new(Features: BicepTestConstants.CreateFeaturesProvider(TestContext, importsEnabled: true));
+
         [TestMethod]
         public void Storage_import_bad_config_is_blocked()
         {
-            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import storage as stg {
   madeUpProperty: 'asdf'
 }
@@ -47,7 +50,7 @@ import storage as stg {
         [TestMethod]
         public void Storage_import_can_be_duplicated()
         {
-            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import storage as stg1 {
   connectionString: 'connectionString1'
 }
@@ -62,7 +65,7 @@ import storage as stg2 {
         [TestMethod]
         public void Storage_import_basic_test()
         {
-            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import storage as stg {
   connectionString: 'asdf'
 }
@@ -83,7 +86,7 @@ resource blob 'blob' = {
         [TestMethod]
         public void Storage_import_basic_test_loops_and_referencing()
         {
-            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import storage as stg {
   connectionString: 'asdf'
 }
@@ -123,7 +126,7 @@ output base64Content string = blobs[3]['base64Content']
         [TestMethod]
         public void Aad_import_basic_test_loops_and_referencing()
         {
-            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import aad as aad
 param numApps int
 
@@ -153,7 +156,7 @@ output myAppsLoopId2 string = myAppsLoop[3]['appId']
         public void Aad_import_existing_requires_uniqueName()
         {
             // we've accidentally used 'name' even though this resource type doesn't support it
-            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import aad as aad
 
 resource myApp 'application' existing = {
@@ -169,7 +172,7 @@ resource myApp 'application' existing = {
             });
 
             // oops! let's change it to 'uniqueName'
-            result = CompilationHelper.Compile(GetCompilationContext(), @"
+            result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import aad as aad
 
 resource myApp 'application' existing = {
@@ -190,7 +193,7 @@ resource myApp 'application' existing = {
 import kubernetes as kubernetes {
   namespace: 'default'
   kubeConfig: ''
-}
+}7
 resource service 'core/Service@v1' existing = {
   metadata: {
     name: 'existing-service'
@@ -210,6 +213,28 @@ resource service 'core/Service@v1' existing = {
                 ("no-unused-existing-resources", DiagnosticLevel.Warning, "Existing resource \"service\" is declared but never used."),
                 ("BCP073", DiagnosticLevel.Warning, "The property \"labels\" is read-only. Expressions cannot be assigned to read-only properties. If this is an inaccuracy in the documentation, please report it to the Bicep Team."),
                 ("BCP073", DiagnosticLevel.Warning, "The property \"annotations\" is read-only. Expressions cannot be assigned to read-only properties. If this is an inaccuracy in the documentation, please report it to the Bicep Team."),
+            });
+        }
+
+        [TestMethod]
+        public void Kubernetes_competing_imports_are_blocked()
+        {
+            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+import kubernetes as k8s1 {
+  namespace: 'default'
+  kubeConfig: ''
+}
+
+import kubernetes as k8s2 {
+  namespace: 'default'
+  kubeConfig: ''
+}
+");
+
+            result.Should().NotGenerateATemplate();
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP207", DiagnosticLevel.Error, "Namespace \"kubernetes\" is imported multiple times. Remove the duplicates."),
+                ("BCP207", DiagnosticLevel.Error, "Namespace \"kubernetes\" is imported multiple times. Remove the duplicates."),
             });
         }
 
@@ -291,7 +316,7 @@ resource secret 'core/Secret@v1' = {
         [TestMethod]
         public void Storage_import_basic_test_with_qualified_type()
         {
-            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import storage as stg {
   connectionString: 'asdf'
 }
@@ -312,7 +337,7 @@ resource blob 'stg:blob' = {
         [TestMethod]
         public void Invalid_namespace_qualifier_returns_error()
         {
-            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import storage as stg {
   connectionString: 'asdf'
 }
@@ -337,7 +362,7 @@ resource blob 'bar:blob' = {
         [TestMethod]
         public void Child_resource_with_parent_namespace_mismatch_returns_error()
         {
-            var result = CompilationHelper.Compile(GetCompilationContext(), @"
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(), @"
 import storage as stg {
   connectionString: 'asdf'
 }
@@ -360,7 +385,7 @@ resource parent 'az:Microsoft.Storage/storageAccounts@2020-01-01' existing = {
         [TestMethod]
         public void Storage_import_end_to_end_test()
         {
-            var result = CompilationHelper.Compile(GetCompilationContext(),
+            var result = CompilationHelper.Compile(GetCompilationContextWithTestExtensibilityProvider(),
                 ("main.bicep", @"
 param accountName string
 

--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -193,7 +193,7 @@ resource myApp 'application' existing = {
 import kubernetes as kubernetes {
   namespace: 'default'
   kubeConfig: ''
-}7
+}
 resource service 'core/Service@v1' existing = {
   metadata: {
     name: 'existing-service'

--- a/src/Bicep.Core.IntegrationTests/ImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ImportTests.cs
@@ -31,6 +31,8 @@ namespace Bicep.Core.IntegrationTests
 
             public bool AllowImportStatements => true;
 
+            public IEnumerable<string> AvailableNamespaces => builderDict.Keys.Concat(new [] { SystemNamespaceType.BuiltInName });
+
             public NamespaceType? TryGetNamespace(string providerName, string aliasName, ResourceScope resourceScope)
             {
                 switch (providerName)

--- a/src/Bicep.Core.IntegrationTests/OutputsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/OutputsTests.cs
@@ -29,7 +29,7 @@ namespace Bicep.Core.IntegrationTests
         {
             var features = BicepTestConstants.CreateFeaturesProvider(TestContext, importsEnabled: true, resourceTypedParamsAndOutputsEnabled: true);
             var resourceTypeLoader = BicepTestConstants.AzResourceTypeLoader;
-            var namespaceProvider = new ExtensibilityNamespaceProvider(resourceTypeLoader, features);
+            var namespaceProvider = new TestExtensibilityNamespaceProvider(resourceTypeLoader, features);
 
             return new(
                 AzResourceTypeLoader: resourceTypeLoader,

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -30,7 +30,7 @@ namespace Bicep.Core.IntegrationTests
         {
             var features = BicepTestConstants.CreateFeaturesProvider(TestContext, importsEnabled: true, resourceTypedParamsAndOutputsEnabled: true);
             var resourceTypeLoader = BicepTestConstants.AzResourceTypeLoader;
-            var namespaceProvider = new ExtensibilityNamespaceProvider(resourceTypeLoader, features);
+            var namespaceProvider = new TestExtensibilityNamespaceProvider(resourceTypeLoader, features);
 
             return new(
                 AzResourceTypeLoader: resourceTypeLoader,

--- a/src/Bicep.Core/Semantics/Namespaces/DefaultNamespaceProvider.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/DefaultNamespaceProvider.cs
@@ -1,39 +1,40 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bicep.Core.Extensions;
 using Bicep.Core.Features;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 
-namespace Bicep.Core.Semantics.Namespaces
+namespace Bicep.Core.Semantics.Namespaces;
+
+public class DefaultNamespaceProvider : INamespaceProvider
 {
-    public class DefaultNamespaceProvider : INamespaceProvider
+    private delegate NamespaceType GetNamespaceDelegate(string aliasName, ResourceScope resourceScope);
+
+    private readonly IFeatureProvider featureProvider;
+    private readonly ImmutableDictionary<string, GetNamespaceDelegate> providerLookup;
+
+    public DefaultNamespaceProvider(IAzResourceTypeLoader azResourceTypeLoader, IFeatureProvider featureProvider)
     {
-        private readonly AzResourceTypeProvider azResourceTypeProvider;
-        private readonly IFeatureProvider featureProvider;
-
-        public DefaultNamespaceProvider(IAzResourceTypeLoader azResourceTypeLoader, IFeatureProvider featureProvider)
+        this.featureProvider = featureProvider;
+        var azResourceTypeProvider = new AzResourceTypeProvider(azResourceTypeLoader);
+        this.providerLookup = new Dictionary<string, GetNamespaceDelegate>
         {
-            this.azResourceTypeProvider = new AzResourceTypeProvider(azResourceTypeLoader);
-            this.featureProvider = featureProvider;
-        }
-
-        public NamespaceType? TryGetNamespace(string providerName, string aliasName, ResourceScope resourceScope)
-        {
-            switch (providerName)
-            {
-                case SystemNamespaceType.BuiltInName:
-                    return SystemNamespaceType.Create(aliasName, featureProvider);
-                case AzNamespaceType.BuiltInName:
-                    return AzNamespaceType.Create(aliasName, resourceScope, azResourceTypeProvider);
-                case K8sNamespaceType.BuiltInName:
-                    return K8sNamespaceType.Create(aliasName);
-            }
-
-            return null;
-        }
-
-        public bool AllowImportStatements
-            => featureProvider.ImportsEnabled;
+            [SystemNamespaceType.BuiltInName] = (alias, scope) => SystemNamespaceType.Create(alias, featureProvider),
+            [AzNamespaceType.BuiltInName] = (alias, scope) => AzNamespaceType.Create(alias, scope, azResourceTypeProvider),
+            [K8sNamespaceType.BuiltInName] = (alias, scope) => K8sNamespaceType.Create(alias),
+        }.ToImmutableDictionary();
     }
+
+    public NamespaceType? TryGetNamespace(string providerName, string aliasName, ResourceScope resourceScope)
+        => providerLookup.TryGetValue(providerName)?.Invoke(aliasName, resourceScope);
+
+    public IEnumerable<string> AvailableNamespaces
+        => providerLookup.Keys;
+
+    public bool AllowImportStatements
+        => featureProvider.ImportsEnabled;
 }

--- a/src/Bicep.Core/Semantics/Namespaces/INamespaceProvider.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/INamespaceProvider.cs
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Bicep.Core.TypeSystem;
 
-namespace Bicep.Core.Semantics.Namespaces
-{
-    public interface INamespaceProvider
-    {
-        NamespaceType? TryGetNamespace(string providerName, string aliasName, ResourceScope resourceScope);
+namespace Bicep.Core.Semantics.Namespaces;
 
-        bool AllowImportStatements { get; }
-    }
+public interface INamespaceProvider
+{
+    NamespaceType? TryGetNamespace(string providerName, string aliasName, ResourceScope resourceScope);
+
+    IEnumerable<string> AvailableNamespaces { get; }
+
+    bool AllowImportStatements { get; }
 }

--- a/src/Bicep.Core/Semantics/Namespaces/K8sNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/K8sNamespaceType.cs
@@ -13,7 +13,7 @@ namespace Bicep.Core.Semantics.Namespaces
         private static readonly IResourceTypeProvider TypeProvider = new K8sResourceTypeProvider(new K8sResourceTypeLoader());
 
         public static NamespaceSettings Settings { get; } = new(
-            IsSingleton: false,
+            IsSingleton: true,
             BicepProviderName: BuiltInName,
             ConfigurationType: GetConfigurationType(),
             ArmTemplateProviderName: "Kubernetes",

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -1174,8 +1174,8 @@ import a|
                 c => c!.Select(x => x.Label).Should().Equal("as"),
                 c => c!.Select(x => x.Label).Should().Equal("as"),
                 c => c!.Select(x => x.Label).Should().BeEmpty(),
-                c => c!.Select(x => x.Label).Should().Equal("az", "sys"),
-                c => c!.Select(x => x.Label).Should().Equal("az", "sys")
+                c => c!.Select(x => x.Label).Should().Equal("az", "kubernetes", "sys"),
+                c => c!.Select(x => x.Label).Should().Equal("az", "kubernetes", "sys")
             ));
 
             await RunCompletionScenarioTest(this.TestContext, ServerWithBuiltInTypesImportsDisabled, fileWithCursors, completions => completions.Should().SatisfyRespectively(

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -17,6 +17,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Parsing;
 using Bicep.Core.Resources;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
 using Bicep.Core.Text;
 using Bicep.Core.TypeSystem;
@@ -44,13 +45,15 @@ namespace Bicep.LanguageServer.Completions
         private readonly ISnippetsProvider SnippetsProvider;
         private readonly ITelemetryProvider TelemetryProvider;
         private readonly IFeatureProvider featureProvider;
+        private readonly INamespaceProvider namespaceProvider;
 
-        public BicepCompletionProvider(IFileResolver fileResolver, ISnippetsProvider snippetsProvider, ITelemetryProvider telemetryProvider, IFeatureProvider featureProvider)
+        public BicepCompletionProvider(IFileResolver fileResolver, ISnippetsProvider snippetsProvider, ITelemetryProvider telemetryProvider, IFeatureProvider featureProvider, INamespaceProvider namespaceProvider)
         {
             this.FileResolver = fileResolver;
             this.SnippetsProvider = snippetsProvider;
             this.TelemetryProvider = telemetryProvider;
             this.featureProvider = featureProvider;
+            this.namespaceProvider = namespaceProvider;
         }
 
         public IEnumerable<CompletionItem> GetFilteredCompletions(Compilation compilation, BicepCompletionContext context)
@@ -897,7 +900,7 @@ namespace Bicep.LanguageServer.Completions
             }
 
             var argType = functionSymbol.GetDeclaredArgumentType(functionArgument.ArgumentIndex);
-            
+
             return GetValueCompletionsForType(model, context, argType, loopsAllowed: false);
         }
 
@@ -935,7 +938,7 @@ namespace Bicep.LanguageServer.Completions
 
             return fileItems.Concat(dirItems);
         }
-        
+
         private IEnumerable<CompletionItem> GetValueCompletionsForType(SemanticModel model, BicepCompletionContext context, TypeSymbol? type, bool loopsAllowed)
         {
             var replacementRange = context.ReplacementRange;
@@ -1348,7 +1351,7 @@ namespace Bicep.LanguageServer.Completions
                 .WithSortText(GetSortText(label, priority))
                 .Build();
 
-        private static CompletionItem CreateSymbolCompletion(Symbol symbol, Range replacementRange, bool disableFollowUp = false, string? insertText = null)
+        private static CompletionItem CreateSymbolCompletion(Symbol symbol, Range replacementRange, string? insertText = null)
         {
             insertText ??= symbol.Name;
             var kind = GetCompletionItemKind(symbol);
@@ -1394,9 +1397,9 @@ namespace Bicep.LanguageServer.Completions
                     .Build();
             }
 
-            // trigger follow up completions
-            if (symbol is INamespaceSymbol && !disableFollowUp)
+            if (symbol is INamespaceSymbol)
             {
+                // trigger follow up completions
                 return completion
                     .WithDetail(insertText)
                     .WithPlainTextEdit(replacementRange, insertText + ".")
@@ -1419,10 +1422,13 @@ namespace Bicep.LanguageServer.Completions
 
             if (context.Kind.HasFlag(BicepCompletionContextKind.ImportFollower))
             {
-                foreach (var builtInNamespace in model.Root.Namespaces.OfType<BuiltInNamespaceSymbol>().OrderBy(x => x.Name, LanguageConstants.IdentifierComparer))
+                foreach (var builtInNamespace in namespaceProvider.AvailableNamespaces.OrderBy(x => x, LanguageConstants.IdentifierComparer))
                 {
-                    // We don't want to trigger follow-up completions for a namespace as we just want to insert "ns" rather than "ns."
-                    yield return CreateSymbolCompletion(builtInNamespace, context.ReplacementRange, disableFollowUp: true);
+                    yield return CompletionItemBuilder.Create(CompletionItemKind.Folder, builtInNamespace)
+                        .WithSortText(GetSortText(builtInNamespace, CompletionPriority.High))
+                        .WithDetail(builtInNamespace)
+                        .WithPlainTextEdit(context.ReplacementRange, builtInNamespace)
+                        .Build();
                 }
             }
         }


### PR DESCRIPTION
* Ensure that the full list of available namespaces are presented when requesting completions after `import ` (closes #7868)
* Ensure that kubernetes cannot be imported twice in the same file (closes #5034)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7870)