### PR TITLE
Added DNS Private Resolver resource snippet

### DIFF
--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -1171,7 +1171,7 @@
     "detail": "",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource dnsResolvers 'Microsoft.Network/dnsResolvers@2022-07-01' = {\n  name: 'name'\n  location: location\n  properties: {\n     virtualNetwork: {\n      id: 'virtualNetworkId'\n     }\n  }\n\n  resource inboundEndpoints 'inboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      ipConfigurations: [\n        {\n          privateIpAllocationMethod: 'Static'\n          subnet: {\n            id: 'subnetId'\n          }\n        }\n      ]\n    }\n  }\n\n  resource outboundEndpoints 'outboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      subnet: {\n        id: 'subnetId'\n      }\n    }\n  }\n}\n\n\n\n```"
+      "value": "```bicep\nresource dnsResolvers 'Microsoft.Network/dnsResolvers@2022-07-01' = {\n  name: 'name'\n  location: location\n  properties: {\n     virtualNetwork: {\n      id: 'virtualNetworkId'\n     }\n  }\n\n  resource inboundEndpoints 'inboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      ipConfigurations: [\n        {\n          privateIpAllocationMethod: 'Static'\n          subnet: {\n            id: 'subnetId'\n          }\n        }\n      ]\n    }\n  }\n\n  resource outboundEndpoints 'outboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      subnet: {\n        id: 'subnetId'\n      }\n    }\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -1180,7 +1180,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:dnsResolvers} 'Microsoft.Network/dnsResolvers@2022-07-01' = {\n  name: ${2:'name'}\n  location: ${3:location}\n  properties: {\n     virtualNetwork: {\n      id: ${4:'virtualNetworkId'}\n     }\n  }\n\n  resource ${5:inboundEndpoints} 'inboundEndpoints' = {\n    name: ${6:'name'}\n    location: ${7:location}\n    properties: {\n      ipConfigurations: [\n        {\n          privateIpAllocationMethod: ${8|'Static','Dynamic'|}\n          subnet: {\n            id: ${9:'subnetId'}\n          }\n        }\n      ]\n    }\n  }\n\n  resource ${10:outboundEndpoints} 'outboundEndpoints' = {\n    name: ${11:'name'}\n    location: ${12:location}\n    properties: {\n      subnet: {\n        id: ${13:'subnetId'}\n      }\n    }\n  }\n}\n\n\n"
+      "newText": "resource ${1:dnsResolvers} 'Microsoft.Network/dnsResolvers@2022-07-01' = {\n  name: ${2:'name'}\n  location: ${3:location}\n  properties: {\n     virtualNetwork: {\n      id: ${4:'virtualNetworkId'}\n     }\n  }\n\n  resource ${5:inboundEndpoints} 'inboundEndpoints' = {\n    name: ${6:'name'}\n    location: ${7:location}\n    properties: {\n      ipConfigurations: [\n        {\n          privateIpAllocationMethod: ${8|'Static','Dynamic'|}\n          subnet: {\n            id: ${9:'subnetId'}\n          }\n        }\n      ]\n    }\n  }\n\n  resource ${10:outboundEndpoints} 'outboundEndpoints' = {\n    name: ${11:'name'}\n    location: ${12:location}\n    properties: {\n      subnet: {\n        id: ${13:'subnetId'}\n      }\n    }\n  }\n}\n"
     },
     "command": {
       "title": "top level snippet completion",

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -1166,6 +1166,36 @@
     }
   },
   {
+    "label": "res-dns-resolver",
+    "kind": "snippet",
+    "detail": "",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource dnsResolvers 'Microsoft.Network/dnsResolvers@2022-07-01' = {\n  name: 'name'\n  location: location\n  properties: {\n     virtualNetwork: {\n      id: 'virtualNetworkId'\n     }\n  }\n\n  resource inboundEndpoints 'inboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      ipConfigurations: [\n        {\n          privateIpAllocationMethod: 'Static'\n          subnet: {\n            id: 'subnetId'\n          }\n        }\n      ]\n    }\n  }\n\n  resource outboundEndpoints 'outboundEndpoints' = {\n    name: 'name'\n    location: location\n    properties: {\n      subnet: {\n        id: 'subnetId'\n      }\n    }\n  }\n}\n\n\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-dns-resolver",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:dnsResolvers} 'Microsoft.Network/dnsResolvers@2022-07-01' = {\n  name: ${2:'name'}\n  location: ${3:location}\n  properties: {\n     virtualNetwork: {\n      id: ${4:'virtualNetworkId'}\n     }\n  }\n\n  resource ${5:inboundEndpoints} 'inboundEndpoints' = {\n    name: ${6:'name'}\n    location: ${7:location}\n    properties: {\n      ipConfigurations: [\n        {\n          privateIpAllocationMethod: ${8|'Static','Dynamic'|}\n          subnet: {\n            id: ${9:'subnetId'}\n          }\n        }\n      ]\n    }\n  }\n\n  resource ${10:outboundEndpoints} 'outboundEndpoints' = {\n    name: ${11:'name'}\n    location: ${12:location}\n    properties: {\n      subnet: {\n        id: ${13:'subnetId'}\n      }\n    }\n  }\n}\n\n\n"
+    },
+    "command": {
+      "title": "top level snippet completion",
+      "command": "bicep.Telemetry",
+      "arguments": [
+        {
+          "EventName": "snippet/toplevel",
+          "Properties": {
+            "name": "res-dns-resolver"
+          }
+        }
+      ]
+    }
+  },
+  {
     "label": "res-dns-zone",
     "kind": "snippet",
     "detail": "DNS Zone",

--- a/src/Bicep.LangServer.IntegrationTests/Files/SnippetTemplates/res-dns-resolver/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Files/SnippetTemplates/res-dns-resolver/main.bicep
@@ -1,0 +1,17 @@
+// $1 = dnsResolvers
+// $2 = 'name'
+// $3 = location
+// $4 = 'virtualNetworkId'
+// $5 = inboundEndpoints
+// $6 = 'name'
+// $7 = location
+// $8 = 'Dynamic'
+// $9 = 'subnetId'
+// $10 = outboundEndpoints
+// $11 = 'name'
+// $12 = location
+// $13 = 'subnetId'
+
+param location string
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Files/SnippetTemplates/res-dns-resolver/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Files/SnippetTemplates/res-dns-resolver/main.combined.bicep
@@ -48,3 +48,7 @@ resource dnsResolvers 'Microsoft.Network/dnsResolvers@2022-07-01' = {
     }
   }
 }
+
+
+// Insert snippet here
+

--- a/src/Bicep.LangServer.IntegrationTests/Files/SnippetTemplates/res-dns-resolver/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Files/SnippetTemplates/res-dns-resolver/main.combined.bicep
@@ -48,7 +48,5 @@ resource dnsResolvers 'Microsoft.Network/dnsResolvers@2022-07-01' = {
     }
   }
 }
-
-
 // Insert snippet here
 

--- a/src/Bicep.LangServer.IntegrationTests/Files/SnippetTemplates/res-dns-resolver/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Files/SnippetTemplates/res-dns-resolver/main.combined.bicep
@@ -1,0 +1,50 @@
+// $1 = dnsResolvers
+// $2 = 'name'
+// $3 = location
+// $4 = 'virtualNetworkId'
+// $5 = inboundEndpoints
+// $6 = 'name'
+// $7 = location
+// $8 = 'Dynamic'
+// $9 = 'subnetId'
+// $10 = outboundEndpoints
+// $11 = 'name'
+// $12 = location
+// $13 = 'subnetId'
+
+param location string
+
+resource dnsResolvers 'Microsoft.Network/dnsResolvers@2022-07-01' = {
+  name: 'name'
+  location: location
+  properties: {
+     virtualNetwork: {
+      id: 'virtualNetworkId'
+     }
+  }
+
+  resource inboundEndpoints 'inboundEndpoints' = {
+    name: 'name'
+    location: location
+    properties: {
+      ipConfigurations: [
+        {
+          privateIpAllocationMethod: 'Dynamic'
+          subnet: {
+            id: 'subnetId'
+          }
+        }
+      ]
+    }
+  }
+
+  resource outboundEndpoints 'outboundEndpoints' = {
+    name: 'name'
+    location: location
+    properties: {
+      subnet: {
+        id: 'subnetId'
+      }
+    }
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-dns-resolver.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-dns-resolver.bicep
@@ -1,0 +1,36 @@
+resource /*${1:dnsResolvers}*/dnsResolvers 'Microsoft.Network/dnsResolvers@2022-07-01' = {
+  name: /*${2:'name'}*/'name'
+  location: /*${3:location}*/'location'
+  properties: {
+     virtualNetwork: {
+      id: /*${4:'virtualNetworkId'}*/'virtualNetworkId'
+     }
+  }
+
+  resource /*${5:inboundEndpoints}*/inboundEndpoints 'inboundEndpoints' = {
+    name: /*${6:'name'}*/'name'
+    location: /*${7:location}*/'location'
+    properties: {
+      ipConfigurations: [
+        {
+          privateIpAllocationMethod: /*${8|'Static','Dynamic'}*/'Dynamic'
+          subnet: {
+            id: /*${9:'subnetId'}*/'subnetId'
+          }
+        }
+      ]
+    }
+  }
+
+  resource /*${10:outboundEndpoints}*/outboundEndpoints 'outboundEndpoints' = {
+    name: /*${11:'name'}*/'name'
+    location: /*${12:location}*/'location'
+    properties: {
+      subnet: {
+        id: /*${13:'subnetId'}*/'subnetId'
+      }
+    }
+  }
+}
+
+

--- a/src/Bicep.LangServer/Snippets/Templates/res-dns-resolver.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-dns-resolver.bicep
@@ -13,7 +13,7 @@ resource /*${1:dnsResolvers}*/dnsResolvers 'Microsoft.Network/dnsResolvers@2022-
     properties: {
       ipConfigurations: [
         {
-          privateIpAllocationMethod: /*${8|'Static','Dynamic'}*/'Dynamic'
+          privateIpAllocationMethod: /*${8|'Static','Dynamic'|}*/'Dynamic'
           subnet: {
             id: /*${9:'subnetId'}*/'subnetId'
           }
@@ -32,5 +32,3 @@ resource /*${1:dnsResolvers}*/dnsResolvers 'Microsoft.Network/dnsResolvers@2022-
     }
   }
 }
-
-


### PR DESCRIPTION
## Contributing a snippet

* [x] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [x] I have checked that there is not an equivalent snippet already submitted
* [x] I have used camelCasing unless I have a justification to use another casing style
* [x] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [x] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [x] I have a resource name property equal to "name"
* [x] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [x] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8787)