### PR TITLE
Add LSP benchmark

### DIFF
--- a/src/Bicep.Core.Samples/DataSet.cs
+++ b/src/Bicep.Core.Samples/DataSet.cs
@@ -147,31 +147,10 @@ namespace Bicep.Core.Samples
         public string GetStreamPrefix() => $"{Prefix}{this.Name}";
 
         public static string ReadFile(string streamName)
-        {
-            using Stream? stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(streamName);
-            stream.Should().NotBeNull($"because stream '{streamName}' should exist");
-
-            using var reader = new StreamReader(stream ?? Stream.Null);
-
-            return reader.ReadToEnd();
-        }
+            => FileHelper.ReadEmbeddedFile(Assembly.GetExecutingAssembly(), streamName);
 
         public static ImmutableDictionary<string, string> ReadDataSetDictionary(string streamNamePrefix)
-        {
-            var matches = Assembly.GetExecutingAssembly()
-                .GetManifestResourceNames()
-                .Where(streamName => streamName.StartsWith(streamNamePrefix, StringComparison.Ordinal))
-                .Select(streamName => (streamName, key: streamName.Substring(streamNamePrefix.Length)));
-
-            var builder = ImmutableDictionary.CreateBuilder<string, string>();
-
-            foreach (var (streamName, key) in matches)
-            {
-                builder.Add(key, ReadFile(streamName));
-            }
-
-            return builder.ToImmutable();
-        }
+            => FileHelper.BuildEmbeddedFileDictionary(Assembly.GetExecutingAssembly(), streamNamePrefix);
 
         public static string AddDiagsToSourceText<T>(DataSet dataSet, IEnumerable<T> items, Func<T, TextSpan> getSpanFunc, Func<T, string> diagsFunc)
             => OutputHelper.AddDiagsToSourceText<T>(dataSet.Bicep, dataSet.HasCrLfNewlines() ? "\r\n" : "\n", items, getSpanFunc, diagsFunc);

--- a/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
@@ -1,10 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
+using System.Collections.Immutable;
 using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bicep.Core.UnitTests.Utils
@@ -78,5 +82,41 @@ namespace Bicep.Core.UnitTests.Utils
         }
 
         public static string GetCacheRootPath(TestContext testContext) => GetUniqueTestOutputPath(testContext);
+
+        public static ImmutableDictionary<string, string> BuildEmbeddedFileDictionary(Assembly containingAssembly, string streamNamePrefix)
+        {
+            var matches = containingAssembly
+                .GetManifestResourceNames()
+                .Where(streamName => streamName.StartsWith(streamNamePrefix, StringComparison.Ordinal))
+                .Select(streamName => (streamName, key: streamName.Substring(streamNamePrefix.Length)));
+
+            var builder = ImmutableDictionary.CreateBuilder<string, string>();
+
+            foreach (var (streamName, key) in matches)
+            {
+                builder.Add(key, ReadEmbeddedFile(containingAssembly, streamName));
+            }
+
+            return builder.ToImmutable();
+        }
+
+        public static string ReadEmbeddedFile(Assembly containingAssembly, string streamName)
+        {
+            using var stream = containingAssembly.GetManifestResourceStream(streamName);
+            stream.Should().NotBeNull($"because stream '{streamName}' should exist");
+
+            using var reader = new StreamReader(stream!);
+
+            return reader.ReadToEnd();
+        }
+
+        public static IFileSystem CreateMockFileSystemForEmbeddedFiles(Assembly containingAssembly, string streamNamePrefix)
+        {
+            var files = BuildEmbeddedFileDictionary(containingAssembly, streamNamePrefix);
+
+            return new MockFileSystem(files.ToDictionary(
+                x => x.Key,
+                x => new MockFileData(x.Value)));
+        }
     }
 }

--- a/src/Bicep.Tools.Benchmark/Bicep.Tools.Benchmark.csproj
+++ b/src/Bicep.Tools.Benchmark/Bicep.Tools.Benchmark.csproj
@@ -10,8 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Bicep.Core\Bicep.Core.csproj" />
-    <ProjectReference Include="..\Bicep.Core.Samples\Bicep.Core.Samples.csproj" />
+    <ProjectReference Include="../Bicep.Core/Bicep.Core.csproj" />
+    <ProjectReference Include="../Bicep.Core.Samples/Bicep.Core.Samples.csproj" />
+    <ProjectReference Include="../Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Tools.Benchmark/Compilation.cs
+++ b/src/Bicep.Tools.Benchmark/Compilation.cs
@@ -24,11 +24,7 @@ public class Compilation
 
     private static BenchmarkData CreateBenchmarkData()
     {
-        var files = DataSet.ReadDataSetDictionary("Files");
-
-        var fileSystem = new MockFileSystem(files.ToDictionary(
-            x => x.Key,
-            x => new MockFileData(x.Value)));
+        var fileSystem = FileHelper.CreateMockFileSystemForEmbeddedFiles(typeof(DataSet).Assembly, "Files");
 
         var dataSets = DataSets.AllDataSets
             .Where(x => !x.HasRegistryModules)

--- a/src/Bicep.Tools.Benchmark/LanguageServer.cs
+++ b/src/Bicep.Tools.Benchmark/LanguageServer.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Samples;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System.IO.Abstractions;
+using Bicep.Core.UnitTests.Utils;
+using System.Threading.Tasks;
+using OmniSharp.Extensions.LanguageServer.Client;
+using System.IO.Pipelines;
+using Bicep.LanguageServer;
+using System.Threading;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using System.Collections.Generic;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Bicep.LangServer.IntegrationTests;
+using System.Reactive.Concurrency;
+
+namespace Bicep.Tools.Benchmark;
+
+[MemoryDiagnoser]
+public class LanguageServer
+{
+    private record BenchmarkData(
+        ILanguageClient Client,
+        MultipleMessageListener<PublishDiagnosticsParams> DiagsListener);
+
+    private static async Task<BenchmarkData> CreateBenchmarkData()
+    {
+        var fileSystem = FileHelper.CreateMockFileSystemForEmbeddedFiles(typeof(DataSet).Assembly, "Files");
+        var diagsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
+        var client = await StartServer(fileSystem, diagsListener);
+
+        return new(client, diagsListener);
+    }
+
+    private static async Task<ILanguageClient> StartServer(IFileSystem fileSystem, MultipleMessageListener<PublishDiagnosticsParams> diagsListener)
+    {
+        var clientPipe = new Pipe();
+        var serverPipe = new Pipe();
+
+        var server = new Server(options => options
+            .WithInput(serverPipe.Reader)
+            .WithOutput(clientPipe.Writer)
+            .WithServices(services => services
+                .AddSingleton<IScheduler>(ImmediateScheduler.Instance) // force work to run on a single thread to make snapshot profiling simpler
+                .AddSingleton(fileSystem)));
+
+        var _ = server.RunAsync(CancellationToken.None); // do not wait on this async method, or you'll be waiting a long time!
+
+        var client = LanguageClient.PreInit(options => {
+            options
+                .WithInput(clientPipe.Reader)
+                .WithOutput(serverPipe.Writer)
+                .OnPublishDiagnostics(x => diagsListener.AddMessage(x));
+
+            options.RegisterForDisposal(server);
+        });
+
+        await client.Initialize(CancellationToken.None);
+
+        return client;
+    }
+
+    private BenchmarkData? benchmarkData;
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        this.benchmarkData = await CreateBenchmarkData();
+    }
+
+    [Benchmark(Description = "Type a document from start to finish")]
+    public async Task Type_a_document_from_start_to_finish()
+    {
+        var (client, diagsListener) = benchmarkData!;
+
+        var dataSet = DataSets.AKS_LF;
+        var version = 0;
+        var documentUri = DocumentUri.Parse($"file:///{dataSet.Name}/main.bicep");
+
+        client.DidOpenTextDocument(new() {
+            TextDocument = new () {
+                LanguageId = "bicep",
+                Text = "",
+                Uri = documentUri,
+                Version = version++,
+            },
+        });
+        var diags = await diagsListener.WaitNext();
+
+        for (var i = 0; i < dataSet.Bicep.Length; i++)
+        {
+            client.DidChangeTextDocument(new() {
+                TextDocument = new () {
+                    Uri = documentUri,
+                    Version = version++,
+                },
+                ContentChanges = new(new List<TextDocumentContentChangeEvent> {
+                    new() {
+                        Text = dataSet.Bicep.Substring(0, i),
+                    },
+                }),
+            });
+            diags = await diagsListener.WaitNext();
+        }
+
+        client.DidCloseTextDocument(new() {
+            TextDocument = new () {
+                Uri = documentUri,
+            },
+        });
+    }
+}

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -237,8 +237,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ=="
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -509,25 +509,25 @@
       },
       "Microsoft.VisualStudio.Threading": {
         "type": "Transitive",
-        "resolved": "16.10.56",
-        "contentHash": "RjV4Y+/Qh+nSFVPJJXby56W4Th5Z4fi8dBfJY5v8HsO7vA749OsqGdVVfUiXAySsZmJTh6cE9kM0faB/dgIPFA==",
+        "resolved": "17.3.48",
+        "contentHash": "9GiMcUu+Hi9bARi+S+ORinw58ttPq9oDCToY/w5CpyAVBhiNOljuKGC9j+2dX6o3+6bYHM4XXHerVTnob34rfg==",
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "Microsoft.VisualStudio.Threading.Analyzers": "16.10.56",
-          "Microsoft.VisualStudio.Validation": "16.9.32",
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.VisualStudio.Threading.Analyzers": "17.3.48",
+          "Microsoft.VisualStudio.Validation": "17.0.58",
           "Microsoft.Win32.Registry": "5.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Transitive",
-        "resolved": "16.10.56",
-        "contentHash": "uTvu9fbmHTtRFY5xUgG45waU+ARad0JxyG/2btOC9Su6RTo3PrGVXKU2vHDtVELqlJsnKImhMaPH3YR0XCVwDg=="
+        "resolved": "17.3.48",
+        "contentHash": "WZgmhbdKg3zRmLzXh2qB9e3K1hzJKZO5Iv3awDupCsMJ4t5r/SOjtP6P3O/phv75SRG38bCOCsd8leZJzXJqOA=="
       },
       "Microsoft.VisualStudio.Validation": {
         "type": "Transitive",
-        "resolved": "16.10.26",
-        "contentHash": "5KXcBcBjvuCZvRrudAEGN64a6OtbRxqLxecKpTSm4p9GCavYtclZYA01csTtmTEkveiAX1k9bpx/4H0ohk2d5g=="
+        "resolved": "17.0.58",
+        "contentHash": "6C24odGmfR9D2aMCpyNfnS2Hf+SXsNtj9ugsxUKNDCCMnjmJz/4C6B+5tY4UZ+tv7tRBusdl6fQM72TbhAIpGQ=="
       },
       "Microsoft.Win32.Primitives": {
         "type": "Transitive",
@@ -732,6 +732,17 @@
         "type": "Transitive",
         "resolved": "0.19.6",
         "contentHash": "9Cv4XnpN1qvu+X8o3Uk0K/eHoQo/bozturZbvjNhovL549Q0aLKOZa3trGjVNYDuu5HzSIEIyx74lWD2SNXNRw=="
+      },
+      "OmniSharp.Extensions.LanguageClient": {
+        "type": "Transitive",
+        "resolved": "0.19.6",
+        "contentHash": "FiaoxQJjkh0euKMSSWNhSKUJ6mu4VZ0RRndkgkbBLdofFrjruFU7SeJgsVYpsq/I2wOYBMRyXNl5/8b6nC5LTw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "6.0.0",
+          "OmniSharp.Extensions.JsonRpc": "0.19.6",
+          "OmniSharp.Extensions.LanguageProtocol": "0.19.6",
+          "OmniSharp.Extensions.LanguageServer.Shared": "0.19.6"
+        }
       },
       "OmniSharp.Extensions.LanguageProtocol": {
         "type": "Transitive",
@@ -2150,6 +2161,20 @@
           "CommandLineParser": "[2.9.1, )",
           "OmniSharp.Extensions.LanguageServer": "[0.19.6, )",
           "SharpYaml": "[2.1.0, )"
+        }
+      },
+      "bicep.langserver.integrationtests": {
+        "type": "Project",
+        "dependencies": {
+          "Bicep.Core.Samples": "[1.0.0, )",
+          "Bicep.LangServer": "[1.0.0, )",
+          "FluentAssertions": "[6.8.0, )",
+          "MSTest.TestAdapter": "[2.2.10, )",
+          "MSTest.TestFramework": "[2.2.10, )",
+          "Microsoft.NET.Test.Sdk": "[17.3.2, )",
+          "Microsoft.VisualStudio.Threading": "[17.3.48, )",
+          "Moq": "[4.18.2, )",
+          "OmniSharp.Extensions.LanguageClient": "[0.19.6, )"
         }
       }
     },


### PR DESCRIPTION
It felt like this would be useful to have for future perf investigations!

Some interesting initial data it turned up - creating built-in namespaces is responsible for 42% of time spent when upserting compilations, and serializing diagnostics to publish is responsible for an additional 37%!
<img width="912" alt="image" src="https://user-images.githubusercontent.com/38542602/204756529-9d810428-ccb9-43cb-b84c-b81d02d27bdc.png">


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9157)