### PR TITLE
Update TypeHelper.IsLiteralType to avoid catching LanguageConstants.Object

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4064,5 +4064,31 @@ output fizzBuzzOrPop string = permittedSubsetArray[0]
             result.Template.Should().HaveValueAtPath("$.parameters.permittedSubsetArray.allowedValues", new JArray("fizz", "buzz", "pop"));
             result.Template.Should().NotHaveValueAtPath("$.parameters.permittedSubsetArray.items");
         }
+
+        /// <summary>
+        /// https://github.com/Azure/bicep/issues/8950
+        /// </summary>
+        [TestMethod]
+        public void Test_Issue8950()
+        {
+            var result = CompilationHelper.Compile(@"
+@description('App Service Plan sku')
+@allowed([
+  {
+    name: 'S1'
+    capacity: 1
+  }
+  {
+    name: 'P1v3'
+    capacity: 1
+  }
+])
+param appServicePlanSku object
+
+output sku string = appServicePlanSku.name
+");
+
+            result.Should().NotHaveAnyDiagnostics();
+        }
     }
 }

--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -102,4 +102,48 @@ param stringParam sys.string = 'foo'
             ("no-unused-params", DiagnosticLevel.Warning, "Parameter \"stringParam\" is declared but never used."),
         });
     }
+
+    [TestMethod]
+    public void Allowed_decorator_may_not_be_used_on_literal_and_union_typed_parameters()
+    {
+        var result = CompilationHelper.Compile(ServicesWithUserDefinedTypes, @"
+@allowed([true])
+param trueParam true
+
+@allowed([false])
+param falseParam !true
+
+@allowed([1])
+param oneParam 1
+
+@allowed([-1])
+param negativeOneParam -1
+
+@allowed([{fizz: 'buzz'}])
+param fizzBuzzParam {fizz: 'buzz'}
+
+@allowed(['fizz'])
+param fizzParam 'fizz'
+
+@allowed(['fizz', 'buzz', 'pop'])
+param fizzBuzzPopParam 'fizz'|'buzz'|'pop'
+");
+
+        result.Should().HaveDiagnostics(new[] {
+            ("BCP295", DiagnosticLevel.Error, "The 'allowed' decorator may not be used on targets of a union or literal type. The allowed values for this parameter or type definition will be derived from the union or literal type automatically."),
+            ("no-unused-params", DiagnosticLevel.Warning, "Parameter \"trueParam\" is declared but never used."),
+            ("BCP295", DiagnosticLevel.Error, "The 'allowed' decorator may not be used on targets of a union or literal type. The allowed values for this parameter or type definition will be derived from the union or literal type automatically."),
+            ("no-unused-params", DiagnosticLevel.Warning, "Parameter \"falseParam\" is declared but never used."),
+            ("BCP295", DiagnosticLevel.Error, "The 'allowed' decorator may not be used on targets of a union or literal type. The allowed values for this parameter or type definition will be derived from the union or literal type automatically."),
+            ("no-unused-params", DiagnosticLevel.Warning, "Parameter \"oneParam\" is declared but never used."),
+            ("BCP295", DiagnosticLevel.Error, "The 'allowed' decorator may not be used on targets of a union or literal type. The allowed values for this parameter or type definition will be derived from the union or literal type automatically."),
+            ("no-unused-params", DiagnosticLevel.Warning, "Parameter \"negativeOneParam\" is declared but never used."),
+            ("BCP295", DiagnosticLevel.Error, "The 'allowed' decorator may not be used on targets of a union or literal type. The allowed values for this parameter or type definition will be derived from the union or literal type automatically."),
+            ("no-unused-params", DiagnosticLevel.Warning, "Parameter \"fizzBuzzParam\" is declared but never used."),
+            ("BCP295", DiagnosticLevel.Error, "The 'allowed' decorator may not be used on targets of a union or literal type. The allowed values for this parameter or type definition will be derived from the union or literal type automatically."),
+            ("no-unused-params", DiagnosticLevel.Warning, "Parameter \"fizzParam\" is declared but never used."),
+            ("BCP295", DiagnosticLevel.Error, "The 'allowed' decorator may not be used on targets of a union or literal type. The allowed values for this parameter or type definition will be derived from the union or literal type automatically."),
+            ("no-unused-params", DiagnosticLevel.Warning, "Parameter \"fizzBuzzPopParam\" is declared but never used."),
+        });
+    }
 }

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -88,7 +88,8 @@ namespace Bicep.Core.TypeSystem
             StringLiteralType => true,
             IntegerLiteralType => true,
             BooleanLiteralType => true,
-            ObjectType objectType => objectType.Properties.All(kvp => IsLiteralType(kvp.Value.TypeReference.Type)),
+            ObjectType objectType => (objectType.AdditionalPropertiesType is null || objectType.AdditionalPropertiesFlags.HasFlag(TypePropertyFlags.FallbackProperty)) &&
+                objectType.Properties.All(kvp => kvp.Value.Flags.HasFlag(TypePropertyFlags.Required) && IsLiteralType(kvp.Value.TypeReference.Type)),
             // TODO for array literals when type system adds support for tuples
             _ => false,
         };

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -88,8 +88,17 @@ namespace Bicep.Core.TypeSystem
             StringLiteralType => true,
             IntegerLiteralType => true,
             BooleanLiteralType => true,
+
+            // An object type can be a literal iff:
+            //   - All properties are themselves of a literal type
+            //   - No properties are optional
+            //   - Only explicitly defined properties are accepted (i.e., no additional properties are permitted)
+            //
+            // The lattermost condition is identified by the object type either not defining an AdditionalPropertiesType
+            // or explicitly flagging the AdditionalPropertiesType as a fallback (the default for non-sealed user-defined types)
             ObjectType objectType => (objectType.AdditionalPropertiesType is null || objectType.AdditionalPropertiesFlags.HasFlag(TypePropertyFlags.FallbackProperty)) &&
                 objectType.Properties.All(kvp => kvp.Value.Flags.HasFlag(TypePropertyFlags.Required) && IsLiteralType(kvp.Value.TypeReference.Type)),
+
             // TODO for array literals when type system adds support for tuples
             _ => false,
         };


### PR DESCRIPTION
A more comprehensive fix is included in #8949, but this should resolve #8950 and adds some tests to prevent a regression.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8952)