### PR TITLE
Refresh compilation before build and deploy to fix 8239

### DIFF
--- a/src/Bicep.Core.UnitTests/Assertions/StringAssertionsExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/StringAssertionsExtensions.cs
@@ -85,6 +85,16 @@ namespace Bicep.Core.UnitTests.Assertions
             return new AndConstraint<StringAssertions>(instance);
         }
 
+        public static AndConstraint<StringAssertions> ContainIgnoringNewlines(this StringAssertions instance, string expected)
+        {
+            var normalizedActual = StringUtils.ReplaceNewlines(instance.Subject, "\n");
+            var normalizedExpected = StringUtils.ReplaceNewlines(expected, "\n");
+
+            normalizedActual.Should().Contain(normalizedExpected);
+
+            return new AndConstraint<StringAssertions>(instance);
+        }
+
         public static AndConstraint<StringAssertions> HaveLengthLessThanOrEqualTo(this StringAssertions instance, int maxLength, string because = "", params object[] becauseArgs)
         {
             int length = instance.Subject.Length;

--- a/src/Bicep.LangServer.UnitTests/Helpers/CompilationHelperTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Helpers/CompilationHelperTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using Bicep.Core.Configuration;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.LanguageServer;
+using Bicep.LanguageServer.Handlers;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using IOFileSystem = System.IO.Abstractions.FileSystem;
+using CompilationHelper = Bicep.LanguageServer.Utils.CompilationHelper;
+
+namespace Bicep.LangServer.UnitTests.Helpers
+{
+    [TestClass]
+    public class CompilationHelperTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        private static readonly FileResolver FileResolver = BicepTestConstants.FileResolver;
+        private static readonly IConfigurationManager configurationManager = new ConfigurationManager(new IOFileSystem());
+        private readonly ModuleDispatcher ModuleDispatcher = new ModuleDispatcher(BicepTestConstants.RegistryProvider, configurationManager);
+
+        [TestMethod]
+        public void GetCompilation_WithNullCompilationContext_ShouldCreateCompilation()
+        {
+            string bicepFileContents = @"resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: 'dnsZone'
+  location: 'global'
+}";
+            string bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            DocumentUri documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            // Do not upsert compilation. This will cause CompilationContext to be null
+            BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, upsertCompilation: false);
+            var compilationContext = bicepCompilationManager.GetCompilation(documentUri);
+
+            compilationContext.Should().BeNull();
+
+            var compilation = CompilationHelper.GetCompilation(
+                documentUri,
+                documentUri.ToUri(),
+                BicepTestConstants.ApiVersionProviderFactory,
+                BicepTestConstants.LinterAnalyzer,
+                bicepCompilationManager,
+                configurationManager,
+                BicepTestConstants.FeatureProviderFactory,
+                FileResolver,
+                ModuleDispatcher,
+                BicepTestConstants.NamespaceProvider);
+
+            compilation.Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void GetCompilation_WithNonNullCompilationContext_ShouldReuseCompilation()
+        {
+            string bicepFileContents = @"resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
+  name: 'dnsZone'
+  location: 'global'
+}";
+            string bicepFilePath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents);
+            DocumentUri documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
+            // Upsert compilation. This will cause CompilationContext to be non null
+            BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, upsertCompilation: true);
+
+            var compilation = CompilationHelper.GetCompilation(
+                documentUri,
+                documentUri.ToUri(),
+                BicepTestConstants.ApiVersionProviderFactory,
+                BicepTestConstants.LinterAnalyzer,
+                bicepCompilationManager,
+                configurationManager,
+                BicepTestConstants.FeatureProviderFactory,
+                FileResolver,
+                ModuleDispatcher,
+                BicepTestConstants.NamespaceProvider);
+
+            compilation.Should().NotBeNull();
+            compilation.Should().BeSameAs(bicepCompilationManager.GetCompilation(documentUri)!.Compilation);
+        }
+    }
+}

--- a/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
@@ -83,6 +83,7 @@ namespace Bicep.LanguageServer.Handlers
 
             var fileUri = documentUri.ToUri();
 
+            // Bicep file could contain load functions like loadTextContent(..). We'll refresh compilation to detect changes in files referenced in load functions.
             compilationManager.RefreshCompilation(fileUri);
             CompilationContext? context = compilationManager.GetCompilation(fileUri);
             Compilation compilation;

--- a/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
@@ -83,6 +83,7 @@ namespace Bicep.LanguageServer.Handlers
 
             var fileUri = documentUri.ToUri();
 
+            compilationManager.RefreshCompilation(fileUri);
             CompilationContext? context = compilationManager.GetCompilation(fileUri);
             Compilation compilation;
 

--- a/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
@@ -83,20 +83,17 @@ namespace Bicep.LanguageServer.Handlers
 
             var fileUri = documentUri.ToUri();
 
-            // Bicep file could contain load functions like loadTextContent(..). We'll refresh compilation to detect changes in files referenced in load functions.
-            compilationManager.RefreshCompilation(fileUri);
-            CompilationContext? context = compilationManager.GetCompilation(fileUri);
-            Compilation compilation;
-
-            if (context is null)
-            {
-                SourceFileGrouping sourceFileGrouping = SourceFileGroupingBuilder.Build(this.fileResolver, this.moduleDispatcher, new Workspace(), fileUri);
-                compilation = new Compilation(featureProviderFactory, namespaceProvider, sourceFileGrouping, configurationManager, apiVersionProviderFactory, bicepAnalyzer);
-            }
-            else
-            {
-                compilation = context.Compilation;
-            }
+            var compilation = CompilationHelper.GetCompilation(
+                documentUri,
+                fileUri,
+                apiVersionProviderFactory,
+                bicepAnalyzer,
+                compilationManager,
+                configurationManager,
+                featureProviderFactory,
+                fileResolver,
+                moduleDispatcher,
+                namespaceProvider);
 
             var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
                 .FirstOrDefault(x => x.Key.FileUri == fileUri);

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
@@ -134,6 +134,7 @@ namespace Bicep.LanguageServer.Handlers
         {
             var fileUri = documentUri.ToUri();
 
+            compilationManager.RefreshCompilation(fileUri);
             CompilationContext? context = compilationManager.GetCompilation(documentUri);
             if (context is null)
             {

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
@@ -134,6 +134,7 @@ namespace Bicep.LanguageServer.Handlers
         {
             var fileUri = documentUri.ToUri();
 
+            // Bicep file could contain load functions like loadTextContent(..). We'll refresh compilation to detect changes in files referenced in load functions.
             compilationManager.RefreshCompilation(fileUri);
             CompilationContext? context = compilationManager.GetCompilation(documentUri);
             if (context is null)

--- a/src/Bicep.LangServer/Utils/CompilationHelper.cs
+++ b/src/Bicep.LangServer/Utils/CompilationHelper.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Bicep.Core.Analyzers.Interfaces;
+using Bicep.Core.Analyzers.Linter.ApiVersions;
+using Bicep.Core.Configuration;
+using Bicep.Core.Features;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
+using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Workspaces;
+using Bicep.LanguageServer.CompilationManager;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+
+namespace Bicep.LanguageServer.Utils
+{
+    public static class CompilationHelper
+    {
+        public static Compilation GetCompilation(
+            DocumentUri documentUri,
+            Uri fileUri,
+            IApiVersionProviderFactory apiVersionProviderFactory,
+            IBicepAnalyzer bicepAnalyzer,
+            ICompilationManager compilationManager,
+            IConfigurationManager configurationManager,
+            IFeatureProviderFactory featureProviderFactory,
+            IFileResolver fileResolver,
+            IModuleDispatcher moduleDispatcher,
+            INamespaceProvider namespaceProvider)
+        {
+            // Bicep file could contain load functions like loadTextContent(..). We'll refresh compilation to detect changes in files referenced in load functions.
+            compilationManager.RefreshCompilation(fileUri);
+            CompilationContext? context = compilationManager.GetCompilation(documentUri);
+            // CompilationContext will be null if the file is not open in the editor.
+            // E.g. When user right clicks on a file from the explorer context menu without opening the file and invokes build/deploy
+            if (context is null)
+            {
+                SourceFileGrouping sourceFileGrouping = SourceFileGroupingBuilder.Build(fileResolver, moduleDispatcher, new Workspace(), fileUri);
+                return new Compilation(featureProviderFactory, namespaceProvider, sourceFileGrouping, configurationManager, apiVersionProviderFactory, bicepAnalyzer);
+            }
+            else
+            {
+                return context.Compilation;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8239

Bicep file used in build and deploy could contain load functions like loadTextContent(..). If files used in load functions are updated, we don't update compilation. We need to manually refresh compilation before build and deploy operations so that file changes are picked up when build/deploy operations are kicked off.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8721)