### PR TITLE
updated to newest GenerateNotice package

### DIFF
--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "Azure.Deployments.Internal.GenerateNotice": {
         "type": "Direct",
-        "requested": "[0.1.10, )",
-        "resolved": "0.1.10",
-        "contentHash": "vzpnk16/RsH6WBJuUgHlVJbqeunLY/FQ1dllraHsHIzZldOWWks4P/um2HOXdPgOhDt6onnaYB2qonY+io0vZQ=="
+        "requested": "[0.1.11, )",
+        "resolved": "0.1.11",
+        "contentHash": "yivndYKRuYWcWQP5dz/Y2RbgLVkXNo+/PXMzpxaElKnK0d6Dzf4dPX/vBYN8Q14MJoimuFDy/6RqVQP6NZBaog=="
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -62,9 +62,9 @@
       },
       "Azure.Deployments.Internal.GenerateNotice": {
         "type": "Direct",
-        "requested": "[0.1.10, )",
-        "resolved": "0.1.10",
-        "contentHash": "vzpnk16/RsH6WBJuUgHlVJbqeunLY/FQ1dllraHsHIzZldOWWks4P/um2HOXdPgOhDt6onnaYB2qonY+io0vZQ=="
+        "requested": "[0.1.11, )",
+        "resolved": "0.1.11",
+        "contentHash": "yivndYKRuYWcWQP5dz/Y2RbgLVkXNo+/PXMzpxaElKnK0d6Dzf4dPX/vBYN8Q14MJoimuFDy/6RqVQP6NZBaog=="
       },
       "Azure.Deployments.Templates": {
         "type": "Direct",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "Azure.Deployments.Internal.GenerateNotice": {
         "type": "Direct",
-        "requested": "[0.1.10, )",
-        "resolved": "0.1.10",
-        "contentHash": "vzpnk16/RsH6WBJuUgHlVJbqeunLY/FQ1dllraHsHIzZldOWWks4P/um2HOXdPgOhDt6onnaYB2qonY+io0vZQ=="
+        "requested": "[0.1.11, )",
+        "resolved": "0.1.11",
+        "contentHash": "yivndYKRuYWcWQP5dz/Y2RbgLVkXNo+/PXMzpxaElKnK0d6Dzf4dPX/vBYN8Q14MJoimuFDy/6RqVQP6NZBaog=="
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "Azure.Deployments.Internal.GenerateNotice": {
         "type": "Direct",
-        "requested": "[0.1.10, )",
-        "resolved": "0.1.10",
-        "contentHash": "vzpnk16/RsH6WBJuUgHlVJbqeunLY/FQ1dllraHsHIzZldOWWks4P/um2HOXdPgOhDt6onnaYB2qonY+io0vZQ=="
+        "requested": "[0.1.11, )",
+        "resolved": "0.1.11",
+        "contentHash": "yivndYKRuYWcWQP5dz/Y2RbgLVkXNo+/PXMzpxaElKnK0d6Dzf4dPX/vBYN8Q14MJoimuFDy/6RqVQP6NZBaog=="
       },
       "CommandLineParser": {
         "type": "Direct",

--- a/src/Bicep.MSBuild/packages.lock.json
+++ b/src/Bicep.MSBuild/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETStandard,Version=v2.0": {
       "Azure.Deployments.Internal.GenerateNotice": {
         "type": "Direct",
-        "requested": "[0.1.10, )",
-        "resolved": "0.1.10",
-        "contentHash": "vzpnk16/RsH6WBJuUgHlVJbqeunLY/FQ1dllraHsHIzZldOWWks4P/um2HOXdPgOhDt6onnaYB2qonY+io0vZQ=="
+        "requested": "[0.1.11, )",
+        "resolved": "0.1.11",
+        "contentHash": "yivndYKRuYWcWQP5dz/Y2RbgLVkXNo+/PXMzpxaElKnK0d6Dzf4dPX/vBYN8Q14MJoimuFDy/6RqVQP6NZBaog=="
       },
       "Microsoft.Build.Framework": {
         "type": "Direct",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -4,9 +4,9 @@
     "net6.0": {
       "Azure.Deployments.Internal.GenerateNotice": {
         "type": "Direct",
-        "requested": "[0.1.10, )",
-        "resolved": "0.1.10",
-        "contentHash": "vzpnk16/RsH6WBJuUgHlVJbqeunLY/FQ1dllraHsHIzZldOWWks4P/um2HOXdPgOhDt6onnaYB2qonY+io0vZQ=="
+        "requested": "[0.1.11, )",
+        "resolved": "0.1.11",
+        "contentHash": "yivndYKRuYWcWQP5dz/Y2RbgLVkXNo+/PXMzpxaElKnK0d6Dzf4dPX/vBYN8Q14MJoimuFDy/6RqVQP6NZBaog=="
       },
       "DiffPlex": {
         "type": "Direct",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,7 +27,11 @@
 
   <PropertyGroup>
     <!-- different projects include the GenerateNotice package via different targets - this allows us to centrally manage the upgrades -->
-    <GenerateNoticePackageVersion>0.1.10</GenerateNoticePackageVersion>
+    <GenerateNoticePackageVersion>0.1.11</GenerateNoticePackageVersion>
+    
+    <!-- settings of the GenerateNotice tool -->
+    <GenerateNoticeRetryCount>3</GenerateNoticeRetryCount>
+    <GenerateNoticeBatchSize>100</GenerateNoticeBatchSize>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pick up changes from https://github.com/Azure/bicep-shared-tools/pull/15. The tool now breaks requests to the notice API into sequential batches as per API owner recommendations. This should improve build failure rate due to notice generation.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8138)