### PR TITLE
Make correct usage of diagnostic level more clear

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterAnalyzerTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterAnalyzerTests.cs
@@ -77,7 +77,7 @@ namespace Bicep.Core.UnitTests.Diagnostics
         {
             var analyzer = new LinterAnalyzer();
             var ruleSet = analyzer.GetRuleSet();
-            var numberEnabled = ruleSet.Where(r => r.DiagnosticLevel != DiagnosticLevel.Off).Count();
+            var numberEnabled = ruleSet.Where(r => r.DefaultDiagnosticLevel != DiagnosticLevel.Off).Count();
             numberEnabled.Should().BeGreaterThan(ruleSet.Count() / 2, "most rules should probably be enabled by default");
         }
 
@@ -93,12 +93,12 @@ namespace Bicep.Core.UnitTests.Diagnostics
         {
             public LinterThrowsTestRule() : base("ThrowsRule", "Throws an exception when used", null, DiagnosticLevel.Warning) { }
 
-            public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+            public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
             {
                 // Have a yield return to force this method to return an iterator like the real rules
                 yield return new AnalyzerDiagnostic(this.AnalyzerName,
                                                     TextSpan.TextDocumentStart,
-                                                    DiagnosticLevel.Warning,
+                                                    diagnosticLevel,
                                                     "fakeRule",
                                                     "Fake Rule",
                                                     null);

--- a/src/Bicep.Core/Analyzers/Interfaces/IBicepAnalyzerRule.cs
+++ b/src/Bicep.Core/Analyzers/Interfaces/IBicepAnalyzerRule.cs
@@ -25,7 +25,7 @@ namespace Bicep.Core.Analyzers.Interfaces
 
         string Description { get; }
 
-        DiagnosticLevel DiagnosticLevel { get; }
+        DiagnosticLevel DefaultDiagnosticLevel { get; }
 
         DiagnosticStyling DiagnosticStyling { get; }
 

--- a/src/Bicep.Core/Analyzers/Linter/LinterRuleBase.cs
+++ b/src/Bicep.Core/Analyzers/Linter/LinterRuleBase.cs
@@ -26,7 +26,7 @@ namespace Bicep.Core.Analyzers.Linter
             this.Code = code;
             this.Description = description;
             this.Uri = docUri;
-            this.DiagnosticLevel = diagnosticLevel;
+            this.DefaultDiagnosticLevel = diagnosticLevel;
             this.DiagnosticStyling = diagnosticStyling;
         }
 
@@ -36,7 +36,7 @@ namespace Bicep.Core.Analyzers.Linter
 
         public readonly string RuleConfigSection = $"{LinterAnalyzer.AnalyzerName}.rules";
 
-        public DiagnosticLevel DiagnosticLevel { get; }
+        public DiagnosticLevel DefaultDiagnosticLevel { get; }
 
         public string Description { get; }
 
@@ -70,7 +70,7 @@ namespace Bicep.Core.Analyzers.Linter
                 return Enumerable.Empty<IDiagnostic>();
             }
 
-            return AnalyzeInternal(model);
+            return AnalyzeInternal(model, GetDiagnosticLevel(model));
         }
 
         /// <summary>
@@ -79,18 +79,18 @@ namespace Bicep.Core.Analyzers.Linter
         /// </summary>
         /// <param name="model"></param>
         /// <returns></returns>
-        public abstract IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model);
+        public abstract IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel);
 
         protected DiagnosticLevel GetDiagnosticLevel(SemanticModel model) => GetDiagnosticLevel(model.Configuration.Analyzers);
 
         protected DiagnosticLevel GetDiagnosticLevel(AnalyzersConfiguration configuration)
         {
-            if (GetConfigurationValue(configuration, "level", DiagnosticLevel.ToString()) is string configuredLevel && Enum.TryParse<DiagnosticLevel>(configuredLevel, true, out var parsed))
+            if (GetConfigurationValue(configuration, "level", DefaultDiagnosticLevel.ToString()) is string configuredLevel && Enum.TryParse<DiagnosticLevel>(configuredLevel, true, out var parsed))
             {
                 return parsed;
             }
 
-            return DiagnosticLevel;
+            return DefaultDiagnosticLevel;
         }
 
         /// <summary>

--- a/src/Bicep.Core/Analyzers/Linter/Rules/AdminUsernameShouldNotBeLiteralRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/AdminUsernameShouldNotBeLiteralRule.cs
@@ -26,9 +26,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public override string FormatMessage(params object[] values)
             => string.Format("{0} Found literal string value \"{1}\"", this.Description, values.First());
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var visitor = new ResourceVisitor(this, model, GetDiagnosticLevel(model));
+            var visitor = new ResourceVisitor(this, model, diagnosticLevel);
             visitor.Visit(model.SourceFile.ProgramSyntax);
             return visitor.diagnostics;
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/ArtifactsParametersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/ArtifactsParametersRule.cs
@@ -37,11 +37,10 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public override string FormatMessage(params object[] values)
             => string.Format((string)values[0]);
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
             var diagnostics = new List<IDiagnostic>();
 
-            var diagnosticLevel = GetDiagnosticLevel(model);
             diagnostics.AddRange(VerifyTopLevelParameters(model, diagnosticLevel));
             diagnostics.AddRange(VerifyModuleParameters(model, diagnosticLevel));
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/ExplicitValuesForLocationParamsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/ExplicitValuesForLocationParamsRule.cs
@@ -26,9 +26,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public override string FormatMessage(params object[] values)
             => string.Format((string)values[0]);
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            Visitor visitor = new(this, model, GetDiagnosticLevel(model));
+            Visitor visitor = new(this, model, diagnosticLevel);
             visitor.Visit(model.SourceFile.ProgramSyntax);
             return visitor.diagnostics;
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberOutputsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberOutputsRule.cs
@@ -26,12 +26,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return string.Format(CoreResources.MaxNumberOutputsRuleMessageFormat, values);
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
             if (model.Root.OutputDeclarations.Count() > MaxNumber)
             {
                 var firstItem = model.Root.OutputDeclarations.First();
-                return new IDiagnostic[] { CreateDiagnosticForSpan(GetDiagnosticLevel(model), firstItem.NameSyntax.Span, MaxNumber) };
+                return new IDiagnostic[] { CreateDiagnosticForSpan(diagnosticLevel, firstItem.NameSyntax.Span, MaxNumber) };
             }
             return Enumerable.Empty<IDiagnostic>();
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberParametersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberParametersRule.cs
@@ -26,12 +26,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return string.Format(CoreResources.MaxNumberParametersRuleMessageFormat, values);
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
             if (model.Root.ParameterDeclarations.Count() > MaxNumber)
             {
                 var firstItem = model.Root.ParameterDeclarations.First();
-                return new IDiagnostic[] { CreateDiagnosticForSpan(GetDiagnosticLevel(model), firstItem.NameSyntax.Span, MaxNumber) };
+                return new IDiagnostic[] { CreateDiagnosticForSpan(diagnosticLevel, firstItem.NameSyntax.Span, MaxNumber) };
             }
             return Enumerable.Empty<IDiagnostic>();
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberResourcesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberResourcesRule.cs
@@ -26,12 +26,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return string.Format(CoreResources.MaxNumberResourcesRuleMessageFormat, values);
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
             if (model.DeclaredResources.Length > MaxNumber)
             {
                 var firstItem = model.DeclaredResources.Where(r => r.Parent is null).First();
-                return new IDiagnostic[] { CreateDiagnosticForSpan(GetDiagnosticLevel(model), firstItem.Symbol.NameSyntax.Span, MaxNumber) };
+                return new IDiagnostic[] { CreateDiagnosticForSpan(diagnosticLevel, firstItem.Symbol.NameSyntax.Span, MaxNumber) };
             }
             return Enumerable.Empty<IDiagnostic>();
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberVariablesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/MaxNumberVariablesRule.cs
@@ -26,12 +26,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return string.Format(CoreResources.MaxNumberVariablesRuleMessageFormat, values);
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
             if (model.Root.VariableDeclarations.Count() > MaxNumber)
             {
                 var firstItem = model.Root.VariableDeclarations.First();
-                return new IDiagnostic[] { CreateDiagnosticForSpan(GetDiagnosticLevel(model), firstItem.NameSyntax.Span, MaxNumber) };
+                return new IDiagnostic[] { CreateDiagnosticForSpan(diagnosticLevel, firstItem.NameSyntax.Span, MaxNumber) };
             }
             return Enumerable.Empty<IDiagnostic>();
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedEnvironmentUrlsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedEnvironmentUrlsRule.cs
@@ -28,7 +28,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public override string FormatMessage(params object[] values)
             => string.Format("{0} Found this disallowed host: \"{1}\"", this.Description, values.First());
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
             var disallowedHosts = GetConfigurationValue(model.Configuration.Analyzers, DisallowedHostsKey.ToLowerInvariant(), Array.Empty<string>()).ToImmutableArray();
             var excludedHosts = GetConfigurationValue(model.Configuration.Analyzers, ExcludedHostsKey.ToLowerInvariant(), Array.Empty<string>()).ToImmutableArray();
@@ -38,7 +38,6 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 var visitor = new Visitor(disallowedHosts, disallowedHosts.Min(h => h.Length), excludedHosts);
                 visitor.Visit(model.SourceFile.ProgramSyntax);
 
-                var diagnosticLevel = GetDiagnosticLevel(model);
                 return visitor.DisallowedHostSpans.Select(entry => CreateDiagnosticForSpan(diagnosticLevel, entry.Key, entry.Value));
             }
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedLocationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedLocationRule.cs
@@ -33,9 +33,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public override string FormatMessage(params object[] values)
             => string.Format((string)values[0]);
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            RuleVisitor visitor = new(this, model, GetDiagnosticLevel(model));
+            RuleVisitor visitor = new(this, model, diagnosticLevel);
             visitor.Visit(model.SourceFile.ProgramSyntax);
             return visitor.diagnostics;
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoLocationExprOutsideParamsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoLocationExprOutsideParamsRule.cs
@@ -25,9 +25,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public override string FormatMessage(params object[] values)
             => string.Format((string)values[0]);
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            RuleVisitor visitor = new(this, GetDiagnosticLevel(model));
+            RuleVisitor visitor = new(this, diagnosticLevel);
             visitor.Visit(model.SourceFile.ProgramSyntax);
             return visitor.diagnostics;
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnnecessaryDependsOnRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnnecessaryDependsOnRule.cs
@@ -27,14 +27,14 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public override string FormatMessage(params object[] values)
             => string.Format(CoreResources.NoUnnecessaryDependsOnRuleMessage, values.First());
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
             Lazy<ImmutableDictionary<DeclaredSymbol, ImmutableHashSet<ResourceDependency>>> inferredDependenciesMap =
                 new(
                     () => ResourceDependencyVisitor.GetResourceDependencies(
                         model,
                         new ResourceDependencyVisitor.Options { IgnoreExplicitDependsOn = true }));
-            var visitor = new ResourceVisitor(this, inferredDependenciesMap, model, GetDiagnosticLevel(model));
+            var visitor = new ResourceVisitor(this, inferredDependenciesMap, model, diagnosticLevel);
             visitor.Visit(model.SourceFile.ProgramSyntax);
             return visitor.diagnostics;
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedExistingResourcesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedExistingResourcesRule.cs
@@ -27,9 +27,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return string.Format(CoreResources.UnusedExistingResourceRuleMessageFormat, values);
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             // TODO: Performance: Use a visitor to visit VariableAccesssyntax and collects the non-error symbols into a list.
             // Then do a symbol visitor to go through all the symbols that exist and compare.
             // Same issue for unused-params and unused-variables rule.

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedParametersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedParametersRule.cs
@@ -26,9 +26,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return string.Format(CoreResources.ParameterMustBeUsedRuleMessageFormat, values);
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             // VariableAccessSyntax indicates a reference to the parameter
             var unreferencedParams = model.Root.ParameterDeclarations
                 .Where(sym => !model.FindReferences(sym).OfType<VariableAccessSyntax>().Any())

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedVariablesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedVariablesRule.cs
@@ -27,9 +27,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return string.Format(CoreResources.UnusedVariableRuleMessageFormat, values);
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             // TODO: Performance: Use a visitor to visit VariableAccesssyntax and collects the non-error symbols into a list.
             // Then do a symbol visitor to go through all the symbols that exist and compare.
             // Same issue for unused-params rule.

--- a/src/Bicep.Core/Analyzers/Linter/Rules/OutputsShouldNotContainSecretsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/OutputsShouldNotContainSecretsRule.cs
@@ -32,9 +32,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 values.First());
         }
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var visitor = new OutputVisitor(this, model, GetDiagnosticLevel(model));
+            var visitor = new OutputVisitor(this, model, diagnosticLevel);
             visitor.Visit(model.SourceFile.ProgramSyntax);
             return visitor.diagnostics;
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/PreferInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/PreferInterpolationRule.cs
@@ -24,9 +24,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             docUri: new Uri($"https://aka.ms/bicep/linter/{Code}"))
         { }
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var visitor = new Visitor(this, model, GetDiagnosticLevel(model));
+            var visitor = new Visitor(this, model, diagnosticLevel);
             visitor.Visit(model.SourceFile.ProgramSyntax);
             return visitor.diagnostics;
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/PreferUnquotedPropertyNamesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/PreferUnquotedPropertyNamesRule.cs
@@ -24,13 +24,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             docUri: new Uri($"https://aka.ms/bicep/linter/{Code}"))
         { }
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
             var spanFixes = new Dictionary<TextSpan, CodeFix>();
             var visitor = new Visitor(spanFixes);
             visitor.Visit(model.SourceFile.ProgramSyntax);
 
-            var diagnosticLevel = GetDiagnosticLevel(model);
             return spanFixes.Select(kvp => CreateFixableDiagnosticForSpan(diagnosticLevel, kvp.Key, kvp.Value));
         }
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
@@ -47,9 +47,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return string.Format(CoreResources.SecretsInParamsRule_MessageFormat, paramName);
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             foreach (var param in model.Root.ParameterDeclarations)
             {
                 if (!param.IsSecure())

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecureParameterDefaultRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecureParameterDefaultRule.cs
@@ -21,9 +21,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             docUri: new Uri($"https://aka.ms/bicep/linter/{Code}"))
         { }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             var defaultValueSyntaxes = model.Root.ParameterDeclarations.Where(p => p.IsSecure())
                 .Select(p => p.DeclaringParameter.Modifier as ParameterDefaultValueSyntax)
                 .OfType<ParameterDefaultValueSyntax>(); // this eliminates nulls (when there's no default value)

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecureParamsInNestedDeploymentsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecureParamsInNestedDeploymentsRule.cs
@@ -37,9 +37,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return $"{problem} {CoreResources.SecureParamsInNestedDeployRule_Solution}";
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             foreach (ResourceSymbol resource in model.Root.ResourceDeclarations)
             {
                 if (GetPropertiesIfOuterScopedDeployment(resource) is ObjectSyntax propertiesObject)

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
@@ -24,13 +24,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             docUri: new Uri($"https://aka.ms/bicep/linter/{Code}"))
         { }
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
             var spanFixes = new Dictionary<TextSpan, CodeFix>();
             var visitor = new Visitor(spanFixes, model);
             visitor.Visit(model.SourceFile.ProgramSyntax);
 
-            var diagnosticLevel = GetDiagnosticLevel(model);
             return spanFixes.Select(kvp => CreateFixableDiagnosticForSpan(diagnosticLevel, kvp.Key, kvp.Value));
         }
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseProtectedSettingsForCommandToExecuteSecretsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseProtectedSettingsForCommandToExecuteSecretsRule.cs
@@ -35,9 +35,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public override string FormatMessage(params object[] values)
             => string.Format(CoreResources.ProtectCommandToExecuteSecretsRuleMessage, (string)values[0]);
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel semanticModel)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel semanticModel, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(semanticModel);
             List<IDiagnostic> diagnostics = new();
 
             foreach (var resource in semanticModel.DeclaredResources.Where(r => r.IsAzResource))

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
@@ -64,9 +64,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 + (acceptableVersionsString.Any() ? " " + string.Format(CoreResources.UseRecentApiVersionRule_AcceptableVersions, acceptableVersionsString) : "");
         }
 
-        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             var today = DateTime.Today;
             // Today's date can be changed to enable testing/debug scenarios
             if (GetConfigurationValue<string?>(model.Configuration.Analyzers, "test-today", null) is string testToday)

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
@@ -113,9 +113,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             IEnumerable<DeclaredSymbol> PathToExpression
         );
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             foreach (var resource in model.DeclaredResources)
             {
                 if (resource.IsAzResource

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
@@ -21,9 +21,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             docUri: new Uri($"https://aka.ms/bicep/linter/{Code}"))
         { }
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             foreach (var resource in model.DeclaredResources)
             {
                 foreach (var identifier in resource.Type.UniqueIdentifierProperties)

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseStableVMImageRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseStableVMImageRule.cs
@@ -31,9 +31,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return string.Format(CoreResources.UseStableVMImageRuleFixMessageFormat, values);
         }
 
-        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model)
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            var diagnosticLevel = GetDiagnosticLevel(model);
             List<IDiagnostic> diagnostics = new();
 
             foreach (DeclaredResourceMetadata resource in model.DeclaredResources)


### PR DESCRIPTION
The current implementation makes it quite likely that a rule implementer will incorrectly use this.DiagnosticLevel instead of GetDiagnosticLevel(model).  This refactoring makes the intended usage completely clear.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8645)