### PR TITLE
Simplify dependabot PR and approval process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "npm"
     directory: "/src/vscode-bicep"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     ignore:
       # we're deliberately taking a dependency on an older version of vscode for back-compatibility
       - dependency-name: "@types/vscode"
@@ -21,28 +23,35 @@ updates:
   - package-ecosystem: "npm"
     directory: "/src/playground"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "npm"
     directory: "/src/Bicep.Cli.E2eTests"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "npm"
     directory: "/src/Bicep.MSBuild.E2eTests"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "npm"
     directory: "/src/textmate"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "npm"
     directory: "/src/highlightjs"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "npm"
     directory: "/src/monarch"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -409,6 +409,46 @@
       "config": {
         "taskName": "Adds a link to a pull request body that allows Microsoft reviewers to open the pull request in CodeFlow"
       }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "dependencies"
+              }
+            },
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": "dependabot"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Reply to dependabot PRs with automation command to squash and merge",
+        "actions": [
+          {
+            "name": "approvePullRequest",
+            "parameters": {
+              "comment": "@dependabot squash and merge"
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -428,7 +428,7 @@
             {
               "name": "isActivitySender",
               "parameters": {
-                "user": "dependabot"
+                "user": "dependabot[bot]"
               }
             }
           ]
@@ -439,7 +439,7 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Reply to dependabot PRs with automation command to squash and merge",
+        "taskName": "Approve dependabot PRs with automation command to squash and merge",
         "actions": [
           {
             "name": "approvePullRequest",


### PR DESCRIPTION
* Change schedule to weekly so that the repo isn't constantly bombarded with dependabot PRs. I picked Sunday to minimize churn during the work week.
* Add fabricbot action to automatically merge dependabot PRs. I've not been able to test this yet - but it's based on [this sample](https://github.com/dotnet/samples/blob/fd2c181e280fbc2ae1b96d33020050fe3676ff4b/.github/fabricbot.json#L170-L209).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8411)