### PR TITLE
Add support for bicep params file to evaluation tests

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -1337,7 +1337,7 @@ output providerOutput object = {
                 }
             };
 
-            var evaluated = TemplateEvaluator.Evaluate(result.Template, config => config with
+            var evaluated = TemplateEvaluator.Evaluate(result.Template, configBuilder: config => config with
             {
                 Metadata = new()
                 {
@@ -1404,7 +1404,7 @@ output providersLocationFirst string = providers('Test.Rp', 'fakeResource').loca
                 }
             };
 
-            var evaluated = TemplateEvaluator.Evaluate(result.Template, config => config with
+            var evaluated = TemplateEvaluator.Evaluate(result.Template, configBuilder: config => config with
             {
                 Metadata = new()
                 {


### PR DESCRIPTION
Doesn't hurt to have a bit of extra coverage of params files. It'll be useful in the future once we add more advanced capabilities such as expression support.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8237)