### PR TITLE
Avoid unnecessary visit* method calls

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParserTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParserTests.cs
@@ -145,7 +145,7 @@ namespace Bicep.Core.IntegrationTests
             };
         }
 
-        private sealed class SpanConsistencyVisitor : AstVisitor
+        private sealed class SpanConsistencyVisitor : CstVisitor
         {
             private int maxPosition = 0;
 

--- a/src/Bicep.Core.IntegrationTests/ParserTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParserTests.cs
@@ -145,7 +145,7 @@ namespace Bicep.Core.IntegrationTests
             };
         }
 
-        private sealed class SpanConsistencyVisitor : SyntaxVisitor
+        private sealed class SpanConsistencyVisitor : AstVisitor
         {
             private int maxPosition = 0;
 

--- a/src/Bicep.Core.UnitTests/Parsing/ExpressionTestVisitor.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/ExpressionTestVisitor.cs
@@ -6,7 +6,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.UnitTests.Parsing
 {
-    public sealed class ExpressionTestVisitor : AstVisitor
+    public sealed class ExpressionTestVisitor : CstVisitor
     {
         private readonly StringBuilder buffer;
 

--- a/src/Bicep.Core.UnitTests/Parsing/ExpressionTestVisitor.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/ExpressionTestVisitor.cs
@@ -6,7 +6,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.UnitTests.Parsing
 {
-    public sealed class ExpressionTestVisitor : SyntaxVisitor
+    public sealed class ExpressionTestVisitor : AstVisitor
     {
         private readonly StringBuilder buffer;
 

--- a/src/Bicep.Core.UnitTests/Syntax/SyntaxCollectorVisitor.cs
+++ b/src/Bicep.Core.UnitTests/Syntax/SyntaxCollectorVisitor.cs
@@ -6,7 +6,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.UnitTests.Syntax
 {
-    public class SyntaxCollectorVisitor : SyntaxVisitor
+    public class SyntaxCollectorVisitor : AstVisitor
     {
         public record SyntaxItem(SyntaxBase Syntax, SyntaxItem? Parent, int Depth)
         {

--- a/src/Bicep.Core.UnitTests/Syntax/SyntaxCollectorVisitor.cs
+++ b/src/Bicep.Core.UnitTests/Syntax/SyntaxCollectorVisitor.cs
@@ -6,7 +6,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.UnitTests.Syntax
 {
-    public class SyntaxCollectorVisitor : AstVisitor
+    public class SyntaxCollectorVisitor : CstVisitor
     {
         public record SyntaxItem(SyntaxBase Syntax, SyntaxItem? Parent, int Depth)
         {

--- a/src/Bicep.Core/Analyzers/Linter/Common/FindPossibleSecretsVisitor.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Common/FindPossibleSecretsVisitor.cs
@@ -10,7 +10,7 @@ using System.Collections.Immutable;
 
 namespace Bicep.Core.Analyzers.Linter.Common
 {
-    public sealed class FindPossibleSecretsVisitor : SyntaxVisitor
+    public sealed class FindPossibleSecretsVisitor : AstVisitor
     {
         // TODO: Refactor to not use visitor
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/AdminUsernameShouldNotBeLiteralRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/AdminUsernameShouldNotBeLiteralRule.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return visitor.diagnostics;
         }
 
-        private class ResourceVisitor : SyntaxVisitor
+        private class ResourceVisitor : AstVisitor
         {
             public List<IDiagnostic> diagnostics = new();
 
@@ -57,7 +57,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private class PropertiesVisitor : SyntaxVisitor
+        private class PropertiesVisitor : AstVisitor
         {
             private readonly List<IDiagnostic> diagnostics;
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/ExplicitValuesForLocationParamsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/ExplicitValuesForLocationParamsRule.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return visitor.diagnostics;
         }
 
-        private sealed class Visitor : SyntaxVisitor
+        private sealed class Visitor : AstVisitor
         {
             public List<IDiagnostic> diagnostics = new();
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/LocationRuleBase.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/LocationRuleBase.cs
@@ -282,7 +282,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return result.ToImmutableArray();
         }
 
-        private class GetParametersUsedInResourceLocationsVisitor : SyntaxVisitor
+        private class GetParametersUsedInResourceLocationsVisitor : AstVisitor
         {
             private readonly SemanticModel semanticModel;
 
@@ -309,7 +309,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private class GetReferencedParametersVisitor : SyntaxVisitor
+        private class GetReferencedParametersVisitor : AstVisitor
         {
             private readonly SemanticModel semanticModel;
 
@@ -331,7 +331,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private class ContainsCallToRgOrDeploymentLocationVisitor : SyntaxVisitor
+        private class ContainsCallToRgOrDeploymentLocationVisitor : AstVisitor
         {
             public string? ActualExpression;
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedEnvironmentUrlsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedEnvironmentUrlsRule.cs
@@ -90,7 +90,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private sealed class Visitor : SyntaxVisitor
+        private sealed class Visitor : AstVisitor
         {
             public readonly Dictionary<TextSpan, string> DisallowedHostSpans = new();
             private readonly ImmutableArray<string> disallowedHosts;

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedLocationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedLocationRule.cs
@@ -156,7 +156,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private sealed class RuleVisitor : SyntaxVisitor
+        private sealed class RuleVisitor : AstVisitor
         {
             public List<IDiagnostic> diagnostics = new();
             private readonly HashSet<VariableSymbol> variablesToChangeToParam = new();

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoLocationExprOutsideParamsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoLocationExprOutsideParamsRule.cs
@@ -32,7 +32,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return visitor.diagnostics;
         }
 
-        private sealed class RuleVisitor : SyntaxVisitor
+        private sealed class RuleVisitor : AstVisitor
         {
             public List<IDiagnostic> diagnostics = new();
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnnecessaryDependsOnRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnnecessaryDependsOnRule.cs
@@ -39,7 +39,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return visitor.diagnostics;
         }
 
-        private class ResourceVisitor : SyntaxVisitor
+        private class ResourceVisitor : AstVisitor
         {
             public List<IDiagnostic> diagnostics = new();
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/OutputsShouldNotContainSecretsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/OutputsShouldNotContainSecretsRule.cs
@@ -39,7 +39,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return visitor.diagnostics;
         }
 
-        private class OutputVisitor : SyntaxVisitor
+        private class OutputVisitor : AstVisitor
         {
             public List<IDiagnostic> diagnostics = new();
 
@@ -70,7 +70,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private class OutputValueVisitor : SyntaxVisitor
+        private class OutputValueVisitor : AstVisitor
         {
             private readonly List<IDiagnostic> diagnostics;
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/PreferInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/PreferInterpolationRule.cs
@@ -31,7 +31,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return visitor.diagnostics;
         }
 
-        private class Visitor : SyntaxVisitor
+        private class Visitor : AstVisitor
         {
             public List<IDiagnostic> diagnostics = new();
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/PreferUnquotedPropertyNamesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/PreferUnquotedPropertyNamesRule.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return spanFixes.Select(kvp => CreateFixableDiagnosticForSpan(diagnosticLevel, kvp.Key, kvp.Value));
         }
 
-        private sealed class Visitor : SyntaxVisitor
+        private sealed class Visitor : AstVisitor
         {
             private readonly Dictionary<TextSpan, CodeFix> spanFixes;
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecureParameterDefaultRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecureParameterDefaultRule.cs
@@ -55,7 +55,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private class NewGuidVisitor : SyntaxVisitor
+        private class NewGuidVisitor : AstVisitor
         {
             public bool hasNewGuid = false;
 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SimplifyInterpolationRule.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return spanFixes.Select(kvp => CreateFixableDiagnosticForSpan(diagnosticLevel, kvp.Key, kvp.Value));
         }
 
-        private sealed class Visitor : SyntaxVisitor
+        private sealed class Visitor : AstVisitor
         {
             private readonly Dictionary<TextSpan, CodeFix> spanFixes;
             private readonly SemanticModel model;

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
@@ -162,7 +162,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return pathMessage is null ? mainMessage : $"{mainMessage} {pathMessage}";
         }
 
-        private class IdPropertyVisitor : SyntaxVisitor
+        private class IdPropertyVisitor : AstVisitor
         {
             private readonly List<Failure> failures = new();
             public IEnumerable<Failure> Failures => failures;

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
@@ -43,7 +43,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public override string FormatMessage(params object[] values)
             => string.Format(CoreResources.UseStableResourceIdentifiersMessageFormat, values);
 
-        private class Visitor : SyntaxVisitor
+        private class Visitor : AstVisitor
         {
             private static readonly IReadOnlySet<string> NonDeterministicFunctionNames = new HashSet<string>
             {

--- a/src/Bicep.Core/DataFlow/LocalSymbolDependencyVisitor.cs
+++ b/src/Bicep.Core/DataFlow/LocalSymbolDependencyVisitor.cs
@@ -8,7 +8,7 @@ using System.Collections.Immutable;
 
 namespace Bicep.Core.DataFlow
 {
-    public sealed class LocalSymbolDependencyVisitor : SyntaxVisitor
+    public sealed class LocalSymbolDependencyVisitor : AstVisitor
     {
         private readonly SemanticModel semanticModel;
 

--- a/src/Bicep.Core/Diagnostics/DisabledDiagnosticsCache.cs
+++ b/src/Bicep.Core/Diagnostics/DisabledDiagnosticsCache.cs
@@ -37,7 +37,7 @@ namespace Bicep.Core.Diagnostics
             return visitor.GetDisableNextLineDiagnosticDirectivesCache();
         }
 
-        private class SyntaxTriviaVisitor : SyntaxVisitor
+        private class SyntaxTriviaVisitor : AstVisitor
         {
             private ImmutableArray<int> lineStarts;
             private ImmutableDictionary<int, DisableNextLineDirectiveEndPositionAndCodes>.Builder disableNextLineDiagnosticDirectivesCacheBuilder = ImmutableDictionary.CreateBuilder<int, DisableNextLineDirectiveEndPositionAndCodes>();

--- a/src/Bicep.Core/Diagnostics/DisabledDiagnosticsCache.cs
+++ b/src/Bicep.Core/Diagnostics/DisabledDiagnosticsCache.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Bicep.Core.Extensions;
+using Bicep.Core.Parsing;
 using Bicep.Core.Syntax;
 using Bicep.Core.Text;
 
@@ -37,10 +38,11 @@ namespace Bicep.Core.Diagnostics
             return visitor.GetDisableNextLineDiagnosticDirectivesCache();
         }
 
-        private class SyntaxTriviaVisitor : AstVisitor
+        private class SyntaxTriviaVisitor : CstVisitor
         {
-            private ImmutableArray<int> lineStarts;
-            private ImmutableDictionary<int, DisableNextLineDirectiveEndPositionAndCodes>.Builder disableNextLineDiagnosticDirectivesCacheBuilder = ImmutableDictionary.CreateBuilder<int, DisableNextLineDirectiveEndPositionAndCodes>();
+            private readonly ImmutableArray<int> lineStarts;
+
+            private readonly ImmutableDictionary<int, DisableNextLineDirectiveEndPositionAndCodes>.Builder disableNextLineDiagnosticDirectivesCacheBuilder = ImmutableDictionary.CreateBuilder<int, DisableNextLineDirectiveEndPositionAndCodes>();
 
             public SyntaxTriviaVisitor(ImmutableArray<int> lineStarts)
             {

--- a/src/Bicep.Core/Emit/ForSyntaxValidatorVisitor.cs
+++ b/src/Bicep.Core/Emit/ForSyntaxValidatorVisitor.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Bicep.Core.Emit
 {
-    public sealed class ForSyntaxValidatorVisitor : SyntaxVisitor
+    public sealed class ForSyntaxValidatorVisitor : AstVisitor
     {
         // we don't support nesting of property loops right now
         private const int MaximumNestedPropertyLoopCount = 1;

--- a/src/Bicep.Core/Emit/FunctionPlacementValidatorVisitor.cs
+++ b/src/Bicep.Core/Emit/FunctionPlacementValidatorVisitor.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace Bicep.Core.Emit
 {
-    public class FunctionPlacementValidatorVisitor : SyntaxVisitor
+    public class FunctionPlacementValidatorVisitor : AstVisitor
     {
         private enum VisitedElement
         {

--- a/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
@@ -11,7 +11,7 @@ using Bicep.Core.TypeSystem.Az;
 
 namespace Bicep.Core.Emit
 {
-    public class InlineDependencyVisitor : SyntaxVisitor
+    public class InlineDependencyVisitor : AstVisitor
     {
         private enum Decision
         {

--- a/src/Bicep.Core/Emit/IntegerValidatorVisitor.cs
+++ b/src/Bicep.Core/Emit/IntegerValidatorVisitor.cs
@@ -7,7 +7,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Emit
 {
-    public class IntegerValidatorVisitor : SyntaxVisitor
+    public class IntegerValidatorVisitor : AstVisitor
     {
         private readonly IDiagnosticWriter diagnosticWriter;
         private readonly SemanticModel semanticModel;

--- a/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/ResourceDependencyVisitor.cs
@@ -13,7 +13,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Emit
 {
-    public class ResourceDependencyVisitor : SyntaxVisitor
+    public class ResourceDependencyVisitor : AstVisitor
     {
         private readonly SemanticModel model;
         private Options? options;

--- a/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
@@ -25,7 +25,7 @@ namespace Bicep.Core.Navigation
             return visitor.Result;
         }
 
-        private sealed class NavigationSearchVisitor : SyntaxVisitor
+        private sealed class NavigationSearchVisitor : AstVisitor
         {
             private readonly int offset;
             private readonly Func<SyntaxBase, bool> predicate;
@@ -89,7 +89,7 @@ namespace Bicep.Core.Navigation
             return sb.ToString();
         }
 
-        private class PrintVisitor : SyntaxVisitor
+        private class PrintVisitor : AstVisitor
         {
             private readonly StringBuilder buffer;
 

--- a/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
@@ -25,7 +25,7 @@ namespace Bicep.Core.Navigation
             return visitor.Result;
         }
 
-        private sealed class NavigationSearchVisitor : AstVisitor
+        private sealed class NavigationSearchVisitor : CstVisitor
         {
             private readonly int offset;
             private readonly Func<SyntaxBase, bool> predicate;
@@ -89,7 +89,7 @@ namespace Bicep.Core.Navigation
             return sb.ToString();
         }
 
-        private class PrintVisitor : AstVisitor
+        private class PrintVisitor : CstVisitor
         {
             private readonly StringBuilder buffer;
 

--- a/src/Bicep.Core/Navigation/SyntaxTriviaExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxTriviaExtensions.cs
@@ -21,7 +21,7 @@ namespace Bicep.Core.Navigation
             return visitor.Result;
         }
 
-        private sealed class NavigationSearchVisitor : SyntaxVisitor
+        private sealed class NavigationSearchVisitor : AstVisitor
         {
             private readonly int offset;
             private readonly Func<SyntaxTrivia, bool> predicate;

--- a/src/Bicep.Core/Navigation/SyntaxTriviaExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxTriviaExtensions.cs
@@ -21,7 +21,7 @@ namespace Bicep.Core.Navigation
             return visitor.Result;
         }
 
-        private sealed class NavigationSearchVisitor : AstVisitor
+        private sealed class NavigationSearchVisitor : CstVisitor
         {
             private readonly int offset;
             private readonly Func<SyntaxTrivia, bool> predicate;

--- a/src/Bicep.Core/Parsing/ParseDiagnosticsVisitor.cs
+++ b/src/Bicep.Core/Parsing/ParseDiagnosticsVisitor.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.Parsing
     /// <summary>
     /// Visitor responsible for collecting all the parse diagnostics from the parse tree.
     /// </summary>
-    public class ParseDiagnosticsVisitor : AstVisitor
+    public class ParseDiagnosticsVisitor : CstVisitor
     {
         private readonly IDiagnosticWriter diagnosticWriter;
 

--- a/src/Bicep.Core/Parsing/ParseDiagnosticsVisitor.cs
+++ b/src/Bicep.Core/Parsing/ParseDiagnosticsVisitor.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.Parsing
     /// <summary>
     /// Visitor responsible for collecting all the parse diagnostics from the parse tree.
     /// </summary>
-    public class ParseDiagnosticsVisitor : SyntaxVisitor
+    public class ParseDiagnosticsVisitor : AstVisitor
     {
         private readonly IDiagnosticWriter diagnosticWriter;
 

--- a/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
+++ b/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
@@ -12,7 +12,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.PrettyPrint
 {
-    public class DocumentBuildVisitor : SyntaxVisitor
+    public class DocumentBuildVisitor : AstVisitor
     {
         private static readonly ILinkedDocument Nil = new NilDocument();
 

--- a/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
+++ b/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
@@ -12,7 +12,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.PrettyPrint
 {
-    public class DocumentBuildVisitor : AstVisitor
+    public class DocumentBuildVisitor : CstVisitor
     {
         private static readonly ILinkedDocument Nil = new NilDocument();
 

--- a/src/Bicep.Core/Semantics/DeclarationVisitor.cs
+++ b/src/Bicep.Core/Semantics/DeclarationVisitor.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Schema;
 
 namespace Bicep.Core.Semantics
 {
-    public sealed class DeclarationVisitor : SyntaxVisitor
+    public sealed class DeclarationVisitor : AstVisitor
     {
         private readonly INamespaceProvider namespaceProvider;
         private readonly IFeatureProvider features;

--- a/src/Bicep.Core/Semantics/NameBindingVisitor.cs
+++ b/src/Bicep.Core/Semantics/NameBindingVisitor.cs
@@ -14,7 +14,7 @@ using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Semantics
 {
-    public sealed class NameBindingVisitor : SyntaxVisitor
+    public sealed class NameBindingVisitor : AstVisitor
     {
         private FunctionFlags allowedFlags;
 

--- a/src/Bicep.Core/Semantics/ResourceAncestorVisitor.cs
+++ b/src/Bicep.Core/Semantics/ResourceAncestorVisitor.cs
@@ -8,7 +8,7 @@ using static Bicep.Core.Semantics.ResourceAncestorGraph;
 
 namespace Bicep.Core.Semantics
 {
-    public sealed class ResourceAncestorVisitor : SyntaxVisitor
+    public sealed class ResourceAncestorVisitor : AstVisitor
     {
         private readonly SemanticModel semanticModel;
         private readonly ImmutableDictionary<DeclaredResourceMetadata, ResourceAncestor>.Builder ancestry;

--- a/src/Bicep.Core/Syntax/AstVisitor.cs
+++ b/src/Bicep.Core/Syntax/AstVisitor.cs
@@ -10,50 +10,33 @@ namespace Bicep.Core.Syntax
     /// <summary>
     /// Visits an <see href="https://en.wikipedia.org/wiki/Abstract_syntax_tree">abstract syntax tree (AST)</see>.
     /// </summary>
-    public abstract class AstVisitor : ISyntaxVisitor
+    public abstract class AstVisitor : SyntaxVisitor
     {
-        public void Visit(SyntaxBase? node)
-        {
-            if (node == null)
-            {
-                return;
-            }
-
-            RuntimeHelpers.EnsureSufficientExecutionStack();
-
-            VisitInternal(node);
-        }
-
-        protected virtual void VisitInternal(SyntaxBase node)
-        {
-            node.Accept(this);
-        }
-
-        public virtual void VisitSyntaxTrivia(SyntaxTrivia syntaxTrivia)
+        public override void VisitSyntaxTrivia(SyntaxTrivia syntaxTrivia)
         {
         }
 
-        public virtual void VisitSkippedTriviaSyntax(SkippedTriviaSyntax syntax)
+        public override void VisitSkippedTriviaSyntax(SkippedTriviaSyntax syntax)
         {
         }
 
-        public virtual void VisitToken(Token token)
+        public override void VisitToken(Token token)
         {
         }
 
-        public virtual void VisitBooleanLiteralSyntax(BooleanLiteralSyntax syntax)
+        public override void VisitBooleanLiteralSyntax(BooleanLiteralSyntax syntax)
         {
         }
 
-        public virtual void VisitIntegerLiteralSyntax(IntegerLiteralSyntax syntax)
+        public override void VisitIntegerLiteralSyntax(IntegerLiteralSyntax syntax)
         {
         }
 
-        public virtual void VisitNullLiteralSyntax(NullLiteralSyntax syntax)
+        public override void VisitNullLiteralSyntax(NullLiteralSyntax syntax)
         {
         }
 
-        public virtual void VisitSeparatedSyntaxList(SeparatedSyntaxList syntax)
+        public override void VisitSeparatedSyntaxList(SeparatedSyntaxList syntax)
         {
             foreach (var element in syntax.Elements)
             {
@@ -61,14 +44,14 @@ namespace Bicep.Core.Syntax
             }
         }
 
-        public virtual void VisitMetadataDeclarationSyntax(MetadataDeclarationSyntax syntax)
+        public override void VisitMetadataDeclarationSyntax(MetadataDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Name);
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitParameterDeclarationSyntax(ParameterDeclarationSyntax syntax)
+        public override void VisitParameterDeclarationSyntax(ParameterDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Name);
@@ -76,30 +59,30 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Modifier);
         }
 
-        public virtual void VisitParameterDefaultValueSyntax(ParameterDefaultValueSyntax syntax)
+        public override void VisitParameterDefaultValueSyntax(ParameterDefaultValueSyntax syntax)
         {
             this.Visit(syntax.DefaultValue);
         }
 
-        public virtual void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax)
+        public override void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Name);
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitLocalVariableSyntax(LocalVariableSyntax syntax)
+        public override void VisitLocalVariableSyntax(LocalVariableSyntax syntax)
         {
             this.Visit(syntax.Name);
         }
 
-        public virtual void VisitTargetScopeSyntax(TargetScopeSyntax syntax)
+        public override void VisitTargetScopeSyntax(TargetScopeSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
+        public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Name);
@@ -107,7 +90,7 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax)
+        public override void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Name);
@@ -115,7 +98,7 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
+        public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Name);
@@ -123,57 +106,56 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitIdentifierSyntax(IdentifierSyntax syntax)
+        public override void VisitIdentifierSyntax(IdentifierSyntax syntax)
         {
             this.Visit(syntax.Child);
         }
 
-        public virtual void VisitResourceTypeSyntax(ResourceTypeSyntax syntax)
+        public override void VisitResourceTypeSyntax(ResourceTypeSyntax syntax)
         {
             this.Visit(syntax.Type);
         }
 
-        public virtual void VisitObjectTypeSyntax(ObjectTypeSyntax syntax)
+        public override void VisitObjectTypeSyntax(ObjectTypeSyntax syntax)
         {
             this.VisitNodes(syntax.Children);
         }
 
-        public virtual void VisitObjectTypePropertySyntax(ObjectTypePropertySyntax syntax)
+        public override void VisitObjectTypePropertySyntax(ObjectTypePropertySyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Key);
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitArrayTypeSyntax(ArrayTypeSyntax syntax)
+        public override void VisitArrayTypeSyntax(ArrayTypeSyntax syntax)
         {
             this.Visit(syntax.Item);
         }
 
-        public virtual void VisitArrayTypeMemberSyntax(ArrayTypeMemberSyntax syntax)
+        public override void VisitArrayTypeMemberSyntax(ArrayTypeMemberSyntax syntax)
         {
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitUnionTypeSyntax(UnionTypeSyntax syntax)
+        public override void VisitUnionTypeSyntax(UnionTypeSyntax syntax)
         {
             this.VisitNodes(syntax.Children);
         }
 
-        public virtual void VisitUnionTypeMemberSyntax(UnionTypeMemberSyntax syntax)
+        public override void VisitUnionTypeMemberSyntax(UnionTypeMemberSyntax syntax)
         {
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitTypeDeclarationSyntax(TypeDeclarationSyntax syntax)
+        public override void VisitTypeDeclarationSyntax(TypeDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
-            this.Visit(syntax.Keyword);
             this.Visit(syntax.Name);
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitStringSyntax(StringSyntax syntax)
+        public override void VisitStringSyntax(StringSyntax syntax)
         {
             for (var i = 0; i < syntax.Expressions.Length; i++)
             {
@@ -183,125 +165,125 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.StringTokens.Last());
         }
 
-        public virtual void VisitProgramSyntax(ProgramSyntax syntax)
+        public override void VisitProgramSyntax(ProgramSyntax syntax)
         {
             this.VisitNodes(syntax.Children);
         }
 
-        public virtual void VisitObjectSyntax(ObjectSyntax syntax)
+        public override void VisitObjectSyntax(ObjectSyntax syntax)
         {
             this.VisitNodes(syntax.Children);
         }
 
-        public virtual void VisitObjectPropertySyntax(ObjectPropertySyntax syntax)
+        public override void VisitObjectPropertySyntax(ObjectPropertySyntax syntax)
         {
             this.Visit(syntax.Key);
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitArraySyntax(ArraySyntax syntax)
+        public override void VisitArraySyntax(ArraySyntax syntax)
         {
             this.VisitNodes(syntax.Children);
         }
 
-        public virtual void VisitArrayItemSyntax(ArrayItemSyntax syntax)
+        public override void VisitArrayItemSyntax(ArrayItemSyntax syntax)
         {
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitIfConditionSyntax(IfConditionSyntax syntax)
+        public override void VisitIfConditionSyntax(IfConditionSyntax syntax)
         {
             this.Visit(syntax.ConditionExpression);
             this.Visit(syntax.Body);
         }
 
-        public virtual void VisitForSyntax(ForSyntax syntax)
+        public override void VisitForSyntax(ForSyntax syntax)
         {
             this.Visit(syntax.VariableSection);
             this.Visit(syntax.Expression);
             this.Visit(syntax.Body);
         }
 
-        public virtual void VisitVariableBlockSyntax(VariableBlockSyntax syntax)
+        public override void VisitVariableBlockSyntax(VariableBlockSyntax syntax)
         {
             this.VisitNodes(syntax.Children);
         }
 
-        public virtual void VisitTernaryOperationSyntax(TernaryOperationSyntax syntax)
+        public override void VisitTernaryOperationSyntax(TernaryOperationSyntax syntax)
         {
             this.Visit(syntax.ConditionExpression);
             this.Visit(syntax.TrueExpression);
             this.Visit(syntax.FalseExpression);
         }
 
-        public virtual void VisitBinaryOperationSyntax(BinaryOperationSyntax syntax)
+        public override void VisitBinaryOperationSyntax(BinaryOperationSyntax syntax)
         {
             this.Visit(syntax.LeftExpression);
             this.Visit(syntax.RightExpression);
         }
 
-        public virtual void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax)
+        public override void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax)
         {
             this.Visit(syntax.Expression);
         }
 
-        public virtual void VisitArrayAccessSyntax(ArrayAccessSyntax syntax)
+        public override void VisitArrayAccessSyntax(ArrayAccessSyntax syntax)
         {
             this.Visit(syntax.BaseExpression);
             this.Visit(syntax.IndexExpression);
         }
 
-        public virtual void VisitPropertyAccessSyntax(PropertyAccessSyntax syntax)
+        public override void VisitPropertyAccessSyntax(PropertyAccessSyntax syntax)
         {
             this.Visit(syntax.BaseExpression);
             this.Visit(syntax.PropertyName);
         }
 
-        public virtual void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
+        public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
         {
             this.Visit(syntax.BaseExpression);
             this.Visit(syntax.ResourceName);
         }
 
-        public virtual void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax)
+        public override void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax)
         {
             this.Visit(syntax.Expression);
         }
 
-        public virtual void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
+        public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
         {
             this.Visit(syntax.Name);
             this.VisitNodes(syntax.Children);
         }
 
-        public virtual void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
+        public override void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
         {
             this.Visit(syntax.BaseExpression);
             this.Visit(syntax.Name);
             this.VisitNodes(syntax.Children);
         }
 
-        public virtual void VisitFunctionArgumentSyntax(FunctionArgumentSyntax syntax)
+        public override void VisitFunctionArgumentSyntax(FunctionArgumentSyntax syntax)
         {
             this.Visit(syntax.Expression);
         }
 
-        public virtual void VisitVariableAccessSyntax(VariableAccessSyntax syntax)
+        public override void VisitVariableAccessSyntax(VariableAccessSyntax syntax)
         {
             this.Visit(syntax.Name);
         }
 
-        public virtual void VisitDecoratorSyntax(DecoratorSyntax syntax)
+        public override void VisitDecoratorSyntax(DecoratorSyntax syntax)
         {
             this.Visit(syntax.Expression);
         }
 
-        public virtual void VisitMissingDeclarationSyntax(MissingDeclarationSyntax syntax)
+        public override void VisitMissingDeclarationSyntax(MissingDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
         }
 
-        public virtual void VisitImportDeclarationSyntax(ImportDeclarationSyntax syntax)
+        public override void VisitImportDeclarationSyntax(ImportDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.SpecificationString);
@@ -309,41 +291,33 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.AsClause);
         }
 
-        public virtual void VisitImportWithClauseSyntax(ImportWithClauseSyntax syntax)
+        public override void VisitImportWithClauseSyntax(ImportWithClauseSyntax syntax)
         {
             this.Visit(syntax.Config);
         }
 
-        public virtual void VisitImportAsClauseSyntax(ImportAsClauseSyntax syntax)
+        public override void VisitImportAsClauseSyntax(ImportAsClauseSyntax syntax)
         {
             this.Visit(syntax.Alias);
         }
 
-        public virtual void VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax)
+        public override void VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Name);
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitUsingDeclarationSyntax(UsingDeclarationSyntax syntax)
+        public override void VisitUsingDeclarationSyntax(UsingDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Path);
         }
 
-        public virtual void VisitLambdaSyntax(LambdaSyntax syntax)
+        public override void VisitLambdaSyntax(LambdaSyntax syntax)
         {
             this.Visit(syntax.VariableSection);
             this.Visit(syntax.Body);
-        }
-
-        protected void VisitNodes(IEnumerable<SyntaxBase> nodes)
-        {
-            foreach (SyntaxBase node in nodes)
-            {
-                this.Visit(node);
-            }
         }
     }
 }

--- a/src/Bicep.Core/Syntax/AstVisitor.cs
+++ b/src/Bicep.Core/Syntax/AstVisitor.cs
@@ -7,7 +7,7 @@ using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax
 {
-    public abstract class SyntaxVisitor : ISyntaxVisitor
+    public abstract class AstVisitor : ISyntaxVisitor
     {
         public void Visit(SyntaxBase? node)
         {

--- a/src/Bicep.Core/Syntax/CstVisitor.cs
+++ b/src/Bicep.Core/Syntax/CstVisitor.cs
@@ -10,26 +10,9 @@ namespace Bicep.Core.Syntax
     /// <summary>
     /// Visits a <see href="https://en.wikipedia.org/wiki/Parse_tree">concrete syntax tree (CST)</see>.
     /// </summary>
-    public abstract class CstVisitor : ISyntaxVisitor
+    public abstract class CstVisitor : SyntaxVisitor
     {
-        public void Visit(SyntaxBase? node)
-        {
-            if (node == null)
-            {
-                return;
-            }
-
-            RuntimeHelpers.EnsureSufficientExecutionStack();
-
-            VisitInternal(node);
-        }
-
-        protected virtual void VisitInternal(SyntaxBase node)
-        {
-            node.Accept(this);
-        }
-
-        public virtual void VisitToken(Token token)
+        public override void VisitToken(Token token)
         {
             foreach (var syntaxTrivia in token.LeadingTrivia)
             {
@@ -42,11 +25,11 @@ namespace Bicep.Core.Syntax
             }
         }
 
-        public virtual void VisitSyntaxTrivia(SyntaxTrivia syntaxTrivia)
+        public override void VisitSyntaxTrivia(SyntaxTrivia syntaxTrivia)
         {
         }
 
-        public virtual void VisitSeparatedSyntaxList(SeparatedSyntaxList syntax)
+        public override void VisitSeparatedSyntaxList(SeparatedSyntaxList syntax)
         {
             // visit paired elements in order
             foreach (var (item, token) in syntax.GetPairedElements())
@@ -56,7 +39,7 @@ namespace Bicep.Core.Syntax
             }
         }
 
-        public virtual void VisitMetadataDeclarationSyntax(MetadataDeclarationSyntax syntax)
+        public override void VisitMetadataDeclarationSyntax(MetadataDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -65,7 +48,7 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitParameterDeclarationSyntax(ParameterDeclarationSyntax syntax)
+        public override void VisitParameterDeclarationSyntax(ParameterDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -74,13 +57,13 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Modifier);
         }
 
-        public virtual void VisitParameterDefaultValueSyntax(ParameterDefaultValueSyntax syntax)
+        public override void VisitParameterDefaultValueSyntax(ParameterDefaultValueSyntax syntax)
         {
             this.Visit(syntax.AssignmentToken);
             this.Visit(syntax.DefaultValue);
         }
 
-        public virtual void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax)
+        public override void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -89,12 +72,12 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitLocalVariableSyntax(LocalVariableSyntax syntax)
+        public override void VisitLocalVariableSyntax(LocalVariableSyntax syntax)
         {
             this.Visit(syntax.Name);
         }
 
-        public virtual void VisitTargetScopeSyntax(TargetScopeSyntax syntax)
+        public override void VisitTargetScopeSyntax(TargetScopeSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -102,7 +85,7 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
+        public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -113,7 +96,7 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax)
+        public override void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -123,7 +106,7 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
+        public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -133,25 +116,25 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitIdentifierSyntax(IdentifierSyntax syntax)
+        public override void VisitIdentifierSyntax(IdentifierSyntax syntax)
         {
             this.Visit(syntax.Child);
         }
 
-        public virtual void VisitResourceTypeSyntax(ResourceTypeSyntax syntax)
+        public override void VisitResourceTypeSyntax(ResourceTypeSyntax syntax)
         {
             this.Visit(syntax.Keyword);
             this.Visit(syntax.Type);
         }
 
-        public virtual void VisitObjectTypeSyntax(ObjectTypeSyntax syntax)
+        public override void VisitObjectTypeSyntax(ObjectTypeSyntax syntax)
         {
             this.Visit(syntax.OpenBrace);
             this.VisitNodes(syntax.Children);
             this.Visit(syntax.CloseBrace);
         }
 
-        public virtual void VisitObjectTypePropertySyntax(ObjectTypePropertySyntax syntax)
+        public override void VisitObjectTypePropertySyntax(ObjectTypePropertySyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Key);
@@ -160,29 +143,29 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitArrayTypeSyntax(ArrayTypeSyntax syntax)
+        public override void VisitArrayTypeSyntax(ArrayTypeSyntax syntax)
         {
             this.Visit(syntax.Item);
             this.Visit(syntax.OpenBracket);
             this.Visit(syntax.CloseBracket);
         }
 
-        public virtual void VisitArrayTypeMemberSyntax(ArrayTypeMemberSyntax syntax)
+        public override void VisitArrayTypeMemberSyntax(ArrayTypeMemberSyntax syntax)
         {
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitUnionTypeSyntax(UnionTypeSyntax syntax)
+        public override void VisitUnionTypeSyntax(UnionTypeSyntax syntax)
         {
             this.VisitNodes(syntax.Children);
         }
 
-        public virtual void VisitUnionTypeMemberSyntax(UnionTypeMemberSyntax syntax)
+        public override void VisitUnionTypeMemberSyntax(UnionTypeMemberSyntax syntax)
         {
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitTypeDeclarationSyntax(TypeDeclarationSyntax syntax)
+        public override void VisitTypeDeclarationSyntax(TypeDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -191,12 +174,12 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitBooleanLiteralSyntax(BooleanLiteralSyntax syntax)
+        public override void VisitBooleanLiteralSyntax(BooleanLiteralSyntax syntax)
         {
             this.Visit(syntax.Literal);
         }
 
-        public virtual void VisitStringSyntax(StringSyntax syntax)
+        public override void VisitStringSyntax(StringSyntax syntax)
         {
             for (var i = 0; i < syntax.Expressions.Length; i++)
             {
@@ -206,23 +189,23 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.StringTokens.Last());
         }
 
-        public virtual void VisitProgramSyntax(ProgramSyntax syntax)
+        public override void VisitProgramSyntax(ProgramSyntax syntax)
         {
             this.VisitNodes(syntax.Children);
             this.Visit(syntax.EndOfFile);
         }
 
-        public virtual void VisitIntegerLiteralSyntax(IntegerLiteralSyntax syntax)
+        public override void VisitIntegerLiteralSyntax(IntegerLiteralSyntax syntax)
         {
             this.Visit(syntax.Literal);
         }
 
-        public virtual void VisitNullLiteralSyntax(NullLiteralSyntax syntax)
+        public override void VisitNullLiteralSyntax(NullLiteralSyntax syntax)
         {
             this.Visit(syntax.NullKeyword);
         }
 
-        public virtual void VisitSkippedTriviaSyntax(SkippedTriviaSyntax syntax)
+        public override void VisitSkippedTriviaSyntax(SkippedTriviaSyntax syntax)
         {
             foreach (var element in syntax.Elements)
             {
@@ -230,40 +213,40 @@ namespace Bicep.Core.Syntax
             }
         }
 
-        public virtual void VisitObjectSyntax(ObjectSyntax syntax)
+        public override void VisitObjectSyntax(ObjectSyntax syntax)
         {
             this.Visit(syntax.OpenBrace);
             this.VisitNodes(syntax.Children);
             this.Visit(syntax.CloseBrace);
         }
 
-        public virtual void VisitObjectPropertySyntax(ObjectPropertySyntax syntax)
+        public override void VisitObjectPropertySyntax(ObjectPropertySyntax syntax)
         {
             this.Visit(syntax.Key);
             this.Visit(syntax.Colon);
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitArraySyntax(ArraySyntax syntax)
+        public override void VisitArraySyntax(ArraySyntax syntax)
         {
             this.Visit(syntax.OpenBracket);
             this.VisitNodes(syntax.Children);
             this.Visit(syntax.CloseBracket);
         }
 
-        public virtual void VisitArrayItemSyntax(ArrayItemSyntax syntax)
+        public override void VisitArrayItemSyntax(ArrayItemSyntax syntax)
         {
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitIfConditionSyntax(IfConditionSyntax syntax)
+        public override void VisitIfConditionSyntax(IfConditionSyntax syntax)
         {
             this.Visit(syntax.Keyword);
             this.Visit(syntax.ConditionExpression);
             this.Visit(syntax.Body);
         }
 
-        public virtual void VisitForSyntax(ForSyntax syntax)
+        public override void VisitForSyntax(ForSyntax syntax)
         {
             this.Visit(syntax.OpenSquare);
             this.Visit(syntax.ForKeyword);
@@ -275,14 +258,14 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.CloseSquare);
         }
 
-        public virtual void VisitVariableBlockSyntax(VariableBlockSyntax syntax)
+        public override void VisitVariableBlockSyntax(VariableBlockSyntax syntax)
         {
             this.Visit(syntax.OpenParen);
             this.VisitNodes(syntax.Children);
             this.Visit(syntax.CloseParen);
         }
 
-        public virtual void VisitTernaryOperationSyntax(TernaryOperationSyntax syntax)
+        public override void VisitTernaryOperationSyntax(TernaryOperationSyntax syntax)
         {
             this.Visit(syntax.ConditionExpression);
             this.Visit(syntax.Question);
@@ -291,20 +274,20 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.FalseExpression);
         }
 
-        public virtual void VisitBinaryOperationSyntax(BinaryOperationSyntax syntax)
+        public override void VisitBinaryOperationSyntax(BinaryOperationSyntax syntax)
         {
             this.Visit(syntax.LeftExpression);
             this.Visit(syntax.OperatorToken);
             this.Visit(syntax.RightExpression);
         }
 
-        public virtual void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax)
+        public override void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax)
         {
             this.Visit(syntax.OperatorToken);
             this.Visit(syntax.Expression);
         }
 
-        public virtual void VisitArrayAccessSyntax(ArrayAccessSyntax syntax)
+        public override void VisitArrayAccessSyntax(ArrayAccessSyntax syntax)
         {
             this.Visit(syntax.BaseExpression);
             this.Visit(syntax.OpenSquare);
@@ -312,28 +295,28 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.CloseSquare);
         }
 
-        public virtual void VisitPropertyAccessSyntax(PropertyAccessSyntax syntax)
+        public override void VisitPropertyAccessSyntax(PropertyAccessSyntax syntax)
         {
             this.Visit(syntax.BaseExpression);
             this.Visit(syntax.Dot);
             this.Visit(syntax.PropertyName);
         }
 
-        public virtual void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
+        public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
         {
             this.Visit(syntax.BaseExpression);
             this.Visit(syntax.DoubleColon);
             this.Visit(syntax.ResourceName);
         }
 
-        public virtual void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax)
+        public override void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax)
         {
             this.Visit(syntax.OpenParen);
             this.Visit(syntax.Expression);
             this.Visit(syntax.CloseParen);
         }
 
-        public virtual void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
+        public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
         {
             this.Visit(syntax.Name);
             this.Visit(syntax.OpenParen);
@@ -341,7 +324,7 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.CloseParen);
         }
 
-        public virtual void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
+        public override void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
         {
             this.Visit(syntax.BaseExpression);
             this.Visit(syntax.Dot);
@@ -351,28 +334,28 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.CloseParen);
         }
 
-        public virtual void VisitFunctionArgumentSyntax(FunctionArgumentSyntax syntax)
+        public override void VisitFunctionArgumentSyntax(FunctionArgumentSyntax syntax)
         {
             this.Visit(syntax.Expression);
         }
 
-        public virtual void VisitVariableAccessSyntax(VariableAccessSyntax syntax)
+        public override void VisitVariableAccessSyntax(VariableAccessSyntax syntax)
         {
             this.Visit(syntax.Name);
         }
 
-        public virtual void VisitDecoratorSyntax(DecoratorSyntax syntax)
+        public override void VisitDecoratorSyntax(DecoratorSyntax syntax)
         {
             this.Visit(syntax.At);
             this.Visit(syntax.Expression);
         }
 
-        public virtual void VisitMissingDeclarationSyntax(MissingDeclarationSyntax syntax)
+        public override void VisitMissingDeclarationSyntax(MissingDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
         }
 
-        public virtual void VisitImportDeclarationSyntax(ImportDeclarationSyntax syntax)
+        public override void VisitImportDeclarationSyntax(ImportDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -381,19 +364,19 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.AsClause);
         }
 
-        public virtual void VisitImportWithClauseSyntax(ImportWithClauseSyntax syntax)
+        public override void VisitImportWithClauseSyntax(ImportWithClauseSyntax syntax)
         {
             this.Visit(syntax.Keyword);
             this.Visit(syntax.Config);
         }
 
-        public virtual void VisitImportAsClauseSyntax(ImportAsClauseSyntax syntax)
+        public override void VisitImportAsClauseSyntax(ImportAsClauseSyntax syntax)
         {
             this.Visit(syntax.Keyword);
             this.Visit(syntax.Alias);
         }
 
-        public virtual void VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax)
+        public override void VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
@@ -402,26 +385,18 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Value);
         }
 
-        public virtual void VisitUsingDeclarationSyntax(UsingDeclarationSyntax syntax)
+        public override void VisitUsingDeclarationSyntax(UsingDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
             this.Visit(syntax.Path);
         }
 
-        public virtual void VisitLambdaSyntax(LambdaSyntax syntax)
+        public override void VisitLambdaSyntax(LambdaSyntax syntax)
         {
             this.Visit(syntax.VariableSection);
             this.Visit(syntax.Arrow);
             this.Visit(syntax.Body);
-        }
-
-        protected void VisitNodes(IEnumerable<SyntaxBase> nodes)
-        {
-            foreach (SyntaxBase node in nodes)
-            {
-                this.Visit(node);
-            }
         }
     }
 }

--- a/src/Bicep.Core/Syntax/SyntaxHierarchy.cs
+++ b/src/Bicep.Core/Syntax/SyntaxHierarchy.cs
@@ -48,7 +48,7 @@ namespace Bicep.Core.Syntax
             return false;
         }
 
-        private sealed class ParentTrackingVisitor : SyntaxVisitor
+        private sealed class ParentTrackingVisitor : AstVisitor
         {
             private readonly Dictionary<SyntaxBase, SyntaxBase?> parentMap;
             private readonly Stack<SyntaxBase> currentParents = new Stack<SyntaxBase>();

--- a/src/Bicep.Core/Syntax/SyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxVisitor.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Parsing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Syntax
+{
+    public abstract class SyntaxVisitor : ISyntaxVisitor
+    {
+        public abstract void VisitSyntaxTrivia(SyntaxTrivia syntaxTrivia);
+
+        public abstract void VisitArrayAccessSyntax(ArrayAccessSyntax syntax);
+
+        public abstract void VisitArrayItemSyntax(ArrayItemSyntax syntax);
+
+        public abstract void VisitArraySyntax(ArraySyntax syntax);
+
+        public abstract void VisitArrayTypeMemberSyntax(ArrayTypeMemberSyntax syntax);
+
+        public abstract void VisitArrayTypeSyntax(ArrayTypeSyntax syntax);
+
+        public abstract void VisitBinaryOperationSyntax(BinaryOperationSyntax syntax);
+
+        public abstract void VisitBooleanLiteralSyntax(BooleanLiteralSyntax syntax);
+
+        public abstract void VisitDecoratorSyntax(DecoratorSyntax syntax);
+
+        public abstract void VisitForSyntax(ForSyntax syntax);
+
+        public abstract void VisitFunctionArgumentSyntax(FunctionArgumentSyntax syntax);
+
+        public abstract void VisitFunctionCallSyntax(FunctionCallSyntax syntax);
+
+        public abstract void VisitIdentifierSyntax(IdentifierSyntax syntax);
+        
+        public abstract void VisitIfConditionSyntax(IfConditionSyntax syntax);
+
+        public abstract void VisitImportAsClauseSyntax(ImportAsClauseSyntax syntax);
+
+        public abstract void VisitImportDeclarationSyntax(ImportDeclarationSyntax syntax);
+
+        public abstract void VisitImportWithClauseSyntax(ImportWithClauseSyntax syntax);
+
+        public abstract void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax);
+
+        public abstract void VisitIntegerLiteralSyntax(IntegerLiteralSyntax syntax);
+
+        public abstract void VisitLambdaSyntax(LambdaSyntax syntax);
+
+        public abstract void VisitLocalVariableSyntax(LocalVariableSyntax syntax);
+
+        public abstract void VisitMetadataDeclarationSyntax(MetadataDeclarationSyntax syntax);
+
+        public abstract void VisitMissingDeclarationSyntax(MissingDeclarationSyntax syntax);
+
+        public abstract void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax);
+
+        public abstract void VisitNullLiteralSyntax(NullLiteralSyntax syntax);
+
+        public abstract void VisitObjectPropertySyntax(ObjectPropertySyntax syntax);
+
+        public abstract void VisitObjectSyntax(ObjectSyntax syntax);
+
+        public abstract void VisitObjectTypePropertySyntax(ObjectTypePropertySyntax syntax);
+
+        public abstract void VisitObjectTypeSyntax(ObjectTypeSyntax syntax);
+
+        public abstract void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax);
+
+        public abstract void VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax);
+
+        public abstract void VisitParameterDeclarationSyntax(ParameterDeclarationSyntax syntax);
+
+        public abstract void VisitParameterDefaultValueSyntax(ParameterDefaultValueSyntax syntax);
+
+        public abstract void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax);
+
+        public abstract void VisitProgramSyntax(ProgramSyntax syntax);
+
+        public abstract void VisitPropertyAccessSyntax(PropertyAccessSyntax syntax);
+
+        public abstract void VisitResourceAccessSyntax(ResourceAccessSyntax syntax);
+
+        public abstract void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax);
+
+        public abstract void VisitResourceTypeSyntax(ResourceTypeSyntax syntax);
+
+        public abstract void VisitSeparatedSyntaxList(SeparatedSyntaxList syntax);
+
+        public abstract void VisitSkippedTriviaSyntax(SkippedTriviaSyntax syntax);
+
+        public abstract void VisitStringSyntax(StringSyntax syntax);
+
+        public abstract void VisitTargetScopeSyntax(TargetScopeSyntax syntax);
+
+        public abstract void VisitTernaryOperationSyntax(TernaryOperationSyntax syntax);
+
+        public abstract void VisitToken(Token token);
+
+        public abstract void VisitTypeDeclarationSyntax(TypeDeclarationSyntax syntax);
+
+        public abstract void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax);
+
+        public abstract void VisitUnionTypeMemberSyntax(UnionTypeMemberSyntax syntax);
+
+        public abstract void VisitUnionTypeSyntax(UnionTypeSyntax syntax);
+
+        public abstract void VisitUsingDeclarationSyntax(UsingDeclarationSyntax syntax);
+
+        public abstract void VisitVariableAccessSyntax(VariableAccessSyntax syntax);
+
+        public abstract void VisitVariableBlockSyntax(VariableBlockSyntax syntax);
+
+        public abstract void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax);
+
+        public void Visit(SyntaxBase? node)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+
+            VisitInternal(node);
+        }
+
+        protected virtual void VisitInternal(SyntaxBase node)
+        {
+            node.Accept(this);
+        }
+
+        protected void VisitNodes(IEnumerable<SyntaxBase> nodes)
+        {
+            foreach (SyntaxBase node in nodes)
+            {
+                this.Visit(node);
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/Syntax/Visitors/CallbackVisitor.cs
+++ b/src/Bicep.Core/Syntax/Visitors/CallbackVisitor.cs
@@ -7,7 +7,7 @@ namespace Bicep.Core.Syntax.Visitors
     /// <summary>
     /// Visitor that executes a callback before visiting a tree node.
     /// </summary>
-    public class CallbackVisitor : SyntaxVisitor
+    public class CallbackVisitor : AstVisitor
     {
         private readonly Func<SyntaxBase, bool> callback;
 

--- a/src/Bicep.Core/Syntax/Visitors/SyntaxAggregator.cs
+++ b/src/Bicep.Core/Syntax/Visitors/SyntaxAggregator.cs
@@ -51,7 +51,7 @@ namespace Bicep.Core.Syntax.Visitors
             where TSyntax : SyntaxBase
             => Aggregate(source, syntax => syntax is TSyntax).OfType<TSyntax>();
 
-        private class AccumulatingVisitor<TAccumulate> : SyntaxVisitor
+        private class AccumulatingVisitor<TAccumulate> : AstVisitor
         {
             private readonly Func<TAccumulate, SyntaxBase, TAccumulate> function;
 

--- a/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
@@ -8,7 +8,7 @@ namespace Bicep.Core.TypeSystem
     /// <summary>
     /// Visitor used to collect errors caused by expression assignment to a compile-time constant property.
     /// </summary>
-    public sealed class CompileTimeConstantVisitor : SyntaxVisitor
+    public sealed class CompileTimeConstantVisitor : AstVisitor
     {
         private readonly IDiagnosticWriter diagnosticWriter;
 

--- a/src/Bicep.Core/TypeSystem/CyclicCheckVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CyclicCheckVisitor.cs
@@ -11,7 +11,7 @@ using Bicep.Core.Utils;
 
 namespace Bicep.Core.TypeSystem
 {
-    public sealed class CyclicCheckVisitor : SyntaxVisitor
+    public sealed class CyclicCheckVisitor : AstVisitor
     {
         private readonly IReadOnlyDictionary<SyntaxBase, Symbol> bindings;
 

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantContainerVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantContainerVisitor.cs
@@ -10,7 +10,7 @@ namespace Bicep.Core.TypeSystem
     /// <summary>
     /// Collects syntaxes that only accept deploy-time constant values (deploy-time constant containers).
     /// </summary>
-    public class DeployTimeConstantContainerVisitor : SyntaxVisitor
+    public class DeployTimeConstantContainerVisitor : AstVisitor
     {
         private readonly SemanticModel semanticModel;
 

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantValidator.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantValidator.cs
@@ -64,7 +64,7 @@ namespace Bicep.Core.TypeSystem
         };
 
 
-        private class VariableDependencyVisitor : SyntaxVisitor
+        private class VariableDependencyVisitor : AstVisitor
         {
             private readonly SemanticModel semanticModel;
 

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantViolationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantViolationVisitor.cs
@@ -13,7 +13,7 @@ using Bicep.Core.TypeSystem.Az;
 
 namespace Bicep.Core.TypeSystem
 {
-    public abstract class DeployTimeConstantViolationVisitor : SyntaxVisitor
+    public abstract class DeployTimeConstantViolationVisitor : AstVisitor
     {
         public DeployTimeConstantViolationVisitor(
             SyntaxBase deployTimeConstantContainer,

--- a/src/Bicep.Core/TypeSystem/NestedRuntimeMemberAccessValidator.cs
+++ b/src/Bicep.Core/TypeSystem/NestedRuntimeMemberAccessValidator.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Bicep.Core.TypeSystem
 {
-    public class NestedRuntimeMemberAccessValidator : SyntaxVisitor
+    public class NestedRuntimeMemberAccessValidator : AstVisitor
     {
         private readonly SemanticModel semanticModel;
 

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -20,7 +20,7 @@ using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.TypeSystem
 {
-    public sealed class TypeAssignmentVisitor : SyntaxVisitor
+    public sealed class TypeAssignmentVisitor : AstVisitor
     {
         private readonly IFeatureProvider features;
         private readonly ITypeManager typeManager;

--- a/src/Bicep.Core/Visitors/FunctionVariableGeneratorVisitor.cs
+++ b/src/Bicep.Core/Visitors/FunctionVariableGeneratorVisitor.cs
@@ -8,7 +8,7 @@ using Bicep.Core.Utils;
 
 namespace Bicep.Core.Visitors
 {
-    public class FunctionVariableGeneratorVisitor : SyntaxVisitor
+    public class FunctionVariableGeneratorVisitor : AstVisitor
     {
         private readonly SemanticModel semanticModel;
         private readonly Dictionary<FunctionCallSyntaxBase, FunctionVariable> variables;

--- a/src/Bicep.Core/Visitors/ResourceDependencyFinderVisitor.cs
+++ b/src/Bicep.Core/Visitors/ResourceDependencyFinderVisitor.cs
@@ -6,7 +6,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Visitors
 {
-    public class ResourceDependencyFinderVisitor : SyntaxVisitor
+    public class ResourceDependencyFinderVisitor : AstVisitor
     {
         private readonly SemanticModel semanticModel;
         private readonly HashSet<DeclaredSymbol> resourceDependencies;

--- a/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTestDirectiveParser.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTestDirectiveParser.cs
@@ -27,7 +27,7 @@ namespace Bicep.LangServer.IntegrationTests.Completions
             return triggers;
         }
 
-        private sealed class CompletionTriggerCollector : SyntaxVisitor
+        private sealed class CompletionTriggerCollector : AstVisitor
         {
             private static readonly Regex TriggerPattern = new Regex(@"#\s*completionTest\s*\(\s*(?<char>\d+)\s*(,\s*(?<char>\d+)\s*)*\)\s*->\s*(?<set>\w+)", RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.CultureInvariant);
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTestDirectiveParser.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/CompletionTestDirectiveParser.cs
@@ -27,9 +27,9 @@ namespace Bicep.LangServer.IntegrationTests.Completions
             return triggers;
         }
 
-        private sealed class CompletionTriggerCollector : AstVisitor
+        private sealed class CompletionTriggerCollector : CstVisitor
         {
-            private static readonly Regex TriggerPattern = new Regex(@"#\s*completionTest\s*\(\s*(?<char>\d+)\s*(,\s*(?<char>\d+)\s*)*\)\s*->\s*(?<set>\w+)", RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            private static readonly Regex TriggerPattern = new(@"#\s*completionTest\s*\(\s*(?<char>\d+)\s*(,\s*(?<char>\d+)\s*)*\)\s*->\s*(?<set>\w+)", RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
             private readonly IList<CompletionTrigger> triggers;
             private readonly ImmutableArray<int> lineStarts;

--- a/src/Bicep.LangServer/Completions/SyntaxPatterns/AncestorsCollector.cs
+++ b/src/Bicep.LangServer/Completions/SyntaxPatterns/AncestorsCollector.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Bicep.LanguageServer.Completions.SyntaxPatterns
 {
-    public class AncestorsCollector : AstVisitor
+    public class AncestorsCollector : CstVisitor
     {
         private readonly int offset;
 

--- a/src/Bicep.LangServer/Completions/SyntaxPatterns/AncestorsCollector.cs
+++ b/src/Bicep.LangServer/Completions/SyntaxPatterns/AncestorsCollector.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Bicep.LanguageServer.Completions.SyntaxPatterns
 {
-    public class AncestorsCollector : SyntaxVisitor
+    public class AncestorsCollector : AstVisitor
     {
         private readonly int offset;
 

--- a/src/Bicep.LangServer/Completions/SyntaxPatterns/LeftSiblingsCollector.cs
+++ b/src/Bicep.LangServer/Completions/SyntaxPatterns/LeftSiblingsCollector.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Bicep.LanguageServer.Completions.SyntaxPatterns
 {
-    public class LeftSiblingsCollector : SyntaxVisitor
+    public class LeftSiblingsCollector : AstVisitor
     {
         private readonly int offset;
 

--- a/src/Bicep.LangServer/Completions/SyntaxPatterns/LeftSiblingsCollector.cs
+++ b/src/Bicep.LangServer/Completions/SyntaxPatterns/LeftSiblingsCollector.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Bicep.LanguageServer.Completions.SyntaxPatterns
 {
-    public class LeftSiblingsCollector : AstVisitor
+    public class LeftSiblingsCollector : CstVisitor
     {
         private readonly int offset;
 

--- a/src/Bicep.LangServer/SemanticTokenVisitor.cs
+++ b/src/Bicep.LangServer/SemanticTokenVisitor.cs
@@ -13,7 +13,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer
 {
-    public class SemanticTokenVisitor : SyntaxVisitor
+    public class SemanticTokenVisitor : AstVisitor
     {
         private readonly SemanticModel model;
         private readonly List<(IPositionable positionable, SemanticTokenType tokenType)> tokens = new();

--- a/src/Bicep.Tools.Benchmark/Visitors.cs
+++ b/src/Bicep.Tools.Benchmark/Visitors.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using BenchmarkDotNet.Attributes;
+using Bicep.Core.Samples;
+using Bicep.Core.Syntax;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Tools.Benchmark;
+
+[MemoryDiagnoser]
+public class Visitors
+{
+    private class BenchmarkCstVisitor : CstVisitor
+    {
+    }
+
+    private class BenchmarkAstVisitor : AstVisitor
+    {
+    }
+
+    private static ImmutableArray<ProgramSyntax> CreateBenchmarkData() => DataSets.AllDataSets
+        .Select(x => ParserHelper.Parse(x.Bicep))
+        .ToImmutableArray();
+
+    private ImmutableArray<ProgramSyntax> benchmarkData;
+
+    private BenchmarkCstVisitor cstVisitor = null!;
+
+    private BenchmarkAstVisitor astVisitor = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        this.benchmarkData = CreateBenchmarkData();
+        this.astVisitor = new();
+        this.cstVisitor = new();
+    }
+
+    [Benchmark(Description = "Visit concret syntax tree.", Baseline = true)]
+    public void Visit_cst()
+    {
+        foreach (var programSyntax in this.benchmarkData)
+        {
+            this.cstVisitor.Visit(programSyntax);
+        }
+    }
+
+    [Benchmark(Description = "Visit abstract syntax tree.")]
+    public void Visit_ast()
+    {
+        foreach (var programSyntax in this.benchmarkData)
+        {
+            this.astVisitor.Visit(programSyntax);
+        }
+    }
+}

--- a/src/Bicep.Wasm/LanguageHelpers/SemanticTokenVisitor.cs
+++ b/src/Bicep.Wasm/LanguageHelpers/SemanticTokenVisitor.cs
@@ -10,7 +10,7 @@ using Bicep.Core.Syntax;
 
 namespace Bicep.Wasm.LanguageHelpers
 {
-    public class SemanticTokenVisitor : SyntaxVisitor
+    public class SemanticTokenVisitor : AstVisitor
     {
         private readonly List<(IPositionable positionable, SemanticTokenType tokenType)> tokens = new();
         private readonly SemanticModel model;


### PR DESCRIPTION
Yet another quick and easy optimization. The current `SyntaxVisitor` is a concrete syntax tree (CST) / parse tree visitor which visits every single syntax tree node, but in most cases, this is not necessary. The PR splits `SyntaxVisitor` into an `AstVisitor` for traversing the AST (which doesn't include tokens such as keywords and brackets) and a `CstVisitor` for visiting the CST. Visitors that need to access all syntax nodes, such as `DocumentBuildVisitor`, `ParseDiagnosticsVisitor`, etc., are inherited from `CstVisitor`. Other visitors are inherited from `AstVisitor`.

Closes #7403.

## Benchmarks

### `CstVisitor` vs. `AstVisitor`
![ast_vs_cst](https://user-images.githubusercontent.com/16367959/203476243-bf81b805-b6d7-4111-8d55-f71016cbe72f.jpg)

### Compilation
#### Before
![Before](https://user-images.githubusercontent.com/16367959/203476434-2886edcc-4f57-4a43-a34e-6a79324db08f.jpg)

#### After
![After](https://user-images.githubusercontent.com/16367959/203476481-e5c25a88-a567-4cc7-b1a5-3ead0c535ce0.jpg)




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9105)