### PR TITLE
Make diff colors correct

### DIFF
--- a/src/Bicep.Core.UnitTests/Assertions/BaselineHelper.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/BaselineHelper.cs
@@ -75,7 +75,7 @@ Baseline {2} has been updated.
             {
                 output.Append(@"
 View this diff with:
-    git diff --color-words --no-index {1} {2}
+    git diff --color-words --no-index {2} {1}
 ");
 
                 if (isWindows)

--- a/src/Bicep.Core.UnitTests/Assertions/StringAssertionsExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/StringAssertionsExtensions.cs
@@ -34,7 +34,7 @@ namespace Bicep.Core.UnitTests.Assertions
         public static AndConstraint<StringAssertions> EqualWithLineByLineDiffOutput(this StringAssertions instance, TestContext testContext, string expected, string expectedLocation, string actualLocation, string because = "", params object[] becauseArgs)
         {
             const int truncate = 100;
-            var diff = InlineDiffBuilder.Diff(instance.Subject, expected, ignoreWhiteSpace: false, ignoreCase: false);
+            var diff = InlineDiffBuilder.Diff(expected, instance.Subject, ignoreWhiteSpace: false, ignoreCase: false);
 
             var lineLogs = diff.Lines
                 .Where(line => line.Type != ChangeType.Unchanged)


### PR DESCRIPTION
The diff commandline suggested when a test baseline diff occurs is backwards - the first argument to diff is the new result and the second the current result, so the ++/-- and red/green displays are backwards.  This fixes so added content shows in green, removed content in red.