### PR TITLE
Update visual studio vsix id

### DIFF
--- a/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/source.extension.vsixmanifest
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ms-azuretools.vs-bicep" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="ms-azuretools.visualstudio-bicep" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Bicep for Visual Studio</DisplayName>
     <Description xml:space="preserve">Bicep language support for Visual Studio.</Description>
     <License>License.txt</License>


### PR DESCRIPTION
@ucheNkadiCode and I ran into below issue while trying to upload visual studio extension on marketplace.

While uploading visual studio vsix on marketplace, there was an issue with the formatting on our landing page. When we tried to edit that page, it asked us to provide a new vsix.  We tried to remove the extension from the marketplace, but now as we're trying to re-upload the VSIX we are getting an error saying id already exists. 

We are working with marketplace folks to understand the issue. In the meantime, we thought we'll use this opportunity to update the id to include 'visualstudio' instead of 'vs'.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8341)