### PR TITLE
Bicep deploy - support deployment to azure cloud

### DIFF
--- a/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
@@ -32,7 +32,9 @@ namespace Bicep.LanguageServer.Handlers
         bool parametersFileExists,
         string parametersFileName,
         ParametersFileUpdateOption parametersFileUpdateOption,
-        List<BicepUpdatedDeploymentParameter> updatedDeploymentParameters) : IRequest<string>;
+        List<BicepUpdatedDeploymentParameter> updatedDeploymentParameters,
+        string resourceManagerEndpointUrl,
+        string audience) : IRequest<string>;
 
     public record BicepDeploymentStartResponse(bool isSuccess, string outputMessage, string? viewDeploymentInPortalMessage);
 
@@ -56,6 +58,7 @@ namespace Bicep.LanguageServer.Handlers
 
             var options = new ArmClientOptions();
             options.Diagnostics.ApplySharedResourceManagerSettings();
+            options.Environment = new ArmEnvironment(new Uri(request.resourceManagerEndpointUrl), request.audience);
 
             var credential = new CredentialFromTokenAndTimeStamp(request.token, request.expiresOnTimestamp);
             var armClient = new ArmClient(credential, default, options);

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -389,6 +389,10 @@ export class DeployCommand implements Command {
         );
       }
 
+      const environment = subscription.environment;
+      const resourceManagerEndpointUrl = environment.resourceManagerEndpointUrl;
+      const audience = environment.activeDirectoryResourceId;
+
       const deploymentStartParams: BicepDeploymentStartParams = {
         documentPath,
         parametersFilePath,
@@ -404,6 +408,8 @@ export class DeployCommand implements Command {
         parametersFileName,
         parametersFileUpdateOption,
         updatedDeploymentParameters,
+        resourceManagerEndpointUrl,
+        audience,
       };
       const deploymentStartResponse: BicepDeploymentStartResponse =
         await this.client.sendRequest("workspace/executeCommand", {

--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -71,6 +71,8 @@ export interface BicepDeploymentStartParams {
   parametersFileName: string;
   parametersFileUpdateOption: ParametersFileUpdateOption;
   updatedDeploymentParameters: BicepUpdatedDeploymentParameter[];
+  resourceManagerEndpointUrl: string;
+  audience: string;
 }
 
 export interface BicepDeploymentStartResponse {


### PR DESCRIPTION
Fixes #8282

Verified the changes in azure cloud and FairfaxDevOps account.

Note: Bicep deploy command from within vscode uses Azure Account extension for authentication. It doesn't use cloud profiles from bicepconfig.json. Created #9096 to update documentation

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9097)