### PR TITLE
Insert resource: restrict command to active editor

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -408,6 +408,7 @@
         },
         {
           "command": "bicep.insertResource",
+          "when": "editorLangId == bicep",
           "group": "0_bicep"
         },
         {


### PR DESCRIPTION
Workaround for the issue described under #9307

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9308)