### PR TITLE
Fixed typo in the trigger for the notice job

### DIFF
--- a/.github/workflows/update-notices.yml
+++ b/.github/workflows/update-notices.yml
@@ -5,7 +5,7 @@ name: Update Local Notice Files
 on:
   workflow_dispatch:
   schedule:
-   - 0 9 * * *
+    - cron: 0 9 * * *
 
 jobs:
   main:


### PR DESCRIPTION
Fixed typo in the trigger for the notice job.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8375)