### PR TITLE
Added outline and breadcrumb support for param files

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/DocumentSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DocumentSymbolTests.cs
@@ -10,29 +10,34 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using Bicep.LangServer.IntegrationTests.Assertions;
 using Bicep.LangServer.IntegrationTests.Helpers;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 
 namespace Bicep.LangServer.IntegrationTests
 {
     [TestClass]
-    [SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "Test methods do not need to follow this convention.")]
     public class DocumentSymbolTests
     {
         [NotNull]
         public TestContext? TestContext { get; set; }
 
+        private static readonly SharedLanguageHelperManager DefaultServer = new();
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext testContext) =>
+            DefaultServer.Initialize(async () => await MultiFileLanguageServerHelper.StartLanguageServer(testContext));
+
+        [ClassCleanup]
+        public static async Task ClassCleanup() =>
+            await DefaultServer.DisposeAsync();
+
         [TestMethod]
         public async Task RequestDocumentSymbol_should_return_full_symbol_list()
         {
-            var diagsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
             var documentUri = DocumentUri.From("/template.bicep");
 
-            using var helper = await LanguageServerHelper.StartServer(
-                this.TestContext,
-                options => options.OnPublishDiagnostics(diagsListener.AddMessage));
-            var client = helper.Client;
-
-            // client opens the document
-            client.TextDocument.DidOpenTextDocument(TextDocumentParamHelper.CreateDidOpenDocumentParams(documentUri, @"
+            // open the document and wait for diagnostics push
+            var helper = await DefaultServer.GetAsync();
+            await helper.OpenFileOnceAsync(TestContext, @"
 param myParam string = 'test'
 resource myRes 'myRp/provider@2019-01-01' = {
   name: 'test'
@@ -45,16 +50,12 @@ module myMod './module.bicep' = {
   name: 'test'
 }
 output myOutput string = 'myOutput'
-", 0));
+", documentUri);
+
+            var client = helper.Client;
 
             // client requests symbols
-            var symbols = await client.TextDocument.RequestDocumentSymbol(new DocumentSymbolParams
-            {
-                TextDocument = new TextDocumentIdentifier
-                {
-                    Uri = documentUri,
-                },
-            });
+            var symbols = await RequestSymbols(client, documentUri);
 
             symbols.Should().SatisfyRespectively(
                 x =>
@@ -62,11 +63,13 @@ output myOutput string = 'myOutput'
                     x.DocumentSymbol!.Name.Should().Be("myParam");
                     x.DocumentSymbol.Kind.Should().Be(SymbolKind.Field);
                     x.DocumentSymbol.Children.Should().BeEmpty();
+                    x.DocumentSymbol.Detail.Should().Be("string");
                 },
                 x =>
                 {
                     x.DocumentSymbol!.Name.Should().Be("myRes");
                     x.DocumentSymbol.Kind.Should().Be(SymbolKind.Object);
+                    x.DocumentSymbol.Detail.Should().Be("myRp/provider@2019-01-01");
 
                     var child = x.DocumentSymbol.Children.Should().ContainSingle().Subject;
                     child.Name.Should().Be("myChild");
@@ -77,17 +80,19 @@ output myOutput string = 'myOutput'
                     x.DocumentSymbol!.Name.Should().Be("myMod");
                     x.DocumentSymbol.Kind.Should().Be(SymbolKind.Module);
                     x.DocumentSymbol.Children.Should().BeEmpty();
+                    x.DocumentSymbol.Detail.Should().Be("error");
                 },
                 x =>
                 {
                     x.DocumentSymbol!.Name.Should().Be("myOutput");
                     x.DocumentSymbol.Kind.Should().Be(SymbolKind.Interface);
                     x.DocumentSymbol.Children.Should().BeEmpty();
+                    x.DocumentSymbol.Detail.Should().Be("string");
                 }
             );
 
             // client deletes the output and renames the resource
-            client.TextDocument.DidChangeTextDocument(TextDocumentParamHelper.CreateDidChangeTextDocumentParams(documentUri, @"
+            await helper.ChangeFileAsync(TestContext, @"
 param myParam string = 'test'
 resource myRenamedRes 'myRp/provider@2019-01-01' = {
   name: 'test'
@@ -95,34 +100,102 @@ resource myRenamedRes 'myRp/provider@2019-01-01' = {
 module myMod './module.bicep' = {
   name: 'test'
 }
-", 1));
+", documentUri, 1);
 
             // client requests symbols
-            symbols = await client.TextDocument.RequestDocumentSymbol(new DocumentSymbolParams
-            {
-                TextDocument = new TextDocumentIdentifier
-                {
-                    Uri = documentUri,
-                },
-            });
+            symbols = await RequestSymbols(client, documentUri);
 
             symbols.Should().SatisfyRespectively(
                 x =>
                 {
                     x.DocumentSymbol!.Name.Should().Be("myParam");
                     x.DocumentSymbol.Kind.Should().Be(SymbolKind.Field);
+                    x.DocumentSymbol.Detail.Should().Be("string");
                 },
                 x =>
                 {
                     x.DocumentSymbol!.Name.Should().Be("myRenamedRes");
                     x.DocumentSymbol.Kind.Should().Be(SymbolKind.Object);
+                    x.DocumentSymbol.Detail.Should().Be("myRp/provider@2019-01-01");
                 },
                 x =>
                 {
                     x.DocumentSymbol!.Name.Should().Be("myMod");
                     x.DocumentSymbol.Kind.Should().Be(SymbolKind.Module);
+                    x.DocumentSymbol.Detail.Should().Be("error");
                 }
             );
         }
+
+        [TestMethod]
+        public async Task RequestDocumentSymbol_should_return_symbols_for_param_files()
+        {
+            var documentUri = DocumentUri.From("/param.bicepparam");
+
+            var helper = await DefaultServer.GetAsync();
+            await helper.OpenFileOnceAsync(TestContext, @"
+param one = 42
+param two = 'hello'
+", documentUri);
+
+            var client = helper.Client;
+            SymbolInformationOrDocumentSymbolContainer symbols = await RequestSymbols(client, documentUri);
+
+            symbols.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.DocumentSymbol!.Name.Should().Be("one");
+                    x.DocumentSymbol.Kind.Should().Be(SymbolKind.Constant);
+                    x.DocumentSymbol.Children.Should().BeEmpty();
+                    x.DocumentSymbol.Detail.Should().Be("42");
+                },
+                x =>
+                {
+                    x.DocumentSymbol!.Name.Should().Be("two");
+                    x.DocumentSymbol.Kind.Should().Be(SymbolKind.Constant);
+                    x.DocumentSymbol.Children.Should().BeEmpty();
+                    x.DocumentSymbol.Detail.Should().Be("'hello'");
+                });
+
+            await helper.ChangeFileAsync(TestContext, @"
+param one = 42
+param two = 'hello'
+param three = []
+", documentUri, 1);
+
+            symbols = await RequestSymbols(client, documentUri);
+
+            symbols.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.DocumentSymbol!.Name.Should().Be("one");
+                    x.DocumentSymbol.Kind.Should().Be(SymbolKind.Constant);
+                    x.DocumentSymbol.Children.Should().BeEmpty();
+                    x.DocumentSymbol.Detail.Should().Be("42");
+                },
+                x =>
+                {
+                    x.DocumentSymbol!.Name.Should().Be("two");
+                    x.DocumentSymbol.Kind.Should().Be(SymbolKind.Constant);
+                    x.DocumentSymbol.Children.Should().BeEmpty();
+                    x.DocumentSymbol.Detail.Should().Be("'hello'");
+                },
+                x =>
+                {
+                    x.DocumentSymbol!.Name.Should().Be("three");
+                    x.DocumentSymbol.Kind.Should().Be(SymbolKind.Constant);
+                    x.DocumentSymbol.Children.Should().BeEmpty();
+                    x.DocumentSymbol.Detail.Should().Be("array");
+                });
+        }
+
+        private static async Task<SymbolInformationOrDocumentSymbolContainer> RequestSymbols(ILanguageClient client, DocumentUri documentUri) =>
+            await client.TextDocument.RequestDocumentSymbol(new DocumentSymbolParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = documentUri
+                }
+            });
     }
 }


### PR DESCRIPTION
Outline view:
<img width="202" alt="image" src="https://user-images.githubusercontent.com/22460039/195963431-d6a4ceaf-d64c-4711-adeb-00296be06a2d.png">

Breadcrumbs:
<img width="787" alt="image" src="https://user-images.githubusercontent.com/22460039/195963442-447e0fbc-73ef-4c34-8fd5-0e07ae554ead.png">

I chose the `Constant` icon but open to better ideas. Most (but not all 😟) of the icons starting with "symbol-" at https://code.visualstudio.com/api/references/icons-in-labels are available to us.

The `using` declaration and `targetScope` do not currently appear in Outline view due to #8450.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8670)