### PR TITLE
Support `@metadata` decorator on outputs

### DIFF
--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1081,7 +1081,7 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return new DecoratorBuilder(LanguageConstants.ParameterMetadataPropertyName)
                 .WithDescription("Defines metadata of the parameter.")
                 .WithRequiredParameter("object", LanguageConstants.Object, "The metadata object.")
-                .WithFlags(FunctionFlags.ParameterDecorator)
+                .WithFlags(FunctionFlags.ParamterOrOutputDecorator)
                 .WithValidator((_, decoratorSyntax, _, typeManager, binder, diagnosticWriter) =>
                     TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, diagnosticWriter, SingleArgumentSelector(decoratorSyntax), LanguageConstants.ParameterModifierMetadata))
                 .WithEvaluator(MergeToTargetObject(LanguageConstants.ParameterMetadataPropertyName, SingleArgumentSelector))

--- a/src/Bicep.Core/TypeSystem/FunctionFlags.cs
+++ b/src/Bicep.Core/TypeSystem/FunctionFlags.cs
@@ -66,9 +66,14 @@ namespace Bicep.Core.TypeSystem
         MetadataDecorator = 1 << 9,
 
         /// <summary>
-        /// The function can be used a resource or module decorator.
+        /// The function can be used as a resource or module decorator.
         /// </summary>
         ResourceOrModuleDecorator = ResourceDecorator | ModuleDecorator,
+
+        /// <summary>
+        /// The function can be used as a parameter or output decorator.
+        /// </summary>
+        ParamterOrOutputDecorator = ParameterDecorator | OutputDecorator,
 
         /// <summary>
         /// The function can be used as a decorator anywhere.


### PR DESCRIPTION
The runtime supports having `metadata` on the output objects (and the `@description` decorator works by adding a value to this) but Bicep did not allow using the `@metadata` decorator on outputs to add custom metadata.

This change fixes that issue.

With this change, you can now write:

```bicep
@metadata({
  works: true
})
@description('an example output, with metadata')
output example string = ''
```

Which is complied down to:

```json
"outputs": {
  "example": {
    "type": "string",
    "value": "",
    "metadata": {
      "description": "an example output, with metadata",
      "works": true
    }
  }
}
```

Fixes #6250

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature

## Notes

I'll admit I'm not 100% familiar with the codebase, so it's possible I missed some additional work that comes from the fallout of allowing `@metadata` on outputs, but all the existing tests continued to pass.  I added a few new tests (hopefully in the right place).  I also verified manually that you can deploy an ARM Template with metadata on outputs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8302)