### PR TITLE
Fix 8321 language configs not found

### DIFF
--- a/src/vscode-bicep/.gitignore
+++ b/src/vscode-bicep/.gitignore
@@ -5,5 +5,6 @@ node_modules
 .vscode-test
 coverage
 syntaxes/bicep.tmlanguage
+syntaxes/language-configuration.json
 bicepLanguageServer
 ThirdPartyNotices.txt

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -108,7 +108,7 @@
         "extensions": [
           ".bicep"
         ],
-        "configuration": "../textmate/language-configuration.json"
+        "configuration": "./syntaxes/language-configuration.json"
       },
       {
         "id": "jsonc",

--- a/src/vscode-bicep/webpack.config.ts
+++ b/src/vscode-bicep/webpack.config.ts
@@ -56,6 +56,14 @@ const extensionConfig: webpack.Configuration = {
         },
       ],
     }) as { apply(...args: unknown[]): void },
+    new CopyPlugin({
+      patterns: [
+        {
+          from: "../textmate/language-configuration.json",
+          to: path.join(__dirname, "syntaxes/language-configuration.json"),
+        },
+      ],
+    }) as { apply(...args: unknown[]): void },
     new ForkTsCheckerWebpackPlugin(),
   ],
   resolve: {


### PR DESCRIPTION
Fixes #8321

Language configuration file was being referenced from parent directory which doesn't get copied into VSIX

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8338)