### PR TITLE
add support for URL encoded local paths

### DIFF
--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -149,7 +149,7 @@ namespace Bicep.Cli.Services
             }
 
             // to verify success we recompile and check for syntax errors.
-            await CompileAsync(decompilation.entrypointUri.AbsolutePath, skipRestore: true);
+            await CompileAsync(decompilation.entrypointUri.LocalPath, skipRestore: true);
 
             return decompilation;
         }

--- a/src/Bicep.Core.UnitTests/FileSystem/PathHelperTests.cs
+++ b/src/Bicep.Core.UnitTests/FileSystem/PathHelperTests.cs
@@ -161,6 +161,18 @@ namespace Bicep.Core.UnitTests.FileSystem
             yield return CreateFullPathRow(@"C:\test\te%2Ast\foo.bicep");
             yield return CreateFullPathRow(@"C:\test\te%00st\foo.bicep");
             yield return CreateFullPathRow(@"C:\test\te%ZZst\foo.bicep");
+#else
+            yield return CreateFullPathRow(@"/lib/var/test");
+            yield return CreateFullPathRow(@"/lib/var/te st");
+            yield return CreateFullPathRow(@"/lib/var/te%20st");
+            yield return CreateFullPathRow(@"/lib/var/test/te%20st");
+            yield return CreateFullPathRow(@"/lib/var/test/te st");
+            yield return CreateFullPathRow(@"/lib/var/test/te%20st/foo.bicep");
+            yield return CreateFullPathRow(@"/lib/var/test/te st/foo.bicep");
+            yield return CreateFullPathRow(@"/lib/var/test/te%20st/foo.bicep");
+            yield return CreateFullPathRow(@"/lib/var/test/te%2Ast/foo.bicep");
+            yield return CreateFullPathRow(@"/lib/var/test/te%00st/foo.bicep");
+            yield return CreateFullPathRow(@"/lib/var/test/te%ZZst/foo.bicep");
 #endif
         }
 

--- a/src/Bicep.Core.UnitTests/FileSystem/PathHelperTests.cs
+++ b/src/Bicep.Core.UnitTests/FileSystem/PathHelperTests.cs
@@ -76,6 +76,13 @@ namespace Bicep.Core.UnitTests.FileSystem
         }
 
         [DataTestMethod]
+        [DynamicData(nameof(GetFilePathToFileUrlData), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetDisplayName))]
+        public void FilePathToFileUrl_ShouldResolveCorrectly(string path, string expectedPath)
+        {
+            PathHelper.FilePathToFileUrl(path).LocalPath.Should().Be(expectedPath);
+        }
+
+        [DataTestMethod]
         [DynamicData(nameof(GetBuildOutputPathData), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetDisplayName))]
         public void GetDefaultBuildOutputPath_ShouldChangeExtensionCorrectly(string path, string expectedPath)
         {
@@ -111,6 +118,12 @@ namespace Bicep.Core.UnitTests.FileSystem
             yield return CreateFullPathRow(@"C:\test\foo.bicep");
             yield return CreateFullPathRow(@"\\reddog\Builds\branches\git_mgmt_governance_blueprint_master\test.bicep");
             yield return CreateFullPathRow(@"C:\test");
+            yield return CreateFullPathRow(@"C:\te st");
+            yield return CreateFullPathRow(@"C:\te%20st");
+            yield return CreateFullPathRow(@"C:\test\te%20st");
+            yield return CreateFullPathRow(@"C:\test\te st");
+            yield return CreateFullPathRow(@"C:\test\te%20st\foo.bicep");
+            yield return CreateFullPathRow(@"C:\test\te st\foo.bicep");
 
             yield return CreateRelativePathRow(@"test");
             yield return CreateRelativePathRow(@"test.bicep");
@@ -128,6 +141,26 @@ namespace Bicep.Core.UnitTests.FileSystem
             yield return CreateRelativePathRow(@"folder/test.bicep");
             yield return CreateRelativePathRow(@"deeper/folder/test.bicep");
             yield return CreateRelativePathRow(@"/deeper/folder/test.bicep");
+#endif
+        }
+
+        private static IEnumerable<object[]> GetFilePathToFileUrlData()
+        {
+            // local function
+            object[] CreateFullPathRow(string path) => CreateRow(path, path);
+
+#if WINDOWS_BUILD
+            yield return CreateFullPathRow(@"C:\test");
+            yield return CreateFullPathRow(@"C:\te st");
+            yield return CreateFullPathRow(@"C:\te%20st");
+            yield return CreateFullPathRow(@"C:\test\te%20st");
+            yield return CreateFullPathRow(@"C:\test\te st");
+            yield return CreateFullPathRow(@"C:\test\te%20st\foo.bicep");
+            yield return CreateFullPathRow(@"C:\test\te st\foo.bicep");
+            yield return CreateFullPathRow(@"C:\test\te%20st\foo.bicep");
+            yield return CreateFullPathRow(@"C:\test\te%2Ast\foo.bicep");
+            yield return CreateFullPathRow(@"C:\test\te%00st\foo.bicep");
+            yield return CreateFullPathRow(@"C:\test\te%ZZst\foo.bicep");
 #endif
         }
 

--- a/src/Bicep.Core/FileSystem/PathHelper.cs
+++ b/src/Bicep.Core/FileSystem/PathHelper.cs
@@ -126,6 +126,7 @@ namespace Bicep.Core.FileSystem
             {
                 filePath = "/" + filePath;
             }
+            filePath = filePath.Replace("%", "%25");
 
             var uriBuilder = new UriBuilder
             {


### PR DESCRIPTION
This PR relates to bug #8383 

Simply replacing the `%` char with the escaped URL version, `%25` solves the bug itself. 
We could also use the method `Uri.EscapeUriString()` to do this, but since that method is deprecated it seemed like a bad idea,
and the suggested replacement `Uri.EscapeDataString()` is not at all useable for bicep as it escapes _way_ to many characters.

When replacing/escaping this it did make `bicep decompile` fail in certain scenarios due to DecomipileAsync using AbsolutePath of the URI, but changing this to LocalPath solved those tests, and solved the compilation bug as well.

I tested this using loads of different URL encoded character paths, and all worked after this fix, but as my c# skills are limited I have not added tests to the project (let me know if needed and I'll try to skill up.)

[x] ran all included tests in test explorer

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8418)