### PR TITLE
Update `Azure.Deployments.*` dependencies

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -114,30 +114,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2008,9 +2009,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -114,30 +114,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -1836,9 +1837,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -98,30 +98,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -1741,9 +1742,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -114,30 +114,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2008,9 +2009,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.bicep
@@ -1,9 +1,9 @@
-﻿// @description('The foo type')
-// @sealed()
+﻿@description('The foo type')
+@sealed()
 type foo = {
   @minLength(3)
   @maxLength(10)
-  // @description('A string property')
+  @description('A string property')
   stringProp: string
 
   objectProp: {
@@ -21,12 +21,12 @@ type foo = {
 }
 
 @minLength(3)
-// @description('An array of array of arrays of arrays of ints')
-// @metadata({
-//   examples: [
-//     [[[[1]]], [[[2]]], [[[3]]]]
-//   ]
-// })
+@description('An array of array of arrays of arrays of ints')
+@metadata({
+  examples: [
+    [[[[1]]], [[[2]]], [[[3]]]]
+  ]
+})
 type bar = int[][][][]
 
 type aUnion = 'snap'|'crackle'|'pop'
@@ -48,3 +48,5 @@ param inlineObjectParam {
 }
 
 param unionParam {property: 'ping'}|{property: 'pong'} = {property: 'pong'}
+
+param paramUsingType mixedArray

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.diagnostics.bicep
@@ -1,9 +1,9 @@
-// @description('The foo type')
-// @sealed()
+@description('The foo type')
+@sealed()
 type foo = {
   @minLength(3)
   @maxLength(10)
-  // @description('A string property')
+  @description('A string property')
   stringProp: string
 
   objectProp: {
@@ -21,12 +21,12 @@ type foo = {
 }
 
 @minLength(3)
-// @description('An array of array of arrays of arrays of ints')
-// @metadata({
-//   examples: [
-//     [[[[1]]], [[[2]]], [[[3]]]]
-//   ]
-// })
+@description('An array of array of arrays of arrays of ints')
+@metadata({
+  examples: [
+    [[[[1]]], [[[2]]], [[[3]]]]
+  ]
+})
 type bar = int[][][][]
 
 type aUnion = 'snap'|'crackle'|'pop'
@@ -50,4 +50,7 @@ param inlineObjectParam {
 
 param unionParam {property: 'ping'}|{property: 'pong'} = {property: 'pong'}
 //@[6:16) [no-unused-params (Warning)] Parameter "unionParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |unionParam|
+
+param paramUsingType mixedArray
+//@[6:20) [no-unused-params (Warning)] Parameter "paramUsingType" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |paramUsingType|
 

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.formatted.bicep
@@ -1,9 +1,9 @@
-// @description('The foo type')
-// @sealed()
+@description('The foo type')
+@sealed()
 type foo = {
   @minLength(3)
   @maxLength(10)
-  // @description('A string property')
+  @description('A string property')
   stringProp: string
 
   objectProp: {
@@ -21,12 +21,12 @@ type foo = {
 }
 
 @minLength(3)
-// @description('An array of array of arrays of arrays of ints')
-// @metadata({
-//   examples: [
-//     [[[[1]]], [[[2]]], [[[3]]]]
-//   ]
-// })
+@description('An array of array of arrays of arrays of ints')
+@metadata({
+  examples: [
+    [ [ [ [ 1 ] ] ], [ [ [ 2 ] ] ], [ [ [ 3 ] ] ] ]
+  ]
+})
 type bar = int[][][][]
 
 type aUnion = 'snap' | 'crackle' | 'pop'
@@ -48,3 +48,5 @@ param inlineObjectParam {
 }
 
 param unionParam { property: 'ping' } | { property: 'pong' } = { property: 'pong' }
+
+param paramUsingType mixedArray

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.json
@@ -7,12 +7,13 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6318384594241971223"
+      "templateHash": "9766386612525987809"
     }
   },
   "definitions": {
     "foo": {
       "type": "object",
+      "sealed": "true",
       "required": [
         "literalProp",
         "objectProp",
@@ -52,12 +53,18 @@
         },
         "stringProp": {
           "type": "string",
+          "metadata": {
+            "description": "A string property"
+          },
           "maxLength": 10,
           "minLength": 3
         },
         "typeRefProp": {
           "$ref": "#/definitions/bar"
         }
+      },
+      "metadata": {
+        "description": "The foo type"
       }
     },
     "bar": {
@@ -73,6 +80,34 @@
             }
           }
         }
+      },
+      "metadata": {
+        "examples": [
+          [
+            [
+              [
+                [
+                  1
+                ]
+              ]
+            ],
+            [
+              [
+                [
+                  2
+                ]
+              ]
+            ],
+            [
+              [
+                [
+                  3
+                ]
+              ]
+            ]
+          ]
+        ],
+        "description": "An array of array of arrays of arrays of ints"
       },
       "minLength": 3
     },
@@ -159,6 +194,9 @@
       "defaultValue": {
         "property": "pong"
       }
+    },
+    "paramUsingType": {
+      "$ref": "#/definitions/mixedArray"
     }
   },
   "resources": {}

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.bicep
@@ -1,17 +1,19 @@
-// @description('The foo type')
-// @sealed()
+@description('The foo type')
+//@[66:66]         "description": "The foo type"
+@sealed()
 type foo = {
-//@[13:61]     "foo": {
+//@[13:68]     "foo": {
   @minLength(3)
-//@[55:55]           "minLength": 3
+//@[59:59]           "minLength": 3
   @maxLength(10)
-//@[54:54]           "maxLength": 10,
-  // @description('A string property')
+//@[58:58]           "maxLength": 10,
+  @description('A string property')
+//@[56:56]             "description": "A string property"
   stringProp: string
 
   objectProp: {
     @minValue(1)
-//@[45:45]               "minValue": 1
+//@[46:46]               "minValue": 1
     intProp: int
 
     intArrayArrayProp?: int [] []
@@ -25,42 +27,48 @@ type foo = {
 }
 
 @minLength(3)
-//@[76:76]       "minLength": 3
-// @description('An array of array of arrays of arrays of ints')
-// @metadata({
-//   examples: [
-//     [[[[1]]], [[[2]]], [[[3]]]]
-//   ]
-// })
+//@[111:111]       "minLength": 3
+@description('An array of array of arrays of arrays of ints')
+//@[109:109]         "description": "An array of array of arrays of arrays of ints"
+@metadata({
+  examples: [
+//@[84:108]         "examples": [
+    [[[[1]]], [[[2]]], [[[3]]]]
+//@[85:107]                   1
+  ]
+})
 type bar = int[][][][]
-//@[62:77]     "bar": {
+//@[69:112]     "bar": {
 
 type aUnion = 'snap'|'crackle'|'pop'
-//@[78:85]     "aUnion": {
+//@[113:120]     "aUnion": {
 
 type expandedUnion = aUnion|'fizz'|'buzz'|'pop'
-//@[86:95]     "expandedUnion": {
+//@[121:130]     "expandedUnion": {
 
 type mixedArray = ('heffalump'|'woozle'|{ shape: '*', size: '*'}|10|-10|true|!true|null)[]
-//@[96:111]     "mixedArray": {
+//@[131:146]     "mixedArray": {
 
 type String = string
-//@[112:114]     "String": {
+//@[147:149]     "String": {
 
 param inlineObjectParam {
-//@[117:147]     "inlineObjectParam": {
+//@[152:182]     "inlineObjectParam": {
   foo: string
   bar: 100|200|300|400|500
   baz: bool
 } = {
   foo: 'foo'
-//@[143:143]         "foo": "foo",
+//@[178:178]         "foo": "foo",
   bar: 300
-//@[144:144]         "bar": 300,
+//@[179:179]         "bar": 300,
   baz: false
-//@[145:145]         "baz": false
+//@[180:180]         "baz": false
 }
 
 param unionParam {property: 'ping'}|{property: 'pong'} = {property: 'pong'}
-//@[148:161]     "unionParam": {
+//@[183:196]     "unionParam": {
+
+param paramUsingType mixedArray
+//@[197:199]     "paramUsingType": {
 

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.json
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.json
@@ -6,15 +6,23 @@
       "SourceMap": [
         {
           "SourceLine": 9,
-          "TargetLine": 45
+          "TargetLine": 46
+        },
+        {
+          "SourceLine": 5,
+          "TargetLine": 56
         },
         {
           "SourceLine": 4,
-          "TargetLine": 54
+          "TargetLine": 58
         },
         {
           "SourceLine": 3,
-          "TargetLine": 55
+          "TargetLine": 59
+        },
+        {
+          "SourceLine": 0,
+          "TargetLine": 66
         },
         {
           "SourceLine": 2,
@@ -146,7 +154,7 @@
         },
         {
           "SourceLine": 2,
-          "TargetLine": 46
+          "TargetLine": 45
         },
         {
           "SourceLine": 2,
@@ -178,19 +186,15 @@
         },
         {
           "SourceLine": 2,
-          "TargetLine": 56
+          "TargetLine": 54
+        },
+        {
+          "SourceLine": 2,
+          "TargetLine": 55
         },
         {
           "SourceLine": 2,
           "TargetLine": 57
-        },
-        {
-          "SourceLine": 2,
-          "TargetLine": 58
-        },
-        {
-          "SourceLine": 2,
-          "TargetLine": 59
         },
         {
           "SourceLine": 2,
@@ -201,36 +205,136 @@
           "TargetLine": 61
         },
         {
-          "SourceLine": 22,
-          "TargetLine": 76
-        },
-        {
-          "SourceLine": 29,
+          "SourceLine": 2,
           "TargetLine": 62
         },
         {
-          "SourceLine": 29,
+          "SourceLine": 2,
           "TargetLine": 63
         },
         {
-          "SourceLine": 29,
+          "SourceLine": 2,
           "TargetLine": 64
         },
         {
-          "SourceLine": 29,
+          "SourceLine": 2,
           "TargetLine": 65
         },
         {
-          "SourceLine": 29,
-          "TargetLine": 66
-        },
-        {
-          "SourceLine": 29,
+          "SourceLine": 2,
           "TargetLine": 67
         },
         {
-          "SourceLine": 29,
+          "SourceLine": 2,
           "TargetLine": 68
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 89
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 88
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 90
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 87
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 91
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 86
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 92
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 96
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 95
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 97
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 94
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 98
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 93
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 99
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 103
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 102
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 104
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 101
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 105
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 100
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 106
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 85
+        },
+        {
+          "SourceLine": 26,
+          "TargetLine": 107
+        },
+        {
+          "SourceLine": 25,
+          "TargetLine": 84
+        },
+        {
+          "SourceLine": 25,
+          "TargetLine": 108
+        },
+        {
+          "SourceLine": 23,
+          "TargetLine": 109
+        },
+        {
+          "SourceLine": 22,
+          "TargetLine": 111
         },
         {
           "SourceLine": 29,
@@ -262,335 +366,383 @@
         },
         {
           "SourceLine": 29,
+          "TargetLine": 76
+        },
+        {
+          "SourceLine": 29,
           "TargetLine": 77
         },
         {
-          "SourceLine": 31,
+          "SourceLine": 29,
           "TargetLine": 78
         },
         {
-          "SourceLine": 31,
+          "SourceLine": 29,
           "TargetLine": 79
         },
         {
-          "SourceLine": 31,
+          "SourceLine": 29,
           "TargetLine": 80
         },
         {
-          "SourceLine": 31,
+          "SourceLine": 29,
           "TargetLine": 81
         },
         {
-          "SourceLine": 31,
+          "SourceLine": 29,
           "TargetLine": 82
         },
         {
-          "SourceLine": 31,
+          "SourceLine": 29,
           "TargetLine": 83
         },
         {
-          "SourceLine": 31,
-          "TargetLine": 84
-        },
-        {
-          "SourceLine": 31,
-          "TargetLine": 85
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 86
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 87
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 88
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 89
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 90
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 91
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 92
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 93
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 94
-        },
-        {
-          "SourceLine": 33,
-          "TargetLine": 95
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 96
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 97
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 98
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 99
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 100
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 101
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 102
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 103
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 104
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 105
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 106
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 107
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 108
-        },
-        {
-          "SourceLine": 35,
-          "TargetLine": 109
-        },
-        {
-          "SourceLine": 35,
+          "SourceLine": 29,
           "TargetLine": 110
         },
         {
-          "SourceLine": 35,
-          "TargetLine": 111
-        },
-        {
-          "SourceLine": 37,
+          "SourceLine": 29,
           "TargetLine": 112
         },
         {
-          "SourceLine": 37,
+          "SourceLine": 31,
           "TargetLine": 113
         },
         {
-          "SourceLine": 37,
+          "SourceLine": 31,
           "TargetLine": 114
         },
         {
-          "SourceLine": 44,
-          "TargetLine": 143
+          "SourceLine": 31,
+          "TargetLine": 115
         },
         {
-          "SourceLine": 45,
-          "TargetLine": 144
+          "SourceLine": 31,
+          "TargetLine": 116
         },
         {
-          "SourceLine": 46,
-          "TargetLine": 145
-        },
-        {
-          "SourceLine": 43,
-          "TargetLine": 142
-        },
-        {
-          "SourceLine": 43,
-          "TargetLine": 146
-        },
-        {
-          "SourceLine": 39,
+          "SourceLine": 31,
           "TargetLine": 117
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 31,
           "TargetLine": 118
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 31,
           "TargetLine": 119
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 31,
           "TargetLine": 120
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 121
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 122
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 123
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 124
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 125
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 126
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 127
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 128
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 129
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 33,
           "TargetLine": 130
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 131
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 132
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 133
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 134
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 135
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 136
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 137
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 138
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 139
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 140
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
           "TargetLine": 141
         },
         {
-          "SourceLine": 39,
+          "SourceLine": 35,
+          "TargetLine": 142
+        },
+        {
+          "SourceLine": 35,
+          "TargetLine": 143
+        },
+        {
+          "SourceLine": 35,
+          "TargetLine": 144
+        },
+        {
+          "SourceLine": 35,
+          "TargetLine": 145
+        },
+        {
+          "SourceLine": 35,
+          "TargetLine": 146
+        },
+        {
+          "SourceLine": 37,
           "TargetLine": 147
         },
         {
-          "SourceLine": 49,
-          "TargetLine": 159
-        },
-        {
-          "SourceLine": 49,
-          "TargetLine": 158
-        },
-        {
-          "SourceLine": 49,
-          "TargetLine": 160
-        },
-        {
-          "SourceLine": 49,
+          "SourceLine": 37,
           "TargetLine": 148
         },
         {
-          "SourceLine": 49,
+          "SourceLine": 37,
           "TargetLine": 149
         },
         {
-          "SourceLine": 49,
-          "TargetLine": 150
+          "SourceLine": 44,
+          "TargetLine": 178
         },
         {
-          "SourceLine": 49,
-          "TargetLine": 151
+          "SourceLine": 45,
+          "TargetLine": 179
         },
         {
-          "SourceLine": 49,
+          "SourceLine": 46,
+          "TargetLine": 180
+        },
+        {
+          "SourceLine": 43,
+          "TargetLine": 177
+        },
+        {
+          "SourceLine": 43,
+          "TargetLine": 181
+        },
+        {
+          "SourceLine": 39,
           "TargetLine": 152
         },
         {
-          "SourceLine": 49,
+          "SourceLine": 39,
           "TargetLine": 153
         },
         {
-          "SourceLine": 49,
+          "SourceLine": 39,
           "TargetLine": 154
         },
         {
-          "SourceLine": 49,
+          "SourceLine": 39,
           "TargetLine": 155
         },
         {
-          "SourceLine": 49,
+          "SourceLine": 39,
           "TargetLine": 156
         },
         {
-          "SourceLine": 49,
+          "SourceLine": 39,
           "TargetLine": 157
         },
         {
-          "SourceLine": 49,
+          "SourceLine": 39,
+          "TargetLine": 158
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 159
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 160
+        },
+        {
+          "SourceLine": 39,
           "TargetLine": 161
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 162
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 163
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 164
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 165
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 166
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 167
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 168
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 169
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 170
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 171
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 172
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 173
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 174
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 175
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 176
+        },
+        {
+          "SourceLine": 39,
+          "TargetLine": 182
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 194
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 193
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 195
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 183
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 184
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 185
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 186
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 187
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 188
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 189
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 190
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 191
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 192
+        },
+        {
+          "SourceLine": 49,
+          "TargetLine": 196
+        },
+        {
+          "SourceLine": 51,
+          "TargetLine": 197
+        },
+        {
+          "SourceLine": 51,
+          "TargetLine": 198
+        },
+        {
+          "SourceLine": 51,
+          "TargetLine": 199
         }
       ]
     }

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbolicnames.json
@@ -7,12 +7,13 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6318384594241971223"
+      "templateHash": "9766386612525987809"
     }
   },
   "definitions": {
     "foo": {
       "type": "object",
+      "sealed": "true",
       "required": [
         "literalProp",
         "objectProp",
@@ -52,12 +53,18 @@
         },
         "stringProp": {
           "type": "string",
+          "metadata": {
+            "description": "A string property"
+          },
           "maxLength": 10,
           "minLength": 3
         },
         "typeRefProp": {
           "$ref": "#/definitions/bar"
         }
+      },
+      "metadata": {
+        "description": "The foo type"
       }
     },
     "bar": {
@@ -73,6 +80,34 @@
             }
           }
         }
+      },
+      "metadata": {
+        "examples": [
+          [
+            [
+              [
+                [
+                  1
+                ]
+              ]
+            ],
+            [
+              [
+                [
+                  2
+                ]
+              ]
+            ],
+            [
+              [
+                [
+                  3
+                ]
+              ]
+            ]
+          ]
+        ],
+        "description": "An array of array of arrays of arrays of ints"
       },
       "minLength": 3
     },
@@ -159,6 +194,9 @@
       "defaultValue": {
         "property": "pong"
       }
+    },
+    "paramUsingType": {
+      "$ref": "#/definitions/mixedArray"
     }
   },
   "resources": {}

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbols.bicep
@@ -1,10 +1,10 @@
-// @description('The foo type')
-// @sealed()
+@description('The foo type')
+@sealed()
 type foo = {
-//@[5:08) TypeAlias foo. Type: Type<{ stringProp: string, objectProp: { intProp: int, intArrayArrayProp?: int[][] }, typeRefProp: bar, literalProp: 'literal', recursion?: foo }>. Declaration start char: 0, length: 262
+//@[5:08) TypeAlias foo. Type: Type<{ stringProp: string, objectProp: { intProp: int, intArrayArrayProp?: int[][] }, typeRefProp: bar, literalProp: 'literal', recursion?: foo }>. Declaration start char: 0, length: 298
   @minLength(3)
   @maxLength(10)
-  // @description('A string property')
+  @description('A string property')
   stringProp: string
 
   objectProp: {
@@ -22,14 +22,14 @@ type foo = {
 }
 
 @minLength(3)
-// @description('An array of array of arrays of arrays of ints')
-// @metadata({
-//   examples: [
-//     [[[[1]]], [[[2]]], [[[3]]]]
-//   ]
-// })
+@description('An array of array of arrays of arrays of ints')
+@metadata({
+  examples: [
+    [[[[1]]], [[[2]]], [[[3]]]]
+  ]
+})
 type bar = int[][][][]
-//@[5:08) TypeAlias bar. Type: Type<int[][][][]>. Declaration start char: 0, length: 181
+//@[5:08) TypeAlias bar. Type: Type<int[][][][]>. Declaration start char: 0, length: 163
 
 type aUnion = 'snap'|'crackle'|'pop'
 //@[5:11) TypeAlias aUnion. Type: Type<'crackle' | 'pop' | 'snap'>. Declaration start char: 0, length: 36
@@ -56,4 +56,7 @@ param inlineObjectParam {
 
 param unionParam {property: 'ping'}|{property: 'pong'} = {property: 'pong'}
 //@[6:16) Parameter unionParam. Type: { property: 'ping' } | { property: 'pong' }. Declaration start char: 0, length: 75
+
+param paramUsingType mixedArray
+//@[6:20) Parameter paramUsingType. Type: ('heffalump' | 'woozle' | -10 | 10 | false | null | true | { shape: '*', size: '*' })[]. Declaration start char: 0, length: 31
 

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.syntax.bicep
@@ -1,19 +1,36 @@
-// @description('The foo type')
-//@[00:894) ProgramSyntax
-//@[31:032) ├─Token(NewLine) |\n|
-// @sealed()
-//@[12:013) ├─Token(NewLine) |\n|
+@description('The foo type')
+//@[00:900) ProgramSyntax
+//@[00:298) ├─TypeDeclarationSyntax
+//@[00:028) | ├─DecoratorSyntax
+//@[00:001) | | ├─Token(At) |@|
+//@[01:028) | | └─FunctionCallSyntax
+//@[01:012) | |   ├─IdentifierSyntax
+//@[01:012) | |   | └─Token(Identifier) |description|
+//@[12:013) | |   ├─Token(LeftParen) |(|
+//@[13:027) | |   ├─FunctionArgumentSyntax
+//@[13:027) | |   | └─StringSyntax
+//@[13:027) | |   |   └─Token(StringComplete) |'The foo type'|
+//@[27:028) | |   └─Token(RightParen) |)|
+//@[28:029) | ├─Token(NewLine) |\n|
+@sealed()
+//@[00:009) | ├─DecoratorSyntax
+//@[00:001) | | ├─Token(At) |@|
+//@[01:009) | | └─FunctionCallSyntax
+//@[01:007) | |   ├─IdentifierSyntax
+//@[01:007) | |   | └─Token(Identifier) |sealed|
+//@[07:008) | |   ├─Token(LeftParen) |(|
+//@[08:009) | |   └─Token(RightParen) |)|
+//@[09:010) | ├─Token(NewLine) |\n|
 type foo = {
-//@[00:262) ├─TypeDeclarationSyntax
 //@[00:004) | ├─Token(Identifier) |type|
 //@[05:008) | ├─IdentifierSyntax
 //@[05:008) | | └─Token(Identifier) |foo|
 //@[09:010) | ├─Token(Assignment) |=|
-//@[11:262) | └─ObjectTypeSyntax
+//@[11:259) | └─ObjectTypeSyntax
 //@[11:012) |   ├─Token(LeftBrace) |{|
 //@[12:013) |   ├─Token(NewLine) |\n|
   @minLength(3)
-//@[02:092) |   ├─ObjectTypePropertySyntax
+//@[02:089) |   ├─ObjectTypePropertySyntax
 //@[02:015) |   | ├─DecoratorSyntax
 //@[02:003) |   | | ├─Token(At) |@|
 //@[03:015) |   | | └─FunctionCallSyntax
@@ -37,8 +54,18 @@ type foo = {
 //@[13:015) |   | |   |   └─Token(Integer) |10|
 //@[15:016) |   | |   └─Token(RightParen) |)|
 //@[16:017) |   | ├─Token(NewLine) |\n|
-  // @description('A string property')
-//@[38:039) |   | ├─Token(NewLine) |\n|
+  @description('A string property')
+//@[02:035) |   | ├─DecoratorSyntax
+//@[02:003) |   | | ├─Token(At) |@|
+//@[03:035) |   | | └─FunctionCallSyntax
+//@[03:014) |   | |   ├─IdentifierSyntax
+//@[03:014) |   | |   | └─Token(Identifier) |description|
+//@[14:015) |   | |   ├─Token(LeftParen) |(|
+//@[15:034) |   | |   ├─FunctionArgumentSyntax
+//@[15:034) |   | |   | └─StringSyntax
+//@[15:034) |   | |   |   └─Token(StringComplete) |'A string property'|
+//@[34:035) |   | |   └─Token(RightParen) |)|
+//@[35:036) |   | ├─Token(NewLine) |\n|
   stringProp: string
 //@[02:012) |   | ├─IdentifierSyntax
 //@[02:012) |   | | └─Token(Identifier) |stringProp|
@@ -131,7 +158,7 @@ type foo = {
 //@[01:003) ├─Token(NewLine) |\n\n|
 
 @minLength(3)
-//@[00:181) ├─TypeDeclarationSyntax
+//@[00:163) ├─TypeDeclarationSyntax
 //@[00:013) | ├─DecoratorSyntax
 //@[00:001) | | ├─Token(At) |@|
 //@[01:013) | | └─FunctionCallSyntax
@@ -143,18 +170,97 @@ type foo = {
 //@[11:012) | |   |   └─Token(Integer) |3|
 //@[12:013) | |   └─Token(RightParen) |)|
 //@[13:014) | ├─Token(NewLine) |\n|
-// @description('An array of array of arrays of arrays of ints')
-//@[64:065) | ├─Token(NewLine) |\n|
-// @metadata({
-//@[14:015) | ├─Token(NewLine) |\n|
-//   examples: [
-//@[16:017) | ├─Token(NewLine) |\n|
-//     [[[[1]]], [[[2]]], [[[3]]]]
-//@[34:035) | ├─Token(NewLine) |\n|
-//   ]
-//@[06:007) | ├─Token(NewLine) |\n|
-// })
-//@[05:006) | ├─Token(NewLine) |\n|
+@description('An array of array of arrays of arrays of ints')
+//@[00:061) | ├─DecoratorSyntax
+//@[00:001) | | ├─Token(At) |@|
+//@[01:061) | | └─FunctionCallSyntax
+//@[01:012) | |   ├─IdentifierSyntax
+//@[01:012) | |   | └─Token(Identifier) |description|
+//@[12:013) | |   ├─Token(LeftParen) |(|
+//@[13:060) | |   ├─FunctionArgumentSyntax
+//@[13:060) | |   | └─StringSyntax
+//@[13:060) | |   |   └─Token(StringComplete) |'An array of array of arrays of arrays of ints'|
+//@[60:061) | |   └─Token(RightParen) |)|
+//@[61:062) | ├─Token(NewLine) |\n|
+@metadata({
+//@[00:064) | ├─DecoratorSyntax
+//@[00:001) | | ├─Token(At) |@|
+//@[01:064) | | └─FunctionCallSyntax
+//@[01:009) | |   ├─IdentifierSyntax
+//@[01:009) | |   | └─Token(Identifier) |metadata|
+//@[09:010) | |   ├─Token(LeftParen) |(|
+//@[10:063) | |   ├─FunctionArgumentSyntax
+//@[10:063) | |   | └─ObjectSyntax
+//@[10:011) | |   |   ├─Token(LeftBrace) |{|
+//@[11:012) | |   |   ├─Token(NewLine) |\n|
+  examples: [
+//@[02:049) | |   |   ├─ObjectPropertySyntax
+//@[02:010) | |   |   | ├─IdentifierSyntax
+//@[02:010) | |   |   | | └─Token(Identifier) |examples|
+//@[10:011) | |   |   | ├─Token(Colon) |:|
+//@[12:049) | |   |   | └─ArraySyntax
+//@[12:013) | |   |   |   ├─Token(LeftSquare) |[|
+//@[13:014) | |   |   |   ├─Token(NewLine) |\n|
+    [[[[1]]], [[[2]]], [[[3]]]]
+//@[04:031) | |   |   |   ├─ArrayItemSyntax
+//@[04:031) | |   |   |   | └─ArraySyntax
+//@[04:005) | |   |   |   |   ├─Token(LeftSquare) |[|
+//@[05:012) | |   |   |   |   ├─ArrayItemSyntax
+//@[05:012) | |   |   |   |   | └─ArraySyntax
+//@[05:006) | |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[06:011) | |   |   |   |   |   ├─ArrayItemSyntax
+//@[06:011) | |   |   |   |   |   | └─ArraySyntax
+//@[06:007) | |   |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[07:010) | |   |   |   |   |   |   ├─ArrayItemSyntax
+//@[07:010) | |   |   |   |   |   |   | └─ArraySyntax
+//@[07:008) | |   |   |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[08:009) | |   |   |   |   |   |   |   ├─ArrayItemSyntax
+//@[08:009) | |   |   |   |   |   |   |   | └─IntegerLiteralSyntax
+//@[08:009) | |   |   |   |   |   |   |   |   └─Token(Integer) |1|
+//@[09:010) | |   |   |   |   |   |   |   └─Token(RightSquare) |]|
+//@[10:011) | |   |   |   |   |   |   └─Token(RightSquare) |]|
+//@[11:012) | |   |   |   |   |   └─Token(RightSquare) |]|
+//@[12:013) | |   |   |   |   ├─Token(Comma) |,|
+//@[14:021) | |   |   |   |   ├─ArrayItemSyntax
+//@[14:021) | |   |   |   |   | └─ArraySyntax
+//@[14:015) | |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[15:020) | |   |   |   |   |   ├─ArrayItemSyntax
+//@[15:020) | |   |   |   |   |   | └─ArraySyntax
+//@[15:016) | |   |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[16:019) | |   |   |   |   |   |   ├─ArrayItemSyntax
+//@[16:019) | |   |   |   |   |   |   | └─ArraySyntax
+//@[16:017) | |   |   |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[17:018) | |   |   |   |   |   |   |   ├─ArrayItemSyntax
+//@[17:018) | |   |   |   |   |   |   |   | └─IntegerLiteralSyntax
+//@[17:018) | |   |   |   |   |   |   |   |   └─Token(Integer) |2|
+//@[18:019) | |   |   |   |   |   |   |   └─Token(RightSquare) |]|
+//@[19:020) | |   |   |   |   |   |   └─Token(RightSquare) |]|
+//@[20:021) | |   |   |   |   |   └─Token(RightSquare) |]|
+//@[21:022) | |   |   |   |   ├─Token(Comma) |,|
+//@[23:030) | |   |   |   |   ├─ArrayItemSyntax
+//@[23:030) | |   |   |   |   | └─ArraySyntax
+//@[23:024) | |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[24:029) | |   |   |   |   |   ├─ArrayItemSyntax
+//@[24:029) | |   |   |   |   |   | └─ArraySyntax
+//@[24:025) | |   |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[25:028) | |   |   |   |   |   |   ├─ArrayItemSyntax
+//@[25:028) | |   |   |   |   |   |   | └─ArraySyntax
+//@[25:026) | |   |   |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[26:027) | |   |   |   |   |   |   |   ├─ArrayItemSyntax
+//@[26:027) | |   |   |   |   |   |   |   | └─IntegerLiteralSyntax
+//@[26:027) | |   |   |   |   |   |   |   |   └─Token(Integer) |3|
+//@[27:028) | |   |   |   |   |   |   |   └─Token(RightSquare) |]|
+//@[28:029) | |   |   |   |   |   |   └─Token(RightSquare) |]|
+//@[29:030) | |   |   |   |   |   └─Token(RightSquare) |]|
+//@[30:031) | |   |   |   |   └─Token(RightSquare) |]|
+//@[31:032) | |   |   |   ├─Token(NewLine) |\n|
+  ]
+//@[02:003) | |   |   |   └─Token(RightSquare) |]|
+//@[03:004) | |   |   ├─Token(NewLine) |\n|
+})
+//@[00:001) | |   |   └─Token(RightBrace) |}|
+//@[01:002) | |   └─Token(RightParen) |)|
+//@[02:003) | ├─Token(NewLine) |\n|
 type bar = int[][][][]
 //@[00:004) | ├─Token(Identifier) |type|
 //@[05:008) | ├─IdentifierSyntax
@@ -423,6 +529,16 @@ param unionParam {property: 'ping'}|{property: 'pong'} = {property: 'pong'}
 //@[68:074) |     | └─StringSyntax
 //@[68:074) |     |   └─Token(StringComplete) |'pong'|
 //@[74:075) |     └─Token(RightBrace) |}|
-//@[75:076) ├─Token(NewLine) |\n|
+//@[75:077) ├─Token(NewLine) |\n\n|
+
+param paramUsingType mixedArray
+//@[00:031) ├─ParameterDeclarationSyntax
+//@[00:005) | ├─Token(Identifier) |param|
+//@[06:020) | ├─IdentifierSyntax
+//@[06:020) | | └─Token(Identifier) |paramUsingType|
+//@[21:031) | └─TypeAccessSyntax
+//@[21:031) |   └─IdentifierSyntax
+//@[21:031) |     └─Token(Identifier) |mixedArray|
+//@[31:032) ├─Token(NewLine) |\n|
 
 //@[00:000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.tokens.bicep
@@ -1,7 +1,16 @@
-// @description('The foo type')
-//@[31:32) NewLine |\n|
-// @sealed()
-//@[12:13) NewLine |\n|
+@description('The foo type')
+//@[00:01) At |@|
+//@[01:12) Identifier |description|
+//@[12:13) LeftParen |(|
+//@[13:27) StringComplete |'The foo type'|
+//@[27:28) RightParen |)|
+//@[28:29) NewLine |\n|
+@sealed()
+//@[00:01) At |@|
+//@[01:07) Identifier |sealed|
+//@[07:08) LeftParen |(|
+//@[08:09) RightParen |)|
+//@[09:10) NewLine |\n|
 type foo = {
 //@[00:04) Identifier |type|
 //@[05:08) Identifier |foo|
@@ -22,8 +31,13 @@ type foo = {
 //@[13:15) Integer |10|
 //@[15:16) RightParen |)|
 //@[16:17) NewLine |\n|
-  // @description('A string property')
-//@[38:39) NewLine |\n|
+  @description('A string property')
+//@[02:03) At |@|
+//@[03:14) Identifier |description|
+//@[14:15) LeftParen |(|
+//@[15:34) StringComplete |'A string property'|
+//@[34:35) RightParen |)|
+//@[35:36) NewLine |\n|
   stringProp: string
 //@[02:12) Identifier |stringProp|
 //@[12:13) Colon |:|
@@ -91,18 +105,58 @@ type foo = {
 //@[11:12) Integer |3|
 //@[12:13) RightParen |)|
 //@[13:14) NewLine |\n|
-// @description('An array of array of arrays of arrays of ints')
-//@[64:65) NewLine |\n|
-// @metadata({
-//@[14:15) NewLine |\n|
-//   examples: [
-//@[16:17) NewLine |\n|
-//     [[[[1]]], [[[2]]], [[[3]]]]
-//@[34:35) NewLine |\n|
-//   ]
-//@[06:07) NewLine |\n|
-// })
-//@[05:06) NewLine |\n|
+@description('An array of array of arrays of arrays of ints')
+//@[00:01) At |@|
+//@[01:12) Identifier |description|
+//@[12:13) LeftParen |(|
+//@[13:60) StringComplete |'An array of array of arrays of arrays of ints'|
+//@[60:61) RightParen |)|
+//@[61:62) NewLine |\n|
+@metadata({
+//@[00:01) At |@|
+//@[01:09) Identifier |metadata|
+//@[09:10) LeftParen |(|
+//@[10:11) LeftBrace |{|
+//@[11:12) NewLine |\n|
+  examples: [
+//@[02:10) Identifier |examples|
+//@[10:11) Colon |:|
+//@[12:13) LeftSquare |[|
+//@[13:14) NewLine |\n|
+    [[[[1]]], [[[2]]], [[[3]]]]
+//@[04:05) LeftSquare |[|
+//@[05:06) LeftSquare |[|
+//@[06:07) LeftSquare |[|
+//@[07:08) LeftSquare |[|
+//@[08:09) Integer |1|
+//@[09:10) RightSquare |]|
+//@[10:11) RightSquare |]|
+//@[11:12) RightSquare |]|
+//@[12:13) Comma |,|
+//@[14:15) LeftSquare |[|
+//@[15:16) LeftSquare |[|
+//@[16:17) LeftSquare |[|
+//@[17:18) Integer |2|
+//@[18:19) RightSquare |]|
+//@[19:20) RightSquare |]|
+//@[20:21) RightSquare |]|
+//@[21:22) Comma |,|
+//@[23:24) LeftSquare |[|
+//@[24:25) LeftSquare |[|
+//@[25:26) LeftSquare |[|
+//@[26:27) Integer |3|
+//@[27:28) RightSquare |]|
+//@[28:29) RightSquare |]|
+//@[29:30) RightSquare |]|
+//@[30:31) RightSquare |]|
+//@[31:32) NewLine |\n|
+  ]
+//@[02:03) RightSquare |]|
+//@[03:04) NewLine |\n|
+})
+//@[00:01) RightBrace |}|
+//@[01:02) RightParen |)|
+//@[02:03) NewLine |\n|
 type bar = int[][][][]
 //@[00:04) Identifier |type|
 //@[05:08) Identifier |bar|
@@ -256,6 +310,12 @@ param unionParam {property: 'ping'}|{property: 'pong'} = {property: 'pong'}
 //@[66:67) Colon |:|
 //@[68:74) StringComplete |'pong'|
 //@[74:75) RightBrace |}|
-//@[75:76) NewLine |\n|
+//@[75:77) NewLine |\n\n|
+
+param paramUsingType mixedArray
+//@[00:05) Identifier |param|
+//@[06:20) Identifier |paramUsingType|
+//@[21:31) Identifier |mixedArray|
+//@[31:32) NewLine |\n|
 
 //@[00:00) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.diagnostics.bicep
@@ -320,7 +320,7 @@ var myBigIntExpression = 2199023255552 * 2
 //@[04:22) [no-unused-vars (Warning)] Variable "myBigIntExpression" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |myBigIntExpression|
 var myBigIntExpression2 = 2199023255552 * 2199023255552
 //@[04:23) [no-unused-vars (Warning)] Variable "myBigIntExpression2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |myBigIntExpression2|
-//@[26:55) [BCP234 (Warning)] The ARM function "mul" failed when invoked on the value [2199023255552, 2199023255552]: The template language function 'mul' overflowed with the operants '2199023255552' and '2199023255552'. Please see https://aka.ms/arm-template-expressions for usage details. (CodeDescription: none) |2199023255552 * 2199023255552|
+//@[26:55) [BCP234 (Warning)] The ARM function "mul" failed when invoked on the value [2199023255552, 2199023255552]: The template language function 'mul' overflowed with the operants '2199023255552' and '2199023255552'. Please see https://aka.ms/arm-functions for usage details. (CodeDescription: none) |2199023255552 * 2199023255552|
 
 // variable loops
 var incrementingNumbers = [for i in range(0,10) : i]

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -114,30 +114,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2008,9 +2009,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -153,30 +153,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2008,9 +2009,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -30,9 +30,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="Azure.Deployments.Core" Version="1.0.694" />
-    <PackageReference Include="Azure.Deployments.Templates" Version="1.0.694" />
-    <PackageReference Include="Azure.Deployments.Expression" Version="1.0.694" />
+    <PackageReference Include="Azure.Deployments.Core" Version="1.0.750" />
+    <PackageReference Include="Azure.Deployments.Templates" Version="1.0.750" />
+    <PackageReference Include="Azure.Deployments.Expression" Version="1.0.750" />
     <PackageReference Include="Azure.Bicep.Types" Version="0.3.28" />
     <PackageReference Include="Azure.Bicep.Types.Az" Version="0.2.170" />
     <PackageReference Include="Azure.Bicep.Types.K8s" Version="0.1.186" />

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -47,22 +47,23 @@
       },
       "Azure.Deployments.Core": {
         "type": "Direct",
-        "requested": "[1.0.694, )",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "requested": "[1.0.750, )",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Direct",
-        "requested": "[1.0.694, )",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "requested": "[1.0.750, )",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -74,12 +75,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Direct",
-        "requested": "[1.0.694, )",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "requested": "[1.0.750, )",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -114,30 +114,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2003,9 +2004,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -114,30 +114,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2003,9 +2004,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -94,30 +94,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -1712,9 +1713,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -148,30 +148,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2022,9 +2023,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -135,30 +135,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2021,9 +2022,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -103,30 +103,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -1877,9 +1878,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -114,30 +114,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2103,9 +2104,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -115,30 +115,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2013,9 +2014,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -114,30 +114,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2103,9 +2104,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -221,30 +221,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2005,9 +2006,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -93,30 +93,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -2093,9 +2094,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -104,30 +104,31 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "kt0lN9Qp5y5yAyjNup3v+EK8b/csLD6PwDctn3PM3AFIPbLZqfrKVUjjCAHvvK7TKBLynRgTFIVYNrJD6AMvcw==",
+        "resolved": "1.0.750",
+        "contentHash": "MlRL1EU+wj5y973CQU0cjKAYm3XXlECpyUeglbjUxHg0kaAkiMmLS8MI1ZVxmp4WHgx2PcJgfEPeKPf/Tf/SVw==",
         "dependencies": {
           "Microsoft.PowerPlatform.ResourceStack": "6.0.0.1323",
           "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "5.0.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "iFawKKAMEG9GrpSwf/lG54r9IyxRY0S1gSHvAUQcNaSuGtIXIALN9nZzNCFNZQs+IeA5r4nLji8+91uQPJYO1A==",
+        "resolved": "1.0.750",
+        "contentHash": "8h+KovzakrCELBpG/azPMkhulgrAxQmZEHrmtGM8yBCWp5bxc156g76FkKdzFcAklZFVrEntq/w7Z4rYrZf8uA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.0.694",
-        "contentHash": "pQz5ZfaZ9FZjWUm2g68OFgwGE8ErZvBROPxC4FwCQZIgk1Ma+CUL/SGJjZxxCHLqvx6PPYGLFBIYZSCqijqoyA==",
+        "resolved": "1.0.750",
+        "contentHash": "++EFkXDze5qWQUCcHsPATB1ZZQu2lkQ2Jhugitv9s+fx4iz83ivB+bADlGSUeaLyDfkVIYS8K20qDX7lvu1Zhg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.0.694",
-          "Azure.Deployments.Expression": "1.0.694",
+          "Azure.Deployments.Core": "1.0.750",
+          "Azure.Deployments.Expression": "1.0.750",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -1831,9 +1832,9 @@
           "Azure.Bicep.Types.Az": "[0.2.170, )",
           "Azure.Bicep.Types.K8s": "[0.1.186, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
-          "Azure.Deployments.Core": "[1.0.694, )",
-          "Azure.Deployments.Expression": "[1.0.694, )",
-          "Azure.Deployments.Templates": "[1.0.694, )",
+          "Azure.Deployments.Core": "[1.0.750, )",
+          "Azure.Deployments.Expression": "[1.0.750, )",
+          "Azure.Deployments.Templates": "[1.0.750, )",
           "Azure.Identity": "[1.7.0, )",
           "Azure.ResourceManager.Resources": "[1.3.0, )",
           "JsonPatch.Net": "[2.0.4, )",


### PR DESCRIPTION
Resolves #8813 

This PR pulls in a recent version of `Azure.Deployments.Core`, `Azure.Deployments.Expressions`, and `Azure.Deployments.Templates`. The lattermost adds support for the `sealed` constraint on objects and `metadata` on types in ARM JSON templates. I also uncommented the lines in the `TypeDeclarations` baseline source using the `@sealed()`, `@description()`, and `@metadata()` decorators, then regenerated baselines.

Almost all changed lines are in commits 2, 4, & 5, which are not manual changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8854)