### PR TITLE
Registry module tool improvements

### DIFF
--- a/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/DescriptionsValidatorTests.cs
+++ b/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/DescriptionsValidatorTests.cs
@@ -5,14 +5,14 @@ using Bicep.Core.Extensions;
 using Bicep.Core.Json;
 using Bicep.RegistryModuleTool.Exceptions;
 using Bicep.RegistryModuleTool.ModuleFiles;
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using Bicep.RegistryModuleTool.TestFixtures.MockFactories;
 using FluentAssertions;
 using Json.More;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO.Abstractions.TestingHelpers;
 
-namespace Bicep.RegistryModuleTool.UnitTests.ModuleFileValidators
+namespace Bicep.RegistryModuleTool.UnitTests.ModuleValidators
 {
     [TestClass]
     public class DescriptionsValidatorTests

--- a/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/DiffValidatorTests.cs
+++ b/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/DiffValidatorTests.cs
@@ -3,7 +3,7 @@
 
 using Bicep.RegistryModuleTool.Exceptions;
 using Bicep.RegistryModuleTool.ModuleFiles;
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using Bicep.RegistryModuleTool.TestFixtures.MockFactories;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,7 +13,7 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Text.RegularExpressions;
 using static FluentAssertions.FluentActions;
 
-namespace Bicep.RegistryModuleTool.UnitTests.ModuleFileValidators
+namespace Bicep.RegistryModuleTool.UnitTests.ModuleValidators
 {
     [TestClass]
     public class DiffValidatorTests

--- a/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/JsonSchemaValidatorTests.cs
+++ b/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/JsonSchemaValidatorTests.cs
@@ -5,7 +5,7 @@ using Bicep.Core.Extensions;
 using Bicep.Core.Json;
 using Bicep.RegistryModuleTool.Exceptions;
 using Bicep.RegistryModuleTool.ModuleFiles;
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using Bicep.RegistryModuleTool.TestFixtures.MockFactories;
 using FluentAssertions;
 using Json.More;
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.IO.Abstractions.TestingHelpers;
 
-namespace Bicep.RegistryModuleTool.UnitTests.ModuleFileValidators
+namespace Bicep.RegistryModuleTool.UnitTests.ModuleValidators
 {
     [TestClass]
     public class JsonSchemaValidatorTests

--- a/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/ModulePathValidatorTests.cs
+++ b/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/ModulePathValidatorTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.RegistryModuleTool.Exceptions;
+using Bicep.RegistryModuleTool.ModuleValidators;
+using Bicep.RegistryModuleTool.TestFixtures.MockFactories;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO.Abstractions.TestingHelpers;
+using static FluentAssertions.FluentActions;
+
+namespace Bicep.RegistryModuleTool.UnitTests.ModuleValidators
+{
+    [TestClass]
+    public class ModulePathValidatorTests
+    {
+        [TestMethod]
+        public void ValidateModulePath_InvalidPath_Throws()
+        {
+            const string currentDirectory = "/foo/bar";
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.AddDirectory(currentDirectory);
+            fileSystem.Directory.SetCurrentDirectory(fileSystem.Path.GetFullPath(currentDirectory));
+
+            Invoking(() => ModulePathValidator.ValidateModulePath(fileSystem))
+                .Should()
+                .Throw<InvalidModuleException>()
+                .WithMessage(@"Could not find the ""modules"" folder in the path ""C:\foo\bar"".");
+        }
+
+        [TestMethod]
+        public void ValidateModulePath_ValidPath_DoesNotThrow()
+        {
+            var fileSystem = MockFileSystemFactory.CreateFileSystemWithEmptyFolder();
+
+            Invoking(() => ModulePathValidator.ValidateModulePath(fileSystem))
+                .Should()
+                .NotThrow();
+        }
+    }
+}

--- a/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/ModulePathValidatorTests.cs
+++ b/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/ModulePathValidatorTests.cs
@@ -26,7 +26,7 @@ namespace Bicep.RegistryModuleTool.UnitTests.ModuleValidators
             Invoking(() => ModulePathValidator.ValidateModulePath(fileSystem))
                 .Should()
                 .Throw<InvalidModuleException>()
-                .WithMessage(@"Could not find the ""modules"" folder in the path ""C:\foo\bar"".");
+                .WithMessage($@"Could not find the ""modules"" folder in the path ""{fileSystem.Directory.GetCurrentDirectory()}"".");
         }
 
         [TestMethod]

--- a/src/Bicep.RegistryModuleTool/Commands/GenerateCommand.cs
+++ b/src/Bicep.RegistryModuleTool/Commands/GenerateCommand.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.RegistryModuleTool.Exceptions;
+using Bicep.RegistryModuleTool.Extensions;
 using Bicep.RegistryModuleTool.ModuleFiles;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using Bicep.RegistryModuleTool.Proxies;
 using Microsoft.Extensions.Logging;
 using System;
@@ -33,6 +36,17 @@ namespace Bicep.RegistryModuleTool.Commands
 
             protected override int Invoke(InvocationContext context)
             {
+                try
+                {
+                    ModulePathValidator.ValidateModulePath(this.FileSystem);
+                }
+                catch (InvalidModuleException exception)
+                {
+                    context.Console.WriteError(exception.Message);
+
+                    return 1;
+                }
+
                 // Read or create main Bicep file.
                 this.Logger.LogInformation("Ensuring {MainBicepFile} exists...", "main Bicep file");
                 var mainBicepFile = MainBicepFile.EnsureInFileSystem(this.FileSystem);

--- a/src/Bicep.RegistryModuleTool/Commands/ValidateCommand.cs
+++ b/src/Bicep.RegistryModuleTool/Commands/ValidateCommand.cs
@@ -1,20 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.Core.Exceptions;
 using Bicep.RegistryModuleTool.Exceptions;
 using Bicep.RegistryModuleTool.Extensions;
 using Bicep.RegistryModuleTool.ModuleFiles;
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using Bicep.RegistryModuleTool.Proxies;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO.Abstractions;
-using System.Linq;
-using System.Security;
 
 namespace Bicep.RegistryModuleTool.Commands
 {
@@ -43,7 +39,7 @@ namespace Bicep.RegistryModuleTool.Commands
                 var valid = true;
 
                 this.Logger.LogInformation("Validating module path...");
-                valid &= Validate(context.Console, () => ValidateModulePath(this.FileSystem));
+                valid &= Validate(context.Console, () => ModulePathValidator.ValidateModulePath(this.FileSystem));
 
                 this.Logger.LogInformation("Validating main Bicep file...");
 
@@ -78,54 +74,6 @@ namespace Bicep.RegistryModuleTool.Commands
                 return valid ? 0 : 1;
             }
 
-            private static void ValidateModulePath(IFileSystem fileSystem)
-            {
-                var directoryPath = fileSystem.Directory.GetCurrentDirectory();
-                var modulePath = GetModulePath(fileSystem, directoryPath);
-
-                if (modulePath.Count(x => x == fileSystem.Path.DirectorySeparatorChar) != 1)
-                {
-                    string modulePathFormat = $"<module-folder>{fileSystem.Path.DirectorySeparatorChar}<module-name>";
-
-                    throw new InvalidModuleException($"The module path \"{modulePath}\" in the path \"{directoryPath}\" is invalid. The module path must be in the format of \"{modulePathFormat}\".");
-                }
-
-                if (modulePath.Any(char.IsUpper))
-                {
-                    throw new InvalidModuleException($"The module path \"{modulePath}\" in the path \"{directoryPath}\" is invalid. All characters in the module path must be in lowercase.");
-                }
-            }
-
-            private static string GetModulePath(IFileSystem fileSystem, string directoryPath)
-            {
-                var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(directoryPath);
-                var directoryStack = new Stack<string>();
-
-                try
-                {
-
-                    while (directoryInfo is not null && !directoryInfo.Name.Equals("modules", StringComparison.OrdinalIgnoreCase))
-                    {
-                        directoryStack.Push(directoryInfo.Name);
-
-                        directoryInfo = directoryInfo.Parent;
-                    }
-
-                    if (directoryInfo is null)
-                    {
-                        throw new InvalidModuleException($"Could not find the \"modules\" folder in the path \"{directoryPath}\".");
-                    }
-                }
-                catch (SecurityException exception)
-                {
-                    throw new BicepException(exception.Message, exception);
-                }
-
-                var modulePath = string.Join(fileSystem.Path.DirectorySeparatorChar, directoryStack.ToArray());
-
-                return modulePath;
-            }
-
             private static bool Validate(IConsole console, Action validateAction)
             {
                 try
@@ -134,15 +82,7 @@ namespace Bicep.RegistryModuleTool.Commands
                 }
                 catch (InvalidModuleException exception)
                 {
-                    // Normalize the error message to make it always end with a new line.
-                    var normalizedErrorMessage = exception.Message.ReplaceLineEndings();
-
-                    if (!normalizedErrorMessage.EndsWith(Environment.NewLine))
-                    {
-                        normalizedErrorMessage = $"{normalizedErrorMessage}{Environment.NewLine}";
-                    }
-
-                    console.WriteError(normalizedErrorMessage);
+                    console.WriteError(exception.Message);
 
                     return false;
                 }

--- a/src/Bicep.RegistryModuleTool/Exceptions/InvalidModuleException.cs
+++ b/src/Bicep.RegistryModuleTool/Exceptions/InvalidModuleException.cs
@@ -8,8 +8,21 @@ namespace Bicep.RegistryModuleTool.Exceptions
     public class InvalidModuleException : Exception
     {
         public InvalidModuleException(string message, Exception? innerException = null)
-            : base(message, innerException)
+            : base(NormalizeLineEndings(message), innerException)
         {
+        }
+
+        public static string NormalizeLineEndings(string message)
+        {
+            // Normalize the message to make it always end with a new line.
+            var normalizedMessage = message.ReplaceLineEndings();
+
+            if (!normalizedMessage.EndsWith(Environment.NewLine))
+            {
+                normalizedMessage = $"{normalizedMessage}{Environment.NewLine}";
+            }
+
+            return normalizedMessage;
         }
     }
 }

--- a/src/Bicep.RegistryModuleTool/ModuleFileValidators/TestValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFileValidators/TestValidator.cs
@@ -59,7 +59,7 @@ namespace Bicep.RegistryModuleTool.ModuleFileValidators
 
             using var tempFileStream = fileSystem.FileStream.CreateDeleteOnCloseStream(tempFilePath);
             var testTemplateElement = JsonElementFactory.CreateElement(tempFileStream);
-            var testDeployments = testTemplateElement.Select($@"$.resources[?(@.type == ""Microsoft.Resources/deployments"" && @.properties.template.metadata._generator.templateHash == ""{this.latestMainArmTemplateFile.TemplateHash}"")]");
+            var testDeployments = testTemplateElement.Select($@"$..resources[?(@.type == ""Microsoft.Resources/deployments"" && @.properties.template.metadata._generator.templateHash == ""{this.latestMainArmTemplateFile.TemplateHash}"")]");
 
             if (testDeployments.IsEmpty())
             {

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -4,7 +4,7 @@
 using Bicep.Core.Extensions;
 using Bicep.Core.Json;
 using Bicep.RegistryModuleTool.Extensions;
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using Bicep.RegistryModuleTool.Proxies;
 using System;
 using System.Collections.Generic;

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainBicepFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainBicepFile.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using System.IO;
 using System.IO.Abstractions;
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainBicepTestFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainBicepTestFile.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using System.IO;
 using System.IO.Abstractions;
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MetadataFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MetadataFile.cs
@@ -4,7 +4,7 @@
 using Bicep.Core.Exceptions;
 using Bicep.Core.Extensions;
 using Bicep.Core.Json;
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/ModuleFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/ModuleFile.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Extensions;
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.RegistryModuleTool.Extensions;
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using Markdig;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/VersionFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/VersionFile.cs
@@ -4,7 +4,7 @@
 using Bicep.Core.Exceptions;
 using Bicep.Core.Extensions;
 using Bicep.Core.Json;
-using Bicep.RegistryModuleTool.ModuleFileValidators;
+using Bicep.RegistryModuleTool.ModuleValidators;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;

--- a/src/Bicep.RegistryModuleTool/ModuleValidators/DescriptionsValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleValidators/DescriptionsValidator.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Text;
 
-namespace Bicep.RegistryModuleTool.ModuleFileValidators
+namespace Bicep.RegistryModuleTool.ModuleValidators
 {
     public sealed class DescriptionsValidator : IModuleFileValidator
     {

--- a/src/Bicep.RegistryModuleTool/ModuleValidators/DiffValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleValidators/DiffValidator.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 using System.IO;
 using System.IO.Abstractions;
 
-namespace Bicep.RegistryModuleTool.ModuleFileValidators
+namespace Bicep.RegistryModuleTool.ModuleValidators
 {
     public sealed class DiffValidator : IModuleFileValidator
     {

--- a/src/Bicep.RegistryModuleTool/ModuleValidators/IModuleFileValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleValidators/IModuleFileValidator.cs
@@ -4,7 +4,7 @@
 using Bicep.RegistryModuleTool.ModuleFiles;
 using System;
 
-namespace Bicep.RegistryModuleTool.ModuleFileValidators
+namespace Bicep.RegistryModuleTool.ModuleValidators
 {
     public interface IModuleFileValidator
     {

--- a/src/Bicep.RegistryModuleTool/ModuleValidators/JsonSchemaValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleValidators/JsonSchemaValidator.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 
-namespace Bicep.RegistryModuleTool.ModuleFileValidators
+namespace Bicep.RegistryModuleTool.ModuleValidators
 {
     public sealed class JsonSchemaValidator : IModuleFileValidator
     {

--- a/src/Bicep.RegistryModuleTool/ModuleValidators/ModulePathValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleValidators/ModulePathValidator.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Exceptions;
+using Bicep.RegistryModuleTool.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Security;
+
+namespace Bicep.RegistryModuleTool.ModuleValidators
+{
+    public static class ModulePathValidator
+    {
+        public static void ValidateModulePath(IFileSystem fileSystem)
+        {
+            var directoryPath = fileSystem.Directory.GetCurrentDirectory();
+            var modulePath = GetModulePath(fileSystem, directoryPath);
+
+            if (modulePath.Count(x => x == fileSystem.Path.DirectorySeparatorChar) != 1)
+            {
+                string modulePathFormat = $"<module-folder>{fileSystem.Path.DirectorySeparatorChar}<module-name>";
+
+                throw new InvalidModuleException($"The module path \"{modulePath}\" in the path \"{directoryPath}\" is invalid. The module path must be in the format of \"{modulePathFormat}\".");
+            }
+
+            if (modulePath.Any(char.IsUpper))
+            {
+                throw new InvalidModuleException($"The module path \"{modulePath}\" in the path \"{directoryPath}\" is invalid. All characters in the module path must be in lowercase.");
+            }
+        }
+
+        private static string GetModulePath(IFileSystem fileSystem, string directoryPath)
+        {
+            var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(directoryPath);
+            var directoryStack = new Stack<string>();
+
+            try
+            {
+
+                while (directoryInfo is not null && !directoryInfo.Name.Equals("modules", StringComparison.OrdinalIgnoreCase))
+                {
+                    directoryStack.Push(directoryInfo.Name);
+
+                    directoryInfo = directoryInfo.Parent;
+                }
+
+                if (directoryInfo is null)
+                {
+                    throw new InvalidModuleException($"Could not find the \"modules\" folder in the path \"{directoryPath}\".");
+                }
+            }
+            catch (SecurityException exception)
+            {
+                throw new BicepException(exception.Message, exception);
+            }
+
+            var modulePath = string.Join(fileSystem.Path.DirectorySeparatorChar, directoryStack.ToArray());
+
+            return modulePath;
+        }
+    }
+}

--- a/src/Bicep.RegistryModuleTool/ModuleValidators/TestValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleValidators/TestValidator.cs
@@ -13,7 +13,7 @@ using System;
 using System.IO.Abstractions;
 using System.Linq;
 
-namespace Bicep.RegistryModuleTool.ModuleFileValidators
+namespace Bicep.RegistryModuleTool.ModuleValidators
 {
     public class TestValidator : IModuleFileValidator
     {


### PR DESCRIPTION
- `brm generate` now validates module path. Closes https://github.com/Azure/bicep-registry-modules/issues/137.
- Added support for indirect tests. Closes https://github.com/Azure/bicep-registry-modules/issues/133.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8191)