### PR TITLE
Add bicep editor factory

### DIFF
--- a/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/BicepVSLanguageServerClientPackage.cs
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/BicepVSLanguageServerClientPackage.cs
@@ -7,7 +7,9 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Bicep.VSLanguageServerClient.Settings;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Package;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 
 namespace Bicep.VSLanguageServerClient.Vsix
@@ -36,6 +38,7 @@ namespace Bicep.VSLanguageServerClient.Vsix
         DefaultToInsertSpaces = true,
         EnableLineNumbers = true,
         RequestStockColors = false)]
+    [ProvideEditorFactory(typeof(BicepEditorFactory), 200, TrustLevel = __VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted)]
     [ProvideBindingPath()]
     public sealed class BicepVSLanguageServerClientPackage : AsyncPackage
     {

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/Settings/BicepEditorFactory.cs
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/Settings/BicepEditorFactory.cs
@@ -1,19 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Runtime.InteropServices;
 using System.Security.Permissions;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Bicep.VSLanguageServerClient.Settings
 {
     [Guid(BicepGuids.EditorFactoryGuidString)]
     public class BicepEditorFactory : IVsEditorFactory
     {
-        #region IVsEditorFactory Members
-
         [SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.UnmanagedCode)]
         public int CreateEditorInstance(uint grfCreateDoc,
                                         string pszMkDocument,
@@ -27,10 +25,9 @@ namespace Bicep.VSLanguageServerClient.Settings
                                         out Guid pguidCmdUI,
                                         out int pgrfCDW)
         {
-            // Initialize to null
             ppunkDocView = IntPtr.Zero;
             ppunkDocData = IntPtr.Zero;
-            pguidCmdUI = Guid.NewGuid();// Editor.DefGuidList.CLSID_TextEditorFactory;
+            pguidCmdUI = Guid.NewGuid();
             pgrfCDW = 0;
             pbstrEditorCaption = string.Empty;
 
@@ -39,17 +36,18 @@ namespace Bicep.VSLanguageServerClient.Settings
 
         public int MapLogicalView(ref Guid rguidLogicalView, out string? pbstrPhysicalView)
         {
-            pbstrPhysicalView = null;    // initialize out parameter
+            pbstrPhysicalView = null;
 
-            // we are both a primary and a text view.
+            // If rguidLogicalView is primary and a text view, return success
             if ((VSConstants.LOGVIEWID_Primary == rguidLogicalView) ||
                 (VSConstants.LOGVIEWID_TextView == rguidLogicalView))
             {
-                return VSConstants.S_OK;        // primary view uses NULL as pbstrPhysicalView
+                return VSConstants.S_OK;
             }
+            // Return E_NOTIMPL for any unrecognized rguidLogicalView values
             else
             {
-                return VSConstants.E_NOTIMPL;   // you must return E_NOTIMPL for any unrecognized rguidLogicalView values
+                return VSConstants.E_NOTIMPL;
             }
         }
 
@@ -62,7 +60,5 @@ namespace Bicep.VSLanguageServerClient.Settings
         {
             return VSConstants.S_OK;
         }
-
-        #endregion
     }
 }

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/Settings/BicepEditorFactory.cs
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/Settings/BicepEditorFactory.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+
+namespace Bicep.VSLanguageServerClient.Settings
+{
+    [Guid(BicepGuids.EditorFactoryGuidString)]
+    public class BicepEditorFactory : IVsEditorFactory
+    {
+        #region IVsEditorFactory Members
+
+        [SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        public int CreateEditorInstance(uint grfCreateDoc,
+                                        string pszMkDocument,
+                                        string pszPhysicalView,
+                                        IVsHierarchy pvHier,
+                                        uint itemid,
+                                        IntPtr punkDocDataExisting,
+                                        out IntPtr ppunkDocView,
+                                        out IntPtr ppunkDocData,
+                                        out string pbstrEditorCaption,
+                                        out Guid pguidCmdUI,
+                                        out int pgrfCDW)
+        {
+            // Initialize to null
+            ppunkDocView = IntPtr.Zero;
+            ppunkDocData = IntPtr.Zero;
+            pguidCmdUI = Guid.NewGuid();// Editor.DefGuidList.CLSID_TextEditorFactory;
+            pgrfCDW = 0;
+            pbstrEditorCaption = string.Empty;
+
+            return VSConstants.S_OK;
+        }
+
+        public int MapLogicalView(ref Guid rguidLogicalView, out string? pbstrPhysicalView)
+        {
+            pbstrPhysicalView = null;    // initialize out parameter
+
+            // we are both a primary and a text view.
+            if ((VSConstants.LOGVIEWID_Primary == rguidLogicalView) ||
+                (VSConstants.LOGVIEWID_TextView == rguidLogicalView))
+            {
+                return VSConstants.S_OK;        // primary view uses NULL as pbstrPhysicalView
+            }
+            else
+            {
+                return VSConstants.E_NOTIMPL;   // you must return E_NOTIMPL for any unrecognized rguidLogicalView values
+            }
+        }
+
+        public int Close()
+        {
+            return VSConstants.S_OK;
+        }
+
+        public int SetSite(Microsoft.VisualStudio.OLE.Interop.IServiceProvider psp)
+        {
+            return VSConstants.S_OK;
+        }
+
+        #endregion
+    }
+}

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/Settings/BicepGuids.cs
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/Settings/BicepGuids.cs
@@ -11,6 +11,7 @@ namespace Bicep.VSLanguageServerClient.Settings
 {
     public class BicepGuids
     {
+        public const string EditorFactoryGuidString = "cca9bf83-1a17-4c2b-946f-e01a4c020b6a";
         public const string LanguageServiceGuidString = "17c12a04-877c-4781-8948-99610a774160";
         public const string PackageGuidString = "7bbebedb-0520-44f3-a5e0-e3d8855f1944";
     }


### PR DESCRIPTION
Fix https://github.com/Azure/bicep/issues/8286

With bicep VS extension installed, first time after VS installation, if project/folder is opened with .bicep file already open, we are seeing above error. The issue doesn't repro for subsequent file opens. As a part of this change, adding a basic implementation of IVsEditorFactory to avoid above error.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8299)