### PR TITLE
Allow test scenarios in Bicep.Core.Samples/Files to define configuration

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -72,8 +72,7 @@ namespace Bicep.Cli.IntegrationTests
             await dataSet.PublishModulesToRegistryAsync(clientFactory, TestContext);
             var bicepFilePath = Path.Combine(outputDirectory, DataSet.TestFileMain);
 
-            var features = BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: dataSet.HasExternalModules);
-            var settings = new InvocationSettings(features, clientFactory, templateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: dataSet.HasExternalModules), clientFactory, templateSpecRepositoryFactory);
             var (output, error, result) = await Bicep(settings, "build", bicepFilePath);
 
             using (new AssertionScope())
@@ -86,8 +85,9 @@ namespace Bicep.Cli.IntegrationTests
             if (dataSet.HasExternalModules)
             {
                 // ensure something got restored
-                Directory.Exists(settings.Features.CacheRootDirectory).Should().BeTrue();
-                Directory.EnumerateFiles(settings.Features.CacheRootDirectory, "*.json", SearchOption.AllDirectories).Should().NotBeEmpty();
+
+                Directory.Exists(settings.FeatureOverrides.CacheRootDirectory).Should().BeTrue();
+                Directory.EnumerateFiles(settings.FeatureOverrides.CacheRootDirectory!, "*.json", SearchOption.AllDirectories).Should().NotBeEmpty();
             }
 
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);
@@ -112,8 +112,7 @@ namespace Bicep.Cli.IntegrationTests
             await dataSet.PublishModulesToRegistryAsync(clientFactory, TestContext);
             var bicepFilePath = Path.Combine(outputDirectory, DataSet.TestFileMain);
 
-            var features = BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: dataSet.HasExternalModules);
-            var settings = new InvocationSettings(features, clientFactory, templateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: dataSet.HasExternalModules), clientFactory, templateSpecRepositoryFactory);
 
             var (output, error, result) = await Bicep(settings, "build", "--stdout", bicepFilePath);
 
@@ -126,7 +125,7 @@ namespace Bicep.Cli.IntegrationTests
 
             if (dataSet.HasExternalModules)
             {
-                settings.Features.Should().HaveValidModules();
+                settings.FeatureOverrides.Should().HaveValidModules();
             }
 
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);
@@ -151,8 +150,7 @@ namespace Bicep.Cli.IntegrationTests
             await dataSet.PublishModulesToRegistryAsync(clientFactory, TestContext);
             var bicepFilePath = Path.Combine(outputDirectory, DataSet.TestFileMain);
 
-            var features = BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: dataSet.HasExternalModules);
-            var settings = new InvocationSettings(features, clientFactory, templateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: dataSet.HasExternalModules), clientFactory, templateSpecRepositoryFactory);
 
             var (restoreOutput, restoreError, restoreResult) = await Bicep(settings, "restore", bicepFilePath);
             using (new AssertionScope())
@@ -191,8 +189,7 @@ namespace Bicep.Cli.IntegrationTests
         {
             var data = baselineData.GetData(TestContext);
 
-            var features = BicepTestConstants.CreateFeatureProvider(TestContext, paramsFilesEnabled: true);
-            var settings = new InvocationSettings(features, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, ParamsFilesEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
 
             var (output, error, result) = await Bicep(settings, "build", data.Parameters.OutputFilePath);
 
@@ -220,7 +217,7 @@ namespace Bicep.Cli.IntegrationTests
 
             var templateSpecRepositoryFactory = BicepTestConstants.TemplateSpecRepositoryFactory;
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), clientFactory.Object, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory.Object, BicepTestConstants.TemplateSpecRepositoryFactory);
 
             var tempDirectory = FileHelper.GetUniqueTestOutputPath(TestContext);
             Directory.CreateDirectory(tempDirectory);
@@ -303,8 +300,7 @@ module empty 'br:{registry}/{repository}@{digest}' = {{
         {
             var data = baselineData.GetData(TestContext);
 
-            var features = BicepTestConstants.CreateFeatureProvider(TestContext, paramsFilesEnabled: true);
-            var settings = new InvocationSettings(features, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, ParamsFilesEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var diagnostics = GetAllParamDiagnostics(data.Parameters.OutputFilePath, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
 
             var (output, error, result) = await Bicep(settings, "build", data.Parameters.OutputFilePath);

--- a/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
@@ -70,7 +70,7 @@ namespace Bicep.Cli.IntegrationTests
         [TestMethod]
         public async Task Publish_InvalidInputFile_ShouldProduceExpectedError()
         {
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var (output, error, result) = await Bicep(settings, "publish", "WrongFile.bicep", "--target", "br:example.azurecr.io/hello/there:v1");
 
             result.Should().Be(1);
@@ -91,7 +91,7 @@ namespace Bicep.Cli.IntegrationTests
         [TestMethod]
         public async Task Publish_OciDigestTarget_ShouldProduceExpectedError()
         {
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var (output, error, result) = await Bicep(settings, "publish", "WrongFile.bicep", "--target", "br:example.com/test@sha256:80f63ced0b80b63874c808a321f472755a3c9e93987d1fa0a51e13c65e4a52b9");
 
             result.Should().Be(1);
@@ -118,7 +118,7 @@ namespace Bicep.Cli.IntegrationTests
             // mock client factory caches the clients
             var testClient = (MockRegistryBlobClient)clientFactory.CreateAuthenticatedBlobClient(BicepTestConstants.BuiltInConfiguration, registryUri, repository);
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), clientFactory, templateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory, templateSpecRepositoryFactory);
 
             var (output, error, result) = await Bicep(settings, "publish", bicepFilePath, "--target", $"br:{registryStr}/{repository}:v1");
             result.Should().Be(0);
@@ -159,7 +159,7 @@ namespace Bicep.Cli.IntegrationTests
             // mock client factory caches the clients
             var testClient = (MockRegistryBlobClient)clientFactory.CreateAuthenticatedBlobClient(BicepTestConstants.BuiltInConfiguration, registryUri, repository);
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), clientFactory, templateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory, templateSpecRepositoryFactory);
 
             var (output, error, result) = await Bicep(settings, "publish", compiledFilePath, "--target", $"br:{registryStr}/{repository}:v1");
             result.Should().Be(0);
@@ -201,7 +201,7 @@ namespace Bicep.Cli.IntegrationTests
 
             var templateSpecRepositoryFactory = StrictMock.Of<ITemplateSpecRepositoryFactory>();
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), clientFactory.Object, templateSpecRepositoryFactory.Object);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory.Object, templateSpecRepositoryFactory.Object);
             var (output, error, result) = await Bicep(settings, "publish", compiledFilePath, "--target", "br:fake/fake:v1");
             using (new AssertionScope())
             {
@@ -230,7 +230,7 @@ namespace Bicep.Cli.IntegrationTests
 
             var templateSpecRepositoryFactory = StrictMock.Of<ITemplateSpecRepositoryFactory>();
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), clientFactory.Object, templateSpecRepositoryFactory.Object);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory.Object, templateSpecRepositoryFactory.Object);
             var (output, error, result) = await Bicep(settings, "publish", compiledFilePath, "--target", "br:fake/fake:v1");
             using (new AssertionScope())
             {
@@ -248,7 +248,7 @@ namespace Bicep.Cli.IntegrationTests
             var bicepFilePath = Path.Combine(outputDirectory, DataSet.TestFileMain);
 
             // publish won't actually happen, so broken client factory is fine
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
 
             var diagnostics = GetAllDiagnostics(bicepFilePath, settings.ClientFactory, settings.TemplateSpecRepositoryFactory);
 

--- a/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
@@ -57,8 +57,8 @@ namespace Bicep.Cli.IntegrationTests
 
             var bicepFilePath = Path.Combine(outputDirectory, DataSet.TestFileMain);
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: dataSet.HasExternalModules), clientFactory, templateSpecRepositoryFactory);
-            TestContext.WriteLine($"Cache root = {settings.Features.CacheRootDirectory}");
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: dataSet.HasExternalModules), clientFactory, templateSpecRepositoryFactory);
+            TestContext.WriteLine($"Cache root = {settings.FeatureOverrides.CacheRootDirectory}");
             var (output, error, result) = await Bicep(settings, "restore", bicepFilePath);
 
             using (new AssertionScope())
@@ -71,7 +71,7 @@ namespace Bicep.Cli.IntegrationTests
             if (dataSet.HasExternalModules)
             {
                 // ensure something got restored
-                settings.Features.Should().HaveValidModules();
+                settings.FeatureOverrides.Should().HaveValidModules();
             }
         }
 
@@ -89,7 +89,7 @@ namespace Bicep.Cli.IntegrationTests
 
             var templateSpecRepositoryFactory = BicepTestConstants.TemplateSpecRepositoryFactory;
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), clientFactory.Object, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory.Object, BicepTestConstants.TemplateSpecRepositoryFactory);
 
             var tempDirectory = FileHelper.GetUniqueTestOutputPath(TestContext);
             Directory.CreateDirectory(tempDirectory);
@@ -141,8 +141,8 @@ module empty 'br:{registry}/{repository}@{digest}' = {{
 
             var bicepFilePath = Path.Combine(outputDirectory, DataSet.TestFileMain);
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: dataSet.HasExternalModules), clientFactory, templateSpecRepositoryFactory);
-            TestContext.WriteLine($"Cache root = {settings.Features.CacheRootDirectory}");
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: dataSet.HasExternalModules), clientFactory, templateSpecRepositoryFactory);
+            TestContext.WriteLine($"Cache root = {settings.FeatureOverrides.CacheRootDirectory}");
             var (output, error, result) = await Bicep(settings, "restore", bicepFilePath);
 
             using (new AssertionScope())
@@ -175,7 +175,7 @@ module empty 'br:{registry}/{repository}@{digest}' = {{
 
             var templateSpecRepositoryFactory = StrictMock.Of<ITemplateSpecRepositoryFactory>();
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), clientFactory.Object, templateSpecRepositoryFactory.Object);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory.Object, templateSpecRepositoryFactory.Object);
             var (output, error, result) = await Bicep(settings, "restore", compiledFilePath);
             using(new AssertionScope())
             {
@@ -207,7 +207,7 @@ module empty 'br:{registry}/{repository}@{digest}' = {{
 
             var templateSpecRepositoryFactory = StrictMock.Of<ITemplateSpecRepositoryFactory>();
 
-            var settings = new InvocationSettings(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true), clientFactory.Object, templateSpecRepositoryFactory.Object);
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory.Object, templateSpecRepositoryFactory.Object);
             var (output, error, result) = await Bicep(settings, "restore", compiledFilePath);
             using (new AssertionScope())
             {

--- a/src/Bicep.Cli.IntegrationTests/RootCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/RootCommandTests.cs
@@ -47,10 +47,7 @@ namespace Bicep.Cli.IntegrationTests
         [TestMethod]
         public async Task BicepHelpShouldPrintHelp()
         {
-            var featuresMock = Repository.Create<IFeatureProvider>();
-            featuresMock.Setup(m => m.RegistryEnabled).Returns(true);
-
-            var settings = CreateDefaultSettings() with { Features = featuresMock.Object };
+            var settings = CreateDefaultSettings() with { FeatureOverrides = new(RegistryEnabled: true) };
 
             var (output, error, result) = await Bicep(settings, "--help");
 
@@ -132,10 +129,7 @@ namespace Bicep.Cli.IntegrationTests
         {
             // disable registry to ensure `bicep --help` is not consulting the feature provider before
             // preparing the help text (as features can only be determined when an input file is specified)
-            var featuresMock = Repository.Create<IFeatureProvider>();
-            featuresMock.Setup(m => m.RegistryEnabled).Returns(false);
-
-            var settings = CreateDefaultSettings() with { Features = featuresMock.Object };
+            var settings = CreateDefaultSettings() with { FeatureOverrides = new(RegistryEnabled: false) };
 
             var (output, error, result) = await Bicep(settings, "--help");
 

--- a/src/Bicep.Cli.IntegrationTests/TestBase.cs
+++ b/src/Bicep.Cli.IntegrationTests/TestBase.cs
@@ -9,6 +9,7 @@ using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
 using Bicep.Core.Text;
 using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
 using FluentAssertions;
@@ -28,12 +29,12 @@ namespace Bicep.Cli.IntegrationTests
 
         protected static readonly MockRepository Repository = new(MockBehavior.Strict);
 
-        protected record InvocationSettings(IFeatureProvider Features, IContainerRegistryClientFactory ClientFactory, ITemplateSpecRepositoryFactory TemplateSpecRepositoryFactory);
+        protected record InvocationSettings(FeatureProviderOverrides FeatureOverrides, IContainerRegistryClientFactory ClientFactory, ITemplateSpecRepositoryFactory TemplateSpecRepositoryFactory);
 
         protected static Task<(string output, string error, int result)> Bicep(params string[] args) => Bicep(CreateDefaultSettings(), args);
 
         protected static InvocationSettings CreateDefaultSettings() => new(
-            Features: BicepTestConstants.Features,
+            FeatureOverrides: BicepTestConstants.FeatureOverrides,
             ClientFactory: Repository.Create<IContainerRegistryClientFactory>().Object,
             TemplateSpecRepositoryFactory: Repository.Create<ITemplateSpecRepositoryFactory>().Object);
 
@@ -43,7 +44,7 @@ namespace Bicep.Cli.IntegrationTests
                     TestTypeHelper.CreateEmptyAzResourceTypeLoader(),
                     @out,
                     err,
-                    featureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(settings.Features),
+                    featureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(settings.FeatureOverrides),
                     clientFactory: settings.ClientFactory,
                     templateSpecRepositoryFactory: settings.TemplateSpecRepositoryFactory)).RunAsync(args));
 

--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -9,14 +9,13 @@ using System.Text;
 using System.Threading.Tasks;
 using Bicep.Core.Configuration;
 using Bicep.Core.Emit;
-using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Parsing;
 using Bicep.Core.Registry;
 using Bicep.Core.Samples;
 using Bicep.Core.Semantics;
-using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
@@ -45,7 +44,8 @@ namespace Bicep.Core.IntegrationTests.Emit
             var bicepFileUri = PathHelper.FilePathToFileUrl(bicepFilePath);
 
             // emitting the template should be successful
-            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver, clientFactory, templateSpecRepositoryFactory, IFeatureProviderFactory.WithStaticFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: dataSet.HasExternalModules)), BicepTestConstants.ConfigurationManager), BicepTestConstants.ConfigurationManager);
+            var configManager = BicepTestConstants.CreateFilesystemConfigurationManager();
+            var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver, clientFactory, templateSpecRepositoryFactory, BicepTestConstants.CreateFeatureProviderFactory(new(TestContext, RegistryEnabled: dataSet.HasExternalModules), configManager), configManager), configManager);
             Workspace workspace = new();
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, workspace, PathHelper.FilePathToFileUrl(bicepFilePath));
             if (await dispatcher.RestoreModules(dispatcher.GetValidModuleReferences(sourceFileGrouping.GetModulesToRestore())))
@@ -64,7 +64,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             var compiledFilePath = FileHelper.GetResultFilePath(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainCompiled));
             var sourceFileGrouping = await GetSourceFileGrouping(dataSet);
 
-            var result = EmitTemplate(sourceFileGrouping, BicepTestConstants.Features, compiledFilePath);
+            var result = EmitTemplate(sourceFileGrouping, new(), compiledFilePath);
             result.Diagnostics.Should().NotHaveErrors();
             result.Status.Should().Be(EmitStatus.Succeeded);
 
@@ -89,7 +89,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             var compiledFilePath = FileHelper.GetResultFilePath(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainCompiledWithSymbolicNames));
             var sourceFileGrouping = await GetSourceFileGrouping(dataSet);
 
-            var result = EmitTemplate(sourceFileGrouping, BicepTestConstants.Features with { SymbolicNameCodegenEnabled = true }, compiledFilePath);
+            var result = EmitTemplate(sourceFileGrouping, new(SymbolicNameCodegenEnabled: true), compiledFilePath);
             result.Diagnostics.Should().NotHaveErrors();
             result.Status.Should().Be(EmitStatus.Succeeded);
 
@@ -111,7 +111,7 @@ namespace Bicep.Core.IntegrationTests.Emit
         [TestCategory(BaselineHelper.BaselineTestCategory)]
         public async Task ValidBicep_TemplateEmitterShouldProduceExpectedSourceMap(DataSet dataSet)
         {
-            var features = BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: dataSet.HasExternalModules, sourceMappingEnabled: true);
+            var features = new FeatureProviderOverrides(TestContext, RegistryEnabled: dataSet.HasExternalModules, SourceMappingEnabled: true);
             var (compilation, outputDirectory, _) = await dataSet.SetupPrerequisitesAndCreateCompilation(TestContext, features);
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel());
             using var memoryStream = new MemoryStream();
@@ -155,7 +155,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             var compiledFilePath = FileHelper.GetResultFilePath(this.TestContext, "main.json");
 
             // emitting the template should be successful
-            var result = this.EmitTemplate(sourceFileGrouping, BicepTestConstants.Features, compiledFilePath);
+            var result = this.EmitTemplate(sourceFileGrouping, new(), compiledFilePath);
             result.Diagnostics.Should().BeEmpty();
             result.Status.Should().Be(EmitStatus.Succeeded);
 
@@ -174,7 +174,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             var sourceFileGrouping = await GetSourceFileGrouping(dataSet);
 
             var memoryStream = new MemoryStream();
-            var result = this.EmitTemplate(sourceFileGrouping, BicepTestConstants.Features, memoryStream);
+            var result = this.EmitTemplate(sourceFileGrouping, new(), memoryStream);
             result.Diagnostics.Should().NotHaveErrors();
             result.Status.Should().Be(EmitStatus.Succeeded);
 
@@ -200,7 +200,7 @@ namespace Bicep.Core.IntegrationTests.Emit
 
             // emitting the template should fail
             var dispatcher = new ModuleDispatcher(BicepTestConstants.RegistryProvider, IConfigurationManager.WithStaticConfiguration(BicepTestConstants.BuiltInConfigurationWithAllAnalyzersDisabled));
-            var result = this.EmitTemplate(SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath)), BicepTestConstants.Features, filePath);
+            var result = this.EmitTemplate(SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, dispatcher, new Workspace(), PathHelper.FilePathToFileUrl(bicepFilePath)), new(), filePath);
             result.Diagnostics.Should().NotBeEmpty();
             result.Status.Should().Be(EmitStatus.Failed);
         }
@@ -214,7 +214,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             data.Compiled.Should().NotBeNull();
 
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, BicepTestConstants.ModuleDispatcher, new Workspace(), PathHelper.FilePathToFileUrl(data.Parameters.OutputFilePath));
-            var result = this.EmitParam(sourceFileGrouping, BicepTestConstants.Features, data.Compiled!.OutputFilePath);
+            var result = this.EmitParam(sourceFileGrouping, new(), data.Compiled!.OutputFilePath);
 
             result.Diagnostics.Should().NotHaveErrors();
             result.Status.Should().Be(EmitStatus.Succeeded);
@@ -230,7 +230,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             var data = baselineData.GetData(TestContext);
 
             var sourceFileGrouping = SourceFileGroupingBuilder.Build(BicepTestConstants.FileResolver, BicepTestConstants.ModuleDispatcher, new Workspace(), PathHelper.FilePathToFileUrl(data.Parameters.OutputFilePath));
-            var result = this.EmitParam(sourceFileGrouping, BicepTestConstants.Features, Path.ChangeExtension(data.Parameters.OutputFilePath, ".json"));
+            var result = this.EmitParam(sourceFileGrouping, new(), Path.ChangeExtension(data.Parameters.OutputFilePath, ".json"));
 
             result.Diagnostics.Should().NotBeEmpty();
             result.Status.Should().Be(EmitStatus.Failed);
@@ -272,30 +272,30 @@ this
             emitter.Emit(stringWriter);
         }
 
-        private EmitResult EmitTemplate(SourceFileGrouping sourceFileGrouping, IFeatureProvider features, string filePath)
+        private EmitResult EmitTemplate(SourceFileGrouping sourceFileGrouping, FeatureProviderOverrides features, string filePath)
         {
-            var compilation = Services.WithFeatureProvider(features).Build().BuildCompilation(sourceFileGrouping);
+            var compilation = Services.WithFeatureOverrides(features).Build().BuildCompilation(sourceFileGrouping);
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel());
 
             using var stream = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
             return emitter.Emit(stream);
         }
 
-        private EmitResult EmitTemplate(SourceFileGrouping sourceFileGrouping, IFeatureProvider features, MemoryStream memoryStream)
+        private EmitResult EmitTemplate(SourceFileGrouping sourceFileGrouping, FeatureProviderOverrides features, MemoryStream memoryStream)
         {
-            var compilation = Services.WithFeatureProvider(features).Build().BuildCompilation(sourceFileGrouping);
+            var compilation = Services.WithFeatureOverrides(features).Build().BuildCompilation(sourceFileGrouping);
             var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel());
 
             TextWriter tw = new StreamWriter(memoryStream);
             return emitter.Emit(tw);
         }
 
-        private EmitResult EmitParam(SourceFileGrouping sourceFileGrouping, IFeatureProvider features, string outputFilePath)
+        private EmitResult EmitParam(SourceFileGrouping sourceFileGrouping, FeatureProviderOverrides features, string outputFilePath)
         {
-            var model = new ParamsSemanticModel(sourceFileGrouping, BicepTestConstants.BuiltInConfiguration, features, file => {
+            var model = new ParamsSemanticModel(sourceFileGrouping, BicepTestConstants.BuiltInConfiguration, BicepTestConstants.Features, file => {
                 var compilationGrouping = new SourceFileGrouping(BicepTestConstants.FileResolver, file.FileUri, sourceFileGrouping.FileResultByUri, sourceFileGrouping.UriResultByModule, sourceFileGrouping.SourceFileParentLookup);
 
-                return Services.WithFeatureProviderFactory(IFeatureProviderFactory.WithStaticFeatureProvider(features)).Build().BuildCompilation(compilationGrouping);
+                return Services.WithFeatureOverrides(features).Build().BuildCompilation(compilationGrouping);
             });
 
             var emitter = new ParametersEmitter(model);

--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -19,7 +19,7 @@ namespace Bicep.Core.IntegrationTests
         public TestContext? TestContext { get; set; }
 
         private ServiceBuilder Services => new ServiceBuilder()
-            .WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, importsEnabled: true))
+            .WithFeatureOverrides(new(ImportsEnabled: true))
             .WithNamespaceProvider(new TestExtensibilityNamespaceProvider(BicepTestConstants.AzResourceTypeLoader));
 
         [TestMethod]

--- a/src/Bicep.Core.IntegrationTests/ImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ImportTests.cs
@@ -10,7 +10,6 @@ using Bicep.Core.Features;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem;
-using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
@@ -22,7 +21,7 @@ namespace Bicep.Core.IntegrationTests
     public class ImportTests
     {
         private ServiceBuilder ServicesWithImports => new ServiceBuilder()
-            .WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, importsEnabled: true));
+            .WithFeatureOverrides(new(TestContext, ImportsEnabled: true));
 
         private class TestNamespaceProvider : INamespaceProvider
         {

--- a/src/Bicep.Core.IntegrationTests/Issue6075Tests.cs
+++ b/src/Bicep.Core.IntegrationTests/Issue6075Tests.cs
@@ -354,7 +354,7 @@ resource thing 'Microsoft.Network/virtualNetworks/subnets/things@2021-05-01' = [
 
         private CompilationHelper.CompilationResult Compile(string bicep, bool symbolicNameCodegenEnabled)
         {
-            var services = new ServiceBuilder().WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(this.TestContext, symbolicNameCodegenEnabled: symbolicNameCodegenEnabled));
+            var services = new ServiceBuilder().WithFeatureOverrides(new(this.TestContext, SymbolicNameCodegenEnabled: symbolicNameCodegenEnabled));
 
             return CompilationHelper.Compile(services, bicep);
         }

--- a/src/Bicep.Core.IntegrationTests/ModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleTests.cs
@@ -36,7 +36,7 @@ namespace Bicep.Core.IntegrationTests
         private static readonly MockRepository Repository = new MockRepository(MockBehavior.Strict);
         private static readonly IConfigurationManager ConfigurationManager = IConfigurationManager.WithStaticConfiguration(BicepTestConstants.BuiltInConfigurationWithAllAnalyzersDisabled);
 
-        private ServiceBuilder ServicesWithResourceTyped => new ServiceBuilder().WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, resourceTypedParamsAndOutputsEnabled: true));
+        private ServiceBuilder ServicesWithResourceTyped => new ServiceBuilder().WithFeatureOverrides(new(TestContext, ResourceTypedParamsAndOutputsEnabled: true));
 
         [NotNull]
         public TestContext? TestContext { get; set; }
@@ -391,7 +391,7 @@ module modulea 'modulea.bicep' = {
         [TestMethod]
         public void External_module_reference_with_unknown_scheme_should_be_rejected()
         {
-            var services = new ServiceBuilder().WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: true));
+            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, RegistryEnabled: true));
             var result = CompilationHelper.Compile(services, @"module test 'fake:totally-fake' = {}");
 
             result.Should().HaveDiagnostics(new[]
@@ -403,7 +403,7 @@ module modulea 'modulea.bicep' = {
         [TestMethod]
         public void External_module_reference_with_oci_scheme_should_be_rejected_if_registry_disabled()
         {
-            var services = new ServiceBuilder().WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, registryEnabled: false));
+            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, RegistryEnabled: false));
             var result = CompilationHelper.Compile(services, @"module test 'br:totally-fake' = {}");
 
             result.Should().HaveDiagnostics(new[]

--- a/src/Bicep.Core.IntegrationTests/OutputsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/OutputsTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 using System.Diagnostics.CodeAnalysis;
 using Bicep.Core.Diagnostics;
-using Bicep.Core.Features;
 using Bicep.Core.IntegrationTests.Extensibility;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.UnitTests;
@@ -17,13 +16,13 @@ namespace Bicep.Core.IntegrationTests
     [TestClass]
     public class OutputsTests
     {
-        private ServiceBuilder ServicesWithResourceTyped => new ServiceBuilder().WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, resourceTypedParamsAndOutputsEnabled: true));
+        private ServiceBuilder ServicesWithResourceTyped => new ServiceBuilder().WithFeatureOverrides(new(TestContext, ResourceTypedParamsAndOutputsEnabled: true));
 
         [NotNull]
         public TestContext? TestContext { get; set; }
 
         private ServiceBuilder ServicesWithExtensibility => new ServiceBuilder()
-            .WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, importsEnabled: true, resourceTypedParamsAndOutputsEnabled: true))
+            .WithFeatureOverrides(new(TestContext, ImportsEnabled: true, ResourceTypedParamsAndOutputsEnabled: true))
             .WithNamespaceProvider(new TestExtensibilityNamespaceProvider(BicepTestConstants.AzResourceTypeLoader));
 
         [TestMethod]

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -3,7 +3,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Bicep.Core.Diagnostics;
-using Bicep.Core.Features;
 using Bicep.Core.IntegrationTests.Extensibility;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
@@ -19,13 +18,13 @@ namespace Bicep.Core.IntegrationTests
     [TestClass]
     public class ParameterTests
     {
-        private ServiceBuilder ServicesWithResourceTyped => new ServiceBuilder().WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, resourceTypedParamsAndOutputsEnabled: true));
+        private ServiceBuilder ServicesWithResourceTyped => new ServiceBuilder().WithFeatureOverrides(new(TestContext, ResourceTypedParamsAndOutputsEnabled: true));
 
         [NotNull]
         public TestContext? TestContext { get; set; }
 
         private ServiceBuilder ServicesWithExtensibility => new ServiceBuilder()
-            .WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, importsEnabled: true, resourceTypedParamsAndOutputsEnabled: true))
+            .WithFeatureOverrides(new(TestContext, ImportsEnabled: true, ResourceTypedParamsAndOutputsEnabled: true))
             .WithNamespaceProvider(new TestExtensibilityNamespaceProvider(BicepTestConstants.AzResourceTypeLoader));
 
         [TestMethod]

--- a/src/Bicep.Core.IntegrationTests/RegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/RegistryTests.cs
@@ -14,7 +14,6 @@ using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Samples;
-using Bicep.Core.Semantics;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Mock;
@@ -55,11 +54,11 @@ namespace Bicep.Core.IntegrationTests
             File.Exists(badCachePath).Should().BeTrue();
 
             // cache root points to a file
-            var features = BicepTestConstants.Features with {
+            var featureOverrides = BicepTestConstants.FeatureOverrides with {
                 RegistryEnabled = true,
                 CacheRootDirectory = badCachePath
             };
-            var featuresFactory = IFeatureProviderFactory.WithStaticFeatureProvider(features);
+            var featuresFactory = BicepTestConstants.CreateFeatureProviderFactory(featureOverrides);
 
             var dispatcher = new ModuleDispatcher(new DefaultModuleRegistryProvider(BicepTestConstants.FileResolver, clientFactory, templateSpecRepositoryFactory, featuresFactory, BicepTestConstants.ConfigurationManager), BicepTestConstants.ConfigurationManager);
 
@@ -70,7 +69,7 @@ namespace Bicep.Core.IntegrationTests
                 sourceFileGrouping = SourceFileGroupingBuilder.Rebuild(dispatcher, workspace, sourceFileGrouping);
             }
 
-            var compilation = Services.WithFeatureProviderFactory(featuresFactory).Build().BuildCompilation(sourceFileGrouping);
+            var compilation = Services.WithFeatureOverrides(featureOverrides).Build().BuildCompilation(sourceFileGrouping);
             var diagnostics = compilation.GetAllDiagnosticsByBicepFile();
             diagnostics.Should().HaveCount(1);
 

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -6,12 +6,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Cryptography;
 using Bicep.Core.Diagnostics;
-using Bicep.Core.Features;
-using Bicep.Core.FileSystem;
 using Bicep.Core.Resources;
-using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem;
-using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
@@ -2865,7 +2861,7 @@ output contentVersion string = deployment().properties.template.contentVersion
         [TestMethod]
         public void Test_Issue6044()
         {
-            var services = new ServiceBuilder().WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, symbolicNameCodegenEnabled: true));
+            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, SymbolicNameCodegenEnabled: true));
 
             var result = CompilationHelper.Compile(services, @"
 var adminUsername = 'cooluser'

--- a/src/Bicep.Core.IntegrationTests/ScopeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScopeTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions.Execution;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.Resources;
-using Bicep.Core.UnitTests;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Bicep.Core.IntegrationTests
@@ -360,7 +359,7 @@ resource resourceA 'My.Rp/myResource@2020-01-01' = {
         [TestMethod]
         public void Existing_resource_with_symbolic_names_enabled_includes_scope_properties()
         {
-            var services = new ServiceBuilder().WithFeatureProvider(BicepTestConstants.CreateFeatureProvider(this.TestContext, symbolicNameCodegenEnabled: true));
+            var services = new ServiceBuilder().WithFeatureOverrides(new(this.TestContext, SymbolicNameCodegenEnabled: true));
             var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
 targetScope = 'subscription'
 

--- a/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT License.
 using System.Collections.Generic;
 using System.Linq;
-using Bicep.Core.Analyzers.Linter;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
-using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem;
-using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
@@ -25,7 +22,7 @@ namespace Bicep.Core.IntegrationTests
         {
             var compilation = Services
                 .WithAzResources(definedTypes)
-                .WithConfigurationManager(IConfigurationManager.WithStaticConfiguration(BicepTestConstants.BuiltInConfigurationWithAllAnalyzersDisabled))
+                .WithConfigurationPatch(c => c.WithAllAnalyzersDisabled())
                 .BuildCompilation(programText);
 
             return compilation.GetEntrypointSemanticModel();

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/child/folder with separate config/bicepconfig.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/child/folder with separate config/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+    "experimentalFeaturesEnabled": {
+        "imports": true
+    }
+}

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/child/folder with separate config/moduleWithAzImport.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/child/folder with separate config/moduleWithAzImport.bicep
@@ -1,0 +1,3 @@
+import az as foo
+
+output str string = 'foo'

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.bicep
@@ -128,7 +128,7 @@ output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputO
 
 /*
   valid loop cases
-*/ 
+*/
 
 @sys.description('this is myModules')
 var myModules = [
@@ -352,4 +352,8 @@ module withSpace 'module with space.bicep' = {
 
 module folderWithSpace 'child/folder with space/child with space.bicep' = {
   name: 'childWithSpace'
+}
+
+module withSeparateConfig './child/folder with separate config/moduleWithAzImport.bicep' = {
+  name: 'withSeparateConfig'
 }

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.diagnostics.bicep
@@ -134,7 +134,7 @@ output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputO
 
 /*
   valid loop cases
-*/ 
+*/
 
 @sys.description('this is myModules')
 var myModules = [
@@ -372,5 +372,9 @@ module withSpace 'module with space.bicep' = {
 
 module folderWithSpace 'child/folder with space/child with space.bicep' = {
   name: 'childWithSpace'
+}
+
+module withSeparateConfig './child/folder with separate config/moduleWithAzImport.bicep' = {
+  name: 'withSeparateConfig'
 }
 

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.formatted.bicep
@@ -349,3 +349,7 @@ module withSpace 'module with space.bicep' = {
 module folderWithSpace 'child/folder with space/child with space.bicep' = {
   name: 'childWithSpace'
 }
+
+module withSeparateConfig './child/folder with separate config/moduleWithAzImport.bicep' = {
+  name: 'withSeparateConfig'
+}

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10244203654925270193"
+      "templateHash": "9273904353462763328"
     }
   },
   "parameters": {
@@ -1941,6 +1941,41 @@
             "loc": {
               "type": "string",
               "value": "[parameters('location')]"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "withSeparateConfig",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "11355552435760822103"
+            }
+          },
+          "imports": {
+            "foo": {
+              "provider": "AzureResourceManager",
+              "version": "1.0"
+            }
+          },
+          "resources": [],
+          "outputs": {
+            "str": {
+              "type": "string",
+              "value": "foo"
             }
           }
         }

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.sourcemap.bicep
@@ -182,19 +182,19 @@ resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
 }
 
 output stringOutputA string = modATest.outputs.stringOutputA
-//@[1950:1953]     "stringOutputA": {
+//@[1985:1988]     "stringOutputA": {
 output stringOutputB string = modATest.outputs.stringOutputB
-//@[1954:1957]     "stringOutputB": {
+//@[1989:1992]     "stringOutputB": {
 output objOutput object = modATest.outputs.objOutput
-//@[1958:1961]     "objOutput": {
+//@[1993:1996]     "objOutput": {
 output arrayOutput array = modATest.outputs.arrayOutput
-//@[1962:1965]     "arrayOutput": {
+//@[1997:2000]     "arrayOutput": {
 output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
-//@[1966:1969]     "modCalculatedNameOutput": {
+//@[2001:2004]     "modCalculatedNameOutput": {
 
 /*
   valid loop cases
-*/ 
+*/
 
 @sys.description('this is myModules')
 var myModules = [
@@ -520,5 +520,11 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
 //@[1913:1947]       "type": "Microsoft.Resources/deployments",
   name: 'childWithSpace'
 //@[1916:1916]       "name": "childWithSpace",
+}
+
+module withSeparateConfig './child/folder with separate config/moduleWithAzImport.bicep' = {
+//@[1948:1982]       "type": "Microsoft.Resources/deployments",
+  name: 'withSeparateConfig'
+//@[1951:1951]       "name": "withSeparateConfig",
 }
 

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.sourcemap.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.sourcemap.json
@@ -7737,84 +7737,224 @@
           "TargetLine": 1947
         },
         {
-          "SourceLine": 122,
-          "TargetLine": 1952
-        },
-        {
-          "SourceLine": 122,
-          "TargetLine": 1950
-        },
-        {
-          "SourceLine": 122,
+          "SourceLine": 357,
           "TargetLine": 1951
         },
         {
-          "SourceLine": 122,
+          "SourceLine": 356,
+          "TargetLine": 1948
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1949
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1950
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1952
+        },
+        {
+          "SourceLine": 356,
           "TargetLine": 1953
         },
         {
-          "SourceLine": 123,
-          "TargetLine": 1956
-        },
-        {
-          "SourceLine": 123,
+          "SourceLine": 356,
           "TargetLine": 1954
         },
         {
-          "SourceLine": 123,
+          "SourceLine": 356,
           "TargetLine": 1955
         },
         {
-          "SourceLine": 123,
+          "SourceLine": 356,
+          "TargetLine": 1956
+        },
+        {
+          "SourceLine": 356,
           "TargetLine": 1957
         },
         {
-          "SourceLine": 124,
-          "TargetLine": 1960
-        },
-        {
-          "SourceLine": 124,
+          "SourceLine": 356,
           "TargetLine": 1958
         },
         {
-          "SourceLine": 124,
+          "SourceLine": 356,
           "TargetLine": 1959
         },
         {
-          "SourceLine": 124,
+          "SourceLine": 356,
+          "TargetLine": 1960
+        },
+        {
+          "SourceLine": 356,
           "TargetLine": 1961
         },
         {
-          "SourceLine": 125,
-          "TargetLine": 1964
-        },
-        {
-          "SourceLine": 125,
+          "SourceLine": 356,
           "TargetLine": 1962
         },
         {
-          "SourceLine": 125,
+          "SourceLine": 356,
           "TargetLine": 1963
         },
         {
-          "SourceLine": 125,
+          "SourceLine": 356,
+          "TargetLine": 1964
+        },
+        {
+          "SourceLine": 356,
           "TargetLine": 1965
         },
         {
-          "SourceLine": 126,
-          "TargetLine": 1968
-        },
-        {
-          "SourceLine": 126,
+          "SourceLine": 356,
           "TargetLine": 1966
         },
         {
-          "SourceLine": 126,
+          "SourceLine": 356,
           "TargetLine": 1967
         },
         {
-          "SourceLine": 126,
+          "SourceLine": 356,
+          "TargetLine": 1968
+        },
+        {
+          "SourceLine": 356,
           "TargetLine": 1969
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1970
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1971
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1972
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1973
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1974
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1975
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1976
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1977
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1978
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1979
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1980
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1981
+        },
+        {
+          "SourceLine": 356,
+          "TargetLine": 1982
+        },
+        {
+          "SourceLine": 122,
+          "TargetLine": 1987
+        },
+        {
+          "SourceLine": 122,
+          "TargetLine": 1985
+        },
+        {
+          "SourceLine": 122,
+          "TargetLine": 1986
+        },
+        {
+          "SourceLine": 122,
+          "TargetLine": 1988
+        },
+        {
+          "SourceLine": 123,
+          "TargetLine": 1991
+        },
+        {
+          "SourceLine": 123,
+          "TargetLine": 1989
+        },
+        {
+          "SourceLine": 123,
+          "TargetLine": 1990
+        },
+        {
+          "SourceLine": 123,
+          "TargetLine": 1992
+        },
+        {
+          "SourceLine": 124,
+          "TargetLine": 1995
+        },
+        {
+          "SourceLine": 124,
+          "TargetLine": 1993
+        },
+        {
+          "SourceLine": 124,
+          "TargetLine": 1994
+        },
+        {
+          "SourceLine": 124,
+          "TargetLine": 1996
+        },
+        {
+          "SourceLine": 125,
+          "TargetLine": 1999
+        },
+        {
+          "SourceLine": 125,
+          "TargetLine": 1997
+        },
+        {
+          "SourceLine": 125,
+          "TargetLine": 1998
+        },
+        {
+          "SourceLine": 125,
+          "TargetLine": 2000
+        },
+        {
+          "SourceLine": 126,
+          "TargetLine": 2003
+        },
+        {
+          "SourceLine": 126,
+          "TargetLine": 2001
+        },
+        {
+          "SourceLine": 126,
+          "TargetLine": 2002
+        },
+        {
+          "SourceLine": 126,
+          "TargetLine": 2004
         }
       ]
     },
@@ -10649,6 +10789,43 @@
         {
           "SourceLine": 1,
           "TargetLine": 1943
+        }
+      ]
+    },
+    {
+      "FilePath": "child/folder%20with%20separate%20config/moduleWithAzImport.bicep",
+      "SourceMap": [
+        {
+          "SourceLine": 0,
+          "TargetLine": 1968
+        },
+        {
+          "SourceLine": 0,
+          "TargetLine": 1969
+        },
+        {
+          "SourceLine": 0,
+          "TargetLine": 1970
+        },
+        {
+          "SourceLine": 0,
+          "TargetLine": 1971
+        },
+        {
+          "SourceLine": 2,
+          "TargetLine": 1977
+        },
+        {
+          "SourceLine": 2,
+          "TargetLine": 1975
+        },
+        {
+          "SourceLine": 2,
+          "TargetLine": 1976
+        },
+        {
+          "SourceLine": 2,
+          "TargetLine": 1978
         }
       ]
     }

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14933037379763841245"
+      "templateHash": "14693010240916279941"
     }
   },
   "parameters": {
@@ -2014,6 +2014,43 @@
             "loc": {
               "type": "string",
               "value": "[parameters('location')]"
+            }
+          }
+        }
+      }
+    },
+    "withSeparateConfig": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "withSeparateConfig",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "1.9-experimental",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "14053067768961449790"
+            }
+          },
+          "imports": {
+            "foo": {
+              "provider": "AzureResourceManager",
+              "version": "1.0"
+            }
+          },
+          "resources": {},
+          "outputs": {
+            "str": {
+              "type": "string",
+              "value": "foo"
             }
           }
         }

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbols.bicep
@@ -147,7 +147,7 @@ output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputO
 
 /*
   valid loop cases
-*/ 
+*/
 
 @sys.description('this is myModules')
 var myModules = [
@@ -429,5 +429,10 @@ module withSpace 'module with space.bicep' = {
 module folderWithSpace 'child/folder with space/child with space.bicep' = {
 //@[07:22) Module folderWithSpace. Type: module. Declaration start char: 0, length: 104
   name: 'childWithSpace'
+}
+
+module withSeparateConfig './child/folder with separate config/moduleWithAzImport.bicep' = {
+//@[07:25) Module withSeparateConfig. Type: module. Declaration start char: 0, length: 125
+  name: 'withSeparateConfig'
 }
 

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.syntax.bicep
@@ -1,5 +1,5 @@
 
-//@[000:8466) ProgramSyntax
+//@[000:8594) ProgramSyntax
 //@[000:0002) ├─Token(NewLine) |\r\n|
 @sys.description('this is deployTimeSuffix param')
 //@[000:0093) ├─ParameterDeclarationSyntax
@@ -1028,8 +1028,8 @@ output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputO
 
 /*
   valid loop cases
-*/ 
-//@[003:0007) ├─Token(NewLine) |\r\n\r\n|
+*/
+//@[002:0006) ├─Token(NewLine) |\r\n\r\n|
 
 @sys.description('this is myModules')
 //@[000:0162) ├─VariableDeclarationSyntax
@@ -3188,6 +3188,29 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
 //@[008:0024) |   | └─StringSyntax
 //@[008:0024) |   |   └─Token(StringComplete) |'childWithSpace'|
 //@[024:0026) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:0001) |   └─Token(RightBrace) |}|
+//@[001:0005) ├─Token(NewLine) |\r\n\r\n|
+
+module withSeparateConfig './child/folder with separate config/moduleWithAzImport.bicep' = {
+//@[000:0125) ├─ModuleDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |module|
+//@[007:0025) | ├─IdentifierSyntax
+//@[007:0025) | | └─Token(Identifier) |withSeparateConfig|
+//@[026:0088) | ├─StringSyntax
+//@[026:0088) | | └─Token(StringComplete) |'./child/folder with separate config/moduleWithAzImport.bicep'|
+//@[089:0090) | ├─Token(Assignment) |=|
+//@[091:0125) | └─ObjectSyntax
+//@[091:0092) |   ├─Token(LeftBrace) |{|
+//@[092:0094) |   ├─Token(NewLine) |\r\n|
+  name: 'withSeparateConfig'
+//@[002:0028) |   ├─ObjectPropertySyntax
+//@[002:0006) |   | ├─IdentifierSyntax
+//@[002:0006) |   | | └─Token(Identifier) |name|
+//@[006:0007) |   | ├─Token(Colon) |:|
+//@[008:0028) |   | └─StringSyntax
+//@[008:0028) |   |   └─Token(StringComplete) |'withSeparateConfig'|
+//@[028:0030) |   ├─Token(NewLine) |\r\n|
 }
 //@[000:0001) |   └─Token(RightBrace) |}|
 //@[001:0003) ├─Token(NewLine) |\r\n|

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.tokens.bicep
@@ -653,8 +653,8 @@ output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputO
 
 /*
   valid loop cases
-*/ 
-//@[003:007) NewLine |\r\n\r\n|
+*/
+//@[002:006) NewLine |\r\n\r\n|
 
 @sys.description('this is myModules')
 //@[000:001) At |@|
@@ -2002,6 +2002,22 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
 //@[006:007) Colon |:|
 //@[008:024) StringComplete |'childWithSpace'|
 //@[024:026) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module withSeparateConfig './child/folder with separate config/moduleWithAzImport.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:025) Identifier |withSeparateConfig|
+//@[026:088) StringComplete |'./child/folder with separate config/moduleWithAzImport.bicep'|
+//@[089:090) Assignment |=|
+//@[091:092) LeftBrace |{|
+//@[092:094) NewLine |\r\n|
+  name: 'withSeparateConfig'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:028) StringComplete |'withSeparateConfig'|
+//@[028:030) NewLine |\r\n|
 }
 //@[000:001) RightBrace |}|
 //@[001:003) NewLine |\r\n|

--- a/src/Bicep.Core.UnitTests/Assertions/FeatureProviderAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/FeatureProviderAssertions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.Core.Features;
+using Bicep.Core.UnitTests.Features;
 using FluentAssertions;
 using FluentAssertions.Primitives;
 using System.Collections.Immutable;
@@ -12,12 +12,12 @@ namespace Bicep.Core.UnitTests.Assertions
 {
     public static class FeatureProviderExtensions
     {
-        public static FeatureProviderAssertions Should(this IFeatureProvider features) => new(features);
+        public static FeatureProviderAssertions Should(this FeatureProviderOverrides features) => new(features);
     }
 
-    public class FeatureProviderAssertions : ReferenceTypeAssertions<IFeatureProvider, FeatureProviderAssertions>
+    public class FeatureProviderAssertions : ReferenceTypeAssertions<FeatureProviderOverrides, FeatureProviderAssertions>
     {
-        public FeatureProviderAssertions(IFeatureProvider features) : base(features)
+        public FeatureProviderAssertions(FeatureProviderOverrides features) : base(features)
         {
         }
 
@@ -26,7 +26,7 @@ namespace Bicep.Core.UnitTests.Assertions
         public AndConstraint<FeatureProviderAssertions> HaveValidModules()
         {
             // ensure something got restored
-            var cacheDir = new DirectoryInfo(this.Subject.CacheRootDirectory);
+            var cacheDir = new DirectoryInfo(this.Subject.CacheRootDirectory!);
             cacheDir.Exists.Should().BeTrue();
 
             // we create it with same casing on all file systems

--- a/src/Bicep.Core.UnitTests/Configuration/PatchingConfigurationManager.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/PatchingConfigurationManager.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Bicep.Core.Configuration;
+
+namespace Bicep.Core.UnitTests.Configuration;
+
+public class PatchingConfigurationManager : IConfigurationManager
+{
+    private readonly IConfigurationManager configurationManager;
+    private readonly Func<RootConfiguration, RootConfiguration> patchFunc;
+
+    public PatchingConfigurationManager(ConfigurationManager configurationManager, Func<RootConfiguration, RootConfiguration> patchFunc)
+    {
+        this.configurationManager = configurationManager;
+        this.patchFunc = patchFunc;
+    }
+
+    public RootConfiguration GetConfiguration(Uri sourceFileUri) => patchFunc(configurationManager.GetConfiguration(sourceFileUri));
+}

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.Core.Analyzers.Linter;
 using Bicep.Core.Analyzers.Linter.ApiVersions;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
@@ -10,7 +9,6 @@ using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -41,7 +39,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         public record Options(
             OnCompileErrors OnCompileErrors = OnCompileErrors.Default,
             IncludePosition IncludePosition = IncludePosition.Default,
-            RootConfiguration? Configuration = null,
+            Func<RootConfiguration, RootConfiguration>? ConfigurationPatch = null,
             ApiVersionProvider? ApiVersionProvider = null,
             (string path, string contents)[]? AdditionalFiles = null
         );
@@ -108,7 +106,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         {
             options ??= new Options();
             var services = new ServiceBuilder();
-            services = options.Configuration is {} ? services.WithConfiguration(options.Configuration) : services;
+            services = options.ConfigurationPatch is {} ? services.WithConfigurationPatch(options.ConfigurationPatch) : services;
             services = options.ApiVersionProvider is {} ? services.WithApiVersionProvider(options.ApiVersionProvider) : services;
             var result = CompilationHelper.Compile(services, files);
             using (new AssertionScope().WithFullSource(result.BicepFile))

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
@@ -42,7 +42,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 new Options(
                     OnCompileErrors: onCompileErrors,
                     IncludePosition.LineNumber,
-                    Configuration: CreateConfigurationWithFakeToday(fakeToday),
+                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday),
                     ApiVersionProvider: apiProvider));
         }
 
@@ -85,31 +85,31 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 new Options(
                     OnCompileErrors.IncludeErrors,
                     IncludePosition.LineNumber,
-                    Configuration: CreateConfigurationWithFakeToday(fakeToday),
+                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday),
                     ApiVersionProvider: apiProvider));
         }
 
-        private static RootConfiguration CreateConfigurationWithFakeToday(string today)
+        private static RootConfiguration CreateConfigurationWithFakeToday(RootConfiguration original, string today)
         {
             return new RootConfiguration(
-                BicepTestConstants.BuiltInConfiguration.Cloud,
-                BicepTestConstants.BuiltInConfiguration.ModuleAliases,
-                    new AnalyzersConfiguration(
-                         JsonElementFactory.CreateElement(@"
-                            {
-                              ""core"": {
-                                ""enabled"": true,
-                                ""rules"": {
-                                  ""use-recent-api-versions"": {
-                                      ""level"": ""warning"",
-                                      ""test-today"": ""<TESTING_TODAY_DATE>"",
-                                      ""test-warn-not-found"": true
-                                  }
+                original.Cloud,
+                original.ModuleAliases,
+                new AnalyzersConfiguration(
+                    JsonElementFactory.CreateElement(@"
+                    {
+                        ""core"": {
+                            ""enabled"": true,
+                            ""rules"": {
+                                ""use-recent-api-versions"": {
+                                    ""level"": ""warning"",
+                                    ""test-today"": ""<TESTING_TODAY_DATE>"",
+                                    ""test-warn-not-found"": true
                                 }
-                              }
-                            }".Replace("<TESTING_TODAY_DATE>", today))),
-                BicepTestConstants.BuiltInConfiguration.CacheRootDirectory,
-                BicepTestConstants.BuiltInConfiguration.ExperimentalFeaturesEnabled,
+                            }
+                        }
+                    }".Replace("<TESTING_TODAY_DATE>", today))),
+                original.CacheRootDirectory,
+                original.ExperimentalFeaturesEnabled,
                 null,
                 null);
         }

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.UnitTests.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Features;
+
+public record FeatureProviderOverrides(
+    string? CacheRootDirectory = null,
+    bool? RegistryEnabled = default,
+    bool? SymbolicNameCodegenEnabled = default,
+    bool? ImportsEnabled = default,
+    bool? AdvancedListComprehensionEnabled = default,
+    bool? ResourceTypedParamsAndOutputsEnabled = default,
+    bool? SourceMappingEnabled = default,
+    bool? ParamsFilesEnabled = default,
+    string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion)
+{
+    public FeatureProviderOverrides(TestContext testContext,
+        bool? RegistryEnabled = default,
+        bool? SymbolicNameCodegenEnabled = default,
+        bool? ImportsEnabled = default,
+        bool? AdvancedListComprehensionEnabled = default,
+        bool? ResourceTypedParamsAndOutputsEnabled = default,
+        bool? SourceMappingEnabled = default,
+        bool? ParamsFilesEnabled = default,
+        string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion
+    ) : this(FileHelper.GetCacheRootPath(testContext), RegistryEnabled, SymbolicNameCodegenEnabled, ImportsEnabled, AdvancedListComprehensionEnabled, ResourceTypedParamsAndOutputsEnabled, SourceMappingEnabled, ParamsFilesEnabled, AssemblyVersion) {}
+}

--- a/src/Bicep.Core.UnitTests/Features/OverridableFeatureProviderFactory.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverridableFeatureProviderFactory.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Bicep.Core.Features;
+
+namespace Bicep.Core.UnitTests.Features;
+
+public class OverriddenFeatureProviderFactory : IFeatureProviderFactory
+{
+    private readonly IFeatureProviderFactory factory;
+    private readonly FeatureProviderOverrides overrides;
+
+    public OverriddenFeatureProviderFactory(FeatureProviderFactory factory, FeatureProviderOverrides overrides)
+    {
+        this.factory = factory;
+        this.overrides = overrides;
+    }
+
+    public IFeatureProvider GetFeatureProvider(Uri templateUri)
+        => new OverriddenFeatureProvider(factory.GetFeatureProvider(templateUri), overrides);
+}

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Features;
+
+namespace Bicep.Core.UnitTests.Features;
+
+public class OverriddenFeatureProvider : IFeatureProvider
+{
+    private readonly IFeatureProvider features;
+    private readonly FeatureProviderOverrides overrides;
+
+    public OverriddenFeatureProvider(IFeatureProvider features, FeatureProviderOverrides overrides)
+    {
+        this.features = features;
+        this.overrides = overrides;
+    }
+
+    public string AssemblyVersion => overrides.AssemblyVersion ?? features.AssemblyVersion;
+
+    public string CacheRootDirectory => overrides.CacheRootDirectory ?? features.CacheRootDirectory;
+
+    public bool RegistryEnabled => overrides.RegistryEnabled ?? features.RegistryEnabled;
+
+    public bool SymbolicNameCodegenEnabled => overrides.SymbolicNameCodegenEnabled ?? features.SymbolicNameCodegenEnabled;
+
+    public bool ImportsEnabled => overrides.ImportsEnabled ?? features.ImportsEnabled;
+
+    public bool ResourceTypedParamsAndOutputsEnabled => overrides.ResourceTypedParamsAndOutputsEnabled ?? features.ResourceTypedParamsAndOutputsEnabled;
+
+    public bool SourceMappingEnabled => overrides.SourceMappingEnabled ?? features.SourceMappingEnabled;
+
+    public bool ParamsFilesEnabled => overrides.ParamsFilesEnabled ?? features.ParamsFilesEnabled;
+}

--- a/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
@@ -63,10 +63,10 @@ namespace Bicep.Core.UnitTests.Utils
         }
 
         public static CompilationResult Compile(IAzResourceTypeLoader resourceTypeLoader, params (string fileName, string fileContents)[] files)
-            => Compile(new ServiceBuilder().WithFeatureProvider(BicepTestConstants.Features).WithAzResourceTypeLoader(resourceTypeLoader), files);
+            => Compile(new ServiceBuilder().WithFeatureOverrides(BicepTestConstants.FeatureOverrides).WithAzResourceTypeLoader(resourceTypeLoader), files);
 
         public static CompilationResult Compile(params (string fileName, string fileContents)[] files)
-            => Compile(new ServiceBuilder().WithFeatureProvider(BicepTestConstants.Features), files);
+            => Compile(new ServiceBuilder().WithFeatureOverrides(BicepTestConstants.FeatureOverrides), files);
 
         public static CompilationResult Compile(string fileContents)
             => Compile(("main.bicep", fileContents));
@@ -76,9 +76,9 @@ namespace Bicep.Core.UnitTests.Utils
 
         public static ParamsCompilationResult CompileParams(params (string fileName, string fileContents)[] files)
         {
-            var features = BicepTestConstants.Features;
+            var features = BicepTestConstants.FeatureOverrides;
             var configuration = BicepTestConstants.BuiltInConfiguration;
-            var services = new ServiceBuilder().WithFeatureProvider(features).WithConfiguration(configuration);
+            var services = new ServiceBuilder().WithFeatureOverrides(features).WithConfigurationPatch(c => configuration);
 
             files.Select(x => x.fileName).Should().Contain("parameters.bicepparam");
 
@@ -91,7 +91,7 @@ namespace Bicep.Core.UnitTests.Utils
 
             var sourceFileGrouping = services.BuildSourceFileGrouping(sourceFiles, entryUri);
 
-            var model = new ParamsSemanticModel(sourceFileGrouping, configuration, features, file => {
+            var model = new ParamsSemanticModel(sourceFileGrouping, configuration, BicepTestConstants.Features, file => {
                 var compilationGrouping = new SourceFileGrouping(fileResolver, file.FileUri, sourceFileGrouping.FileResultByUri, sourceFileGrouping.UriResultByModule, sourceFileGrouping.SourceFileParentLookup);
 
                 return services.Build().BuildCompilation(sourceFileGrouping);

--- a/src/Bicep.LangServer.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/BuildCommandTests.cs
@@ -13,7 +13,6 @@ using Newtonsoft.Json.Linq;
 using Bicep.Core.UnitTests;
 using Bicep.LangServer.IntegrationTests.Helpers;
 using FluentAssertions;
-using Bicep.Core.Features;
 using Bicep.Core.Samples;
 using Bicep.Core.UnitTests.Assertions;
 
@@ -29,16 +28,13 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task Build_command_should_generate_template()
         {
             var diagnosticsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
-            var features = BicepTestConstants.CreateFeatureProvider(
-                TestContext,
-                assemblyFileVersion: BicepTestConstants.DevAssemblyFileVersion);
 
             using var helper = await LanguageServerHelper.StartServerWithClientConnectionAsync(
                 this.TestContext,
                 options => options.OnPublishDiagnostics(diagnosticsParams => diagnosticsListener.AddMessage(diagnosticsParams)),
                 new LanguageServer.Server.CreationOptions(
                     NamespaceProvider: BuiltInTestTypes.Create(),
-                    FeatureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(features)));
+                    FeatureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(new(TestContext))));
             var client = helper.Client;
 
             var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(
@@ -68,17 +64,13 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task Build_command_should_generate_template_with_symbolic_names_if_enabled()
         {
             var diagnosticsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
-            var features = BicepTestConstants.CreateFeatureProvider(
-                TestContext,
-                symbolicNameCodegenEnabled: true,
-                assemblyFileVersion: BicepTestConstants.DevAssemblyFileVersion);
 
             using var helper = await LanguageServerHelper.StartServerWithClientConnectionAsync(
                 this.TestContext,
                 options => options.OnPublishDiagnostics(diagnosticsParams => diagnosticsListener.AddMessage(diagnosticsParams)),
                 new LanguageServer.Server.CreationOptions(
                     NamespaceProvider: BuiltInTestTypes.Create(),
-                    FeatureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(features)));
+                    FeatureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(new(TestContext, SymbolicNameCodegenEnabled: true))));
             var client = helper.Client;
 
             var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -11,11 +11,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Bicep.Core;
 using Bicep.Core.Extensions;
-using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Parsing;
 using Bicep.Core.Samples;
-using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Text;
 using Bicep.Core.UnitTests;
@@ -87,7 +85,7 @@ namespace Bicep.LangServer.IntegrationTests
             ServerWithImportsEnabled.Initialize(
                 async () => await MultiFileLanguageServerHelper.StartLanguageServer(
                     testContext,
-                    new LanguageServer.Server.CreationOptions(FeatureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(BicepTestConstants.CreateFeatureProvider(testContext, importsEnabled: true)))));
+                    new LanguageServer.Server.CreationOptions(FeatureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(new(testContext, ImportsEnabled: true)))));
 
             ServerWithBuiltInTypes.Initialize(
                 async () => await MultiFileLanguageServerHelper.StartLanguageServer(

--- a/src/Bicep.LangServer.IntegrationTests/GenerateParamsCommandTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/GenerateParamsCommandTests.cs
@@ -13,7 +13,6 @@ using Newtonsoft.Json.Linq;
 using Bicep.Core.UnitTests;
 using Bicep.LangServer.IntegrationTests.Helpers;
 using FluentAssertions;
-using Bicep.Core.Features;
 using Bicep.Core.Samples;
 using Bicep.Core.UnitTests.Assertions;
 
@@ -29,16 +28,13 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task GenerateParams_command_should_generate_paramsfile()
         {
             var diagnosticsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
-            var features = BicepTestConstants.CreateFeatureProvider(
-                TestContext,
-                assemblyFileVersion: BicepTestConstants.DevAssemblyFileVersion);
 
             using var helper = await LanguageServerHelper.StartServerWithClientConnectionAsync(
                 this.TestContext,
                 options => options.OnPublishDiagnostics(diagnosticsParams => diagnosticsListener.AddMessage(diagnosticsParams)),
                 new LanguageServer.Server.CreationOptions(
                     NamespaceProvider: BuiltInTestTypes.Create(),
-                    FeatureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(features)));
+                    FeatureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(new(TestContext))));
             var client = helper.Client;
 
             var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(

--- a/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
@@ -5,15 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Bicep.Core.Features;
-using Bicep.Core.FileSystem;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.FileSystem;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LangServer.IntegrationTests.Completions
@@ -142,7 +139,7 @@ new CompletionItemKind[] { CompletionItemKind.Field, CompletionItemKind.Field }
                 creationOptions: new LanguageServer.Server.CreationOptions(
                     NamespaceProvider: BuiltInTestTypes.Create(),
                     FileResolver: fileResolver,
-                    FeatureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, paramsFilesEnabled: true))));
+                    FeatureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(new(TestContext, ParamsFilesEnabled: true))));
 
             var file = new FileRequestHelper(helper.Client, paramFile);
 
@@ -240,7 +237,7 @@ new CompletionItemKind[] { CompletionItemKind.EnumMember, CompletionItemKind.Enu
                 paramFileTextNoCursor,
                 paramUri,
                 creationOptions: new LanguageServer.Server.CreationOptions(NamespaceProvider: BuiltInTestTypes.Create(), FileResolver: fileResolver,
-                FeatureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, paramsFilesEnabled: true))));
+                FeatureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(new(TestContext, ParamsFilesEnabled: true))));
 
             var file = new FileRequestHelper(helper.Client, paramFile);
 
@@ -281,7 +278,7 @@ using |
                 paramFileTextNoCursor,
                 paramUri,
                 creationOptions: new LanguageServer.Server.CreationOptions(NamespaceProvider: BuiltInTestTypes.Create(), FileResolver: fileResolver,
-                    FeatureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, paramsFilesEnabled: true))));
+                FeatureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(new(TestContext, ParamsFilesEnabled: true))));
 
             var file = new FileRequestHelper(helper.Client, paramFile);
 
@@ -327,7 +324,7 @@ using './nested1/|'
                 paramFileTextNoCursor,
                 paramUri,
                 creationOptions: new LanguageServer.Server.CreationOptions(NamespaceProvider: BuiltInTestTypes.Create(), FileResolver: fileResolver,
-                    FeatureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, paramsFilesEnabled: true))));
+                FeatureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(new(TestContext, ParamsFilesEnabled: true))));
 
             var file = new FileRequestHelper(helper.Client, paramFile);
 

--- a/src/Bicep.LangServer.IntegrationTests/SemanticTokenTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/SemanticTokenTests.cs
@@ -20,8 +20,6 @@ using Bicep.Core.Workspaces;
 using Bicep.LangServer.IntegrationTests.Helpers;
 using System;
 using System.Collections.Immutable;
-using Bicep.Core.Features;
-using Bicep.Core.FileSystem;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.FileSystem;
@@ -108,7 +106,7 @@ namespace Bicep.LangServer.IntegrationTests
                 creationOptions: new LanguageServer.Server.CreationOptions(
                     NamespaceProvider: BuiltInTestTypes.Create(),
                     FileResolver: fileResolver,
-                    FeatureProviderFactory: IFeatureProviderFactory.WithStaticFeatureProvider(BicepTestConstants.CreateFeatureProvider(TestContext, paramsFilesEnabled: true))));
+                    FeatureProviderFactory: BicepTestConstants.CreateFeatureProviderFactory(new(TestContext, ParamsFilesEnabled: true))));
 
             var semanticTokens = await helper.Client.TextDocument.RequestSemanticTokens(new SemanticTokensParams
             {


### PR DESCRIPTION
This PR allows `bicepconfig.json` files in the Bicep.Core.Samples package to influence compilation in the repo's integration tests. The use of static configuration and `FeatureProvider`s in the integration test suite means that any config included in the scenario is ignored, so adding scenarios that require an experimental feature to be enabled requires manual code changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8649)