### PR TITLE
Cancel deployment on ESC entering params (7639)

### DIFF
--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -504,7 +504,7 @@ export class DeployCommand implements Command {
       const paramName = deploymentParameter.name;
       let paramValue = undefined;
       if (deploymentParameter.isMissingParam) {
-        paramValue = await vscode.window.showInputBox({
+        paramValue = await _context.ui.showInputBox({
           title: `Parameter: ${paramName}`,
           placeHolder: `Please enter value for parameter "${paramName}"`,
         });
@@ -521,10 +521,11 @@ export class DeployCommand implements Command {
             value: deploymentParameter.value,
             placeHolder: `Please enter value for parameter "${paramName}"`,
           };
-          paramValue = await vscode.window.showInputBox(options);
+          paramValue = await _context.ui.showInputBox(options);
         }
       }
 
+      // undefined indicates to use the expression in the parameter default value
       if (paramValue !== undefined) {
         const updatedDeploymentParameter: BicepUpdatedDeploymentParameter = {
           name: paramName,
@@ -622,7 +623,7 @@ export class DeployCommand implements Command {
     );
 
     if (result === enterNewValue) {
-      const paramValue = await vscode.window.showInputBox({
+      const paramValue = await _context.ui.showInputBox({
         placeHolder: `Please enter value for parameter "${paramName}"`,
       });
 


### PR DESCRIPTION
Fixes #7639

Should be using _context.ui for all UI actions - besides adding testing capabilities, they're also designed to throw on user cancel unlike the built-in UI actions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8017)