### PR TITLE
Update use-stable-resource-identifiers linter rule to support multiple violations on the same root

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseStableResourceIdentifiersRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseStableResourceIdentifiersRuleTests.cs
@@ -91,6 +91,28 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> snap (default value) -> utcNow('F')).",
             "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> crackle -> snap (default value) -> utcNow('F'))."
         )]
+        [DataRow(@"
+            param location string = resourceGroup().location
+            param snap string = '${newGuid()}${newGuid()}${utcNow('u')}'
+
+            var crackle = snap
+            var pop = '${snap}${crackle}'
+
+            resource storage 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+              name: pop
+              location: location
+              kind: 'StorageV2'
+              sku: {
+                name: 'Standard_LRS'
+              }
+            }",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> snap (default value) -> newGuid()).",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> snap (default value) -> newGuid()).",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> snap (default value) -> utcNow('u')).",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> crackle -> snap (default value) -> newGuid()).",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> crackle -> snap (default value) -> newGuid()).",
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> crackle -> snap (default value) -> utcNow('u'))."
+        )]
         [DataTestMethod]
         public void TestRule(string text, params string[] expectedMessages)
         {

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
@@ -51,7 +51,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 "utcNow",
             };
             private readonly SemanticModel model;
-            private readonly Dictionary<string, string> pathsToNonDeterministicFunctionsUsed = new();
+            private readonly List<(string, string)> pathsToNonDeterministicFunctionsUsed = new();
             private readonly LinkedList<Symbol> pathSegments = new();
 
             internal Visitor(SemanticModel model)
@@ -59,13 +59,13 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 this.model = model;
             }
 
-            internal IEnumerable<KeyValuePair<string, string>> PathsToNonDeterministicFunctionsUsed => pathsToNonDeterministicFunctionsUsed;
+            internal IEnumerable<(string path, string functionName)> PathsToNonDeterministicFunctionsUsed => pathsToNonDeterministicFunctionsUsed;
 
             public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
             {
                 if (NonDeterministicFunctionNames.Contains(syntax.Name.IdentifierName))
                 {
-                    pathsToNonDeterministicFunctionsUsed.Add(FormatPath(syntax.ToText()), syntax.Name.IdentifierName);
+                    pathsToNonDeterministicFunctionsUsed.Add((FormatPath(syntax.ToText()), syntax.Name.IdentifierName));
                 }
                 base.VisitFunctionCallSyntax(syntax);
             }


### PR DESCRIPTION
Resolves #7869

Updates the UseStableResourceIdentifiersRule inner visitor to use a list of tuples instead of a dictionary to support cases where a single parameter uses multiple non-deterministic function calls in its default value.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7910)