### PR TITLE
Prevent broken VS integration tests from failing the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,7 +267,6 @@ jobs:
           if-no-files-found: error
 
       - name: Upload BicepLanguageServerClient VSIX
-        id: upload-vs-vsix
         uses: actions/upload-artifact@v3
         with:
           name: Bicep.VSLanguageServerClient.Vsix.vsix
@@ -288,11 +287,9 @@ jobs:
         with:
           testAssembly: src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/bin/Release/net472/Bicep.VSLanguageServerClient.IntegrationTests.dll
           runInParallel: false
-
-      # Temporary workaround to force a green build - VS tests are flaky
-      - name: Ignore flaky tests
-        if: failure() && steps.upload-vs-vsix.outcome == 'success'
-        run: exit 0
+        # Temporary workaround to force a green build - VS tests are flaky
+        # Proper fix tracked under https://github.com/Azure/bicep/issues/8078
+        continue-on-error: true
 
   build-windows-setup:
     name: Build Windows Setup


### PR DESCRIPTION
Prevent broken VS integration tests from failing the build.

The proper fix will be addressed under #8078

Once merged, we can re-enable the `Required` check for the "Build Visual Studio Extension" job, so that we block build errors from being checked in.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8567)