### PR TITLE
Script to compare bicep builds across multiple repos

### DIFF
--- a/.github/workflows/run-compile-samples.yml
+++ b/.github/workflows/run-compile-samples.yml
@@ -1,0 +1,29 @@
+name: Compile Samples
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'GH Actions Run Id for the version of Bicep to use'
+        required: true
+
+jobs:
+  run-benchmarks:
+    name: Compile Samples
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Bicep
+        run: |
+          gh run download ${{ github.event.inputs.run_id }} -n bicep-release-linux-x64 -D /tmp/bicep-release-linux-x64
+          chmod +x /tmp/bicep-release-linux-x64/bicep
+
+      - name: Compile Sample Files
+        run: ./scripts/compile_samples.sh /tmp/bicep-release-linux-x64/bicep > results.txt
+
+      - name: Upload Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: results.txt
+          path: ./results.txt
+          if-no-files-found: error

--- a/scripts/compile_samples.sh
+++ b/scripts/compile_samples.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+usage="Usage: ./scripts/compile_samples.sh <path_to_bicep>"
+bicep=${1:?"Missing path to Bicep executable. ${usage}"}
+
+dir=$(mktemp -d)
+bicepVersion=$($bicep --version | sed 's/Bicep CLI version \([^ ]*\) .*/\1/')
+
+REPOS=(
+  # Add repos to scan to this list in format <repo name>@<git sha>
+  "Azure/azure-quickstart-templates@417fca2db8a15a09767533b4c513b734229a4ea4"
+  "Azure/bicep-registry-modules@7b39b00c1ddb869f7b9b3c083f629b239c9f87c3"
+  "Azure/azure-docs-bicep-samples@b6f45e30f890a1c50d72ce05ecfcc76453e19617"
+  "Azure/ResourceModules@fc818d651c1391c889097bd02a4507665d9d0265"
+)
+
+echo "BICEP VERSION: $bicepVersion"
+for REPO in "${REPOS[@]}"; do
+  repoName=${REPO%%@*}
+  refName=${REPO#*@}
+  gh repo clone $repoName $dir -- --quiet
+  pushd $dir > /dev/null
+  git checkout $refName --quiet
+
+  echo "REPO NAME: $repoName"
+  echo "REPO REF: $refName"
+
+  for file in $(find . -type f -name "*.bicep"); do
+    echo "FILE: $file"
+    ($bicep build --stdout "$file" 2>&1 || true) | sed 's/"version": "'$bicepVersion'[^"]*"/"version": "<REMOVED>"/g'
+    echo ""
+  done
+
+  popd > /dev/null
+  rm -Rf $dir
+done


### PR DESCRIPTION
This script / github action gives us the ability to compile files across multiple repos, and compare the results between different Bicep builds.

This can potentially be used as a sanity check for regressions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9237)