### PR TITLE
Allow union declarations to be include a newline before any pipe

### DIFF
--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.bicep
@@ -33,7 +33,9 @@ type aUnion = 'snap'|'crackle'|'pop'
 
 type expandedUnion = aUnion|'fizz'|'buzz'|'pop'
 
-type tupleUnion = ['foo', 'bar', 'baz']|['fizz', 'buzz']|['snap', 'crackle', 'pop']
+type tupleUnion = ['foo', 'bar', 'baz']
+|['fizz', 'buzz']
+|['snap', 'crackle', 'pop']
 
 type mixedArray = ('heffalump'|'woozle'|{ shape: '*', size: '*'}|10|-10|true|!true|null)[]
 

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.diagnostics.bicep
@@ -33,7 +33,9 @@ type aUnion = 'snap'|'crackle'|'pop'
 
 type expandedUnion = aUnion|'fizz'|'buzz'|'pop'
 
-type tupleUnion = ['foo', 'bar', 'baz']|['fizz', 'buzz']|['snap', 'crackle', 'pop']
+type tupleUnion = ['foo', 'bar', 'baz']
+|['fizz', 'buzz']
+|['snap', 'crackle', 'pop']
 
 type mixedArray = ('heffalump'|'woozle'|{ shape: '*', size: '*'}|10|-10|true|!true|null)[]
 
@@ -63,3 +65,4 @@ type tuple = [
     @description('A second element using a type alias')
     bar
 ]
+

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.formatted.bicep
@@ -33,7 +33,9 @@ type aUnion = 'snap' | 'crackle' | 'pop'
 
 type expandedUnion = aUnion | 'fizz' | 'buzz' | 'pop'
 
-type tupleUnion = [ 'foo', 'bar', 'baz' ] | [ 'fizz', 'buzz' ] | [ 'snap', 'crackle', 'pop' ]
+type tupleUnion = [ 'foo', 'bar', 'baz' ]
+  | [ 'fizz', 'buzz' ]
+  | [ 'snap', 'crackle', 'pop' ]
 
 type mixedArray = ('heffalump' | 'woozle' | { shape: '*', size: '*' } | 10 | -10 | true | !true | null)[]
 

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.bicep
@@ -151,7 +151,7 @@ type expandedUnion = aUnion|'fizz'|'buzz'|'pop'
 //@      ]
 //@    },
 
-type tupleUnion = ['foo', 'bar', 'baz']|['fizz', 'buzz']|['snap', 'crackle', 'pop']
+type tupleUnion = ['foo', 'bar', 'baz']
 //@    "tupleUnion": {
 //@      "type": "array",
 //@      "allowedValues": [
@@ -171,6 +171,8 @@ type tupleUnion = ['foo', 'bar', 'baz']|['fizz', 'buzz']|['snap', 'crackle', 'po
 //@        ]
 //@      ]
 //@    },
+|['fizz', 'buzz']
+|['snap', 'crackle', 'pop']
 
 type mixedArray = ('heffalump'|'woozle'|{ shape: '*', size: '*'}|10|-10|true|!true|null)[]
 //@    "mixedArray": {
@@ -267,3 +269,4 @@ type tuple = [
     @description('A second element using a type alias')
     bar
 ]
+

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbols.bicep
@@ -37,8 +37,10 @@ type aUnion = 'snap'|'crackle'|'pop'
 type expandedUnion = aUnion|'fizz'|'buzz'|'pop'
 //@[5:18) TypeAlias expandedUnion. Type: Type<'buzz' | 'crackle' | 'fizz' | 'pop' | 'snap'>. Declaration start char: 0, length: 47
 
-type tupleUnion = ['foo', 'bar', 'baz']|['fizz', 'buzz']|['snap', 'crackle', 'pop']
-//@[5:15) TypeAlias tupleUnion. Type: Type<['fizz', 'buzz'] | ['foo', 'bar', 'baz'] | ['snap', 'crackle', 'pop']>. Declaration start char: 0, length: 83
+type tupleUnion = ['foo', 'bar', 'baz']
+//@[5:15) TypeAlias tupleUnion. Type: Type<['fizz', 'buzz'] | ['foo', 'bar', 'baz'] | ['snap', 'crackle', 'pop']>. Declaration start char: 0, length: 85
+|['fizz', 'buzz']
+|['snap', 'crackle', 'pop']
 
 type mixedArray = ('heffalump'|'woozle'|{ shape: '*', size: '*'}|10|-10|true|!true|null)[]
 //@[5:15) TypeAlias mixedArray. Type: Type<('heffalump' | 'woozle' | -10 | 10 | false | null | true | { shape: '*', size: '*' })[]>. Declaration start char: 0, length: 90
@@ -71,3 +73,4 @@ type tuple = [
     @description('A second element using a type alias')
     bar
 ]
+

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 @description('The foo type')
-//@[00:1117) ProgramSyntax
+//@[00:1120) ProgramSyntax
 //@[00:0298) ├─TypeDeclarationSyntax
 //@[00:0028) | ├─DecoratorSyntax
 //@[00:0001) | | ├─Token(At) |@|
@@ -335,13 +335,13 @@ type expandedUnion = aUnion|'fizz'|'buzz'|'pop'
 //@[42:0047) |       └─Token(StringComplete) |'pop'|
 //@[47:0049) ├─Token(NewLine) |\n\n|
 
-type tupleUnion = ['foo', 'bar', 'baz']|['fizz', 'buzz']|['snap', 'crackle', 'pop']
-//@[00:0083) ├─TypeDeclarationSyntax
+type tupleUnion = ['foo', 'bar', 'baz']
+//@[00:0085) ├─TypeDeclarationSyntax
 //@[00:0004) | ├─Token(Identifier) |type|
 //@[05:0015) | ├─IdentifierSyntax
 //@[05:0015) | | └─Token(Identifier) |tupleUnion|
 //@[16:0017) | ├─Token(Assignment) |=|
-//@[18:0083) | └─UnionTypeSyntax
+//@[18:0085) | └─UnionTypeSyntax
 //@[18:0039) |   ├─UnionTypeMemberSyntax
 //@[18:0039) |   | └─TupleTypeSyntax
 //@[18:0019) |   |   ├─Token(LeftSquare) |[|
@@ -357,35 +357,39 @@ type tupleUnion = ['foo', 'bar', 'baz']|['fizz', 'buzz']|['snap', 'crackle', 'po
 //@[33:0038) |   |   | └─StringSyntax
 //@[33:0038) |   |   |   └─Token(StringComplete) |'baz'|
 //@[38:0039) |   |   └─Token(RightSquare) |]|
-//@[39:0040) |   ├─Token(Pipe) |||
-//@[40:0056) |   ├─UnionTypeMemberSyntax
-//@[40:0056) |   | └─TupleTypeSyntax
-//@[40:0041) |   |   ├─Token(LeftSquare) |[|
-//@[41:0047) |   |   ├─TupleTypeItemSyntax
-//@[41:0047) |   |   | └─StringSyntax
-//@[41:0047) |   |   |   └─Token(StringComplete) |'fizz'|
-//@[47:0048) |   |   ├─Token(Comma) |,|
-//@[49:0055) |   |   ├─TupleTypeItemSyntax
-//@[49:0055) |   |   | └─StringSyntax
-//@[49:0055) |   |   |   └─Token(StringComplete) |'buzz'|
-//@[55:0056) |   |   └─Token(RightSquare) |]|
-//@[56:0057) |   ├─Token(Pipe) |||
-//@[57:0083) |   └─UnionTypeMemberSyntax
-//@[57:0083) |     └─TupleTypeSyntax
-//@[57:0058) |       ├─Token(LeftSquare) |[|
-//@[58:0064) |       ├─TupleTypeItemSyntax
-//@[58:0064) |       | └─StringSyntax
-//@[58:0064) |       |   └─Token(StringComplete) |'snap'|
-//@[64:0065) |       ├─Token(Comma) |,|
-//@[66:0075) |       ├─TupleTypeItemSyntax
-//@[66:0075) |       | └─StringSyntax
-//@[66:0075) |       |   └─Token(StringComplete) |'crackle'|
-//@[75:0076) |       ├─Token(Comma) |,|
-//@[77:0082) |       ├─TupleTypeItemSyntax
-//@[77:0082) |       | └─StringSyntax
-//@[77:0082) |       |   └─Token(StringComplete) |'pop'|
-//@[82:0083) |       └─Token(RightSquare) |]|
-//@[83:0085) ├─Token(NewLine) |\n\n|
+//@[39:0040) |   ├─Token(NewLine) |\n|
+|['fizz', 'buzz']
+//@[00:0001) |   ├─Token(Pipe) |||
+//@[01:0017) |   ├─UnionTypeMemberSyntax
+//@[01:0017) |   | └─TupleTypeSyntax
+//@[01:0002) |   |   ├─Token(LeftSquare) |[|
+//@[02:0008) |   |   ├─TupleTypeItemSyntax
+//@[02:0008) |   |   | └─StringSyntax
+//@[02:0008) |   |   |   └─Token(StringComplete) |'fizz'|
+//@[08:0009) |   |   ├─Token(Comma) |,|
+//@[10:0016) |   |   ├─TupleTypeItemSyntax
+//@[10:0016) |   |   | └─StringSyntax
+//@[10:0016) |   |   |   └─Token(StringComplete) |'buzz'|
+//@[16:0017) |   |   └─Token(RightSquare) |]|
+//@[17:0018) |   ├─Token(NewLine) |\n|
+|['snap', 'crackle', 'pop']
+//@[00:0001) |   ├─Token(Pipe) |||
+//@[01:0027) |   └─UnionTypeMemberSyntax
+//@[01:0027) |     └─TupleTypeSyntax
+//@[01:0002) |       ├─Token(LeftSquare) |[|
+//@[02:0008) |       ├─TupleTypeItemSyntax
+//@[02:0008) |       | └─StringSyntax
+//@[02:0008) |       |   └─Token(StringComplete) |'snap'|
+//@[08:0009) |       ├─Token(Comma) |,|
+//@[10:0019) |       ├─TupleTypeItemSyntax
+//@[10:0019) |       | └─StringSyntax
+//@[10:0019) |       |   └─Token(StringComplete) |'crackle'|
+//@[19:0020) |       ├─Token(Comma) |,|
+//@[21:0026) |       ├─TupleTypeItemSyntax
+//@[21:0026) |       | └─StringSyntax
+//@[21:0026) |       |   └─Token(StringComplete) |'pop'|
+//@[26:0027) |       └─Token(RightSquare) |]|
+//@[27:0029) ├─Token(NewLine) |\n\n|
 
 type mixedArray = ('heffalump'|'woozle'|{ shape: '*', size: '*'}|10|-10|true|!true|null)[]
 //@[00:0090) ├─TypeDeclarationSyntax
@@ -652,4 +656,6 @@ type tuple = [
 //@[07:0008) |   ├─Token(NewLine) |\n|
 ]
 //@[00:0001) |   └─Token(RightSquare) |]|
-//@[01:0001) └─Token(EndOfFile) ||
+//@[01:0002) ├─Token(NewLine) |\n|
+
+//@[00:0000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.tokens.bicep
@@ -196,7 +196,7 @@ type expandedUnion = aUnion|'fizz'|'buzz'|'pop'
 //@[42:47) StringComplete |'pop'|
 //@[47:49) NewLine |\n\n|
 
-type tupleUnion = ['foo', 'bar', 'baz']|['fizz', 'buzz']|['snap', 'crackle', 'pop']
+type tupleUnion = ['foo', 'bar', 'baz']
 //@[00:04) Identifier |type|
 //@[05:15) Identifier |tupleUnion|
 //@[16:17) Assignment |=|
@@ -207,21 +207,25 @@ type tupleUnion = ['foo', 'bar', 'baz']|['fizz', 'buzz']|['snap', 'crackle', 'po
 //@[31:32) Comma |,|
 //@[33:38) StringComplete |'baz'|
 //@[38:39) RightSquare |]|
-//@[39:40) Pipe |||
-//@[40:41) LeftSquare |[|
-//@[41:47) StringComplete |'fizz'|
-//@[47:48) Comma |,|
-//@[49:55) StringComplete |'buzz'|
-//@[55:56) RightSquare |]|
-//@[56:57) Pipe |||
-//@[57:58) LeftSquare |[|
-//@[58:64) StringComplete |'snap'|
-//@[64:65) Comma |,|
-//@[66:75) StringComplete |'crackle'|
-//@[75:76) Comma |,|
-//@[77:82) StringComplete |'pop'|
-//@[82:83) RightSquare |]|
-//@[83:85) NewLine |\n\n|
+//@[39:40) NewLine |\n|
+|['fizz', 'buzz']
+//@[00:01) Pipe |||
+//@[01:02) LeftSquare |[|
+//@[02:08) StringComplete |'fizz'|
+//@[08:09) Comma |,|
+//@[10:16) StringComplete |'buzz'|
+//@[16:17) RightSquare |]|
+//@[17:18) NewLine |\n|
+|['snap', 'crackle', 'pop']
+//@[00:01) Pipe |||
+//@[01:02) LeftSquare |[|
+//@[02:08) StringComplete |'snap'|
+//@[08:09) Comma |,|
+//@[10:19) StringComplete |'crackle'|
+//@[19:20) Comma |,|
+//@[21:26) StringComplete |'pop'|
+//@[26:27) RightSquare |]|
+//@[27:29) NewLine |\n\n|
 
 type mixedArray = ('heffalump'|'woozle'|{ shape: '*', size: '*'}|10|-10|true|!true|null)[]
 //@[00:04) Identifier |type|
@@ -376,4 +380,6 @@ type tuple = [
 //@[07:08) NewLine |\n|
 ]
 //@[00:01) RightSquare |]|
-//@[01:01) EndOfFile ||
+//@[01:02) NewLine |\n|
+
+//@[00:00) EndOfFile ||

--- a/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
@@ -418,18 +418,44 @@ type aTuple = [
 ]";
 
             var parsed = ParserHelper.Parse(typeDeclaration);
-            parsed.Should().BeOfType<ProgramSyntax>();
-            (parsed as ProgramSyntax).Declarations.Should().HaveCount(1);
-            (parsed as ProgramSyntax).Declarations.Single().Should().BeOfType<TypeDeclarationSyntax>();
-            var declaration = (TypeDeclarationSyntax) (parsed as ProgramSyntax).Declarations.Single();
+            parsed.Declarations.Should().HaveCount(1);
+            parsed.Declarations.Single().Should().BeOfType<TypeDeclarationSyntax>();
+            var declaration = (TypeDeclarationSyntax) parsed.Declarations.Single();
 
             declaration.Value.Should().BeOfType<TupleTypeSyntax>();
-            var declaredObject = (TupleTypeSyntax) declaration.Value;
-            declaredObject.Items.Should().HaveCount(2);
-            declaredObject.Items.First().Decorators.Should().HaveCount(2);
-            declaredObject.Items.First().Value.Should().BeOfType<VariableAccessSyntax>();
-            declaredObject.Items.Last().Decorators.Should().HaveCount(1);
-            declaredObject.Items.Last().Value.Should().BeOfType<UnionTypeSyntax>();
+            var declaredTuple = (TupleTypeSyntax) declaration.Value;
+            declaredTuple.Items.Should().HaveCount(2);
+            declaredTuple.Items.First().Decorators.Should().HaveCount(2);
+            declaredTuple.Items.First().Value.Should().BeOfType<VariableAccessSyntax>();
+            declaredTuple.Items.Last().Decorators.Should().HaveCount(1);
+            declaredTuple.Items.Last().Value.Should().BeOfType<UnionTypeSyntax>();
+        }
+
+        [TestMethod]
+        public void MultilineUnionTypeLiteralsShouldParseSuccessfully()
+        {
+            var typeDeclaration = @"
+type multilineUnion = 'a'
+  | 'multiline'
+  | 'union'
+";
+
+            var parsed = ParserHelper.Parse(typeDeclaration);
+            parsed.Declarations.Should().HaveCount(1);
+            parsed.Declarations.Single().Should().BeOfType<TypeDeclarationSyntax>();
+            var declaration = (TypeDeclarationSyntax) parsed.Declarations.Single();
+
+            declaration.Value.Should().BeOfType<UnionTypeSyntax>();
+
+            var expectedMemberValues = new[] { "a", "multiline", "union" };
+            var actualMembers = declaration.Value.As<UnionTypeSyntax>().Members.ToArray();
+            actualMembers.Should().HaveCount(expectedMemberValues.Length);
+
+            for (int i = 0; i < expectedMemberValues.Length; i++)
+            {
+                actualMembers[i].Value.Should().BeOfType<StringSyntax>();
+                actualMembers[i].Value.As<StringSyntax>().TryGetLiteralValue().Should().Be(expectedMemberValues[i]);
+            }
         }
 
         private static SyntaxBase RunExpressionTest(string text, string expected, Type expectedRootType)

--- a/src/Bicep.Core/Syntax/UnionTypeSyntax.cs
+++ b/src/Bicep.Core/Syntax/UnionTypeSyntax.cs
@@ -19,7 +19,7 @@ public class UnionTypeSyntax : TypeSyntax
         }
     }
 
-    public IEnumerable<SyntaxBase> Children { get; }
+    public ImmutableArray<SyntaxBase> Children { get; }
 
     public override void Accept(ISyntaxVisitor visitor) => visitor.VisitUnionTypeSyntax(this);
 


### PR DESCRIPTION
This PR allows union type expressions to be spread across multiple lines provided that the newline character precedes rather than follows the `|` operator.

Previously, multiline unions were disallowed because incomplete unions could lead to incorrect error messages. For example,

```bicep
type aUnion = 'foo' | 'bar' |
param myParam string
```

would report that `param` was not a recognized symbol, as the trailing `|` would be interpreted as preceding a type expression (rather than just being recognized as the end of an incomplete line).

By allowing a newline before the `|`, however, the parser can keep building a UnionTypeSyntax so long as the token following a type expression is either a `|` or a newline immediately followed by a `|`. Consequently, `invalidUnionSyntax` in the following example would be a parse error, whereas `validMultilineUnion` would be legal with this PR:

```bicep
type invalidUnionSyntax = 'foo' |
  'bar' |
  'baz'

type validMultilineUnion = 'foo'
  | 'bar'
  | 'baz'
```