### PR TITLE
Change casing of secureString to comply with deploymentTemplate schema

### DIFF
--- a/src/Bicep.Cli.E2eTests/src/examples/101/aks.ff/main.json
+++ b/src/Bicep.Cli.E2eTests/src/examples/101/aks.ff/main.json
@@ -22,7 +22,7 @@
       "type": "string"
     },
     "servicePrincipalClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "clusterName": {
       "type": "string",

--- a/src/Bicep.Cli.E2eTests/src/examples/101/aks.prod/main.json
+++ b/src/Bicep.Cli.E2eTests/src/examples/101/aks.prod/main.json
@@ -22,7 +22,7 @@
       "type": "string"
     },
     "servicePrincipalClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "clusterName": {
       "type": "string",

--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -512,7 +512,7 @@ Hello from Bicep!"));
           },
           ""parameters"": {
             ""connectionString"": {
-              ""type"": ""secureString""
+              ""type"": ""securestring""
             }
           },
           ""variables"": {

--- a/src/Bicep.Core.Samples/Files/AKS_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/AKS_LF/main.json
@@ -19,10 +19,10 @@
       "type": "string"
     },
     "servcePrincipalClientId": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "servicePrincipalClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "clusterName": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/AKS_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/AKS_LF/main.symbolicnames.json
@@ -21,10 +21,10 @@
       "type": "string"
     },
     "servcePrincipalClientId": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "servicePrincipalClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "clusterName": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/Completions/paramTypes.json
+++ b/src/Bicep.Core.Samples/Files/Completions/paramTypes.json
@@ -80,7 +80,7 @@
     ]
   },
   {
-    "label": "secureString",
+    "label": "securestring",
     "kind": "snippet",
     "detail": "Secure string",
     "documentation": {
@@ -89,7 +89,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "2_secureString",
+    "sortText": "2_securestring",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
@@ -1741,10 +1741,10 @@
           },
           "parameters": {
             "secureStringParam1": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "secureStringParam2": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": ""
             }
           },
@@ -1798,10 +1798,10 @@
           },
           "parameters": {
             "secureStringParam1": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "secureStringParam2": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": ""
             }
           },
@@ -1859,10 +1859,10 @@
           },
           "parameters": {
             "secureStringParam1": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "secureStringParam2": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": ""
             }
           },
@@ -1901,10 +1901,10 @@
           },
           "parameters": {
             "secureStringParam1": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "secureStringParam2": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": ""
             }
           },

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
@@ -1806,10 +1806,10 @@
           },
           "parameters": {
             "secureStringParam1": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "secureStringParam2": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": ""
             }
           },
@@ -1865,10 +1865,10 @@
           },
           "parameters": {
             "secureStringParam1": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "secureStringParam2": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": ""
             }
           },
@@ -1928,10 +1928,10 @@
           },
           "parameters": {
             "secureStringParam1": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "secureStringParam2": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": ""
             }
           },
@@ -1972,10 +1972,10 @@
           },
           "parameters": {
             "secureStringParam1": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "secureStringParam2": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": ""
             }
           },

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.json
@@ -71,7 +71,7 @@
       ]
     },
     "password": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "secretObject": {
       "type": "secureObject"
@@ -122,7 +122,7 @@
       }
     },
     "someParameter": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Name of the storage account"
       },
@@ -155,7 +155,7 @@
       ]
     },
     "decoratedString": {
-      "type": "secureString",
+      "type": "securestring",
       "allowedValues": [
         "Apple",
         "Banana"

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.symbolicnames.json
@@ -73,7 +73,7 @@
       ]
     },
     "password": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "secretObject": {
       "type": "secureObject"
@@ -124,7 +124,7 @@
       }
     },
     "someParameter": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Name of the storage account"
       },
@@ -157,7 +157,7 @@
       ]
     },
     "decoratedString": {
-      "type": "secureString",
+      "type": "securestring",
       "allowedValues": [
         "Apple",
         "Banana"

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.json
@@ -81,7 +81,7 @@
       ]
     },
     "password": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "secretObject": {
       "type": "secureObject"
@@ -140,7 +140,7 @@
       }
     },
     "someParameter": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Name of the storage account"
       },
@@ -173,7 +173,7 @@
       ]
     },
     "decoratedString": {
-      "type": "secureString",
+      "type": "securestring",
       "allowedValues": [
         "Apple",
         "Banana"

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.symbolicnames.json
@@ -83,7 +83,7 @@
       ]
     },
     "password": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "secretObject": {
       "type": "secureObject"
@@ -142,7 +142,7 @@
       }
     },
     "someParameter": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Name of the storage account"
       },
@@ -175,7 +175,7 @@
       ]
     },
     "decoratedString": {
-      "type": "secureString",
+      "type": "securestring",
       "allowedValues": [
         "Apple",
         "Banana"

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/1vm-2nics-2subnets-1vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/1vm-2nics-2subnets-1vnet/main.json
@@ -23,7 +23,7 @@
       }
     },
     "adminPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Default Admin password"
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
@@ -25,7 +25,7 @@
       }
     },
     "adminPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Default Admin password"
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/aks/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/aks/main.json
@@ -22,7 +22,7 @@
       "type": "string"
     },
     "servicePrincipalClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "clusterName": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/aks/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/aks/main.symbolicnames.json
@@ -24,7 +24,7 @@
       "type": "string"
     },
     "servicePrincipalClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "clusterName": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hdinsight-spark-linux/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hdinsight-spark-linux/main.json
@@ -24,7 +24,7 @@
       }
     },
     "clusterLoginPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "minLength": 10,
       "metadata": {
         "description": "The password must be at least 10 characters in length and must contain at least one digit, one upper case letter, one lower case letter, and one non-alphanumeric character except (single-quote, double-quote, backslash, right-bracket, full-stop). Also, the password must not contain 3 consecutive characters from the cluster username or SSH username."
@@ -38,7 +38,7 @@
       }
     },
     "sshPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "maxLength": 72,
       "minLength": 6,
       "metadata": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hdinsight-spark-linux/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hdinsight-spark-linux/main.symbolicnames.json
@@ -26,7 +26,7 @@
       }
     },
     "clusterLoginPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "minLength": 10,
       "metadata": {
         "description": "The password must be at least 10 characters in length and must contain at least one digit, one upper case letter, one lower case letter, and one non-alphanumeric character except (single-quote, double-quote, backslash, right-bracket, full-stop). Also, the password must not contain 3 consecutive characters from the cluster username or SSH username."
@@ -40,7 +40,7 @@
       }
     },
     "sshPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "maxLength": 72,
       "minLength": 6,
       "metadata": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-create/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-create/main.json
@@ -98,11 +98,11 @@
       "defaultValue": "prodKey"
     },
     "secretName": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "bankAccountPassword"
     },
     "secretValue": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "12345"
     },
     "networkAcls": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-create/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-create/main.symbolicnames.json
@@ -100,11 +100,11 @@
       "defaultValue": "prodKey"
     },
     "secretName": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "bankAccountPassword"
     },
     "secretValue": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "12345"
     },
     "networkAcls": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-secret-only/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-secret-only/main.json
@@ -17,7 +17,7 @@
       "defaultValue": "superSecretPassword"
     },
     "secretValue": {
-      "type": "secureString"
+      "type": "securestring"
     }
   },
   "resources": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-secret-only/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-secret-only/main.symbolicnames.json
@@ -19,7 +19,7 @@
       "defaultValue": "superSecretPassword"
     },
     "secretValue": {
-      "type": "secureString"
+      "type": "securestring"
     }
   },
   "resources": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/sql-database/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/sql-database/main.json
@@ -25,7 +25,7 @@
       "type": "string"
     },
     "administratorLoginPassword": {
-      "type": "secureString"
+      "type": "securestring"
     }
   },
   "resources": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/sql-database/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/sql-database/main.symbolicnames.json
@@ -27,7 +27,7 @@
       "type": "string"
     },
     "administratorLoginPassword": {
-      "type": "secureString"
+      "type": "securestring"
     }
   },
   "resources": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/sqlmi-new-vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/sqlmi-new-vnet/main.json
@@ -16,7 +16,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/sqlmi-new-vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/sqlmi-new-vnet/main.symbolicnames.json
@@ -18,7 +18,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-linux/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-linux/main.json
@@ -23,7 +23,7 @@
       }
     },
     "vmSshKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-linux/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-linux/main.symbolicnames.json
@@ -25,7 +25,7 @@
       }
     },
     "vmSshKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-windows/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-windows/main.json
@@ -16,7 +16,7 @@
       }
     },
     "adminPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "minLength": 12,
       "metadata": {
         "description": "Password for the Virtual Machine."

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-windows/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-windows/main.symbolicnames.json
@@ -18,7 +18,7 @@
       }
     },
     "adminPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "minLength": 12,
       "metadata": {
         "description": "Password for the Virtual Machine."

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/webapp-managed-mysql/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/webapp-managed-mysql/main.json
@@ -23,7 +23,7 @@
       }
     },
     "administratorLoginPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "maxLength": 128,
       "minLength": 8,
       "metadata": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/webapp-managed-mysql/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/webapp-managed-mysql/main.symbolicnames.json
@@ -25,7 +25,7 @@
       }
     },
     "administratorLoginPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "maxLength": 128,
       "minLength": 8,
       "metadata": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.json
@@ -16,7 +16,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "storageAccountType": {
       "type": "string"
@@ -222,7 +222,7 @@
               "type": "string"
             },
             "adminPassword": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "location": {
               "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
@@ -18,7 +18,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "storageAccountType": {
       "type": "string"
@@ -226,7 +226,7 @@
               "type": "string"
             },
             "adminPassword": {
-              "type": "secureString"
+              "type": "securestring"
             },
             "location": {
               "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/vm.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/vm.json
@@ -16,7 +16,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/vm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/vm.symbolicnames.json
@@ -18,7 +18,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/aci-sftp-files/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/aci-sftp-files/main.json
@@ -21,7 +21,7 @@
       "type": "string"
     },
     "sftpPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/aci-sftp-files/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/aci-sftp-files/main.symbolicnames.json
@@ -23,7 +23,7 @@
       "type": "string"
     },
     "sftpPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.json
@@ -27,7 +27,7 @@
       "defaultValue": "[parameters('storageAccountName')]"
     },
     "mySqlPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.symbolicnames.json
@@ -29,7 +29,7 @@
       "defaultValue": "[parameters('storageAccountName')]"
     },
     "mySqlPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/api-management-create-all-resources/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/api-management-create-all-resources/main.json
@@ -29,7 +29,7 @@
       "defaultValue": 1
     },
     "mutualAuthenticationCertificate": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "certificatePassword": {
       "type": "string"
@@ -38,10 +38,10 @@
       "type": "string"
     },
     "googleClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "openIdConnectClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "tenantPolicy": {
       "type": "string"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/api-management-create-all-resources/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/api-management-create-all-resources/main.symbolicnames.json
@@ -31,7 +31,7 @@
       "defaultValue": 1
     },
     "mutualAuthenticationCertificate": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "certificatePassword": {
       "type": "string"
@@ -40,10 +40,10 @@
       "type": "string"
     },
     "googleClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "openIdConnectClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "tenantPolicy": {
       "type": "string"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.json
@@ -70,7 +70,7 @@
       }
     },
     "vmSshKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Specifies the SSH Key or password for the virtual machine. SSH key is recommended."
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.symbolicnames.json
@@ -72,7 +72,7 @@
       }
     },
     "vmSshKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Specifies the SSH Key or password for the virtual machine. SSH key is recommended."
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.json
@@ -404,7 +404,7 @@
       }
     },
     "vmSshKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Specifies the SSH Key or password for the virtual machine. SSH key is recommended."
       }
@@ -1143,7 +1143,7 @@
               }
             },
             "vmSshKey": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "Specifies the SSH Key or password for the virtual machine. SSH key is recommended."
               }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
@@ -406,7 +406,7 @@
       }
     },
     "vmSshKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Specifies the SSH Key or password for the virtual machine. SSH key is recommended."
       }
@@ -1180,7 +1180,7 @@
               }
             },
             "vmSshKey": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "Specifies the SSH Key or password for the virtual machine. SSH key is recommended."
               }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/sql/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/sql/main.json
@@ -13,7 +13,7 @@
       "type": "string"
     },
     "sqlAdministratorLoginPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "transparentDataEncryption": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/sql/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/sql/main.symbolicnames.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "sqlAdministratorLoginPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "transparentDataEncryption": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-copy-managed-disks/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-copy-managed-disks/main.json
@@ -14,7 +14,7 @@
       "defaultValue": "azadmin"
     },
     "virtualMachineAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "virtualMachineNamePrefix": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-copy-managed-disks/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-copy-managed-disks/main.symbolicnames.json
@@ -16,7 +16,7 @@
       "defaultValue": "azadmin"
     },
     "virtualMachineAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "virtualMachineNamePrefix": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-domain-join/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-domain-join/main.json
@@ -31,7 +31,7 @@
       "type": "string"
     },
     "domainPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "ouPath": {
       "type": "string"
@@ -47,7 +47,7 @@
       "type": "string"
     },
     "vmAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-domain-join/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-domain-join/main.symbolicnames.json
@@ -33,7 +33,7 @@
       "type": "string"
     },
     "domainPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "ouPath": {
       "type": "string"
@@ -49,7 +49,7 @@
       "type": "string"
     },
     "vmAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-new-or-existing-conditions/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-new-or-existing-conditions/main.json
@@ -41,7 +41,7 @@
       ]
     },
     "adminPasswordOrKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Password or ssh key for the Virtual Machine."
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-new-or-existing-conditions/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-new-or-existing-conditions/main.symbolicnames.json
@@ -43,7 +43,7 @@
       ]
     },
     "adminPasswordOrKey": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Password or ssh key for the Virtual Machine."
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-push-certificate-windows/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-push-certificate-windows/main.json
@@ -25,7 +25,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "keyVaultName": {
       "type": "string"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-push-certificate-windows/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-push-certificate-windows/main.symbolicnames.json
@@ -27,7 +27,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "keyVaultName": {
       "type": "string"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows-with-custom-script-extension/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows-with-custom-script-extension/main.json
@@ -34,7 +34,7 @@
       "type": "string"
     },
     "virtualMachineAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "virtualMachineSize": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows-with-custom-script-extension/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows-with-custom-script-extension/main.symbolicnames.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "virtualMachineAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "virtualMachineSize": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.json
@@ -14,7 +14,7 @@
       "defaultValue": "localadmin"
     },
     "localAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "vnetName": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.symbolicnames.json
@@ -16,7 +16,7 @@
       "defaultValue": "localadmin"
     },
     "localAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "vnetName": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vmss-windows-autoscale/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vmss-windows-autoscale/main.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vmss-windows-autoscale/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vmss-windows-autoscale/main.symbolicnames.json
@@ -38,7 +38,7 @@
       "type": "string"
     },
     "adminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-to-vnet-bgp/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-to-vnet-bgp/main.json
@@ -10,7 +10,7 @@
   },
   "parameters": {
     "sharedKey": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "gatewaySku": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-to-vnet-bgp/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-to-vnet-bgp/main.symbolicnames.json
@@ -12,7 +12,7 @@
   },
   "parameters": {
     "sharedKey": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "gatewaySku": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-sql-database/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-sql-database/main.json
@@ -36,7 +36,7 @@
       "type": "string"
     },
     "sqlAdministratorLoginPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-sql-database/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-sql-database/main.symbolicnames.json
@@ -38,7 +38,7 @@
       "type": "string"
     },
     "sqlAdministratorLoginPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "location": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.json
@@ -84,7 +84,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
@@ -98,7 +98,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
@@ -957,7 +957,7 @@
               }
             },
             "administratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The password that corresponds to the existing domain username."
               }
@@ -970,7 +970,7 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": "",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
@@ -1643,7 +1643,7 @@
               }
             },
             "administratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The password that corresponds to the existing domain username."
               }
@@ -1656,7 +1656,7 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": "",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
@@ -2314,7 +2314,7 @@
               }
             },
             "administratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The password that corresponds to the existing domain username."
               }
@@ -2327,7 +2327,7 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": "",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
@@ -2981,7 +2981,7 @@
               }
             },
             "administratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The password that corresponds to the existing domain username."
               }
@@ -2994,7 +2994,7 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": "",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.symbolicnames.json
@@ -86,7 +86,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
@@ -100,7 +100,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
@@ -965,7 +965,7 @@
               }
             },
             "administratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The password that corresponds to the existing domain username."
               }
@@ -978,7 +978,7 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": "",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
@@ -1655,7 +1655,7 @@
               }
             },
             "administratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The password that corresponds to the existing domain username."
               }
@@ -1668,7 +1668,7 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": "",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
@@ -2330,7 +2330,7 @@
               }
             },
             "administratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The password that corresponds to the existing domain username."
               }
@@ -2343,7 +2343,7 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": "",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."
@@ -3001,7 +3001,7 @@
               }
             },
             "administratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The password that corresponds to the existing domain username."
               }
@@ -3014,7 +3014,7 @@
               }
             },
             "vmAdministratorAccountPassword": {
-              "type": "secureString",
+              "type": "securestring",
               "defaultValue": "",
               "metadata": {
                 "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customimagevm.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customimagevm.json
@@ -125,7 +125,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -138,7 +138,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customimagevm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customimagevm.symbolicnames.json
@@ -127,7 +127,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -140,7 +140,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.json
@@ -125,7 +125,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -138,7 +138,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.symbolicnames.json
@@ -127,7 +127,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -140,7 +140,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-galleryvm.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-galleryvm.json
@@ -125,7 +125,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -138,7 +138,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-galleryvm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-galleryvm.symbolicnames.json
@@ -127,7 +127,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -140,7 +140,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.json
@@ -125,7 +125,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -138,7 +138,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.symbolicnames.json
@@ -127,7 +127,7 @@
       }
     },
     "administratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The password that corresponds to the existing domain username."
       }
@@ -140,7 +140,7 @@
       }
     },
     "vmAdministratorAccountPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The password associated with the virtual machine administrator account. The vmAdministratorAccountUsername and  vmAdministratorAccountPassword parameters must both be provided. Otherwise, domain administrator credentials provided by administratorAccountUsername and administratorAccountPassword will be used."

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.json
@@ -31,7 +31,7 @@
       }
     },
     "psk": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "[uniqueString(subscription().id)]",
       "metadata": {
         "description": "Pre-Shared Key used to establish the site to site tunnel between the Virtual Hub and On-Prem VNet"
@@ -1648,7 +1648,7 @@
               "type": "string"
             },
             "psk": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "Specifies the pre-shared key to use for the VPN Connection"
               }
@@ -1771,7 +1771,7 @@
               }
             },
             "psk": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "Specifies the pre-shared key to use for the VPN Connection"
               }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.symbolicnames.json
@@ -33,7 +33,7 @@
       }
     },
     "psk": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "[uniqueString(subscription().id)]",
       "metadata": {
         "description": "Pre-Shared Key used to establish the site to site tunnel between the Virtual Hub and On-Prem VNet"
@@ -1674,7 +1674,7 @@
               "type": "string"
             },
             "psk": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "Specifies the pre-shared key to use for the VPN Connection"
               }
@@ -1799,7 +1799,7 @@
               }
             },
             "psk": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "Specifies the pre-shared key to use for the VPN Connection"
               }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngwcon.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngwcon.json
@@ -13,7 +13,7 @@
       "type": "string"
     },
     "psk": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Specifies the pre-shared key to use for the VPN Connection"
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngwcon.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngwcon.symbolicnames.json
@@ -15,7 +15,7 @@
       "type": "string"
     },
     "psk": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Specifies the pre-shared key to use for the VPN Connection"
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.json
@@ -45,7 +45,7 @@
       }
     },
     "psk": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Specifies the pre-shared key to use for the VPN Connection"
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.symbolicnames.json
@@ -47,7 +47,7 @@
       }
     },
     "psk": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "Specifies the pre-shared key to use for the VPN Connection"
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.json
@@ -14,7 +14,7 @@
       "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/301-nested-vms-in-virtual-network/"
     },
     "_artifactsLocationSasToken": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": ""
     },
     "location": {
@@ -112,7 +112,7 @@
       "type": "string"
     },
     "HostAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     }
   },
   "variables": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.symbolicnames.json
@@ -16,7 +16,7 @@
       "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/301-nested-vms-in-virtual-network/"
     },
     "_artifactsLocationSasToken": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": ""
     },
     "location": {
@@ -114,7 +114,7 @@
       "type": "string"
     },
     "HostAdminPassword": {
-      "type": "secureString"
+      "type": "securestring"
     }
   },
   "variables": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.json
@@ -168,7 +168,7 @@
                       }
                     },
                     "password": {
-                      "type": "secureString",
+                      "type": "securestring",
                       "metadata": {
                         "description": "The SQL Logical Server password."
                       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
@@ -186,7 +186,7 @@
                       }
                     },
                     "password": {
-                      "type": "secureString",
+                      "type": "securestring",
                       "metadata": {
                         "description": "The SQL Logical Server password."
                       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.json
@@ -16,7 +16,7 @@
       }
     },
     "password": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The SQL Logical Server password."
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
@@ -18,7 +18,7 @@
       }
     },
     "password": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The SQL Logical Server password."
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.json
@@ -116,7 +116,7 @@
               }
             },
             "password": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The SQL Logical Server password."
               }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
@@ -132,7 +132,7 @@
               }
             },
             "password": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "The SQL Logical Server password."
               }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/web-app-managed-identity-sql-db/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/web-app-managed-identity-sql-db/main.json
@@ -40,7 +40,7 @@
       "type": "string"
     },
     "sqlAdministratorLoginPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "managedIdentityName": {
       "type": "string"

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/web-app-managed-identity-sql-db/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/web-app-managed-identity-sql-db/main.symbolicnames.json
@@ -42,7 +42,7 @@
       "type": "string"
     },
     "sqlAdministratorLoginPassword": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "managedIdentityName": {
       "type": "string"

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/main.json
@@ -169,7 +169,7 @@
           },
           "parameters": {
             "kubeConfig": {
-              "type": "secureString"
+              "type": "securestring"
             }
           },
           "variables": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/modules/kubernetes.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/modules/kubernetes.json
@@ -12,7 +12,7 @@
   },
   "parameters": {
     "kubeConfig": {
-      "type": "secureString"
+      "type": "securestring"
     }
   },
   "variables": {

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/ArtifactsParametersRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/ArtifactsParametersRuleTests.cs
@@ -274,7 +274,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             /* TTK result:
                 [-] artifacts parameter (2 ms)                                                                                      
                     The _artifactsLocation in "mainTemplate.json" parameter must be a 'string' type in the parameter declaration "array"
-                    The _artifactsLocationSasToken in "mainTemplate.json" parameter must be of type 'secureString'.                 
+                    The _artifactsLocationSasToken in "mainTemplate.json" parameter must be of type 'securestring'.                 
                     The _artifactsLocation parameter in "mainTemplate.json" must have a defaultValue in the main template           
                     The _artifactsLocationSasToken in "mainTemplate.json" has an incorrect defaultValue, must be an empty string    
              */
@@ -298,7 +298,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             /* TTK result:
                 [-] artifacts parameter (2 ms)                                                                                      
                     The _artifactsLocation in "mainTemplate.json" parameter must be a 'string' type in the parameter declaration "array"
-                    The _artifactsLocationSasToken in "mainTemplate.json" parameter must be of type 'secureString'.                 
+                    The _artifactsLocationSasToken in "mainTemplate.json" parameter must be of type 'securestring'.                 
                     The _artifactsLocation parameter in "mainTemplate.json" must have a defaultValue in the main template           
                     The _artifactsLocationSasToken in "mainTemplate.json" has an incorrect defaultValue, must be an empty string    
              */

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseProtectedSettingsForCommandToExecuteSecretsRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseProtectedSettingsForCommandToExecuteSecretsRuleTests.cs
@@ -49,7 +49,7 @@ resource customScriptExtension 'Microsoft.HybridCompute/machines/extensions@2019
               new string[] {
                 // TTK error message:
                 //  [-] CommandToExecute Must Use ProtectedSettings For Secrets (62 ms)
-                //    CommandToExecute references parameter 'arguments' of type 'secureString', but is not in .protectedSettings
+                //    CommandToExecute references parameter 'arguments' of type 'securestring', but is not in .protectedSettings
                 "[23] Use protectedSettings for commandToExecute secrets. Found possible secret: secure parameter 'arguments'"
               }
             );

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1068,7 +1068,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 {
                     if (TypeValidator.AreTypesAssignable(targetType, LanguageConstants.String))
                     {
-                        return targetObject.MergeProperty("type", "secureString");
+                        return targetObject.MergeProperty("type", "securestring");
                     }
 
                     if (TypeValidator.AreTypesAssignable(targetType, LanguageConstants.Object))

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/copyloop/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/copyloop/main.json
@@ -24,7 +24,7 @@
             "type": "string"
         },
         "adminPassword": {
-            "type": "secureString"
+            "type": "securestring"
         }
     },
     "variables": {

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue5455/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue5455/main.json
@@ -18,7 +18,7 @@
             "type": "string"
         },
         "sqlAdministratorLoginPassword": {
-            "type": "secureString",
+            "type": "securestring",
             "defaultValue": ""
         },
         "setWorkspaceIdentityRbacOnStorageAccount": {

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -282,7 +282,7 @@ output length int =
                 },
                 c =>
                 {
-                    c.Label.Should().Be("secureString");
+                    c.Label.Should().Be("securestring");
                     c.Kind.Should().Be(CompletionItemKind.Snippet);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
                     c.TextEdit!.TextEdit!.NewText.Should().StartWith("string");
@@ -329,7 +329,7 @@ output length int =
                 },
                 c =>
                 {
-                    c.Label.Should().Be("secureString");
+                    c.Label.Should().Be("securestring");
                     c.Kind.Should().Be(CompletionItemKind.Snippet);
                     c.InsertTextFormat.Should().Be(InsertTextFormat.Snippet);
                     c.TextEdit!.TextEdit!.NewText.Should().Be("string");

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
@@ -625,11 +625,11 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   },
   ""parameters"": {
     ""adminUsername"": {
-      ""type"": ""secureString"",
+      ""type"": ""securestring"",
       ""defaultValue"": ""abc""
     },
     ""location"": {
-      ""type"": ""secureString""
+      ""type"": ""securestring""
     },
     ""zoneType"": {
       ""type"": ""string"",

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -683,7 +683,7 @@ namespace Bicep.LanguageServer.Completions
                                                                context.ReplacementRange,
                                                                new TextEdit[] { textEdit });
 
-                yield return CreateContextualSnippetCompletion("secureString",
+                yield return CreateContextualSnippetCompletion("securestring",
                                                                "Secure string",
                                                                "string",
                                                                context.ReplacementRange,

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Invalid/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Invalid/main.json
@@ -31,7 +31,7 @@
       }
     },
     "servicePrincipalClientSecret": {
-      "type": "secureString"
+      "type": "securestring"
     },
     "clusterName": {
       "type": "string",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/README.md
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/README.md
@@ -16,7 +16,7 @@ The quick brown fox jumps over the lazy dog.
 | `linuxAdminUsername`           | `string`       | Yes      | The linux administrator username                                                |
 | `sshRSAPublicKey`              | `string`       | Yes      | The RSA public key for SSH                                                      |
 | `servicePrincipalClientId`     | `string`       | Yes      | The service principal client ID                                                 |
-| `servicePrincipalClientSecret` | `secureString` | Yes      | The service principal client secret                                             |
+| `servicePrincipalClientSecret` | `securestring` | Yes      | The service principal client secret                                             |
 | `clusterName`                  | `string`       | No       | The cluster name                                                                |
 | `location`                     | `string`       | No       | The deployment location                                                         |
 | `osDiskSizeGB`                 | `int`          | Yes      | The OS disk size (in GB)<br />- Minimum value is 0<br />- Maximum value is 1023 |

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/main.json
@@ -34,7 +34,7 @@
       }
     },
     "servicePrincipalClientSecret": {
-      "type": "secureString",
+      "type": "securestring",
       "metadata": {
         "description": "The service principal client secret"
       }


### PR DESCRIPTION
According to https://github.com/Azure/azure-resource-manager-schemas/blob/main/schemas/2019-04-01/deploymentTemplate.json, the parameter for a secure string is `securestring` and not `secureString`.

Fixes #9224 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9225)