### PR TITLE
Improve performance of NoUnusedVariablesRule & NoUnusedParametersRule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -584,6 +584,29 @@ jobs:
         with:
           flags: dotnet
 
+  run-benchmarks:
+    name: Run Benchmarks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+          submodules: true
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+
+      - name: Run Benchmarks
+        run: dotnet run --configuration Release --project src/Bicep.Tools.Benchmark -- --filter '*' --profiler EP
+
+      - name: Upload Benchmarks
+        uses: actions/upload-artifact@v3
+        with:
+          name: BenchmarkDotNet.Artifacts
+          path: ./BenchmarkDotNet.Artifacts
+          if-no-files-found: error
+
   can-run-live-tests:
     name: Check secret access
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -584,29 +584,6 @@ jobs:
         with:
           flags: dotnet
 
-  run-benchmarks:
-    name: Run Benchmarks
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-          submodules: true
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
-
-      - name: Run Benchmarks
-        run: dotnet run --configuration Release --project src/Bicep.Tools.Benchmark -- --filter '*' --profiler EP
-
-      - name: Upload Benchmarks
-        uses: actions/upload-artifact@v3
-        with:
-          name: BenchmarkDotNet.Artifacts
-          path: ./BenchmarkDotNet.Artifacts
-          if-no-files-found: error
-
   can-run-live-tests:
     name: Check secret access
     runs-on: ubuntu-latest

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,0 +1,34 @@
+name: Run Benchmarks
+# This action can be run on-demand against a branch.
+# It runs Bicep Benchmarks, and uploads the results as an artifact
+
+on:
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  run-benchmarks:
+    name: Run Benchmarks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+          submodules: true
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v3
+
+      - name: Run Benchmarks
+        run: dotnet run --configuration Release --project src/Bicep.Tools.Benchmark -- --filter '*' --profiler EP
+
+      - name: Upload Benchmarks
+        uses: actions/upload-artifact@v3
+        with:
+          name: BenchmarkDotNet.Artifacts
+          path: ./BenchmarkDotNet.Artifacts
+          if-no-files-found: error

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -22,7 +22,6 @@ va
 // unassigned variable
 var foo
 //@[04:07) [BCP028 (Error)] Identifier "foo" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |foo|
-//@[04:07) [no-unused-vars (Warning)] Variable "foo" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |foo|
 //@[07:07) [BCP018 (Error)] Expected the "=" character at this location. (CodeDescription: none) ||
 
 // #completionTest(18,19) -> symbols
@@ -164,13 +163,11 @@ var doubleString = "bad string"
 //@[30:31) [BCP103 (Error)] The following token is not recognized: """. Strings are defined using single quotes in bicep. (CodeDescription: none) |"|
 
 var resourceGroup = ''
-//@[04:17) [no-unused-vars (Warning)] Variable "resourceGroup" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |resourceGroup|
 var rgName = resourceGroup().name
 //@[04:10) [no-unused-vars (Warning)] Variable "rgName" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |rgName|
 //@[13:26) [BCP265 (Error)] The name "resourceGroup" is not a function. Did you mean "az.resourceGroup"? (CodeDescription: none) |resourceGroup|
 
 var subscription = ''
-//@[04:16) [no-unused-vars (Warning)] Variable "subscription" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |subscription|
 var subName = subscription().name
 //@[04:11) [no-unused-vars (Warning)] Variable "subName" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |subName|
 //@[14:26) [BCP265 (Error)] The name "subscription" is not a function. Did you mean "az.subscription"? (CodeDescription: none) |subscription|
@@ -414,7 +411,6 @@ var keyVaultSecretArrayInterpolatedVar = [
 ]
 
 var listSecrets= ''
-//@[04:15) [no-unused-vars (Warning)] Variable "listSecrets" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |listSecrets|
 var listSecretsVar = listSecrets()
 //@[04:18) [no-unused-vars (Warning)] Variable "listSecretsVar" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |listSecretsVar|
 //@[21:32) [BCP265 (Error)] The name "listSecrets" is not a function. Did you mean "az.listSecrets"? (CodeDescription: none) |listSecrets|

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedExistingResourcesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedExistingResourcesRule.cs
@@ -29,14 +29,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
         override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            // TODO: Performance: Use a visitor to visit VariableAccesssyntax and collects the non-error symbols into a list.
-            // Then do a symbol visitor to go through all the symbols that exist and compare.
-            // Same issue for unused-params and unused-variables rule.
+            var invertedBindings = model.Binder.Bindings.ToLookup(kvp => kvp.Value, kvp => kvp.Key);
 
-            var unreferencedResources = model.Root.Declarations.OfType<ResourceSymbol>()
+            var unreferencedResources = model.Root.ResourceDeclarations
                 .Where(sym => sym.NameSyntax.IsValid)
                 .Where(sym => sym.DeclaringResource.IsExistingResource())
-                .Where(sym => !model.FindReferences(sym).Any(rf => rf != sym.DeclaringResource))
+                .Where(sym => !invertedBindings[sym].Any(x => x != sym.DeclaringSyntax))
                 .Where(sym => !(sym.DeclaringResource.TryGetBody()?.Resources ?? Enumerable.Empty<ResourceDeclarationSyntax>()).Any());
             foreach (var sym in unreferencedResources)
             {

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedParametersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedParametersRule.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Extensions;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using System;
@@ -28,12 +29,17 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
         override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
+            var invertedBindings = model.Binder.Bindings.ToLookup(kvp => kvp.Value, kvp => kvp.Key);
+
             // VariableAccessSyntax indicates a reference to the parameter
             var unreferencedParams = model.Root.ParameterDeclarations
-                .Where(sym => !model.FindReferences(sym).OfType<VariableAccessSyntax>().Any())
-                .Where(sym => sym.NameSyntax.IsValid);
+                .Where(sym => sym.NameSyntax.IsValid)
+                .Where(sym => !invertedBindings[sym].Any(x => x != sym.DeclaringSyntax));
 
-            return unreferencedParams.Select(param => CreateRemoveUnusedDiagnosticForSpan(diagnosticLevel, param.Name, param.NameSyntax, param.DeclaringSyntax, model.SourceFile.ProgramSyntax));
+            foreach (var param in unreferencedParams)
+            {
+                yield return CreateRemoveUnusedDiagnosticForSpan(diagnosticLevel, param.Name, param.NameSyntax, param.DeclaringSyntax, model.SourceFile.ProgramSyntax);
+            }
         }
 
         override protected string GetCodeFixDescription(string name)

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedVariablesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnusedVariablesRule.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Extensions;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using System;
@@ -29,14 +30,13 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
         override public IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
-            // TODO: Performance: Use a visitor to visit VariableAccesssyntax and collects the non-error symbols into a list.
-            // Then do a symbol visitor to go through all the symbols that exist and compare.
-            // Same issue for unused-params rule.
+            var invertedBindings = model.Binder.Bindings.ToLookup(kvp => kvp.Value, kvp => kvp.Key);
 
             // variables must have a reference of type VariableAccessSyntax
-            var unreferencedVariables = model.Root.Declarations.OfType<VariableSymbol>()
-                .Where(sym => !model.FindReferences(sym).OfType<VariableAccessSyntax>().Any())
-                .Where(sym => sym.NameSyntax.IsValid);
+            var unreferencedVariables = model.Root.VariableDeclarations
+                .Where(sym => sym.NameSyntax.IsValid)
+                .Where(sym => !invertedBindings[sym].Any(x => x != sym.DeclaringSyntax));
+
             foreach (var sym in unreferencedVariables)
             {
                 yield return CreateRemoveUnusedDiagnosticForSpan(diagnosticLevel, sym.Name, sym.NameSyntax, sym.DeclaringSyntax, model.SourceFile.ProgramSyntax);
@@ -47,8 +47,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             // local variables must have a reference of type VariableAccessSyntax
             var unreferencedLocalVariables = model.Root.Declarations.OfType<LocalVariableSymbol>()
-                        .Where(sym => !model.FindReferences(sym).OfType<VariableAccessSyntax>().Any())
-                        .Where(sym => sym.NameSyntax.IsValid);
+                .Where(sym => sym.NameSyntax.IsValid)
+                .Where(sym => !invertedBindings[sym].Any(x => x != sym.DeclaringSyntax));
 
             foreach (var sym in unreferencedLocalVariables)
             {

--- a/src/Bicep.Core/Semantics/IBinder.cs
+++ b/src/Bicep.Core/Semantics/IBinder.cs
@@ -17,6 +17,8 @@ namespace Bicep.Core.Semantics
 
         Symbol? GetSymbolInfo(SyntaxBase syntax);
 
+        ImmutableDictionary<SyntaxBase, Symbol> Bindings { get; }
+
         ImmutableArray<DeclaredSymbol>? TryGetCycle(DeclaredSymbol declaredSymbol);
     }
 }


### PR DESCRIPTION
Noticed when implementing #8844 - `NoUnusedVariablesRule` is consuming ~34% total CPU time when running benchmarks. This PR drops that down to ~2.5%.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8853)