### PR TITLE
IR part 1: Introduce IR for simple syntax conversions

### DIFF
--- a/src/Bicep.Core/Emit/StringFormatConverter.cs
+++ b/src/Bicep.Core/Emit/StringFormatConverter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Collections.Immutable;
 using System.Text;
 using Bicep.Core.Syntax;
 
@@ -7,20 +8,19 @@ namespace Bicep.Core.Emit
 {
     public static class StringFormatConverter
     {
-        public static string BuildFormatString(StringSyntax syntax)
+        public static string BuildFormatString(ImmutableArray<string> segmentValues)
         {
             var stringBuilder = new StringBuilder();
-            var values = syntax.SegmentValues;
 
-            for (var i = 0; i < values.Length - 1; i++)
+            for (var i = 0; i < segmentValues.Length - 1; i++)
             {
-                AppendAndEscapeCurlies(stringBuilder, values[i]);
+                AppendAndEscapeCurlies(stringBuilder, segmentValues[i]);
                 stringBuilder.Append('{');
                 stringBuilder.Append(i);
                 stringBuilder.Append('}');
             }
 
-            AppendAndEscapeCurlies(stringBuilder, values[values.Length - 1]);
+            AppendAndEscapeCurlies(stringBuilder, segmentValues[segmentValues.Length - 1]);
 
             return stringBuilder.ToString();
         }

--- a/src/Bicep.Core/Intermediate/Expression.cs
+++ b/src/Bicep.Core/Intermediate/Expression.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Intermediate;
+
+public abstract record Expression()
+{
+    public abstract void Accept(IExpressionVisitor visitor);
+}
+
+public record BooleanLiteralExpression(
+    bool Value
+) : Expression
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitBooleanLiteralExpression(this);
+}
+
+public record IntegerLiteralExpression(
+    long Value
+) : Expression
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitIntegerLiteralExpression(this);
+}
+
+public record StringLiteralExpression(
+    string Value
+) : Expression
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitStringLiteralExpression(this);
+}
+
+public record NullLiteralExpression() : Expression
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitNullLiteralExpression(this);
+}
+
+public record SyntaxExpression(
+    SyntaxBase Syntax
+) : Expression
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitSyntaxExpression(this);
+}
+
+public record InterpolatedStringExpression(
+    ImmutableArray<string> SegmentValues,
+    ImmutableArray<Expression> Expressions
+) : Expression
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitInterpolatedStringExpression(this);
+}
+
+public record ObjectProperty(
+    Expression Key,
+    Expression Value);
+
+public record ObjectExpression(
+    ImmutableArray<ObjectProperty> Properties
+) : Expression
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitObjectExpression(this);
+}
+
+public record ArrayExpression(
+    ImmutableArray<Expression> Items
+) : Expression
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitArrayExpression(this);
+}

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Intermediate;
+
+public static class ExpressionBuilder
+{
+    public static Expression Build(SyntaxBase syntax)
+    {
+        return syntax switch {
+            StringSyntax x when !x.IsInterpolated() => new StringLiteralExpression(x.SegmentValues[0]),
+            StringSyntax x => new InterpolatedStringExpression(x.SegmentValues, x.Expressions.Select(Build).ToImmutableArray()),
+            IntegerLiteralSyntax x when TryGetIntegerLiteralValue(x) is {} val => new IntegerLiteralExpression(val),
+            UnaryOperationSyntax x when TryGetIntegerLiteralValue(x) is {} val => new IntegerLiteralExpression(val),
+            BooleanLiteralSyntax x => new BooleanLiteralExpression(x.Value),
+            NullLiteralSyntax => new NullLiteralExpression(),
+            ParenthesizedExpressionSyntax x => Build(x.Expression),
+            ObjectSyntax x => new ObjectExpression(x.Properties.Select(x => new ObjectProperty(Build(x.Key), Build(x.Value))).ToImmutableArray()),
+            ArraySyntax x => new ArrayExpression(x.Items.Select(x => Build(x.Value)).ToImmutableArray()),
+            _ => new SyntaxExpression(syntax),
+        };
+    }
+
+    private static long? TryGetIntegerLiteralValue(SyntaxBase syntax)
+    {
+        // We depend here on the fact that type validation has already checked that the integer is valid.
+        return syntax switch {
+            // Because integerSyntax.Value is a ulong type, it is always positive. we need to first cast it to a long in order to negate it.
+            UnaryOperationSyntax { Operator: UnaryOperator.Minus } unary when unary.Expression is IntegerLiteralSyntax x => x.Value switch {
+                <= long.MaxValue => -(long)x.Value,
+                (ulong)long.MaxValue + 1 => long.MinValue,
+                _ => null,
+            },
+            IntegerLiteralSyntax x => x.Value switch {
+                <= long.MaxValue => (long)x.Value,
+                _ => null,
+            },
+            _ => null,
+        };
+    }
+}

--- a/src/Bicep.Core/Intermediate/IExpressionVisitor.cs
+++ b/src/Bicep.Core/Intermediate/IExpressionVisitor.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Intermediate;
+
+public interface IExpressionVisitor
+{
+    void VisitBooleanLiteralExpression(BooleanLiteralExpression expression);
+
+    void VisitIntegerLiteralExpression(IntegerLiteralExpression expression);
+
+    void VisitStringLiteralExpression(StringLiteralExpression expression);
+
+    void VisitNullLiteralExpression(NullLiteralExpression expression);
+
+    void VisitSyntaxExpression(SyntaxExpression expression);
+
+    void VisitInterpolatedStringExpression(InterpolatedStringExpression expression);
+
+    void VisitObjectExpression(ObjectExpression expression);
+
+    void VisitArrayExpression(ArrayExpression expression);
+}


### PR DESCRIPTION
Introduce IR for simple syntax conversions. This PR makes a start, and hopefully gives us a path to introducing further changes incrementally.

Long-term goals for an IR are:
* Open the door to constant folding, inline expression evaluation & lowering
* Simplify syntax traversal where an abstract syntax tree is more desirable (e.g. emit limitation calculation)
* Converge with `ResourceMetadata`, `ScopeHelper` logic to simplify and make this logic more robust

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9047)