### PR TITLE
Restrict visual studio vsix version to 17.3 and above

### DIFF
--- a/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/source.extension.vsixmanifest
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/source.extension.vsixmanifest
@@ -8,7 +8,7 @@
     <Icon>Icons\bicep-logo-256.png</Icon>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.3, 18.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
   </Installation>
@@ -21,6 +21,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.3,18.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Restrict visual studio vsix version to 17.3 and above.

Verified the vsix on 17.3 and 17.4. On 17.2, we get the below message as expected:
![image](https://user-images.githubusercontent.com/30270536/188003074-45e0ddf9-f64c-4d9a-a9cd-a608fdec0aee.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8226)