### PR TITLE
Revert "Bump babel-jest from 28.1.3 to 29.0.2 in /src/monarch"

### DIFF
--- a/src/monarch/package-lock.json
+++ b/src/monarch/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@babel/core": "^7.19.0",
         "@babel/plugin-transform-modules-commonjs": "^7.18.6",
-        "babel-jest": "^29.0.2"
+        "babel-jest": "^28.1.3"
       },
       "devDependencies": {
         "@types/html-escaper": "^3.0.0",
@@ -916,7 +916,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
       "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
-      "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.24.1"
       },
@@ -972,7 +971,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz",
       "integrity": "sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^28.1.3",
@@ -998,7 +996,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
       "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
-      "dev": true,
       "dependencies": {
         "@jest/schemas": "^28.1.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1045,9 +1042,9 @@
       "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1640,150 +1637,23 @@
       "dev": true
     },
     "node_modules/babel-jest": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.0.2.tgz",
-      "integrity": "sha512-yTu4/WSi/HzarjQtrJSwV+/0maoNt+iP0DmpvFJdv9yY+5BuNle8TbheHzzcSWj5gIHfuhpbLYHWRDYhWKyeKQ==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
+      "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
       "dependencies": {
-        "@jest/transform": "^29.0.2",
+        "@jest/transform": "^28.1.3",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.0.2",
+        "babel-preset-jest": "^28.1.3",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/@jest/schemas": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
-      "dependencies": {
-        "@sinclair/typebox": "^0.24.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/@jest/transform": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.0.2.tgz",
-      "integrity": "sha512-lajVQx2AnsR+Pa17q2zR7eikz2PkPs1+g/qPbZkqQATeS/s6eT55H+yHcsLfuI/0YQ/4VSBepSu3bOX+44q0aA==",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.0.2",
-        "@jridgewell/trace-mapping": "^0.3.15",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^1.4.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.0.2",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.2",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/@jest/types": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-      "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
-      "dependencies": {
-        "@jest/schemas": "^29.0.0",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/jest-haste-map": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.0.2.tgz",
-      "integrity": "sha512-SOorh2ysQ0fe8gsF4gaUDhoMIWAvi2hXOkwThEO48qT3JqA8GLAUieQcIvdSEd6M0scRDe1PVmKc5tXR3Z0U0A==",
-      "dependencies": {
-        "@jest/types": "^29.0.2",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.0.0",
-        "jest-util": "^29.0.2",
-        "jest-worker": "^29.0.2",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/babel-jest/node_modules/jest-regex-util": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
-      "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/jest-util": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.0.2.tgz",
-      "integrity": "sha512-ozk8ruEEEACxqpz0hN9UOgtPZS0aN+NffwQduR5dVlhN+eN47vxurtvgZkYZYMpYrsmlAEx1XabkB3BnN0GfKQ==",
-      "dependencies": {
-        "@jest/types": "^29.0.2",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/jest-worker": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.0.2.tgz",
-      "integrity": "sha512-EyvBlYcvd2pg28yg5A3OODQnqK9LI1kitnGUZUG5/NYIeaRgewtYBKB5wlr7oXj8zPCkzev7EmnTCsrXK7V+Xw==",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/babel-plugin-dynamic-import-node": {
@@ -1810,9 +1680,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz",
-      "integrity": "sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
+      "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
       "dependencies": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
@@ -1820,7 +1690,7 @@
         "@types/babel__traverse": "^7.0.6"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -1846,15 +1716,15 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz",
-      "integrity": "sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
+      "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
       "dependencies": {
-        "babel-plugin-jest-hoist": "^29.0.2",
+        "babel-plugin-jest-hoist": "^28.1.3",
         "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -3587,58 +3457,6 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/babel-jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
-      "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
-      "dev": true,
-      "dependencies": {
-        "@jest/transform": "^28.1.3",
-        "@types/babel__core": "^7.1.14",
-        "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^28.1.3",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.8.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/babel-plugin-jest-hoist": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
-      "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.3.3",
-        "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.1.14",
-        "@types/babel__traverse": "^7.0.6"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/babel-preset-jest": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
-      "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
-      "dev": true,
-      "dependencies": {
-        "babel-plugin-jest-hoist": "^28.1.3",
-        "babel-preset-current-node-syntax": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/jest-diff": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
@@ -3868,7 +3686,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
       "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
-      "dev": true,
       "dependencies": {
         "@jest/types": "^28.1.3",
         "@types/graceful-fs": "^4.1.3",
@@ -3971,7 +3788,6 @@
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
       "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
-      "dev": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
@@ -4127,7 +3943,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
       "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
-      "dev": true,
       "dependencies": {
         "@jest/types": "^28.1.3",
         "@types/node": "*",
@@ -4192,7 +4007,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
       "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -4206,7 +4020,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6445,7 +6258,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
       "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
-      "dev": true,
       "requires": {
         "@sinclair/typebox": "^0.24.1"
       }
@@ -6489,7 +6301,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-28.1.3.tgz",
       "integrity": "sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==",
-      "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^28.1.3",
@@ -6512,7 +6323,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
       "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
-      "dev": true,
       "requires": {
         "@jest/schemas": "^28.1.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6547,9 +6357,9 @@
       "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
+      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -6994,117 +6804,17 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.0.2.tgz",
-      "integrity": "sha512-yTu4/WSi/HzarjQtrJSwV+/0maoNt+iP0DmpvFJdv9yY+5BuNle8TbheHzzcSWj5gIHfuhpbLYHWRDYhWKyeKQ==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
+      "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
       "requires": {
-        "@jest/transform": "^29.0.2",
+        "@jest/transform": "^28.1.3",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.0.2",
+        "babel-preset-jest": "^28.1.3",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "@jest/schemas": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-          "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
-          "requires": {
-            "@sinclair/typebox": "^0.24.1"
-          }
-        },
-        "@jest/transform": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.0.2.tgz",
-          "integrity": "sha512-lajVQx2AnsR+Pa17q2zR7eikz2PkPs1+g/qPbZkqQATeS/s6eT55H+yHcsLfuI/0YQ/4VSBepSu3bOX+44q0aA==",
-          "requires": {
-            "@babel/core": "^7.11.6",
-            "@jest/types": "^29.0.2",
-            "@jridgewell/trace-mapping": "^0.3.15",
-            "babel-plugin-istanbul": "^6.1.1",
-            "chalk": "^4.0.0",
-            "convert-source-map": "^1.4.0",
-            "fast-json-stable-stringify": "^2.1.0",
-            "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.0.2",
-            "jest-regex-util": "^29.0.0",
-            "jest-util": "^29.0.2",
-            "micromatch": "^4.0.4",
-            "pirates": "^4.0.4",
-            "slash": "^3.0.0",
-            "write-file-atomic": "^4.0.1"
-          }
-        },
-        "@jest/types": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.0.2.tgz",
-          "integrity": "sha512-5WNMesBLmlkt1+fVkoCjHa0X3i3q8zc4QLTDkdHgCa2gyPZc7rdlZBWgVLqwS1860ZW5xJuCDwAzqbGaXIr/ew==",
-          "requires": {
-            "@jest/schemas": "^29.0.0",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.8",
-            "chalk": "^4.0.0"
-          }
-        },
-        "jest-haste-map": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.0.2.tgz",
-          "integrity": "sha512-SOorh2ysQ0fe8gsF4gaUDhoMIWAvi2hXOkwThEO48qT3JqA8GLAUieQcIvdSEd6M0scRDe1PVmKc5tXR3Z0U0A==",
-          "requires": {
-            "@jest/types": "^29.0.2",
-            "@types/graceful-fs": "^4.1.3",
-            "@types/node": "*",
-            "anymatch": "^3.0.3",
-            "fb-watchman": "^2.0.0",
-            "fsevents": "^2.3.2",
-            "graceful-fs": "^4.2.9",
-            "jest-regex-util": "^29.0.0",
-            "jest-util": "^29.0.2",
-            "jest-worker": "^29.0.2",
-            "micromatch": "^4.0.4",
-            "walker": "^1.0.8"
-          }
-        },
-        "jest-regex-util": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
-          "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug=="
-        },
-        "jest-util": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.0.2.tgz",
-          "integrity": "sha512-ozk8ruEEEACxqpz0hN9UOgtPZS0aN+NffwQduR5dVlhN+eN47vxurtvgZkYZYMpYrsmlAEx1XabkB3BnN0GfKQ==",
-          "requires": {
-            "@jest/types": "^29.0.2",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "ci-info": "^3.2.0",
-            "graceful-fs": "^4.2.9",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "jest-worker": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.0.2.tgz",
-          "integrity": "sha512-EyvBlYcvd2pg28yg5A3OODQnqK9LI1kitnGUZUG5/NYIeaRgewtYBKB5wlr7oXj8zPCkzev7EmnTCsrXK7V+Xw==",
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^8.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -7128,9 +6838,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz",
-      "integrity": "sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
+      "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
       "requires": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
@@ -7158,11 +6868,11 @@
       }
     },
     "babel-preset-jest": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz",
-      "integrity": "sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==",
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
+      "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
       "requires": {
-        "babel-plugin-jest-hoist": "^29.0.2",
+        "babel-plugin-jest-hoist": "^28.1.3",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -8423,45 +8133,6 @@
         "pretty-format": "^28.1.3",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "babel-jest": {
-          "version": "28.1.3",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
-          "integrity": "sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==",
-          "dev": true,
-          "requires": {
-            "@jest/transform": "^28.1.3",
-            "@types/babel__core": "^7.1.14",
-            "babel-plugin-istanbul": "^6.1.1",
-            "babel-preset-jest": "^28.1.3",
-            "chalk": "^4.0.0",
-            "graceful-fs": "^4.2.9",
-            "slash": "^3.0.0"
-          }
-        },
-        "babel-plugin-jest-hoist": {
-          "version": "28.1.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz",
-          "integrity": "sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.3.3",
-            "@babel/types": "^7.3.3",
-            "@types/babel__core": "^7.1.14",
-            "@types/babel__traverse": "^7.0.6"
-          }
-        },
-        "babel-preset-jest": {
-          "version": "28.1.3",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz",
-          "integrity": "sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-jest-hoist": "^28.1.3",
-            "babel-preset-current-node-syntax": "^1.0.0"
-          }
-        }
       }
     },
     "jest-diff": {
@@ -8647,7 +8318,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
       "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
-      "dev": true,
       "requires": {
         "@jest/types": "^28.1.3",
         "@types/graceful-fs": "^4.1.3",
@@ -8722,8 +8392,7 @@
     "jest-regex-util": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
-      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
-      "dev": true
+      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw=="
     },
     "jest-resolve": {
       "version": "28.1.3",
@@ -8857,7 +8526,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
       "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
-      "dev": true,
       "requires": {
         "@jest/types": "^28.1.3",
         "@types/node": "*",
@@ -8909,7 +8577,6 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
       "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -8920,7 +8587,6 @@
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
           "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/src/monarch/package.json
+++ b/src/monarch/package.json
@@ -30,6 +30,6 @@
   "dependencies": {
     "@babel/core": "^7.19.0",
     "@babel/plugin-transform-modules-commonjs": "^7.18.6",
-    "babel-jest": "^29.0.2"
+    "babel-jest": "^28.1.3"
   }
 }


### PR DESCRIPTION
This breaks the build for highlight libraries as there is a NPM versioning conflict

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8336)