### PR TITLE
Add flexible servers and private DNS zone fall through switches

### DIFF
--- a/src/vscode-bicep/src/visualizer/app/assets/icons/azure/index.ts
+++ b/src/vscode-bicep/src/visualizer/app/assets/icons/azure/index.ts
@@ -56,6 +56,7 @@ export async function importResourceIconInline(
         await import("./databases/10121-icon-service-Azure-Cosmos-DB.svg")
       ).default;
     case "microsoft.dbformysql/servers":
+    case "microsoft.dbformysql/flexibleservers":
       return (
         await import(
           "./databases/10122-icon-service-Azure-Database-MySQL-Server.svg"
@@ -74,6 +75,7 @@ export async function importResourceIconInline(
       return (await import("./databases/10126-icon-service-Data-Factory.svg"))
         .default;
     case "microsoft.dbforpostgressql/servers":
+    case "microsoft.dbforpostgressql/flexibleservers":
       return (
         await import(
           "./databases/10131-icon-service-Azure-Database-PostgreSQL-Server.svg"
@@ -105,6 +107,7 @@ export async function importResourceIconInline(
         .default;
 
     // microsoft.network
+    case "microsoft.network/privatednszones":
     case "microsoft.network/dnszones":
       return (await import("./networking/10064-icon-service-DNS-Zones.svg"))
         .default;


### PR DESCRIPTION
The visualiser doesn't show icons for MySQL and Postgres Flexible server and Private DNS Zones.

This PR adds switch statements for those

Fixes #7997 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/7996)