### PR TITLE
increased notice retry limit again

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,7 +30,7 @@
     <GenerateNoticePackageVersion>0.1.11</GenerateNoticePackageVersion>
     
     <!-- settings of the GenerateNotice tool -->
-    <GenerateNoticeRetryCount>6</GenerateNoticeRetryCount>
+    <GenerateNoticeRetryCount>9</GenerateNoticeRetryCount>
     <GenerateNoticeBatchSize>100</GenerateNoticeBatchSize>
   </PropertyGroup>
 


### PR DESCRIPTION
Increased notice generator tool retry limit to mitigate some of the build failures.