### PR TITLE
Reproduce decompile errors when using modules

### DIFF
--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
@@ -67,3 +67,5 @@ module moduleWithSub 'nested/module1.bicep' = {
 //@[02:08) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "arrayParam", "location", "objectParam". (CodeDescription: none) |params|
   }
 }
+
+output sampleOutput string = module1Deploy.output.module1Deploy

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
@@ -68,4 +68,4 @@ module moduleWithSub 'nested/module1.bicep' = {
   }
 }
 
-output sampleOutput string = module1Deploy.output.module1Deploy
+output sampleOutput string = module1Deploy.outputs.module1Deploy

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
@@ -24,6 +24,7 @@ module module1Deploy 'nested/module1.bicep' = {
   name: 'module1Deploy'
   params: {
     location: location
+    sample_param: 'Hello!'
     objectParam: objectVar
     arrayParam: arrayVar
     _artifactsLocation: _artifactsLocation

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
@@ -1,3 +1,8 @@
+param _artifactsLocation string = deployment().properties.templateLink.uri
+
+@secure()
+param _artifactsLocationSasToken string = ''
+
 param location string = resourceGroup().location
 
 @description('Base URL for the reference templates and scripts')
@@ -21,6 +26,8 @@ module module1Deploy 'nested/module1.bicep' = {
     location: location
     objectParam: objectVar
     arrayParam: arrayVar
+    _artifactsLocation: _artifactsLocation
+    _artifactsLocationSasToken: _artifactsLocationSasToken
   }
 }
 

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.json
@@ -139,5 +139,9 @@
         }
     ],
 
-    "outputs": {}
+    "outputs": {
+      "logAnalyticsWorkspaceName": {
+        "value": "[reference('module1Deploy').outputs.sampleOutput.value]"
+      }
+    }
 }

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.json
@@ -52,6 +52,9 @@
                     "_artifactsLocationSasToken": {
                       "value": "[parameters('_artifactsLocationSasToken')]"
                     },
+                    "sample-param": {
+                      "value": "hello!"
+                    },
                     "location": {
                         "value": "[parameters('location')]"
                     },

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.json
@@ -46,6 +46,12 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "_artifactsLocation": {
+                      "value": "[parameters('_artifactsLocation')]"
+                    },
+                    "_artifactsLocationSasToken": {
+                      "value": "[parameters('_artifactsLocationSasToken')]"
+                    },
                     "location": {
                         "value": "[parameters('location')]"
                     },

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.json
@@ -2,6 +2,14 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "_artifactsLocation": {
+          "type": "string",
+          "defaultValue": "[deployment().properties.templateLink.uri]"
+        },
+        "_artifactsLocationSasToken": {
+          "type": "securestring",
+          "defaultValue": ""
+        },
         "location": {
             "type": "string",
             "defaultValue": "[resourceGroup().location]"
@@ -16,7 +24,7 @@
     },
     "variables": {
         "armBaseUrl": "[parameters('baseUrl')]",
-        "module1Url": "[concat(variables('armBaseUrl'),'/nested/module1.json')]",
+        "module1Url": "[uri(parameters('_artifactsLocation'), concat('/nested/module1.json', parameters('_artifactsLocationSasToken')))]"
         "module2Url": "[concat(variables('armBaseUrl'),'/nested/module2.jsonc')]",
         "objectVar": {
             "val1": "[concat('a', parameters('location'), 'b')]"

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.bicep
@@ -1,3 +1,8 @@
+param _artifactsLocation string = deployment().properties.templateLink.uri
+//@[6:14) [no-unused-params (Warning)] Parameter "_artifactsLocation" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |location|
+@secure()
+param _artifactsLocationSasToken string = ''
+//@[6:14) [no-unused-params (Warning)] Parameter "_artifactsLocationSasToken" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |location|
 param location string
 //@[6:14) [no-unused-params (Warning)] Parameter "location" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |location|
 param objectParam object

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.bicep
@@ -5,4 +5,5 @@ param objectParam object
 param arrayParam array
 //@[6:16) [no-unused-params (Warning)] Parameter "arrayParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |arrayParam|
 param optionalParam string = 'hello!'
-//@[6:19) [no-unused-params (Warning)] Parameter "optionalParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |optionalParam|
+
+output sampleOutput string = optionalParam

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.bicep
@@ -3,6 +3,7 @@ param _artifactsLocation string = deployment().properties.templateLink.uri
 @secure()
 param _artifactsLocationSasToken string = ''
 //@[6:14) [no-unused-params (Warning)] Parameter "_artifactsLocationSasToken" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |location|
+param sample_param string = 'hello!'
 param location string
 //@[6:14) [no-unused-params (Warning)] Parameter "location" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |location|
 param objectParam object

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.json
@@ -2,6 +2,12 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "_artifactsLocation": {
+          "type": "string"
+        },
+        "_artifactsLocationSasToken": {
+          "type": "securestring"
+        },
         "location": {
             "type": "string"
         },

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.json
@@ -8,6 +8,10 @@
         "_artifactsLocationSasToken": {
           "type": "securestring"
         },
+        "sample-param": {
+          "type": "string",
+          "defaultValue": "hello!"
+        },
         "location": {
             "type": "string"
         },

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/nested/module1.json
@@ -18,5 +18,10 @@
     },
     "variables": {},
     "resources": [],
-    "outputs": {}
+    "outputs": {
+        "sampleOutput": {
+          "type": "string",
+          "value": "[parameters('optionalParam')]"
+        }
+    }
 }


### PR DESCRIPTION
# Contributing a Pull Request

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8879)

Reproducing a series of decompile issues I have found. Might need to divide these up and fix separately in separate PRs.. 

1. Module File Path not extracted from complex declaration
2. Outputs from module have "properites" and "values" incorrectly added
3.  Parameter names are wrapped into unnecessary quotes.
4. Parameter name that contains "-" is converted to "_" in module, but not in usage.

2.
<img width="419" alt="image" src="https://user-images.githubusercontent.com/9027725/199846810-6074ea0b-ab74-4b5c-9436-59c73c20082e.png">
3.
<img width="419" alt="image" src="https://user-images.githubusercontent.com/9027725/199858128-c5892336-5b26-4407-aa21-ecf33f6ca893.png">

4. 
<img width="370" alt="image" src="https://user-images.githubusercontent.com/9027725/199864284-37d7374f-2f18-4f30-99ca-29dda48f69bb.png">
<img width="324" alt="image" src="https://user-images.githubusercontent.com/9027725/199864312-2bf65182-88a2-443f-8b0b-f26e7e5d0316.png">

