### PR TITLE
Support fully-qualified ambient type symbols in output declaration type clauses

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4090,5 +4090,19 @@ output sku string = appServicePlanSku.name
 
             result.Should().NotHaveAnyDiagnostics();
         }
+
+        /// <summary>
+        /// https://github.com/Azure/bicep/issues/8950
+        /// </summary>
+        [TestMethod]
+        public void Test_Issue8960()
+        {
+            var result = CompilationHelper.Compile(@"
+param string sys.string = 'hello'
+output message sys.string = string
+");
+
+            result.Should().NotHaveAnyDiagnostics();
+        }
     }
 }

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -1169,7 +1169,14 @@ namespace Bicep.Core.Parsing
                 return new ResourceTypeSyntax(resourceKeyword, type);
             }
 
-            return new VariableAccessSyntax(new(Expect(TokenType.Identifier, b => b.ExpectedOutputType())));
+            SyntaxBase current = new VariableAccessSyntax(new(Expect(TokenType.Identifier, b => b.ExpectedOutputType())));
+
+            while (this.Check(TokenType.Dot))
+            {
+                current = new PropertyAccessSyntax(current, this.reader.Read(), this.IdentifierOrSkip(b => b.ExpectedFunctionOrPropertyName()));
+            }
+
+            return current;
         }
 
         protected SyntaxBase Type(bool allowOptionalResourceType)


### PR DESCRIPTION
Addresses bug reported in #8960

#8876 missed adding a branch in the parser for output types.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/8961)