### PR TITLE
Correct union assignability check when both sides of the assignment are unions

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4018,7 +4018,8 @@ resource functionApp 'Microsoft.Web/sites@2022-03-01' = {
 
             result.Should().NotHaveAnyDiagnostics();
         }
-        
+
+        /// <summary>
         /// https://github.com/Azure/bicep/issues/8884
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
Resolves #8890

Union type checking was augmented in 0.12.1 to support assigning an object to a union of objects. This introduced a regression when a union-typed value was assigned to a location accepting a union type.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8899)