### PR TITLE
Two unit tests for source mapping feature

### DIFF
--- a/src/Bicep.Core.UnitTests/Emit/PositionTrackingJsonTextWriterTests.cs
+++ b/src/Bicep.Core.UnitTests/Emit/PositionTrackingJsonTextWriterTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Bicep.Core.Emit;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Parsing;
+using Bicep.Core.Semantics;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Emit
+{
+    [TestClass]
+    public class PositionTrackingJsonTextWriterTests
+    {
+        private static ServiceBuilder Services => new ServiceBuilder().WithEmptyAzResources();
+
+        private Uri FileUri = new("file:///main.bicep");
+        private const string LeadingNodes = "@minValue(0)\n@maxValue(1023)\n";
+        private const string BicepStatement = "param osDiskSizeGB int = 0";
+        private readonly string Text = $"{LeadingNodes}{BicepStatement}";
+
+        [TestMethod]
+        public void SourceMapShouldAccountForDecoratorsInStatementSyntax()
+        {
+            var compilation = Services.BuildCompilation(Text);
+            var parameterSymbol = compilation.GetEntrypointSemanticModel().Root.ParameterDeclarations.First();
+
+            var rawSourceMap = new RawSourceMap(new List<RawSourceMapFileEntry>());
+            var jsonWriter = new PositionTrackingJsonTextWriter(
+                BicepTestConstants.FileResolver,
+                new StringWriter(),
+                SourceFileFactory.CreateBicepFile(FileUri, Text),
+                rawSourceMap);
+            jsonWriter.WritePropertyWithPosition(parameterSymbol.DeclaringParameter, parameterSymbol.Name, () => { });
+
+            var sourcePosition = rawSourceMap.Entries[0].SourceMap[0].SourcePosition;
+            var sourceText = Text[sourcePosition.Position..(sourcePosition.Position + sourcePosition.Length)];
+            sourceText.Should().Be(BicepStatement);
+        }
+
+        [TestMethod]
+        public void SourceMapShouldAccountForNestedTemplateOffset()
+        {
+            var sourceFile = SourceFileFactory.CreateBicepFile(FileUri, String.Empty);
+
+            var parentRawSourceMap = new RawSourceMap(new List<RawSourceMapFileEntry>());
+            var parentJsonWriter = new PositionTrackingJsonTextWriter(
+                BicepTestConstants.FileResolver,
+                new StringWriter(),
+                sourceFile,
+                parentRawSourceMap);
+            parentJsonWriter.WriteComment(BicepStatement);
+
+            // create raw source map with single entry with known target position
+            var nestedStartPosition = 10;
+            var nestedRawSourceMap = new RawSourceMap(
+                new List<RawSourceMapFileEntry>(){ new (sourceFile,
+                new List<SourceMapRawEntry>() { new (new (0, 0),
+                new List<TextSpan>() { new (nestedStartPosition, 0) })}) }
+            );
+            var nestedJsonWriter = new PositionTrackingJsonTextWriter(
+                BicepTestConstants.FileResolver,
+                new StringWriter(),
+                sourceFile,
+                nestedRawSourceMap);
+
+            parentJsonWriter.AddNestedSourceMap(nestedJsonWriter);
+
+            var expectedPosition = nestedStartPosition + (BicepStatement.Length + 4); // add 4 to account for JSON comment characters "/*" and "*/"
+            parentRawSourceMap.Entries[0].SourceMap[0].TargetPositions[0].Position.Should().Be(expectedPosition);
+        }
+    }
+}

--- a/src/Bicep.Core/Emit/PositionTrackingJsonTextWriter.cs
+++ b/src/Bicep.Core/Emit/PositionTrackingJsonTextWriter.cs
@@ -68,17 +68,17 @@ namespace Bicep.Core.Emit
         private readonly BicepSourceFile? sourceFile;
         private readonly PositionTrackingTextWriter trackingWriter;
 
-        public PositionTrackingJsonTextWriter(IFileResolver fileResolver, TextWriter textWriter, BicepSourceFile? sourceFile = null)
-            : this(fileResolver, new(textWriter), sourceFile)
+        public PositionTrackingJsonTextWriter(IFileResolver fileResolver, TextWriter textWriter, BicepSourceFile? sourceFile = null, RawSourceMap? rawSourceMap = null)
+            : this(fileResolver, new(textWriter), sourceFile, rawSourceMap)
         {
         }
 
-        private PositionTrackingJsonTextWriter(IFileResolver fileResolver, PositionTrackingTextWriter trackingWriter, BicepSourceFile? sourceFile)
+        private PositionTrackingJsonTextWriter(IFileResolver fileResolver, PositionTrackingTextWriter trackingWriter, BicepSourceFile? sourceFile, RawSourceMap? rawSourceMap)
             : base(trackingWriter)
         {
             this.fileResolver = fileResolver;
+            this.rawSourceMap = rawSourceMap ?? new RawSourceMap(new List<RawSourceMapFileEntry>());
             this.sourceFile = sourceFile;
-            this.rawSourceMap = new RawSourceMap(new List<RawSourceMapFileEntry>());
             this.trackingWriter = trackingWriter;
         }
 
@@ -149,7 +149,7 @@ namespace Bicep.Core.Emit
                 {
                     bicepPosition = new TextSpan(
                         lastLeadingNode.Span.Position + lastLeadingNode.Span.Length,
-                        syntax.Span.Length - lastLeadingNode.Span.Length);
+                        syntax.Span.Length - syntax.LeadingNodes.Sum(node => node.Span.Length));
                 }
             }
 


### PR DESCRIPTION
This is a small follow-up to the source mapping feature recently merged earlier this year. It includes a couple simple unit tests to detect a change/regression for specific functionality in PositionTrackingJsonTextWriter.

I am open to any suggestions for additional coverage.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9167)