### PR TITLE
Use imported type rather than narrowed type for union branches within resource declaration

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4000,6 +4000,8 @@ resource vm 'Microsoft.Compute/virtualMachines@2021-07-01' = {
   identity: identity
 }
 
+output vmPrincipalId string = vm.identity.principalId
+
 param usePython bool
 
 resource functionApp 'Microsoft.Web/sites@2022-03-01' = {

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -491,7 +491,11 @@ namespace Bicep.Core.TypeSystem
             }
 
             var viableCandidates = candidacyEvaluations
-                .Select(c => c.NarrowedType is {} Narrowed && !c.Errors.Any() ? new ViableTypeCandidate(Narrowed, c.Diagnostics) : null)
+                .Select(c => c.NarrowedType is {} Narrowed && !c.Errors.Any()
+                    // If this node was encountered in a resource declaration, use the target type rather than the narrowed type, as the
+                    // target type describes what will be returned by the service (included derived and read-only fields)
+                    ? new ViableTypeCandidate(config.IsResourceDeclaration ? c.UnionTypeMemberEvaluated.Type : Narrowed, c.Diagnostics)
+                    : null)
                 .WhereNotNull()
                 .ToImmutableArray();
 


### PR DESCRIPTION
Found another regression related to deep union inspection: when inside a resource declaration, this union type narrower was returning the narrowed type of what was assigned vs what was expected, which has the effect of dropping readonly properties (as these will be missing from what was assigned but will be populated by the RP).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8902)