### PR TITLE
IR part 3: Source mapping

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -2733,7 +2733,7 @@ var myValue = -9223372036854775808
 ");
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
-            result.Template.Should().HaveValueAtPath("$.variables.myValue", "[json('-9223372036854775808')]");
+            result.Template.Should().HaveValueAtPath("$.variables.myValue", -9223372036854775808);
         }
 
         [TestMethod]

--- a/src/Bicep.Core.IntegrationTests/Scenarios/LoadFunctionsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/LoadFunctionsTests.cs
@@ -527,7 +527,7 @@ output out string = script
   ""propInt"": 1073741824,
   ""propIntNegative"": -1073741824,
   ""propBigInt"": 4611686018427387904,
-  ""propBigIntNegative"": ""[json('-4611686018427387904')]"",
+  ""propBigIntNegative"": -4611686018427387904,
   ""propFloat"": ""[json('1.618033988749894')]"",
   ""propFloatNegative"": ""[json('-1.618033988749894')]"",
   ""propArrayString"": [
@@ -758,7 +758,7 @@ var fileObj = loadJsonContent('file.json')
     ""products"" : /* block-comment */ [
         { //item-1
             ""name"": ""pizza"", //the-name
-            ""price"": 5.00 
+            ""price"": 5.00
         },
         //---
         { //item-2

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.sourcemap.bicep
@@ -25,30 +25,30 @@ var loadedTextInterpolation2 = 'Text: ${loadTextContent('Assets/TextFile.LF.txt'
 
 var loadedTextObject1 = {
 //@    "loadedTextObject1": {
+//@      "text": "[variables('$fxv#2')]"
 //@    },
   'text' : loadTextContent('Assets/TextFile.CRLF.txt')
-//@      "text": "[variables('$fxv#2')]"
 }
 var loadedTextObject2 = {
 //@    "loadedTextObject2": {
+//@      "text": "[variables('$fxv#3')]"
 //@    },
   'text' : loadTextContent('Assets/TextFile.LF.txt')  
-//@      "text": "[variables('$fxv#3')]"
 }
 var loadedBinaryInObject = {
 //@    "loadedBinaryInObject": {
+//@      "file": "[variables('$fxv#4')]"
 //@    },
   file: loadFileAsBase64('Assets/binary')
-//@      "file": "[variables('$fxv#4')]"
 }
 
 var loadedTextArray = [
 //@    "loadedTextArray": [
+//@      "[variables('$fxv#5')]",
+//@      "[variables('$fxv#6')]"
 //@    ],
   loadTextContent('Assets/TextFile.LF.txt')
-//@      "[variables('$fxv#5')]",
   loadFileAsBase64('Assets/binary')
-//@      "[variables('$fxv#6')]"
 ]
 
 var loadedTextArrayInObject = {
@@ -56,11 +56,11 @@ var loadedTextArrayInObject = {
 //@    },
   'files' : [
 //@      "files": [
+//@        "[variables('$fxv#7')]",
+//@        "[variables('$fxv#8')]"
 //@      ]
     loadTextContent('Assets/TextFile.CRLF.txt')
-//@        "[variables('$fxv#7')]",
     loadFileAsBase64('Assets/binary')
-//@        "[variables('$fxv#8')]"
   ]
 }
 

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12517966412979818437"
+      "templateHash": "8820744274097135450"
     }
   },
   "parameters": {
@@ -218,8 +218,8 @@
     "isFalse": "[not(variables('isTrue'))]",
     "someText": "[if(variables('isTrue'), concat('a', concat('b', 'c')), 'someText')]",
     "scopesWithoutArmRepresentation": {
-      "subscription": "[createObject()]",
-      "resourceGroup": "[createObject()]"
+      "subscription": {},
+      "resourceGroup": {}
     },
     "scopesWithArmRepresentation": {
       "tenant": "[tenant()]",

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.sourcemap.bicep
@@ -389,11 +389,11 @@ var someText = isTrue ? sys.concat('a', sys.concat('b', 'c')) : 'someText'
 // Bicep functions that cannot be converted into ARM functions
 var scopesWithoutArmRepresentation = {
 //@    "scopesWithoutArmRepresentation": {
+//@      "subscription": {},
+//@      "resourceGroup": {}
 //@    },
   subscription: subscription('10b57a01-6350-4ce2-972a-6a13642f00bf')
-//@      "subscription": "[createObject()]",
   resourceGroup: az.resourceGroup('10b57a01-6350-4ce2-972a-6a13642f00bf', 'myRgName')
-//@      "resourceGroup": "[createObject()]"
 }
 
 var scopesWithArmRepresentation = {

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14237309335148944435"
+      "templateHash": "4655166543508546916"
     }
   },
   "parameters": {
@@ -220,8 +220,8 @@
     "isFalse": "[not(variables('isTrue'))]",
     "someText": "[if(variables('isTrue'), concat('a', concat('b', 'c')), 'someText')]",
     "scopesWithoutArmRepresentation": {
-      "subscription": "[createObject()]",
-      "resourceGroup": "[createObject()]"
+      "subscription": {},
+      "resourceGroup": {}
     },
     "scopesWithArmRepresentation": {
       "tenant": "[tenant()]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/policy-with-initiative-definition-and-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/policy-with-initiative-definition-and-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16725308854916544444"
+      "templateHash": "2187496986171293588"
     }
   },
   "parameters": {
@@ -51,7 +51,11 @@
         "parameters": {
           "listOfAllowedLocations": {
             "type": "Array",
-            "metadata": "[createObject('description', 'The List of Allowed Locations for Resource Groups and Resources.', 'strongtype', 'location', 'displayName', 'Allowed Locations')]"
+            "metadata": {
+              "description": "The List of Allowed Locations for Resource Groups and Resources.",
+              "strongtype": "location",
+              "displayName": "Allowed Locations"
+            }
           },
           "listOfAllowedSKUs": {
             "type": "Array",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/policy-with-initiative-definition-and-assignment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/policy-with-initiative-definition-and-assignment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14234582424103721348"
+      "templateHash": "5423294562473628901"
     }
   },
   "parameters": {
@@ -53,7 +53,11 @@
         "parameters": {
           "listOfAllowedLocations": {
             "type": "Array",
-            "metadata": "[createObject('description', 'The List of Allowed Locations for Resource Groups and Resources.', 'strongtype', 'location', 'displayName', 'Allowed Locations')]"
+            "metadata": {
+              "description": "The List of Allowed Locations for Resource Groups and Resources.",
+              "strongtype": "location",
+              "displayName": "Allowed Locations"
+            }
           },
           "listOfAllowedSKUs": {
             "type": "Array",

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -92,10 +92,16 @@ namespace Bicep.Core.Emit
             );
         }
 
-        public LanguageExpression ConvertExpression(SyntaxBase syntax)
+        public Expression ConvertToIntermediateExpression(SyntaxBase syntax)
         {
             var expression = expressionBuilder.Convert(syntax);
-            expression = ExpressionLoweringVisitor.Lower(expression);
+
+            return ExpressionLoweringVisitor.Lower(expression);
+        }
+
+        public LanguageExpression ConvertExpression(SyntaxBase syntax)
+        {
+            var expression = ConvertToIntermediateExpression(syntax);
 
             return ConvertExpression(expression);
         }

--- a/src/Bicep.Core/Emit/ExpressionEmitter.cs
+++ b/src/Bicep.Core/Emit/ExpressionEmitter.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Azure.Deployments.Expression.Configuration;
 using Azure.Deployments.Expression.Expressions;
 using Azure.Deployments.Expression.Serializers;
 using Bicep.Core.Extensions;
+using Bicep.Core.Intermediate;
+using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
@@ -37,63 +40,52 @@ namespace Bicep.Core.Emit
             this.converter = new ExpressionConverter(context);
         }
 
-        public void EmitExpression(SyntaxBase syntax)
+        public void EmitExpression(Expression expression)
         {
-            switch (syntax)
+            switch (expression)
             {
-                case BooleanLiteralSyntax boolSyntax:
-                    writer.WriteValue(boolSyntax.Value);
+                case BooleanLiteralExpression @bool:
+                    writer.WriteValue(@bool.Value);
                     break;
 
-                case IntegerLiteralSyntax integerSyntax:
-                    writer.WriteValue(integerSyntax.Value);
+                case IntegerLiteralExpression @int:
+                    writer.WriteValue(@int.Value);
                     break;
 
-                case NullLiteralSyntax _:
+                case NullLiteralExpression _:
                     writer.WriteNull();
 
                     break;
 
-                case ObjectSyntax objectSyntax:
+                case ObjectExpression @object:
                     writer.WriteStartObject();
-                    EmitObjectProperties(objectSyntax);
+                    EmitObjectProperties(@object);
                     writer.WriteEndObject();
 
                     break;
 
-                case ArraySyntax arraySyntax:
+                case ArrayExpression @array:
                     writer.WriteStartArray();
 
-                    foreach (ArrayItemSyntax itemSyntax in arraySyntax.Items)
+                    foreach (var item in @array.Items)
                     {
                         writer.WriteExpressionWithPosition(
-                            itemSyntax.Value,
-                            () => EmitExpression(itemSyntax.Value));
+                            item.SourceSyntax,
+                            () => EmitExpression(item));
                     }
 
                     writer.WriteEndArray();
 
                     break;
 
-                case ParenthesizedExpressionSyntax _:
-                case UnaryOperationSyntax _:
-                case BinaryOperationSyntax _:
-                case TernaryOperationSyntax _:
-                case StringSyntax _:
-                case InstanceFunctionCallSyntax _:
-                case FunctionCallSyntax _:
-                case ArrayAccessSyntax _:
-                case PropertyAccessSyntax _:
-                case ResourceAccessSyntax _:
-                case VariableAccessSyntax _:
-                    EmitLanguageExpression(syntax);
-
-                    break;
-
                 default:
-                    throw new NotImplementedException($"Cannot emit unexpected expression of type {syntax.GetType().Name}");
+                    EmitLanguageExpression(expression);
+                    break;
             }
         }
+
+        public void EmitExpression(SyntaxBase syntax)
+            => EmitExpression(converter.ConvertToIntermediateExpression(syntax));
 
         public void EmitExpression(SyntaxBase resourceNameSyntax, SyntaxBase? indexExpression, SyntaxBase newContext)
         {
@@ -174,63 +166,67 @@ namespace Bicep.Core.Emit
             return converterForContext.GenerateManagementGroupResourceId(managementGroupNameProperty, fullyQualified);
         }
 
-        public void EmitLanguageExpression(SyntaxBase syntax)
+        public void EmitLanguageExpression(Expression expression)
         {
-            var symbol = context.SemanticModel.GetSymbolInfo(syntax);
-            if (symbol is VariableSymbol variableSymbol && context.VariablesToInline.Contains(variableSymbol))
+            if (expression is VariableReferenceExpression varRef && context.VariablesToInline.Contains(varRef.Variable))
             {
-                EmitExpression(variableSymbol.Value);
+                EmitExpression(varRef.Variable.Value);
                 return;
             }
 
-            if (syntax is FunctionCallSyntax functionCall &&
-                symbol is FunctionSymbol functionSymbol &&
-                string.Equals(functionSymbol.Name, LanguageConstants.AnyFunction, LanguageConstants.IdentifierComparison))
+            if (expression is FunctionCallExpression functionCall &&
+                string.Equals(functionCall.Name, LanguageConstants.AnyFunction, LanguageConstants.IdentifierComparison))
             {
                 // the outermost function in the current syntax node is the "any" function
                 // we should emit its argument directly
                 // otherwise, they'd get wrapped in a json() template function call in the converted expression
 
                 // we have checks for function parameter count mismatch, which should prevent an exception from being thrown
-                EmitExpression(functionCall.Arguments.Single().Expression);
+                EmitExpression(functionCall.Parameters.Single());
                 return;
             }
 
-            LanguageExpression converted = converter.ConvertExpression(syntax);
+            var converted = converter.ConvertExpression(expression);
 
             if (converted is JTokenExpression valueExpression && valueExpression.Value.Type == JTokenType.Integer)
             {
-                // the converted expression is an integer literal
-                JToken value = valueExpression.Value;
-
                 // for integer literals the expression will look like "[42]" or "[-12]"
                 // while it's still a valid template expression that works in ARM, it looks weird
                 // and is also not recognized by the template language service in VS code
                 // let's serialize it as a proper integer instead
-                writer.WriteValue(value);
-
-                return;
+                writer.WriteValue(valueExpression.Value);
             }
+            else
+            {
+                // strings literals and other expressions must be processed with the serializer to ensure correct conversion and escaping
+                var serialized = ExpressionSerializer.SerializeExpression(converted);
 
-            // strings literals and other expressions must be processed with the serializer to ensure correct conversion and escaping
-            var serialized = ExpressionSerializer.SerializeExpression(converted);
-
-            writer.WriteValue(serialized);
+                writer.WriteValue(serialized);
+            }
         }
-        public void EmitCopyObject(string? name, ForSyntax syntax, SyntaxBase? input, string? copyIndexOverride = null, ulong? batchSize = null)
+
+        public void EmitCopyObject(string? name, SyntaxBase forExpression, SyntaxBase? input, string? copyIndexOverride = null, ulong? batchSize = null)
+            => EmitCopyObject(
+                name,
+                converter.ConvertToIntermediateExpression(forExpression),
+                input is null ? null : converter.ConvertToIntermediateExpression(input),
+                copyIndexOverride,
+                batchSize);
+
+        public void EmitCopyObject(string? name, Expression forExpression, Expression? input, string? copyIndexOverride = null, ulong? batchSize = null)
         {
             // local function
-            static bool CanEmitAsInputDirectly(SyntaxBase input)
+            static bool CanEmitAsInputDirectly(Expression input)
             {
                 // the deployment engine only allows JTokenType of String or Object in the copy loop "input" property
                 // everything else must be converted into an expression
                 return input switch
                 {
                     // objects should be emitted as is
-                    ObjectSyntax => true,
+                    ObjectExpression => true,
 
-                    // non-interpolated strings should be emitted as-is
-                    StringSyntax @string when !@string.IsInterpolated() => true,
+                    // string literal values should be emitted as-is
+                    StringLiteralExpression => true,
 
                     // all other expressions should be converted into a language expression before emitting
                     // which will have the resulting JTokenType of String
@@ -238,7 +234,7 @@ namespace Bicep.Core.Emit
                 };
             }
 
-            writer.WriteObjectWithPosition(syntax, () =>
+            writer.WriteObjectWithPosition(forExpression.SourceSyntax, () =>
             {
                 if (name is not null)
                 {
@@ -247,10 +243,7 @@ namespace Bicep.Core.Emit
 
                 // construct the length ARM expression from the Bicep array expression
                 // type check has already ensured that the array expression is an array
-                this.EmitPropertyWithTransform(
-                    "count",
-                    syntax.Expression,
-                    arrayExpression => new FunctionExpression("length", new[] { arrayExpression }, Array.Empty<LanguageExpression>()));
+                this.EmitProperty("count", new FunctionCallExpression(forExpression.SourceSyntax, "length", new [] { forExpression }.ToImmutableArray()));
 
                 if (batchSize.HasValue)
                 {
@@ -311,7 +304,22 @@ namespace Bicep.Core.Emit
 
         public void EmitObjectProperties(ObjectSyntax objectSyntax, ISet<string>? propertiesToOmit = null)
         {
-            var propertyLookup = objectSyntax.Properties.ToLookup(property => property.Value is ForSyntax);
+            var properties = objectSyntax.Properties
+                .Where(x => x.TryGetKeyText() is not {} keyName || propertiesToOmit?.Contains(keyName) != true);
+
+            objectSyntax = new ObjectSyntax(objectSyntax.OpenBrace, properties, objectSyntax.CloseBrace);
+
+            if (converter.ConvertToIntermediateExpression(objectSyntax) is not ObjectExpression objectExpression)
+            {
+                throw new InvalidOperationException();
+            }
+
+            EmitObjectProperties(objectExpression);
+        }
+
+        private void EmitObjectProperties(ObjectExpression @object)
+        {
+            var propertyLookup = @object.Properties.OfType<ObjectPropertyExpression>().ToLookup(property => property.Value is ForLoopExpression);
 
             // emit loop properties first (if any)
             if (propertyLookup.Contains(true))
@@ -323,14 +331,14 @@ namespace Bicep.Core.Emit
 
                     foreach (var property in propertyLookup[true])
                     {
-                        var key = property.TryGetKeyText();
-                        if (key is null || property.Value is not ForSyntax @for)
+                        if (property.Key is not StringLiteralExpression stringKeyExpression ||
+                            property.Value is not ForLoopExpression forLoop)
                         {
                             // should be caught by loop emit limitation checks
                             throw new InvalidOperationException("Encountered a property with an expression-based key whose value is a for-expression.");
                         }
 
-                        this.EmitCopyObject(key, @for, @for.Body);
+                        this.EmitCopyObject(stringKeyExpression.Value, forLoop.Expression, forLoop.Body);
                     }
 
                     this.writer.WriteEndArray();
@@ -338,22 +346,16 @@ namespace Bicep.Core.Emit
             }
 
             // emit non-loop properties
-            foreach (ObjectPropertySyntax propertySyntax in propertyLookup[false])
+            foreach (var property in propertyLookup[false])
             {
                 // property whose value is not a for-expression
-
-                if (propertySyntax.TryGetKeyText() is string keyName)
+                if (property.Key is StringLiteralExpression stringKeyExpression)
                 {
-                    if (propertiesToOmit?.Contains(keyName) == true)
-                    {
-                        continue;
-                    }
-
-                    EmitProperty(keyName, propertySyntax.Value);
+                    EmitProperty(stringKeyExpression.Value, property.Value);
                 }
                 else
                 {
-                    EmitProperty(propertySyntax.Key, propertySyntax.Value);
+                    EmitProperty(property.Key, property.Value);
                 }
             }
         }
@@ -430,6 +432,22 @@ namespace Bicep.Core.Emit
                 writer.WriteValue(propertyValue);
             });
 
+        public void EmitProperty(Expression name, Expression expression)
+            => EmitPropertyInternal(converter.ConvertExpression(name), () => EmitExpression(expression), expression.SourceSyntax);
+
+        public void EmitProperty(string name, Expression expression)
+            => EmitProperty(new StringLiteralExpression(expression.SourceSyntax, name), expression);
+
+        public void EmitPropertyWithTransform(string name, Expression expression, Func<LanguageExpression, LanguageExpression> convertedValueTransform)
+            => EmitPropertyInternal(new JTokenExpression(name), () =>
+            {
+                var converted = converter.ConvertExpression(expression);
+                var transformed = convertedValueTransform(converted);
+                var serialized = ExpressionSerializer.SerializeExpression(transformed);
+
+                this.writer.WriteValue(serialized);
+            });
+
         public void EmitPropertyWithTransform(string name, SyntaxBase value, Func<LanguageExpression, LanguageExpression> convertedValueTransform)
             => EmitPropertyInternal(new JTokenExpression(name), () =>
             {
@@ -456,7 +474,7 @@ namespace Bicep.Core.Emit
         public void EmitProperty(SyntaxBase syntaxKey, SyntaxBase syntaxValue)
             => EmitPropertyInternal(converter.ConvertExpression(syntaxKey), syntaxValue);
 
-        private void EmitPropertyInternal(LanguageExpression expressionKey, Action valueFunc, SyntaxBase? location = null, bool skipCopyCheck = false)
+        private void EmitPropertyInternal(LanguageExpression expressionKey, Action valueFunc, IPositionable? location = null, bool skipCopyCheck = false)
         {
             var serializedName = ExpressionSerializer.SerializeExpression(expressionKey);
             if (!skipCopyCheck && serializedName.Equals(LanguageConstants.CopyLoopIdentifier, StringComparison.OrdinalIgnoreCase))

--- a/src/Bicep.Core/Emit/PositionTrackingJsonTextWriter.cs
+++ b/src/Bicep.Core/Emit/PositionTrackingJsonTextWriter.cs
@@ -82,7 +82,7 @@ namespace Bicep.Core.Emit
             this.trackingWriter = trackingWriter;
         }
 
-        public void WriteExpressionWithPosition(SyntaxBase? sourcePosition, Action expressionFunc)
+        public void WriteExpressionWithPosition(IPositionable? sourcePosition, Action expressionFunc)
         {
             var startPos = this.trackingWriter.CurrentPosition;
 
@@ -91,7 +91,7 @@ namespace Bicep.Core.Emit
             AddSourceMapping(sourcePosition, startPos);
         }
 
-        public void WriteObjectWithPosition(SyntaxBase? sourcePosition, Action propertiesFunc)
+        public void WriteObjectWithPosition(IPositionable? sourcePosition, Action propertiesFunc)
         {
             var startPos = this.trackingWriter.CurrentPosition;
 
@@ -102,7 +102,7 @@ namespace Bicep.Core.Emit
             AddSourceMapping(sourcePosition, startPos);
         }
 
-        public void WritePropertyWithPosition(SyntaxBase? keyPosition, string name, Action valueFunc)
+        public void WritePropertyWithPosition(IPositionable? keyPosition, string name, Action valueFunc)
         {
             var startPos = this.trackingWriter.CurrentPosition;
 
@@ -132,7 +132,7 @@ namespace Bicep.Core.Emit
 
         public override string? ToString() => this.trackingWriter.ToString();
 
-        private void AddSourceMapping(SyntaxBase? bicepSyntax, int jsonStartPosition)
+        private void AddSourceMapping(IPositionable? bicepSyntax, int jsonStartPosition)
         {
             if (this.sourceFile == null || bicepSyntax == null || bicepSyntax.Span.Length == 0)
             {

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -534,7 +534,7 @@ namespace Bicep.Core.Emit
                         // enforced by the lookup predicate above
                         var @for = (ForSyntax)variableSymbol.Value;
 
-                        emitter.EmitCopyObject(variableSymbol.Name, @for, @for.Body);
+                        emitter.EmitCopyObject(variableSymbol.Name, @for.Expression, @for.Body);
                     }
 
                     jsonWriter.WriteEndArray();
@@ -725,7 +725,7 @@ namespace Bicep.Core.Emit
                 if (loops.Count == 1)
                 {
                     var batchSize = GetBatchSize(resource.Symbol.DeclaringResource);
-                    emitter.EmitCopyProperty(() => emitter.EmitCopyObject(loops[0].name, loops[0].@for, loops[0].input, batchSize: batchSize));
+                    emitter.EmitCopyProperty(() => emitter.EmitCopyObject(loops[0].name, loops[0].@for.Expression, loops[0].input, batchSize: batchSize));
                 }
                 else if (loops.Count > 1)
                 {
@@ -824,7 +824,7 @@ namespace Bicep.Core.Emit
                     emitter.EmitCopyProperty(() =>
                     {
                         jsonWriter.WriteStartArray();
-                        emitter.EmitCopyObject("value", @for, @for.Body, "value");
+                        emitter.EmitCopyObject("value", @for.Expression, @for.Body, "value");
                         jsonWriter.WriteEndArray();
                     });
                     jsonWriter.WriteEndObject();
@@ -875,7 +875,7 @@ namespace Bicep.Core.Emit
                         }
 
                         var batchSize = GetBatchSize(moduleSymbol.DeclaringModule);
-                        emitter.EmitCopyProperty(() => emitter.EmitCopyObject(moduleSymbol.Name, @for, input: null, batchSize: batchSize));
+                        emitter.EmitCopyProperty(() => emitter.EmitCopyObject(moduleSymbol.Name, @for.Expression, input: null, batchSize: batchSize));
                         break;
                 }
 
@@ -1133,7 +1133,7 @@ namespace Bicep.Core.Emit
 
                 if (outputSymbol.Value is ForSyntax @for)
                 {
-                    emitter.EmitCopyProperty(() => emitter.EmitCopyObject(name: null, @for, @for.Body));
+                    emitter.EmitCopyProperty(() => emitter.EmitCopyObject(name: null, @for.Expression, @for.Body));
                 }
                 else
                 {

--- a/src/Bicep.Core/Intermediate/Expression.cs
+++ b/src/Bicep.Core/Intermediate/Expression.cs
@@ -12,36 +12,42 @@ public record IndexReplacementContext(
     ImmutableDictionary<LocalVariableSymbol, Expression> LocalReplacements,
     Expression Index);
 
-public abstract record Expression()
+public abstract record Expression(
+    SyntaxBase? SourceSyntax)
 {
     public abstract void Accept(IExpressionVisitor visitor);
 }
 
 public record BooleanLiteralExpression(
+    SyntaxBase? SourceSyntax,
     bool Value
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitBooleanLiteralExpression(this);
 }
 
 public record IntegerLiteralExpression(
+    SyntaxBase? SourceSyntax,
     long Value
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitIntegerLiteralExpression(this);
 }
 
 public record StringLiteralExpression(
+    SyntaxBase? SourceSyntax,
     string Value
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitStringLiteralExpression(this);
 }
 
-public record NullLiteralExpression() : Expression
+public record NullLiteralExpression(
+    SyntaxBase? SourceSyntax
+): Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitNullLiteralExpression(this);
@@ -49,152 +55,193 @@ public record NullLiteralExpression() : Expression
 
 public record SyntaxExpression(
     SyntaxBase Syntax
-) : Expression
+) : Expression(Syntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitSyntaxExpression(this);
 }
 
 public record InterpolatedStringExpression(
+    SyntaxBase? SourceSyntax,
     ImmutableArray<string> SegmentValues,
     ImmutableArray<Expression> Expressions
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitInterpolatedStringExpression(this);
 }
 
-public record ObjectProperty(
+public record ObjectPropertyExpression(
+    SyntaxBase? SourceSyntax,
     Expression Key,
-    Expression Value);
+    Expression Value
+) : Expression(SourceSyntax)
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitObjectPropertyExpression(this);
+}
 
 public record ObjectExpression(
-    ImmutableArray<ObjectProperty> Properties
-) : Expression
+    SyntaxBase? SourceSyntax,
+    ImmutableArray<ObjectPropertyExpression> Properties
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitObjectExpression(this);
 }
 
 public record ArrayExpression(
+    SyntaxBase? SourceSyntax,
     ImmutableArray<Expression> Items
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitArrayExpression(this);
 }
 
 public record TernaryExpression(
+    SyntaxBase? SourceSyntax,
     Expression Condition,
     Expression True,
     Expression False
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitTernaryExpression(this);
 }
 
 public record BinaryExpression(
+    SyntaxBase? SourceSyntax,
     BinaryOperator Operator,
     Expression Left,
     Expression Right
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitBinaryExpression(this);
 }
 
 public record UnaryExpression(
+    SyntaxBase? SourceSyntax,
     UnaryOperator Operator,
     Expression Expression
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitUnaryExpression(this);
 }
 
 public record FunctionCallExpression(
+    SyntaxBase? SourceSyntax,
     string Name,
     ImmutableArray<Expression> Parameters
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitFunctionCallExpression(this);
 }
 
 public record ArrayAccessExpression(
+    SyntaxBase? SourceSyntax,
     Expression Base,
     Expression Access
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitArrayAccessExpression(this);
 }
 
 public record PropertyAccessExpression(
+    SyntaxBase? SourceSyntax,
     Expression Base,
     string PropertyName
-) : Expression
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitPropertyAccessExpression(this);
 }
 
 public record ResourceReferenceExpression(
+    SyntaxBase? SourceSyntax,
     ResourceMetadata Metadata,
-    IndexReplacementContext? IndexContext) : Expression
+    IndexReplacementContext? IndexContext
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitResourceReferenceExpression(this);
 }
 
 public record ModuleReferenceExpression(
+    SyntaxBase? SourceSyntax,
     ModuleSymbol Module,
-    IndexReplacementContext? IndexContext) : Expression
+    IndexReplacementContext? IndexContext
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitModuleReferenceExpression(this);
 }
 
 public record ModuleOutputPropertyAccessExpression(
+    SyntaxBase? SourceSyntax,
     Expression Base,
-    string PropertyName) : Expression
+    string PropertyName)
+: Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitModuleOutputPropertyAccessExpression(this);
 }
 
 public record VariableReferenceExpression(
-    VariableSymbol Variable) : Expression
+    SyntaxBase? SourceSyntax,
+    VariableSymbol Variable
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitVariableReferenceExpression(this);
 }
 
 public record ParametersReferenceExpression(
-    ParameterSymbol Parameter) : Expression
+    SyntaxBase? SourceSyntax,
+    ParameterSymbol Parameter
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitParametersReferenceExpression(this);
 }
 
 public record LambdaVariableReferenceExpression(
-    LocalVariableSymbol Variable) : Expression
+    SyntaxBase? SourceSyntax,
+    LocalVariableSymbol Variable
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitLambdaVariableReferenceExpression(this);
 }
 
+public record ForLoopExpression(
+    SyntaxBase? SourceSyntax,
+    Expression Expression,
+    Expression Body
+) : Expression(SourceSyntax)
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitForLoopExpression(this);
+}
+
 public record CopyIndexExpression(
-    string? Name) : Expression
+    SyntaxBase? SourceSyntax,
+    string? Name
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitCopyIndexExpression(this);
 }
 
 public record LambdaExpression(
+    SyntaxBase? SourceSyntax,
     ImmutableArray<string> Parameters,
-    Expression Body) : Expression
+    Expression Body
+) : Expression(SourceSyntax)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitLambdaExpression(this);

--- a/src/Bicep.Core/Intermediate/ExpressionLoweringVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionLoweringVisitor.cs
@@ -10,7 +10,7 @@ public class ExpressionLoweringVisitor : ExpressionRewriteVisitor
     public static Expression Lower(Expression expression)
     {
         var visitor = new ExpressionLoweringVisitor();
-        
+
         return visitor.Replace(expression);
     }
 
@@ -18,7 +18,7 @@ public class ExpressionLoweringVisitor : ExpressionRewriteVisitor
     {
         if (expression.Access is StringLiteralExpression stringLiteral)
         {
-            return base.Replace(new PropertyAccessExpression(expression.Base, stringLiteral.Value));
+            return base.Replace(new PropertyAccessExpression(expression.SourceSyntax, expression.Base, stringLiteral.Value));
         }
 
         return base.ReplaceArrayAccessExpression(expression);

--- a/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Bicep.Core.Intermediate;
@@ -13,30 +14,30 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     void IExpressionVisitor.VisitArrayAccessExpression(ArrayAccessExpression expression) => ReplaceCurrent(expression, ReplaceArrayAccessExpression);
     public virtual Expression ReplaceArrayAccessExpression(ArrayAccessExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Base, out var @base) |
             TryRewrite(expression.Access, out var access);
 
-        return hasChanges ? new(@base, access) : expression;
+        return hasChanges ? new(expression.SourceSyntax, @base, access) : expression;
     }
 
     void IExpressionVisitor.VisitArrayExpression(ArrayExpression expression) => ReplaceCurrent(expression, ReplaceArrayExpression);
     public virtual Expression ReplaceArrayExpression(ArrayExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Items, out var items);
 
-        return hasChanges ? new(items) : expression;
+        return hasChanges ? new(expression.SourceSyntax, items) : expression;
     }
 
     void IExpressionVisitor.VisitBinaryExpression(BinaryExpression expression) => ReplaceCurrent(expression, ReplaceBinaryExpression);
     public virtual Expression ReplaceBinaryExpression(BinaryExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Left, out var left) |
             TryRewrite(expression.Right, out var right);
 
-        return hasChanges ? new(expression.Operator, left, right) : expression;
+        return hasChanges ? new(expression.SourceSyntax, expression.Operator, left, right) : expression;
     }
 
     void IExpressionVisitor.VisitBooleanLiteralExpression(BooleanLiteralExpression expression) => ReplaceCurrent(expression, ReplaceBooleanLiteralExpression);
@@ -51,13 +52,23 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
         return expression;
     }
 
+    void IExpressionVisitor.VisitForLoopExpression(ForLoopExpression expression) => ReplaceCurrent(expression, ReplaceForLoopExpression);
+    public virtual Expression ReplaceForLoopExpression(ForLoopExpression expression)
+    {
+        var hasChanges =
+            TryRewrite(expression.Expression, out var newExpression) |
+            TryRewrite(expression.Body, out var body);
+
+        return hasChanges ? new(expression.SourceSyntax, newExpression, body) : expression;
+    }
+
     void IExpressionVisitor.VisitFunctionCallExpression(FunctionCallExpression expression) => ReplaceCurrent(expression, ReplaceFunctionCallExpression);
     public virtual Expression ReplaceFunctionCallExpression(FunctionCallExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Parameters, out var parameters);
 
-        return hasChanges ? new(expression.Name, parameters) : expression;
+        return hasChanges ? new(expression.SourceSyntax, expression.Name, parameters) : expression;
     }
 
     void IExpressionVisitor.VisitIntegerLiteralExpression(IntegerLiteralExpression expression) => ReplaceCurrent(expression, ReplaceIntegerLiteralExpression);
@@ -69,19 +80,19 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     void IExpressionVisitor.VisitInterpolatedStringExpression(InterpolatedStringExpression expression) => ReplaceCurrent(expression, ReplaceInterpolatedStringExpression);
     public virtual Expression ReplaceInterpolatedStringExpression(InterpolatedStringExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Expressions, out var expressions);
 
-        return hasChanges ? new(expression.SegmentValues, expressions) : expression;
+        return hasChanges ? new(expression.SourceSyntax, expression.SegmentValues, expressions) : expression;
     }
 
     void IExpressionVisitor.VisitLambdaExpression(LambdaExpression expression) => ReplaceCurrent(expression, ReplaceLambdaExpression);
     public virtual Expression ReplaceLambdaExpression(LambdaExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Body, out var body);
 
-        return hasChanges ? new(expression.Parameters, body) : expression;
+        return hasChanges ? new(expression.SourceSyntax, expression.Parameters, body) : expression;
     }
 
     void IExpressionVisitor.VisitLambdaVariableReferenceExpression(LambdaVariableReferenceExpression expression) => ReplaceCurrent(expression, ReplaceLambdaVariableReferenceExpression);
@@ -93,10 +104,10 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     void IExpressionVisitor.VisitModuleOutputPropertyAccessExpression(ModuleOutputPropertyAccessExpression expression) => ReplaceCurrent(expression, ReplaceModuleOutputPropertyAccessExpression);
     public virtual Expression ReplaceModuleOutputPropertyAccessExpression(ModuleOutputPropertyAccessExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Base, out var @base);
 
-        return hasChanges ? new(@base, expression.PropertyName) : expression;
+        return hasChanges ? new(expression.SourceSyntax, @base, expression.PropertyName) : expression;
     }
 
     void IExpressionVisitor.VisitModuleReferenceExpression(ModuleReferenceExpression expression) => ReplaceCurrent(expression, ReplaceModuleReferenceExpression);
@@ -114,18 +125,20 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     void IExpressionVisitor.VisitObjectExpression(ObjectExpression expression) => ReplaceCurrent(expression, ReplaceObjectExpression);
     public virtual Expression ReplaceObjectExpression(ObjectExpression expression)
     {
-        var hasChanges = false;
-        var newPropertyList = new List<ObjectProperty>();
-        foreach (var property in expression.Properties)
-        {
-            var hasPropertyChanges = TryRewrite(property.Key, out var key) | TryRewrite(property.Value, out var value);
-            hasChanges |= hasPropertyChanges;
+        var hasChanges =
+            TryRewriteStrict(expression.Properties, out var properties);
 
-            newPropertyList.Add(hasPropertyChanges ? new(key, value) : property);
-        }
+        return hasChanges ? new(expression.SourceSyntax, properties) : expression;
+    }
 
-        var newProperties = hasChanges ? newPropertyList.ToImmutableArray() : expression.Properties;
-        return hasChanges ? new(newProperties) : expression;
+    void IExpressionVisitor.VisitObjectPropertyExpression(ObjectPropertyExpression expression) => ReplaceCurrent(expression, ReplaceObjectPropertyExpression);
+    public virtual Expression ReplaceObjectPropertyExpression(ObjectPropertyExpression expression)
+    {
+        var hasChanges =
+            TryRewrite(expression.Key, out var key) |
+            TryRewrite(expression.Value, out var value);
+
+        return hasChanges ? new(expression.SourceSyntax, key, value) : expression;
     }
 
     void IExpressionVisitor.VisitParametersReferenceExpression(ParametersReferenceExpression expression) => ReplaceCurrent(expression, ReplaceParametersReferenceExpression);
@@ -137,10 +150,10 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     void IExpressionVisitor.VisitPropertyAccessExpression(PropertyAccessExpression expression) => ReplaceCurrent(expression, ReplacePropertyAccessExpression);
     public virtual Expression ReplacePropertyAccessExpression(PropertyAccessExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Base, out var @base);
 
-        return hasChanges ? new(@base, expression.PropertyName) : expression;
+        return hasChanges ? new(expression.SourceSyntax, @base, expression.PropertyName) : expression;
     }
 
     void IExpressionVisitor.VisitResourceReferenceExpression(ResourceReferenceExpression expression) => ReplaceCurrent(expression, ReplaceResourceReferenceExpression);
@@ -164,21 +177,21 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     void IExpressionVisitor.VisitTernaryExpression(TernaryExpression expression) => ReplaceCurrent(expression, ReplaceTernaryExpression);
     public virtual Expression ReplaceTernaryExpression(TernaryExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Condition, out var condition) |
             TryRewrite(expression.True, out var @true) |
             TryRewrite(expression.False, out var @false);
 
-        return hasChanges ? new(condition, @true, @false) : expression;
+        return hasChanges ? new(expression.SourceSyntax, condition, @true, @false) : expression;
     }
 
     void IExpressionVisitor.VisitUnaryExpression(UnaryExpression expression) => ReplaceCurrent(expression, ReplaceUnaryExpression);
     public virtual Expression ReplaceUnaryExpression(UnaryExpression expression)
     {
-        var hasChanges = 
+        var hasChanges =
             TryRewrite(expression.Expression, out var newExpression);
 
-        return hasChanges ? new(expression.Operator, newExpression) : expression;
+        return hasChanges ? new(expression.SourceSyntax, expression.Operator, newExpression) : expression;
     }
 
     void IExpressionVisitor.VisitVariableReferenceExpression(VariableReferenceExpression expression) => ReplaceCurrent(expression, ReplaceVariableReferenceExpression);
@@ -204,26 +217,41 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
 
     private Expression? current;
 
-    private bool TryRewrite(Expression expression, out Expression rewritten)
+    private bool TryRewriteStrict<TExpression>(TExpression expression, [NotNullIfNotNull("expression")] out TExpression newExpression)
+        where TExpression : Expression
     {
-        rewritten = Replace(expression);
+        var newExpressionUntyped = Replace(expression);
+        var hasChanges = !object.ReferenceEquals(expression, newExpressionUntyped);
 
-        return !object.ReferenceEquals(expression, rewritten);
+        if (newExpressionUntyped is not TExpression newExpressionTyped)
+        {
+            throw new InvalidOperationException($"Expected {nameof(newExpression)} to be of type {typeof(TExpression)}");
+        }
+
+        newExpression = newExpressionTyped;
+        return hasChanges;
     }
 
-    private bool TryRewrite(ImmutableArray<Expression> expressions, out ImmutableArray<Expression> newExpressions)
+    private bool TryRewrite(Expression expression, out Expression rewritten)
+        => TryRewriteStrict(expression, out rewritten);
+
+    private bool TryRewriteStrict<TExpression>(ImmutableArray<TExpression> expressions, out ImmutableArray<TExpression> newExpressions)
+        where TExpression : Expression
     {
         var hasChanges = false;
-        var newExpressionList = new List<Expression>();
+        var newExpressionList = new List<TExpression>();
         foreach (var expression in expressions)
         {
-            hasChanges |= TryRewrite(expression, out var newExpression);
+            hasChanges |= TryRewriteStrict(expression, out var newExpression);
             newExpressionList.Add(newExpression);
         }
 
         newExpressions = hasChanges ? newExpressionList.ToImmutableArray() : expressions;
         return hasChanges;
     }
+
+    private bool TryRewrite(ImmutableArray<Expression> expressions, out ImmutableArray<Expression> newExpressions)
+        => TryRewriteStrict(expressions, out newExpressions);
 
     private void ReplaceCurrent<TExpression>(TExpression expression, Func<TExpression, Expression> replaceFunc)
         where TExpression : Expression

--- a/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
@@ -33,6 +33,12 @@ public abstract class ExpressionVisitor : IExpressionVisitor
     {
     }
 
+    public void VisitForLoopExpression(ForLoopExpression expression)
+    {
+        Visit(expression.Expression);
+        Visit(expression.Body);
+    }
+
     public void VisitFunctionCallExpression(FunctionCallExpression expression)
     {
         VisitMultiple(expression.Parameters);
@@ -71,11 +77,13 @@ public abstract class ExpressionVisitor : IExpressionVisitor
 
     public void VisitObjectExpression(ObjectExpression expression)
     {
-        foreach (var prop in expression.Properties)
-        {
-            Visit(prop.Key);
-            Visit(prop.Value);
-        }
+        VisitMultiple(expression.Properties);
+    }
+
+    public void VisitObjectPropertyExpression(ObjectPropertyExpression expression)
+    {
+        Visit(expression.Key);
+        Visit(expression.Value);
     }
 
     public void VisitParametersReferenceExpression(ParametersReferenceExpression expression)

--- a/src/Bicep.Core/Intermediate/IExpressionVisitor.cs
+++ b/src/Bicep.Core/Intermediate/IExpressionVisitor.cs
@@ -19,6 +19,8 @@ public interface IExpressionVisitor
 
     void VisitObjectExpression(ObjectExpression expression);
 
+    void VisitObjectPropertyExpression(ObjectPropertyExpression expression);
+
     void VisitArrayExpression(ArrayExpression expression);
 
     void VisitTernaryExpression(TernaryExpression expression);
@@ -44,6 +46,8 @@ public interface IExpressionVisitor
     void VisitParametersReferenceExpression(ParametersReferenceExpression expression);
 
     void VisitLambdaVariableReferenceExpression(LambdaVariableReferenceExpression expression);
+
+    void VisitForLoopExpression(ForLoopExpression expression);
 
     void VisitCopyIndexExpression(CopyIndexExpression expression);
 


### PR DESCRIPTION
This PR adds source mapping to IR expressions via the `SourceSyntax` field, and expands the scope of IR usage by allowing the `ExpressionEmitter` to emit IR directly.

Long-term goals for an IR are:
* Open the door to constant folding, inline expression evaluation & lowering
* Simplify syntax traversal where an abstract syntax tree is more desirable (e.g. emit limitation calculation)
* Converge with `ResourceMetadata`, `ScopeHelper` logic to simplify and make this logic more robust

Part 2: #9170

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9170)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9306)