### PR TITLE
Abernardi/basic setup

### DIFF
--- a/src/vscode-bicep/.vscode/launch.json
+++ b/src/vscode-bicep/.vscode/launch.json
@@ -13,7 +13,7 @@
       ],
       "stopOnEntry": false,
       "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+      //"outFiles": ["${workspaceRoot}/out/src/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}",
       "env": {
         "BICEP_TRACING_ENABLED": "true",
@@ -35,7 +35,7 @@
       ],
       "stopOnEntry": false,
       "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+      //"outFiles": ["${workspaceRoot}/out/src/**/*.js"],
       "preLaunchTask": "build:prod",
       "env": {
         "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll"
@@ -52,7 +52,7 @@
       ],
       "stopOnEntry": false,
       "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+      //"outFiles": ["${workspaceRoot}/out/src/**/*.js"],
       "preLaunchTask": "watch",
       "env": {
         "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll"
@@ -67,7 +67,7 @@
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--extensionTestsPath=${workspaceFolder}/out/test/e2e/index"
       ],
-      "outFiles": ["${workspaceRoot}/out/test/e2e/**/*.js"],
+      //"outFiles": ["${workspaceRoot}/out/test/e2e/**/*.js"],
       "preLaunchTask": "build:e2e",
       "env": {
         "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll",
@@ -83,7 +83,7 @@
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--extensionTestsPath=${workspaceFolder}/out/test/e2e/index"
       ],
-      "outFiles": ["${workspaceRoot}/out/test/e2e/**/*.js"],
+      //"outFiles": ["${workspaceRoot}/out/test/e2e/**/*.js"],
       "preLaunchTask": "build:e2e:dev",
       "env": {
         "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll",
@@ -99,9 +99,9 @@
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--extensionTestsPath=${workspaceFolder}/out/test/unit/index"
       ],
-      "outFiles": [
-        "${workspaceRoot}/out/test/unit/**/*.js"
-      ],
+      //"outFiles": [
+      //  "${workspaceRoot}/out/test/unit/**/*.js"
+      //],
       "preLaunchTask": "build:unit:dev",
       "env": {}
     },

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -44,6 +44,7 @@
     "onCommand:bicep.insertResource",
     "onCommand:bicep.importKubernetesManifest",
     "onCommand:bicep.showSource",
+    "onCommand:bicep.showVisualEditor",
     "onCommand:bicep.showVisualizer",
     "onCommand:bicep.showVisualizerToSide",
     "onCommand:bicep.gettingStarted.copyToClipboard",
@@ -135,6 +136,12 @@
       }
     ],
     "commands": [
+      {
+        "command": "bicep.showVisualEditor",
+        "title": "Open Bicep Visual Editor",
+        "category": "Bicep",
+        "icon": "$(type-hierarchy-sub)"
+      },
       {
         "command": "bicep.showVisualizer",
         "title": "Open Bicep Visualizer",

--- a/src/vscode-bicep/src/commands/index.ts
+++ b/src/vscode-bicep/src/commands/index.ts
@@ -10,4 +10,5 @@ export * from "./gettingStarted/WalkthroughOpenBicepFileCommand";
 export * from "./gettingStarted/WalkthroughCreateBicepFileCommand";
 export * from "./gettingStarted/WalkthroughCopyToClipboardCommand";
 export * from "./showSource";
+export * from "./showVisualEditor";
 export * from "./showVisualizer";

--- a/src/vscode-bicep/src/commands/showVisualEditor.ts
+++ b/src/vscode-bicep/src/commands/showVisualEditor.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import vscode from "vscode";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+
+import { BicepVisualizerViewManager } from "../visualizer";
+import { Command } from "./types";
+import { findOrCreateActiveBicepFile } from "./findOrCreateActiveBicepFile";
+
+async function showVisualEditor(
+  context: IActionContext,
+  viewManager: BicepVisualizerViewManager,
+  documentUri: vscode.Uri | undefined,
+  sideBySide = false
+) {
+  documentUri = await findOrCreateActiveBicepFile(
+    context,
+    documentUri,
+    "Choose which Bicep file to edit"
+  );
+
+  const viewColumn = sideBySide
+    ? vscode.ViewColumn.Beside
+    : vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.One;
+
+  await viewManager.openView(documentUri, viewColumn);
+
+  return viewColumn;
+}
+
+export class ShowVisualEditorCommand implements Command {
+  public readonly id = "bicep.showVisualEditor";
+
+  public constructor(
+    private readonly viewManager: BicepVisualizerViewManager
+  ) {}
+
+  public async execute(
+    context: IActionContext,
+    documentUri?: vscode.Uri | undefined
+  ): Promise<vscode.ViewColumn | undefined> {
+    return await showVisualEditor(context, this.viewManager, documentUri);
+  }
+}

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -17,6 +17,7 @@ import {
   GenerateParamsCommand,
   InsertResourceCommand,
   ShowSourceCommand,
+  ShowVisualEditorCommand,
   ShowVisualizerCommand,
   ShowVisualizerToSideCommand,
   WalkthroughCopyToClipboardCommand,
@@ -125,6 +126,7 @@ export async function activate(
               outputChannelManager
             ),
             new InsertResourceCommand(languageClient),
+            new ShowVisualEditorCommand(viewManager),
             new ShowVisualizerCommand(viewManager),
             new ShowVisualizerToSideCommand(viewManager),
             new ShowSourceCommand(viewManager),


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8436)